### PR TITLE
Escape T-SQL identifiers and string literals

### DIFF
--- a/src/NineLives.Tests/CredentialInjectionTests.cs
+++ b/src/NineLives.Tests/CredentialInjectionTests.cs
@@ -1,0 +1,145 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Live proof that a credential name cannot break out of its bracket quoting.
+///
+/// CREATE/DROP CREDENTIAL take the name as an identifier, so it cannot be parameterised and has
+/// to be quoted. It was previously interpolated raw, and the name is auto-populated from the
+/// container URL in config.json - a plain-text file with no integrity check - so a single local
+/// file write turned into arbitrary T-SQL on whichever instance the DBA connected to.
+///
+/// These tests create and drop credentials on the target instance, so they are gated on
+/// NINELIVES_TEST_SQL like the other live tests and clean up after themselves. The payload used
+/// below is deliberately harmless: if the injection were still open it would create a second,
+/// clearly-named credential rather than change any permissions.
+/// </summary>
+public class CredentialInjectionTests
+{
+    private static string? TestServerName =>
+        Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL");
+
+    private static ServerConnection TestServer() => new()
+    {
+        Name = "ninelives-test",
+        ServerName = TestServerName!,
+        AuthMode = AuthMode.WindowsAuth,
+        Encrypt = EncryptMode.No,
+        TrustServerCertificate = true,
+        ConnectionTimeoutSeconds = 15
+    };
+
+    private static SqlServerService Service() => new(new CredentialStore());
+
+    private const string DecoyName = "nl-decoy";
+    private const string FakeSas = "sv=2026-01-01&sig=not-a-real-token";
+
+    /// <summary>
+    /// A name that, unescaped, closes the bracket, completes the CREATE CREDENTIAL statement,
+    /// runs a second statement, and opens a decoy CREATE CREDENTIAL to absorb the trailing
+    /// WITH IDENTITY / SECRET lines the caller appends. Verified to execute both statements
+    /// against SQL Server when interpolated raw.
+    ///
+    /// Kept under 128 characters because a credential name is sysname: a longer payload is
+    /// rejected by SQL Server as a single over-long identifier, which proves the quoting works
+    /// but does so by erroring rather than by letting the assertion below run.
+    /// </summary>
+    private static string InjectionPayload =>
+        $"nl] WITH IDENTITY='SHARED ACCESS SIGNATURE', SECRET='z'; CREATE CREDENTIAL [{DecoyName}";
+
+    [RequiresSqlFact]
+    public async Task EnsureCredentialExists_InjectionPayloadName_CreatesExactlyOneCredential()
+    {
+        var payload = InjectionPayload;
+        try
+        {
+            await Service().EnsureCredentialExistsAsync(
+                TestServer(), payload, "https://acct.blob.core.windows.net/backups", FakeSas);
+
+            // The decoy is the tell: if the payload had escaped its quoting, SQL Server would
+            // have executed a second CREATE CREDENTIAL and this would exist.
+            Assert.False(
+                await CredentialExists(DecoyName),
+                "Injection succeeded: the payload created a second credential.");
+
+            // ...and the whole payload should have been stored as one literal credential name.
+            Assert.True(
+                await CredentialExists(payload),
+                "The payload should be stored verbatim as a single credential name.");
+        }
+        finally
+        {
+            await DropCredentialIfExists(payload);
+            await DropCredentialIfExists(DecoyName);
+        }
+    }
+
+    [RequiresSqlFact]
+    public async Task EnsureCredentialExists_Ipv6EndpointName_Succeeds()
+    {
+        // The benign half of the same bug: an IPv6-literal endpoint is a legal URL containing a
+        // ']', and previously failed with an opaque syntax error.
+        const string name = "https://[fe80::1]:10000/devstoreaccount1/backups";
+        try
+        {
+            await Service().EnsureCredentialExistsAsync(TestServer(), name, name, FakeSas);
+            Assert.True(await CredentialExists(name));
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    [RequiresSqlFact]
+    public async Task EnsureCredentialExists_IsIdempotentForAwkwardNames()
+    {
+        // Second call takes the DROP-then-CREATE path, which is the other interpolation site.
+        const string name = "ninelives-test]awkward]name";
+        try
+        {
+            await Service().EnsureCredentialExistsAsync(TestServer(), name, name, FakeSas);
+            await Service().EnsureCredentialExistsAsync(TestServer(), name, name, FakeSas);
+            Assert.True(await CredentialExists(name));
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    [RequiresSqlFact]
+    public async Task EnsureCredentialExists_NameWithLineBreak_IsRejectedBeforeReachingTheServer()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            Service().EnsureCredentialExistsAsync(
+                TestServer(), "name\nGO\nDROP DATABASE [x]", "https://acct/x", FakeSas));
+    }
+
+    // ── helpers (parameterised, so they cannot themselves be a vector) ───────────
+
+    private static async Task<bool> CredentialExists(string name)
+    {
+        await using var conn = new SqlConnection(Service().BuildConnectionString(TestServer()));
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM sys.credentials WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", name);
+        return (int)(await cmd.ExecuteScalarAsync())! > 0;
+    }
+
+    private static async Task DropCredentialIfExists(string name)
+    {
+        if (!await CredentialExists(name)) return;
+
+        await using var conn = new SqlConnection(Service().BuildConnectionString(TestServer()));
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DROP CREDENTIAL {TSql.QuoteName(name)}";
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
+++ b/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
@@ -216,6 +216,73 @@ public class RestoreScriptGeneratorTests
     }
 
     [Fact]
+    public void Generate_DbNameWithCloseBracket_IsEscaped()
+    {
+        // Previously produced RESTORE DATABASE [My]DB] - a syntax error, because the bracket
+        // was not doubled and so terminated the identifier early.
+        var script = _generator.Generate(FullOnlyChain(), Options(o => o.TargetDatabaseName = "My]DB"));
+
+        Assert.Contains("RESTORE DATABASE [My]]DB]", script);
+        Assert.DoesNotContain("RESTORE DATABASE [My]DB]", script);
+    }
+
+    [Fact]
+    public void Generate_DbNameWithCloseBracket_EscapedInDisconnectBlockToo()
+    {
+        var script = _generator.Generate(FullOnlyChain(), Options(o =>
+        {
+            o.TargetDatabaseName = "My]DB";
+            o.DisconnectSessions = true;
+        }));
+
+        // Identifier positions are bracket-quoted...
+        Assert.Contains("ALTER DATABASE [My]]DB] SET SINGLE_USER", script);
+        Assert.Contains("ALTER DATABASE [My]]DB] SET MULTI_USER", script);
+        // ...and the DB_ID argument is the bare name as a string literal, not a mangled one.
+        Assert.Contains("IF DB_ID('My]DB') IS NOT NULL", script);
+    }
+
+    [Fact]
+    public void Generate_DbNameWithApostrophe_EscapedInDbIdLiteral()
+    {
+        // DB_ID takes the name as data; an apostrophe would otherwise terminate the literal.
+        var script = _generator.Generate(FullOnlyChain(), Options(o =>
+        {
+            o.TargetDatabaseName = "O'Brien";
+            o.DisconnectSessions = true;
+        }));
+
+        Assert.Contains("IF DB_ID('O''Brien') IS NOT NULL", script);
+        Assert.Contains("ALTER DATABASE [O'Brien] SET SINGLE_USER", script);
+    }
+
+    [Fact]
+    public void Generate_StandbyPathWithApostrophe_IsEscaped()
+    {
+        var script = _generator.Generate(FullOnlyChain(), Options(o =>
+        {
+            o.RecoveryMode = RecoveryMode.Standby;
+            o.StandbyFilePath = @"D:\O'Brien\standby.tuf";
+        }));
+
+        Assert.Contains(@"STANDBY = 'D:\O''Brien\standby.tuf'", script);
+    }
+
+    [Fact]
+    public void Generate_FileMovePathWithApostrophe_IsEscaped()
+    {
+        var script = _generator.Generate(FullOnlyChain(), Options(o =>
+        {
+            o.FileMoves =
+            [
+                new FileMoveOption { LogicalName = "O'Data", NewPhysicalName = @"D:\O'Brien\db.mdf" }
+            ];
+        }));
+
+        Assert.Contains(@"MOVE N'O''Data' TO N'D:\O''Brien\db.mdf',", script);
+    }
+
+    [Fact]
     public void Generate_EmptyDbName_UsesPlaceholder()
     {
         var script = _generator.Generate(FullOnlyChain(), Options(o => o.TargetDatabaseName = ""));

--- a/src/NineLives.Tests/TSqlTests.cs
+++ b/src/NineLives.Tests/TSqlTests.cs
@@ -1,0 +1,182 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+public class TSqlTests
+{
+    // ── QuoteName ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void QuoteName_PlainName_IsBracketed()
+        => Assert.Equal("[MyDb]", TSql.QuoteName("MyDb"));
+
+    [Fact]
+    public void QuoteName_NameWithSpaces_IsBracketed()
+        => Assert.Equal("[My Db]", TSql.QuoteName("My Db"));
+
+    [Fact]
+    public void QuoteName_EmbeddedCloseBracket_IsDoubled()
+    {
+        // The bug: [My]DB] parses as identifier `My` followed by stray text.
+        Assert.Equal("[My]]DB]", TSql.QuoteName("My]DB"));
+    }
+
+    [Fact]
+    public void QuoteName_MultipleCloseBrackets_AllDoubled()
+        => Assert.Equal("[a]]b]]c]", TSql.QuoteName("a]b]c"));
+
+    [Fact]
+    public void QuoteName_AlreadyBracketed_IsUnwrappedAndRequoted()
+    {
+        // A user who types [My Db] means the database My Db, not `[My Db]`.
+        Assert.Equal("[My Db]", TSql.QuoteName("[My Db]"));
+    }
+
+    [Fact]
+    public void QuoteName_IsIdempotent()
+    {
+        var once = TSql.QuoteName("My]DB");
+        Assert.Equal(once, TSql.QuoteName(once));
+    }
+
+    [Fact]
+    public void QuoteName_OpenBracketOnly_IsTreatedAsPartOfTheName()
+    {
+        // Not a wrapped name (no trailing ]), so it is data.
+        Assert.Equal("[[MyDb]", TSql.QuoteName("[MyDb"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void QuoteName_EmptyInput_UsesFallback(string? input)
+        => Assert.Equal("[DatabaseName]", TSql.QuoteName(input, fallback: "DatabaseName"));
+
+    [Fact]
+    public void QuoteName_Trims()
+        => Assert.Equal("[MyDb]", TSql.QuoteName("  MyDb  "));
+
+    [Fact]
+    public void QuoteName_InjectionShapedName_IsNeutralised()
+    {
+        // The payload from the security report: without doubling this closes the bracket and
+        // opens a new statement. With doubling it stays a single (absurd) identifier.
+        const string payload =
+            "https://acct.blob.core.windows.net/backups] WITH IDENTITY='SHARED ACCESS SIGNATURE', " +
+            "SECRET='z'; ALTER SERVER ROLE sysadmin ADD MEMBER [svc]; CREATE CREDENTIAL [decoy";
+
+        var quoted = TSql.QuoteName(payload);
+
+        Assert.StartsWith("[", quoted);
+        Assert.EndsWith("]", quoted);
+        // Every ] from the payload survives as a doubled pair, so none of them terminates
+        // the identifier: the only single ] in the result is the final delimiter.
+        Assert.Equal(1, CountUnpairedCloseBrackets(quoted));
+    }
+
+    [Fact]
+    public void QuoteName_Ipv6EndpointUrl_IsQuotedNotBroken()
+    {
+        // A legal container URL for an emulator; the ] is data, not syntax.
+        Assert.Equal(
+            "[https://[fe80::1]]:10000/devstoreaccount1/backups]",
+            TSql.QuoteName("https://[fe80::1]:10000/devstoreaccount1/backups"));
+    }
+
+    // ── EscapeLiteral ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EscapeLiteral_Apostrophe_IsDoubled()
+        => Assert.Equal("O''Brien", TSql.EscapeLiteral("O'Brien"));
+
+    [Fact]
+    public void EscapeLiteral_NoApostrophe_Unchanged()
+        => Assert.Equal(@"D:\Data\db.mdf", TSql.EscapeLiteral(@"D:\Data\db.mdf"));
+
+    [Fact]
+    public void EscapeLiteral_LiteralTerminatorPayload_IsNeutralised()
+    {
+        // The apostrophe that would have closed the literal early is doubled, so the payload
+        // stays inside the string rather than becoming statement structure.
+        Assert.Equal("x''; DROP TABLE t; --", TSql.EscapeLiteral("x'; DROP TABLE t; --"));
+    }
+
+    [Fact]
+    public void EscapeLiteral_ResultHasNoUnpairedApostrophe()
+    {
+        // The property that actually matters: every apostrophe in the output is part of a pair,
+        // so none of them can terminate the surrounding literal.
+        var escaped = TSql.EscapeLiteral("a'b''c'''d");
+        Assert.Equal(0, CountUnpairedApostrophes(escaped));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void EscapeLiteral_NullOrEmpty_ReturnsEmpty(string? input)
+        => Assert.Equal(string.Empty, TSql.EscapeLiteral(input));
+
+    // ── UnquoteName ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void UnquoteName_Bracketed_ReturnsBareName()
+        => Assert.Equal("My Db", TSql.UnquoteName("[My Db]"));
+
+    [Fact]
+    public void UnquoteName_BracketedWithDoubledBracket_Unescapes()
+        => Assert.Equal("My]DB", TSql.UnquoteName("[My]]DB]"));
+
+    [Fact]
+    public void UnquoteName_Unbracketed_ReturnsAsIs()
+        => Assert.Equal("MyDb", TSql.UnquoteName("MyDb"));
+
+    // ── ValidateIdentifier ───────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("MyDb")]
+    [InlineData("https://acct.blob.core.windows.net/backups")]
+    [InlineData("name]with]brackets")]
+    public void ValidateIdentifier_AcceptableNames_DoNotThrow(string name)
+        => TSql.ValidateIdentifier(name, "test");
+
+    [Theory]
+    [InlineData("line\nbreak")]
+    [InlineData("carriage\rreturn")]
+    [InlineData("tab\there")]
+    [InlineData("null\0char")]
+    public void ValidateIdentifier_ControlCharacters_Throw(string name)
+        => Assert.Throws<ArgumentException>(() => TSql.ValidateIdentifier(name, "test"));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateIdentifier_EmptyName_Throws(string? name)
+        => Assert.Throws<ArgumentException>(() => TSql.ValidateIdentifier(name, "test"));
+
+    private static int CountUnpairedApostrophes(string value)
+    {
+        int count = 0;
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (value[i] != '\'') continue;
+            if (i + 1 < value.Length && value[i + 1] == '\'') { i++; continue; }
+            count++;
+        }
+        return count;
+    }
+
+    private static int CountUnpairedCloseBrackets(string value)
+    {
+        int count = 0;
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (value[i] != ']') continue;
+            if (i + 1 < value.Length && value[i + 1] == ']') { i++; continue; }
+            count++;
+        }
+        return count;
+    }
+}

--- a/src/NineLives/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives/Services/RestoreScriptGenerator.cs
@@ -56,8 +56,13 @@ public class RestoreScriptGenerator
 
     private static void AppendDisconnectSessions(StringBuilder sb, string dbName)
     {
+        // DB_ID takes the name as DATA, so unwrap the brackets and escape it as a string
+        // literal. Stripping every ']' (the previous approach) corrupted a name that legitimately
+        // contained one and left an embedded apostrophe free to terminate the literal.
+        var dbNameLiteral = TSql.EscapeLiteral(TSql.UnquoteName(dbName));
+
         sb.AppendLine("-- Disconnect all active sessions");
-        sb.AppendLine($"IF DB_ID('{dbName.Replace("[", "").Replace("]", "")}') IS NOT NULL");
+        sb.AppendLine($"IF DB_ID('{dbNameLiteral}') IS NOT NULL");
         sb.AppendLine("BEGIN");
         sb.AppendLine($"    ALTER DATABASE {dbName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;");
         sb.AppendLine("END");
@@ -128,7 +133,7 @@ public class RestoreScriptGenerator
             var url = BlobUrlEncoder.Encode(file.BlobUrl);
             var prefix = i == 0 ? "    FROM" : "        ";
             var suffix = i < set.Files.Count - 1 ? "," : "";
-            sb.AppendLine($"{prefix} URL = N'{url.Replace("'", "''")}'{suffix}");
+            sb.AppendLine($"{prefix} URL = N'{TSql.EscapeLiteral(url)}'{suffix}");
         }
 
         sb.AppendLine("    WITH");
@@ -140,7 +145,12 @@ public class RestoreScriptGenerator
         {
             if (!string.IsNullOrWhiteSpace(move.NewPhysicalName))
             {
-                sb.AppendLine($"         MOVE N'{move.LogicalName}' TO N'{move.NewPhysicalName}',");
+                // Both are string literals, not identifiers. LogicalName comes from
+                // RESTORE FILELISTONLY (sysname, so an apostrophe is legal) and NewPhysicalName
+                // is a user-editable path.
+                sb.AppendLine(
+                    $"         MOVE N'{TSql.EscapeLiteral(move.LogicalName)}' " +
+                    $"TO N'{TSql.EscapeLiteral(move.NewPhysicalName)}',");
             }
         }
     }
@@ -177,15 +187,15 @@ public class RestoreScriptGenerator
         {
             RecoveryMode.Recovery => "RECOVERY",
             RecoveryMode.NoRecovery => "NORECOVERY",
-            RecoveryMode.Standby => $"STANDBY = '{options.StandbyFilePath}'",
+            RecoveryMode.Standby => $"STANDBY = '{TSql.EscapeLiteral(options.StandbyFilePath)}'",
             _ => "RECOVERY"
         };
     }
 
+    // Delegates to TSql so identifier quoting lives in exactly one place. The previous
+    // implementation added brackets without doubling an embedded ']', and returned any
+    // already-bracketed value untouched - so a database named My]DB produced the invalid
+    // RESTORE DATABASE [My]DB].
     private static string EscapeName(string name)
-    {
-        if (string.IsNullOrEmpty(name)) return "[DatabaseName]";
-        if (name.StartsWith('[')) return name;
-        return $"[{name}]";
-    }
+        => TSql.QuoteName(name, fallback: "DatabaseName");
 }

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -81,7 +81,7 @@ public class SqlServerService
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
-        cmd.CommandText = $"RESTORE HEADERONLY FROM URL = N'{blobUrl.Replace("'", "''")}' WITH CREDENTIAL = N'{credentialName.Replace("'", "''")}'";
+        cmd.CommandText = $"RESTORE HEADERONLY FROM URL = N'{TSql.EscapeLiteral(blobUrl)}' WITH CREDENTIAL = N'{TSql.EscapeLiteral(credentialName)}'";
 
         var results = new List<BackupFileInfo>();
         await using var reader = await cmd.ExecuteReaderAsync(ct);
@@ -126,9 +126,9 @@ public class SqlServerService
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
 
-        var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{u.Replace("'", "''")}'"));
+        var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var withCredential = !urlsContainSas && !string.IsNullOrEmpty(credentialName)
-            ? $" WITH CREDENTIAL = N'{credentialName!.Replace("'", "''")}'"
+            ? $" WITH CREDENTIAL = N'{TSql.EscapeLiteral(credentialName)}'"
             : "";
         cmd.CommandText = $"RESTORE FILELISTONLY FROM {urlClauses}{withCredential}";
 
@@ -158,9 +158,9 @@ public class SqlServerService
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
 
-        var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{u.Replace("'", "''")}'"));
+        var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var withCredential = !urlsContainSas && !string.IsNullOrEmpty(credentialName)
-            ? $" WITH CREDENTIAL = N'{credentialName!.Replace("'", "''")}'"
+            ? $" WITH CREDENTIAL = N'{TSql.EscapeLiteral(credentialName)}'"
             : "";
         cmd.CommandText = $"RESTORE HEADERONLY FROM {urlClauses}{withCredential}";
 
@@ -343,10 +343,24 @@ public class SqlServerService
         return (true, isSas);
     }
 
+    // CREATE/DROP CREDENTIAL cannot take the name as a parameter - it is an identifier, not a
+    // value - so it must be quoted. Both statements previously interpolated it raw between
+    // brackets without doubling an embedded ']', which meant the brackets did not actually
+    // delimit anything: a name ending in '] WITH IDENTITY=... SECRET=...; <statement>; CREATE
+    // CREDENTIAL [decoy' produced a well-formed multi-statement batch that ran on a connection
+    // holding CONTROL SERVER. The name is auto-populated from the container URL in config.json
+    // (plain text, no integrity check) and is editable free text in the UI, so it is attacker-
+    // reachable via a single local file write.
+    //
+    // It also broke benignly: an IPv6-literal endpoint such as https://[fe80::1]:10000/... is a
+    // legal URL containing ']' and failed with an opaque syntax error.
     public async Task EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
         CancellationToken ct = default)
     {
+        TSql.ValidateIdentifier(credentialName, nameof(credentialName));
+        var quotedName = TSql.QuoteName(credentialName);
+
         await using var conn = new SqlConnection(BuildConnectionString(server));
         await conn.OpenAsync(ct);
 
@@ -358,16 +372,16 @@ public class SqlServerService
         if (exists)
         {
             await using var dropCmd = conn.CreateCommand();
-            dropCmd.CommandText = $"DROP CREDENTIAL [{credentialName}]";
+            dropCmd.CommandText = $"DROP CREDENTIAL {quotedName}";
             await dropCmd.ExecuteNonQueryAsync(ct);
         }
 
         var cleanSas = sasToken.TrimStart('?');
         await using var createCmd = conn.CreateCommand();
         createCmd.CommandText = $@"
-            CREATE CREDENTIAL [{credentialName}]
+            CREATE CREDENTIAL {quotedName}
             WITH IDENTITY = 'SHARED ACCESS SIGNATURE',
-            SECRET = '{cleanSas.Replace("'", "''")}'";
+            SECRET = '{TSql.EscapeLiteral(cleanSas)}'";
         await createCmd.ExecuteNonQueryAsync(ct);
     }
 

--- a/src/NineLives/Services/TSql.cs
+++ b/src/NineLives/Services/TSql.cs
@@ -1,0 +1,71 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Quoting helpers for the T-SQL this app generates and executes.
+///
+/// Every identifier and string literal that reaches a command must go through here. Two of the
+/// values involved are free text the user can type (the target database name and the STANDBY
+/// path) and one is auto-populated from a container URL that round-trips through plain-text
+/// config.json - so "it will always look like a URL" is not a safety property we can rely on.
+/// </summary>
+public static class TSql
+{
+    /// <summary>
+    /// Wraps an identifier in brackets, doubling any embedded <c>]</c> so the brackets actually
+    /// delimit it. Without the doubling, <c>My]DB</c> yields <c>[My]DB]</c>, which SQL Server
+    /// parses as the identifier <c>My</c> followed by stray text - a syntax error at best, and
+    /// an injection point where the identifier is concatenated into a larger statement.
+    ///
+    /// A value that is already bracketed is unwrapped first and then re-quoted, so a user who
+    /// types <c>[My Db]</c> gets the database they meant and the function stays idempotent.
+    /// </summary>
+    public static string QuoteName(string? name, string fallback = "")
+    {
+        var raw = Unwrap(name);
+        if (string.IsNullOrWhiteSpace(raw))
+            return string.IsNullOrEmpty(fallback) ? "[]" : QuoteName(fallback);
+
+        return $"[{raw.Replace("]", "]]")}]";
+    }
+
+    /// <summary>
+    /// Escapes a value for use inside a single-quoted T-SQL string literal (does not add the
+    /// surrounding quotes). Applies to SAS secrets, blob URLs, STANDBY paths and MOVE targets.
+    /// </summary>
+    public static string EscapeLiteral(string? value)
+        => (value ?? string.Empty).Replace("'", "''");
+
+    /// <summary>
+    /// Returns the bare identifier with any bracket quoting removed - for when a name is needed
+    /// as DATA rather than as an identifier, e.g. inside <c>DB_ID('...')</c>. Callers must still
+    /// pass the result through <see cref="EscapeLiteral"/>.
+    /// </summary>
+    public static string UnquoteName(string? name) => Unwrap(name);
+
+    /// <summary>
+    /// Rejects identifiers that cannot be safely quoted. Bracket doubling handles <c>]</c>, but
+    /// control characters and line breaks have no business in a credential or database name and
+    /// would let a value smuggle statement structure past a human reading the generated script.
+    /// </summary>
+    public static void ValidateIdentifier(string? name, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Value cannot be empty.", parameterName);
+
+        foreach (var c in name)
+        {
+            if (char.IsControl(c))
+                throw new ArgumentException(
+                    "Value cannot contain control characters or line breaks.", parameterName);
+        }
+    }
+
+    private static string Unwrap(string? name)
+    {
+        var trimmed = (name ?? string.Empty).Trim();
+        if (trimmed.Length >= 2 && trimmed[0] == '[' && trimmed[^1] == ']')
+            return trimmed[1..^1].Replace("]]", "]");
+
+        return trimmed;
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -959,7 +959,7 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || RestoreChain.FullSet.Files.Count == 0) return;
         var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-        var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{u.Replace("'", "''")}'"));
+        var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var sql = $"RESTORE FILELISTONLY FROM {urlClauses}";
         try
         {
@@ -978,7 +978,7 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || RestoreChain.FullSet.Files.Count == 0) return;
         var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-        var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{u.Replace("'", "''")}'"));
+        var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var sql = $"RESTORE HEADERONLY FROM {urlClauses}";
         try
         {


### PR DESCRIPTION
Closes #15. Closes #9.

Both issues are the same root cause — values reaching T-SQL without being quoted — so they share one helper and one test surface.

## #15: the injection was real, and I proved it

`CREATE`/`DROP CREDENTIAL` take the credential name as an **identifier**, so it cannot be parameterised and has to be quoted. Both statements interpolated it raw between brackets **without doubling an embedded `]`**, so the brackets did not actually delimit anything.

The name is auto-populated from the container URL in `config.json` — plain text, no integrity check — and is editable free text in the UI. So a single local file write became arbitrary T-SQL on whichever instance the DBA connects to, on a connection that must already hold `CONTROL SERVER`.

**Demonstrated against SQL Server 2025.** Executing the pre-fix interpolation shape with a crafted name created **two** credentials — the intended one plus an injected decoy:

```
https://acct.blob.core.windows.net/backups
ninelives-proof-decoy            <- injected, should not exist
(2 rows affected)
```

That is arbitrary statement execution, not a theoretical parse. (Both were dropped afterwards; a `sys.credentials` sweep confirms no test artifacts remain.)

## #9: the same bug in the generated script

- `EscapeName` added brackets without doubling `]`, so a database named `My]DB` produced the invalid `RESTORE DATABASE [My]DB]`, and already-bracketed input was returned untouched.
- The `STANDBY` path was interpolated into a string literal with no `'` doubling.
- The `DB_ID` guard **stripped every bracket** from the name rather than quoting it — corrupting a name that legitimately contained one, and leaving an apostrophe free to terminate the literal.

## The fix

New `Services/TSql.cs` as the single place quoting is defined:

| Member | Purpose |
|---|---|
| `QuoteName` | Bracket-quote, doubling `]`. Unwraps already-bracketed input and re-quotes, so it is **idempotent** and `[My Db]` still means the database `My Db`. |
| `EscapeLiteral` | Doubles `'` for string-literal positions. |
| `UnquoteName` | Bare name for data positions such as `DB_ID('...')`. |
| `ValidateIdentifier` | Rejects control characters and line breaks — they have no business in a credential or database name and would smuggle statement structure past a human reading the script. |

Every identifier and string literal in `RestoreScriptGenerator` and `SqlServerService` now routes through it, so **"all generated SQL goes through `TSql`" is greppable** — including the URL, `MOVE` logical/physical name, and `WITH CREDENTIAL` literals that were already escaped correctly but by hand.

### Bonus: fixes a benign break too

An IPv6-literal endpoint like `https://[fe80::1]:10000/devstoreaccount1/backups` is a legal URL containing `]`, and previously failed credential creation with an opaque syntax error. Covered by a test.

## Tests — 41 new, 176 total

- **`TSqlTests`** — quoting, doubling, idempotency, trimming, fallback, the injection payload shape, and the IPv6 case. Two property-style assertions check that no unpaired `]` or `'` survives escaping, which is the invariant that actually matters.
- **`RestoreScriptGeneratorTests`** — bracket and apostrophe escaping across all four positions: identifier, `DB_ID` literal, `STANDBY`, and `MOVE`.
- **`CredentialInjectionTests`** (live SQL) — runs the real payload against a server and asserts **exactly one** credential is created with the name stored verbatim and no decoy; plus idempotency over the DROP-then-CREATE path, the IPv6 name, and control-character rejection.

| | Result |
|---|---|
| Full suite, live SQL | **176 passed** |
| Full suite, no SQL | **165 passed, 11 skipped** |

### A note on the payload length

The live payload is kept under 128 characters because a credential name is `sysname`. A longer one is rejected by SQL Server as *"The identifier that starts with '...' is too long"* — which is itself proof the quoting works (the whole payload arrived as **one** identifier), but it proves it by erroring rather than by letting the assertion run.

## Not included

The issue also suggested validating the auto-populated credential name as an absolute URI in the ViewModel. I left that out deliberately: `ValidateIdentifier` closes the injection at the service boundary where it belongs, and a URI-shape check in the UI is a usability improvement rather than a security control — it would also wrongly reject the perfectly valid non-URL credential names some shops use. Happy to add it separately if you'd rather have it.
