### PR TITLE
Add true point-in-time restore with STOPAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Nine Lives points at a container, discovers every backup, groups striped sets, c
 - Colour-coded dots for Full (blue), Differential (orange), and Log (green) backups
 - Clickable restore points with automatic chain calculation
 - Intelligent backup chain building including required differentials
+- **Stop at an exact moment (`STOPAT`)** — select a transaction log restore point and specify a
+  precise time within it, rather than being limited to the end of a log backup. `STOPAT` is
+  emitted on every `RESTORE LOG` in the chain, so recovery stops in whichever log actually
+  contains the target time.
 
 ### Restore Script Generation
 - Complete T-SQL restore scripts with proper `FROM URL` syntax
@@ -189,6 +193,10 @@ The executable will be created at `./publish/NineLives.exe`.
    - **WITH REPLACE** - Overwrite if database exists
    - **WITH MOVE** - Relocate files (paths auto-detected from connected server)
    - **Recovery Mode** - RECOVERY (online), NORECOVERY (for more restores), or STANDBY
+   - **Point in Time** - when a transaction log restore point is selected, tick *Stop at a
+     specific time* and enter the target as `yyyy-MM-dd HH:mm:ss`. The time must fall within the
+     selected log's window (after the previous restore point, up to the selected one); to stop
+     earlier or later, pick a different point on the timeline.
 7. Click **Generate Script** to create the T-SQL
 8. Either:
    - **Copy to Clipboard** or **Save to File** to run manually in SSMS

--- a/src/NineLives.Tests/BackupChainBuilderTests.cs
+++ b/src/NineLives.Tests/BackupChainBuilderTests.cs
@@ -521,4 +521,98 @@ public class BackupChainBuilderTests
         Assert.Same(point.RequiredLogSets, chain.LogSets);
         Assert.Null(chain.StopAt);
     }
+
+    // ---- StopAtWindow (point-in-time bounds) -----------------------------
+
+    [Fact]
+    public void StopAtWindow_NoLogs_IsNull()
+    {
+        var chain = new BackupChain { FullSet = Set(BackupType.Full, T(1)) };
+        Assert.Null(chain.StopAtWindow);
+    }
+
+    [Fact]
+    public void StopAtWindow_SingleLogAfterFull_SpansFullToLog()
+    {
+        var chain = new BackupChain
+        {
+            FullSet = Set(BackupType.Full, T(1)),
+            LogSets = [Set(BackupType.TransactionLog, T(2))]
+        };
+
+        var window = chain.StopAtWindow;
+
+        Assert.NotNull(window);
+        Assert.Equal(T(1), window!.Value.Earliest);
+        Assert.Equal(T(2), window.Value.Latest);
+    }
+
+    [Fact]
+    public void StopAtWindow_SingleLogAfterDiff_StartsAtTheDiff()
+    {
+        // The database is restored up to the differential before the log is applied, so the
+        // differential - not the full - is the lower bound.
+        var chain = new BackupChain
+        {
+            FullSet = Set(BackupType.Full, T(1)),
+            DiffSets = [Set(BackupType.Differential, T(4))],
+            LogSets = [Set(BackupType.TransactionLog, T(5))]
+        };
+
+        Assert.Equal(T(4), chain.StopAtWindow!.Value.Earliest);
+        Assert.Equal(T(5), chain.StopAtWindow.Value.Latest);
+    }
+
+    [Fact]
+    public void StopAtWindow_MultipleLogs_StartsAtThePenultimateLog()
+    {
+        // The target must land inside the LAST log; every earlier log applies in full.
+        var chain = new BackupChain
+        {
+            FullSet = Set(BackupType.Full, T(1)),
+            LogSets =
+            [
+                Set(BackupType.TransactionLog, T(2)),
+                Set(BackupType.TransactionLog, T(3)),
+                Set(BackupType.TransactionLog, T(4))
+            ]
+        };
+
+        Assert.Equal(T(3), chain.StopAtWindow!.Value.Earliest);
+        Assert.Equal(T(4), chain.StopAtWindow.Value.Latest);
+    }
+
+    [Fact]
+    public void StopAtWindow_PrefersPenultimateLogOverAnEarlierDiff()
+    {
+        var chain = new BackupChain
+        {
+            FullSet = Set(BackupType.Full, T(1)),
+            DiffSets = [Set(BackupType.Differential, T(4))],
+            LogSets =
+            [
+                Set(BackupType.TransactionLog, T(5)),
+                Set(BackupType.TransactionLog, T(6))
+            ]
+        };
+
+        Assert.Equal(T(5), chain.StopAtWindow!.Value.Earliest);
+    }
+
+    [Fact]
+    public void StopAtWindow_UpperBoundMatchesTheSelectedRestorePoint()
+    {
+        // The bound the UI offers must equal the point the user clicked on the timeline.
+        var points = _builder.ComputeRestorePoints(
+        [
+            Set(BackupType.Full, T(1)),
+            Set(BackupType.TransactionLog, T(2)),
+            Set(BackupType.TransactionLog, T(3))
+        ]);
+
+        var selected = points.Last(p => p.Type == BackupType.TransactionLog);
+        var chain = _builder.BuildChainFromRestorePoint(selected);
+
+        Assert.Equal(selected.Timestamp, chain.StopAtWindow!.Value.Latest);
+    }
 }

--- a/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
+++ b/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
@@ -149,15 +149,56 @@ public class RestoreScriptGeneratorTests
     }
 
     [Fact]
-    public void Generate_StopAtWithLogs_EmittedOnceOnLastLog()
+    public void Generate_StopAtWithLogs_EmittedOnEveryLogRestore()
     {
+        // Microsoft's guidance is to repeat STOPAT on each RESTORE LOG so SQL Server stops in
+        // whichever log actually contains the target. Emitting it only on the last statement
+        // overshoots when the target falls in an earlier log.
+        var stopAt = T0.AddHours(5).AddMinutes(30);
+        var chain = FullDiffLogChain(); // 2 log sets
+        var script = _generator.Generate(chain, Options(o => o.StopAt = stopAt));
+
+        Assert.Equal(chain.LogSets.Count, CountOccurrences(script, "STOPAT"));
+        Assert.Equal(2, CountOccurrences(script, $"STOPAT = '{stopAt:yyyy-MM-ddTHH:mm:ss}',"));
+    }
+
+    [Fact]
+    public void Generate_StopAt_NotEmittedOnFullOrDiffRestore()
+    {
+        // STOPAT belongs to the log chain; putting it on the data restores is not the pattern.
         var stopAt = T0.AddHours(5).AddMinutes(30);
         var script = _generator.Generate(FullDiffLogChain(), Options(o => o.StopAt = stopAt));
 
+        var firstLogIdx = script.IndexOf("RESTORE LOG");
+        var beforeLogs = script[..firstLogIdx];
+        Assert.DoesNotContain("STOPAT", beforeLogs);
+    }
+
+    [Fact]
+    public void Generate_StopAtSingleLogChain_EmittedOnce()
+    {
+        var stopAt = T0.AddHours(5).AddMinutes(1);
+        var chain = new BackupChain
+        {
+            FullSet = Set(BackupType.Full, T0),
+            LogSets = [Set(BackupType.TransactionLog, T0.AddHours(5))]
+        };
+
+        var script = _generator.Generate(chain, Options(o => o.StopAt = stopAt));
+
         Assert.Equal(1, CountOccurrences(script, "STOPAT"));
         Assert.Contains($"STOPAT = '{stopAt:yyyy-MM-ddTHH:mm:ss}',", script);
-        // STOPAT belongs to the last log block: it appears after the final RESTORE LOG
-        Assert.True(script.LastIndexOf("RESTORE LOG") < script.IndexOf("STOPAT"));
+    }
+
+    [Fact]
+    public void Generate_StopAt_UsesIsoFormatSqlServerParsesUnambiguously()
+    {
+        // A locale-dependent format here would be read differently by a server in another
+        // region; the ISO form removes the ambiguity between dd/MM and MM/dd.
+        var stopAt = new DateTime(2026, 3, 4, 14, 23, 41);
+        var script = _generator.Generate(FullDiffLogChain(), Options(o => o.StopAt = stopAt));
+
+        Assert.Contains("STOPAT = '2026-03-04T14:23:41',", script);
     }
 
     [Fact]

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -296,6 +296,36 @@ public class BackupChain
         }
     }
 
+    /// <summary>
+    /// The window a STOPAT target must fall within for this chain.
+    ///
+    /// Lower bound (exclusive) is whatever the database is restored up to before the final log is
+    /// applied - the previous log, else the latest differential, else the full. Upper bound
+    /// (inclusive) is the final log itself.
+    ///
+    /// Constraining the target to the LAST log's window is what keeps the generated chain valid:
+    /// every earlier log ends before the target and so applies in full, introducing no gap. A
+    /// target inside an EARLIER log would require truncating the chain to that log, otherwise the
+    /// later logs restore across a gap and fail with error 4305.
+    ///
+    /// Null when the chain has no logs - STOPAT only applies to a log restore.
+    /// </summary>
+    public (DateTime Earliest, DateTime Latest)? StopAtWindow
+    {
+        get
+        {
+            if (LogSets.Count == 0) return null;
+
+            var earliest = LogSets.Count >= 2
+                ? LogSets[^2].Timestamp
+                : DiffSets.Count > 0
+                    ? DiffSets[^1].Timestamp
+                    : FullSet.Timestamp;
+
+            return (earliest, LogSets[^1].Timestamp);
+        }
+    }
+
     public static BackupChain FromRestorePoint(RestorePoint rp)
     {
         return new BackupChain

--- a/src/NineLives/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives/Services/RestoreScriptGenerator.cs
@@ -116,7 +116,15 @@ public class RestoreScriptGenerator
         sb.AppendLine($"RESTORE LOG {dbName}");
         AppendFromUrls(sb, logSet, options);
 
-        if (isLast && usePit && options.StopAt.HasValue)
+        // STOPAT goes on EVERY log restore in the chain, not just the last one. Microsoft's
+        // guidance is to repeat it: SQL Server then stops in whichever log actually contains the
+        // target time, and errors early if the point precedes the chain. Emitting it only on the
+        // last statement overshoots when the target falls in an earlier log, silently replaying
+        // transactions the user was trying to stop before.
+        //
+        // The UI bounds the target to within the SELECTED log's window, so earlier logs in the
+        // chain end before it and are applied in full - no gap is introduced.
+        if (usePit && options.StopAt.HasValue)
             sb.AppendLine($"         STOPAT = '{options.StopAt.Value:yyyy-MM-ddTHH:mm:ss}',");
 
         sb.AppendLine($"         {recoveryClause},");

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -98,6 +99,42 @@ public partial class RestoreViewModel : ViewModelBase
 
     [ObservableProperty]
     private string _standbyFilePath = string.Empty;
+
+    // ── Point-in-time (STOPAT) ───────────────────────────────────────────────────
+    // Only meaningful for a transaction-log restore point. Without this the granularity of a
+    // "point in time" restore is the end of whichever log backup was selected - so with
+    // 15-minute logs, recovering from a bad DELETE at 14:23:41 could only land on 14:15 or
+    // 14:30. The target is bounded to within the selected log's window; to stop earlier the
+    // user picks an earlier restore point, which keeps the generated chain correct.
+
+    /// <summary>True when the selected restore point is a log, so STOPAT applies.</summary>
+    [ObservableProperty]
+    private bool _canUsePointInTime;
+
+    [ObservableProperty]
+    private bool _usePointInTime;
+
+    /// <summary>User-entered target time, parsed into <see cref="StopAtDateTime"/>.</summary>
+    [ObservableProperty]
+    private string _stopAtText = string.Empty;
+
+    /// <summary>Parsed and validated target, or null when unusable.</summary>
+    [ObservableProperty]
+    private DateTime? _stopAtDateTime;
+
+    /// <summary>Exclusive lower bound: the end of the previous set in the chain.</summary>
+    [ObservableProperty]
+    private DateTime? _stopAtEarliest;
+
+    /// <summary>Inclusive upper bound: the end of the selected log backup.</summary>
+    [ObservableProperty]
+    private DateTime? _stopAtLatest;
+
+    [ObservableProperty]
+    private string _pointInTimeMessage = string.Empty;
+
+    [ObservableProperty]
+    private bool _hasPointInTimeError;
 
     [ObservableProperty]
     private bool _disconnectSessions = true;
@@ -384,6 +421,7 @@ public partial class RestoreViewModel : ViewModelBase
             ChainFiles.Clear();
             ChainSets.Clear();
             ChainSummary = string.Empty;
+            UpdatePointInTimeWindow(null);
             FetchedFileMoves = [];
             HasFetchedFileMoves = false;
             BackupMetadataSummary = null;
@@ -400,6 +438,7 @@ public partial class RestoreViewModel : ViewModelBase
         ChainFiles = new ObservableCollection<BackupFileInfo>(chain.AllFiles);
         ChainSets = new ObservableCollection<BackupSet>(chain.AllSets);
         ChainSummary = $"{chain.Summary} | {chain.FileCount} files | Target: {value.Timestamp:yyyy-MM-dd HH:mm:ss}";
+        UpdatePointInTimeWindow(value);
         UpdateRestoreSummary();
         FetchLogicalNamesCommand.NotifyCanExecuteChanged();
         InspectBackupMetadataCommand.NotifyCanExecuteChanged();
@@ -673,7 +712,9 @@ public partial class RestoreViewModel : ViewModelBase
         parts.Add($"Restore '{SelectedDatabaseName}' as '{TargetDatabaseName}'");
         parts.Add($"using {RestoreChain.Summary} ({RestoreChain.FileCount} files total).");
 
-        if (SelectedRestorePoint != null && SelectedRestorePoint.Type == BackupType.TransactionLog)
+        if (EffectiveStopAt is DateTime stopAt)
+            parts.Add($"Stop at {stopAt:yyyy-MM-dd HH:mm:ss} (point-in-time recovery).");
+        else if (SelectedRestorePoint != null && SelectedRestorePoint.Type == BackupType.TransactionLog)
             parts.Add($"Restore to end of log backup at {SelectedRestorePoint.Timestamp:yyyy-MM-dd HH:mm:ss}.");
 
         var optionsList = new List<string>();
@@ -702,6 +743,112 @@ public partial class RestoreViewModel : ViewModelBase
             parts.Add("Options: " + string.Join("; ", optionsList) + ".");
 
         RestoreSummaryText = string.Join(" ", parts);
+    }
+
+    /// <summary>
+    /// Recomputes the STOPAT window for the selected restore point. The window itself is
+    /// <see cref="BackupChain.StopAtWindow"/>; this only projects it onto the UI state.
+    /// </summary>
+    private void UpdatePointInTimeWindow(RestorePoint? point)
+    {
+        var window = point?.Type == BackupType.TransactionLog
+            ? RestoreChain?.StopAtWindow
+            : null;
+
+        if (window == null)
+        {
+            CanUsePointInTime = false;
+            UsePointInTime = false;
+            StopAtEarliest = null;
+            StopAtLatest = null;
+            StopAtText = string.Empty;
+            StopAtDateTime = null;
+            PointInTimeMessage = string.Empty;
+            HasPointInTimeError = false;
+            return;
+        }
+
+        CanUsePointInTime = true;
+        StopAtEarliest = window.Value.Earliest;
+        StopAtLatest = window.Value.Latest;
+        UsePointInTime = false;
+        StopAtText = window.Value.Latest.ToString(StopAtFormat);
+        ValidatePointInTime();
+    }
+
+    private const string StopAtFormat = "yyyy-MM-dd HH:mm:ss";
+
+    private static readonly string[] StopAtAcceptedFormats =
+    [
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy-MM-ddTHH:mm:ss",
+        "yyyy-MM-dd HH:mm",
+        "yyyy-MM-ddTHH:mm"
+    ];
+
+    private void ValidatePointInTime()
+    {
+        if (!CanUsePointInTime)
+        {
+            StopAtDateTime = null;
+            PointInTimeMessage = string.Empty;
+            HasPointInTimeError = false;
+            return;
+        }
+
+        if (!DateTime.TryParseExact(
+                StopAtText?.Trim(), StopAtAcceptedFormats,
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            StopAtDateTime = null;
+            HasPointInTimeError = UsePointInTime;
+            PointInTimeMessage = $"Enter a time as {StopAtFormat}.";
+            UpdateRestoreSummary();
+            return;
+        }
+
+        // Exclusive lower bound: at exactly the previous set's time nothing from this log has
+        // been applied yet, which is the earlier restore point, not this one.
+        if (parsed <= StopAtEarliest)
+        {
+            StopAtDateTime = null;
+            HasPointInTimeError = UsePointInTime;
+            PointInTimeMessage =
+                $"Must be after {StopAtEarliest:yyyy-MM-dd HH:mm:ss} — to stop earlier, " +
+                "select an earlier restore point on the timeline.";
+            UpdateRestoreSummary();
+            return;
+        }
+
+        if (parsed > StopAtLatest)
+        {
+            StopAtDateTime = null;
+            HasPointInTimeError = UsePointInTime;
+            PointInTimeMessage =
+                $"Must be at or before {StopAtLatest:yyyy-MM-dd HH:mm:ss} — to stop later, " +
+                "select a later restore point on the timeline.";
+            UpdateRestoreSummary();
+            return;
+        }
+
+        StopAtDateTime = parsed;
+        HasPointInTimeError = false;
+        PointInTimeMessage = UsePointInTime
+            ? $"Recovery will stop at {parsed:yyyy-MM-dd HH:mm:ss}; later transactions in this log are discarded."
+            : $"Valid range: after {StopAtEarliest:yyyy-MM-dd HH:mm:ss} up to {StopAtLatest:yyyy-MM-dd HH:mm:ss}.";
+        UpdateRestoreSummary();
+    }
+
+    /// <summary>The STOPAT value to generate, or null to restore the whole log chain.</summary>
+    private DateTime? EffectiveStopAt =>
+        CanUsePointInTime && UsePointInTime && !HasPointInTimeError ? StopAtDateTime : null;
+
+    partial void OnStopAtTextChanged(string value) => ValidatePointInTime();
+
+    partial void OnUsePointInTimeChanged(bool value)
+    {
+        ValidatePointInTime();
+        UpdateRestoreSummary();
     }
 
     partial void OnWithReplaceChanged(bool value) => UpdateRestoreSummary();
@@ -739,6 +886,14 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
+        // Refuse to silently fall back to a full-chain restore when the user asked to stop at a
+        // time we could not use - that would replay exactly the transactions they meant to skip.
+        if (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null)
+        {
+            SetError($"Point-in-time target is not valid. {PointInTimeMessage}");
+            return;
+        }
+
         var sasToken = SelectedContainer != null
             ? _credentialStore.GetSasToken(SelectedContainer)
             : null;
@@ -770,7 +925,7 @@ public partial class RestoreViewModel : ViewModelBase
             StandbyFilePath = string.IsNullOrWhiteSpace(StandbyFilePath) ? null : StandbyFilePath,
             DisconnectSessions = DisconnectSessions,
             StatsPercent = StatsPercent,
-            StopAt = RestoreChain.StopAt,
+            StopAt = EffectiveStopAt,
             KeepReplication = KeepReplication,
             EnableBroker = EnableBroker,
             NewBroker = NewBroker,

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -604,6 +604,26 @@
                                      Margin="0,0,0,16"
                                      Visibility="{Binding IsStandbyMode, Converter={StaticResource BoolToVis}}" />
 
+                            <!-- Point-in-time (STOPAT): only shown for a log restore point, where
+                                 stopping partway through the log is meaningful. -->
+                            <StackPanel Visibility="{Binding CanUsePointInTime, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Text="POINT IN TIME" Style="{StaticResource LabelText}" />
+                                <CheckBox Content="Stop at a specific time (STOPAT)"
+                                          IsChecked="{Binding UsePointInTime}"
+                                          Style="{StaticResource DarkCheckBox}"
+                                          Margin="0,4,0,8"
+                                          ToolTip="Recover to an exact moment inside the selected log backup instead of restoring the whole log." />
+                                <TextBox Text="{Binding StopAtText, UpdateSourceTrigger=PropertyChanged}"
+                                         Style="{StaticResource DarkTextBox}"
+                                         IsEnabled="{Binding UsePointInTime}"
+                                         Width="180" HorizontalAlignment="Left"
+                                         ToolTip="yyyy-MM-dd HH:mm:ss" />
+                                <TextBlock Text="{Binding PointInTimeMessage}"
+                                           Style="{StaticResource SecondaryText}"
+                                           TextWrapping="Wrap"
+                                           Margin="0,4,0,16" />
+                            </StackPanel>
+
                             <TextBlock Text="STATS PERCENT" Style="{StaticResource LabelText}" />
                             <TextBox Text="{Binding StatsPercent, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"


### PR DESCRIPTION
Closes #22.

## The gap

`RestoreScriptGenerator` supported `STOPAT` and had tests for it — but **nothing in the app ever set a non-null `StopAt`**. `BackupChain.FromRestorePoint` hardcoded `null` and the ViewModel read that value straight through, so the whole branch was dead in the shipping app.

Restore granularity was therefore *"the end of whichever log backup you selected"*. Recovering from an accidental `DELETE` at 14:23:41 with 15-minute logs could only land on 14:15 or 14:30 — either losing 7 minutes of good transactions or replaying the damage. The README's "Point-in-Time Recovery" headline promised something the app did not do.

## The design decision that matters

The target time is bounded to **within the selected log's window** — after the previous restore point, up to the selected one.

That constraint is what keeps the generated chain valid. Every earlier log in the chain ends before the target, so each applies in full and no gap is introduced. Allowing a target inside an *earlier* log would require truncating the chain to the log containing it — otherwise the later logs restore across a gap and fail with **error 4305** ("the log backup is too recent to apply").

Rather than build truncation logic, the UI tells the user the honest thing: *"to stop earlier, select an earlier restore point on the timeline."* The timeline already offers a point per log, so nothing is unreachable.

`BackupChain.StopAtWindow` computes the bounds:

| Chain shape | Lower bound (exclusive) |
|---|---|
| full + logs | the full |
| full + diff + log | the differential |
| full + several logs | the **penultimate** log |

Upper bound is always the final log, which equals the restore point the user clicked.

## STOPAT now goes on every log restore

Previously the generator emitted it only on the last statement (`isLast && usePit`). Per Microsoft's guidance it should be repeated on each `RESTORE LOG`: SQL Server then stops in whichever log actually contains the target time, and errors early if the point precedes the chain. Last-only **overshoots** when the target falls in an earlier log.

It is deliberately *not* emitted on the full or differential restores — that is not the pattern, and a test pins it.

## Safety

If the user ticks *Stop at a specific time* and the entered value cannot be used, **generation is refused** rather than silently falling back to a whole-chain restore. Falling back would replay exactly the transactions they were trying to stop before — the failure mode this feature exists to prevent.

Times are parsed with `CultureInfo.InvariantCulture` and emitted as ISO (`2026-03-04T14:23:41`), so a server in another locale cannot read `dd/MM` as `MM/dd`.

## UI

A **Point In Time** section appears in the restore options, only when a transaction-log restore point is selected. It shows the valid range, validates as you type, and states what will happen:

> *Recovery will stop at 2026-03-04 14:23:41; later transactions in this log are discarded.*

## Tests — 9 new, 185 total

**Window bounds** (`BackupChainBuilderTests`): no logs → null; log after full; log after diff; multiple logs → penultimate; a differential that is *not* the adjacent set is correctly ignored; and the upper bound agrees with the selected restore point's timestamp.

**Generation** (`RestoreScriptGeneratorTests`): `STOPAT` on every log in the chain, absent from the full/diff restores, correct for a single-log chain, and emitted in unambiguous ISO format.

| | Result |
|---|---|
| Full suite, live SQL | **185 passed** |
| App smoke launch | starts, XAML parses, options section loads |

## Follow-ups this does not cover

- **Validating the target against the backup's actual finish time.** The bounds come from filename timestamps, not `RESTORE HEADERONLY` LSN data — so a target that looks valid can still be rejected by SQL Server. #23 (LSN-based chain validation) is where that belongs, and it would let the window be derived from `BackupFinishDate` instead.
- **`STOPATMARK` / `STOPBEFOREMARK`** (marked-transaction recovery) are not implemented; worth a separate issue if there is demand.
