### PR TITLE
Fix failed restores being reported as successful

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,24 @@ jobs:
       - name: Build
         run: dotnet build NineLives.sln -c Release --no-restore -warnaserror
 
+      # SqlExecutionFailureTests pin the "a failed restore must not report success" contract and
+      # need a real instance. windows-latest ships SQL Server Express LocalDB; if it starts, point
+      # the suite at it. Best effort by design — if LocalDB is ever absent from the image those
+      # tests skip and the rest of the suite is unaffected, rather than the build breaking on an
+      # environment detail.
+      - name: Start SQL Server LocalDB (best effort)
+        shell: pwsh
+        run: |
+          sqllocaldb create MSSQLLocalDB 2>$null
+          sqllocaldb start MSSQLLocalDB
+          if ($LASTEXITCODE -eq 0) {
+            "NINELIVES_TEST_SQL=(localdb)\MSSQLLocalDB" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            Write-Host "::notice title=Live SQL tests enabled::LocalDB started; SqlExecutionFailureTests will run."
+          } else {
+            Write-Host "::warning title=Live SQL tests skipped::LocalDB unavailable on this runner."
+          }
+          exit 0
+
       - name: Run tests
         run: dotnet test src/NineLives.Tests/NineLives.Tests.csproj -c Release --no-build --verbosity normal
 

--- a/src/NineLives.Tests/SqlExecutionFailureTests.cs
+++ b/src/NineLives.Tests/SqlExecutionFailureTests.cs
@@ -1,0 +1,150 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Marks a test that needs a real SQL Server. Set NINELIVES_TEST_SQL to an instance
+/// name (e.g. ".\SQLEXPRESS") to run these; they skip otherwise, so CI and a plain
+/// `dotnet test` on a machine without SQL Server stay green.
+/// </summary>
+public sealed class RequiresSqlFactAttribute : FactAttribute
+{
+    public RequiresSqlFactAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(SqlExecutionFailureTests.TestServerName))
+            Skip = "Set NINELIVES_TEST_SQL to a SQL Server instance name to run live SQL tests.";
+    }
+}
+
+/// <summary>
+/// Regression tests for the failure-reporting contract of the execution methods.
+///
+/// These exist because of a defect where FireInfoMessageEventOnUserErrors = true routed
+/// every error of severity &lt;= 16 - which is essentially every real RESTORE failure - to the
+/// InfoMessage handler instead of throwing. Nothing threw, the statement loop ran to
+/// completion, and the app reported "Restore completed successfully!" over a total failure.
+///
+/// The contract these pin down:
+///   1. a failing statement throws, so the caller can report failure;
+///   2. execution STOPS at the first failure instead of running the rest of the chain;
+///   3. informational messages (RESTORE progress/STATS) still reach the callback.
+/// </summary>
+public class SqlExecutionFailureTests
+{
+    internal static string? TestServerName =>
+        Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL");
+
+    private static ServerConnection TestServer() => new()
+    {
+        Name = "ninelives-test",
+        ServerName = TestServerName!,
+        AuthMode = AuthMode.WindowsAuth,
+        Encrypt = EncryptMode.No,
+        TrustServerCertificate = true,
+        ConnectionTimeoutSeconds = 15
+    };
+
+    private static SqlServerService Service() => new(new CredentialStore());
+
+    // Severity 16 is the band that matters: SQL Server reports almost every restore failure
+    // there (3201 cannot open backup device, 3013 terminating abnormally, 4305 log too recent,
+    // 3136 differential base mismatch).
+    private const string FailingBatch = "RAISERROR('nine-lives-test-failure', 16, 1);";
+
+    // A real restore failure rather than a synthetic RAISERROR: 3201 + 3013, the exact pair an
+    // expired SAS token produces. FROM DISK keeps it local and fast - no network, no container.
+    private const string FailingRestore =
+        @"RESTORE DATABASE [NineLives_DoesNotExist] FROM DISK = N'C:\NineLives_NoSuchPath\nope.bak' WITH FILE = 1;";
+
+    [RequiresSqlFact]
+    public async Task ExecuteRestoreWithProgress_FailingStatement_Throws()
+    {
+        var messages = new List<string>();
+
+        await Assert.ThrowsAsync<SqlException>(() =>
+            Service().ExecuteRestoreWithProgressAsync(
+                TestServer(), FailingBatch, messages.Add));
+    }
+
+    [RequiresSqlFact]
+    public async Task ExecuteRestoreWithProgress_FailingRestore_Throws()
+    {
+        var messages = new List<string>();
+
+        var ex = await Assert.ThrowsAsync<SqlException>(() =>
+            Service().ExecuteRestoreWithProgressAsync(
+                TestServer(), FailingRestore, messages.Add));
+
+        // 3201 = cannot open backup device. This is the error an expired SAS produces.
+        Assert.Contains(ex.Errors.Cast<SqlError>(), e => e.Number == 3201);
+    }
+
+    [RequiresSqlFact]
+    public async Task ExecuteRestoreWithProgress_StopsAtFirstFailure()
+    {
+        // The heart of the bug: a chain is GO-split and executed statement by statement. When
+        // an early statement fails, the remaining restores must NOT run - previously they all
+        // ran against a database that was never created.
+        var messages = new List<string>();
+        var script = string.Join("\n", [
+            "PRINT 'nine-lives-statement-1';",
+            "GO",
+            FailingBatch,
+            "GO",
+            "PRINT 'nine-lives-statement-3-should-not-run';",
+            "GO"
+        ]);
+
+        await Assert.ThrowsAsync<SqlException>(() =>
+            Service().ExecuteRestoreWithProgressAsync(TestServer(), script, messages.Add));
+
+        Assert.Contains(messages, m => m.Contains("nine-lives-statement-1"));
+        Assert.DoesNotContain(messages, m => m.Contains("should-not-run"));
+    }
+
+    [RequiresSqlFact]
+    public async Task ExecuteRestoreWithProgress_InformationalMessages_StillReachTheCallback()
+    {
+        // The progress console depends on InfoMessage delivery. Severity <= 10 messages - which
+        // is what RESTORE's "X percent processed" and PRINT are - must still arrive after the fix.
+        var messages = new List<string>();
+
+        await Service().ExecuteRestoreWithProgressAsync(
+            TestServer(), "PRINT 'nine-lives-progress-message';", messages.Add);
+
+        Assert.Contains(messages, m => m.Contains("nine-lives-progress-message"));
+    }
+
+    [RequiresSqlFact]
+    public async Task ExecuteRestoreWithProgress_LowSeverityRaiserror_DoesNotFailTheRun()
+    {
+        // Severity <= 10 is informational by definition and must not be treated as failure,
+        // otherwise ordinary restore chatter would abort a healthy restore.
+        var messages = new List<string>();
+
+        await Service().ExecuteRestoreWithProgressAsync(
+            TestServer(), "RAISERROR('nine-lives-informational', 10, 1);", messages.Add);
+
+        Assert.Contains(messages, m => m.Contains("nine-lives-informational"));
+    }
+
+    [RequiresSqlFact]
+    public async Task ExecuteNonQuery_FailingStatement_Throws()
+    {
+        // Same contract on the other execution path, which credential creation uses.
+        await Assert.ThrowsAsync<SqlException>(() =>
+            Service().ExecuteNonQueryAsync(TestServer(), FailingBatch));
+    }
+
+    [RequiresSqlFact]
+    public async Task ExecuteNonQuery_FailingStatement_ThrowsEvenWithNoMessageCallback()
+    {
+        // The original defect set the flag even when messageCallback was null, so errors
+        // vanished entirely with nowhere to surface.
+        await Assert.ThrowsAsync<SqlException>(() =>
+            Service().ExecuteNonQueryAsync(TestServer(), FailingBatch, messageCallback: null));
+    }
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -239,6 +239,22 @@ public class SqlServerService
         };
     }
 
+    // DO NOT set conn.FireInfoMessageEventOnUserErrors = true on these connections.
+    //
+    // That flag routes every error of severity <= 16 to the InfoMessage event INSTEAD of
+    // throwing SqlException - and severity 16 is where SQL Server reports essentially every
+    // real restore failure: 3201 (cannot open backup device, i.e. a bad or expired SAS),
+    // 3013 (RESTORE terminating abnormally), 4305 (log too recent), 3136 (differential base
+    // mismatch), 3154 (backup set is for a different database).
+    //
+    // With the flag on, nothing threw, the GO-split statement loop below ran the rest of the
+    // chain against a database that was never created, and the caller reported
+    // "Restore completed successfully!" over a total failure - the worst possible outcome for
+    // a restore tool. Progress output does NOT depend on the flag: STATS "X percent processed"
+    // and PRINT are severity <= 10 and arrive through InfoMessage either way.
+    //
+    // Pinned by SqlExecutionFailureTests (live SQL, gated on NINELIVES_TEST_SQL).
+
     public async Task ExecuteNonQueryAsync(
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default)
@@ -248,7 +264,6 @@ public class SqlServerService
         {
             conn.InfoMessage += (_, e) => messageCallback(e.Message);
         }
-        conn.FireInfoMessageEventOnUserErrors = true;
         await conn.OpenAsync(ct);
 
         await using var cmd = conn.CreateCommand();
@@ -266,23 +281,41 @@ public class SqlServerService
         {
             conn.InfoMessage += (_, e) => messageCallback(e.Message);
         }
-        conn.FireInfoMessageEventOnUserErrors = true;
         await conn.OpenAsync(ct);
 
         var statements = SplitGoStatements(sql);
-        foreach (var statement in statements)
+        var executable = statements.Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+
+        for (int i = 0; i < executable.Count; i++)
         {
-            if (string.IsNullOrWhiteSpace(statement)) continue;
+            var statement = executable[i];
             ct.ThrowIfCancellationRequested();
 
-            messageCallback?.Invoke($"Executing: {statement[..Math.Min(80, statement.Length)].Trim()}...");
+            messageCallback?.Invoke(
+                $"Executing statement {i + 1} of {executable.Count}: {Summarize(statement)}...");
 
             await using var cmd = conn.CreateCommand();
             cmd.CommandTimeout = 0;
             cmd.CommandText = statement;
-            await cmd.ExecuteNonQueryAsync(ct);
+
+            try
+            {
+                await cmd.ExecuteNonQueryAsync(ct);
+            }
+            catch (SqlException)
+            {
+                // Say WHICH step of the chain failed before it propagates. Without this the
+                // user sees a bare SQL error and has to work out whether the full, a
+                // differential, or a log restore was the one that died.
+                messageCallback?.Invoke(
+                    $"FAILED on statement {i + 1} of {executable.Count}: {Summarize(statement)}");
+                throw;
+            }
         }
     }
+
+    private static string Summarize(string statement)
+        => statement[..Math.Min(80, statement.Length)].Trim();
 
     /// <summary>Checks if a credential with the given name exists on the server and has identity SHARED ACCESS SIGNATURE (for blob URL restores).</summary>
     public async Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(


### PR DESCRIPTION
Closes #6.

## The bug

`SqlServerService` set `conn.FireInfoMessageEventOnUserErrors = true` on both execution paths. That flag routes **every error of severity ≤ 16 to the `InfoMessage` event instead of throwing `SqlException`** — and severity 16 is exactly where SQL Server reports essentially every real restore failure:

| Msg | Meaning |
|---|---|
| 3201 | Cannot open backup device (bad or **expired SAS**) |
| 3013 | RESTORE DATABASE is terminating abnormally |
| 4305 | The log backup is too recent to apply |
| 3136 | Differential cannot be restored (wrong base) |
| 3154 | Backup set holds a backup of a different database |

So nothing threw, the GO-split statement loop carried on executing the differential and every log restore against a database that was never created, and `RestoreViewModel` set `ExecutionSuccess = true` and logged **"Restore completed successfully!"** over a total failure.

## The fix

**Leave the flag at its default `false`** on both paths, so those errors surface as `SqlException` and the existing `catch` in `RestoreViewModel` reports the failure it was always written to report.

Progress output is unaffected — `STATS` "X percent processed" and `PRINT` are severity ≤ 10 and arrive through `InfoMessage` either way. That is pinned by a test.

Two supporting changes:

- **Say which step failed.** The loop now reports `FAILED on statement 3 of 7: RESTORE LOG [Sales] ...` before rethrowing. Without it, a chain failure gives a bare SQL error with no indication of whether the full, a differential, or a log was the step that died.
- **A comment at the call site** explaining why the flag must stay off, so it does not get re-added as a way to "capture progress messages".

## Tests

New `SqlExecutionFailureTests` — 7 tests against a real SQL Server, pinning the contract:

1. a failing statement throws (`RAISERROR ... 16`)
2. a real failing restore throws, and carries Msg **3201** — the expired-SAS error
3. **execution stops at the first failure** instead of running the rest of the chain
4. informational messages still reach the progress callback
5. severity ≤ 10 `RAISERROR` does not fail the run
6. `ExecuteNonQueryAsync` throws on failure
7. …and throws even when `messageCallback` is null (the original defect set the flag there too, so errors vanished entirely)

### Evidence

Run against **SQL Server 2025 Express** and **LocalDB**:

| | Before | After |
|---|---|---|
| `SqlExecutionFailureTests` | **5 failed** — *"Assert.Throws() Failure: No exception was thrown"* | **7 passed** |
| Full suite (live SQL) | — | **135 passed** |
| Full suite (no SQL) | — | **128 passed, 7 skipped** |

The two that passed before the fix are the informational-message tests, which correctly assert *no* throw.

### Gating

The live tests are gated on `NINELIVES_TEST_SQL`, so `dotnet test` on a machine without SQL Server skips them rather than failing. CI starts LocalDB **best effort**: if it comes up the tests run, and if LocalDB is ever absent from the runner image they skip and the rest of the suite is unaffected — an environment detail should not break the build.

To run them locally:

```
$env:NINELIVES_TEST_SQL = ".\SQLEXPRESS"
dotnet test
```

## Follow-ups this unblocks

Fixing this changes the severity of several other issues, because failures are now actually detected:

- **#49** (copy-only fulls) stops being silently data-destructive — a chain that overwrites the target `WITH REPLACE` and then fails at the differential now reports the failure instead of success.
- **#14** (no recovery guidance for a database stranded in RESTORING) becomes implementable, since there is now a detectable failure to hang it off.
- **#44** likewise depends on execution failures being visible.
