### PR TITLE
Adopt a dev/main branching model

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,14 @@
 
 <!-- A short description of the change and the motivation for it. -->
 
+<!-- Target `dev`, not `main` — see CONTRIBUTING.md. `main` only receives release PRs from `dev`. -->
+
 ## Checklist
 
+- [ ] Targets `dev` (release PRs from `dev` → `main` are the exception)
 - [ ] `dotnet build NineLives.sln -c Release` succeeds with **no new warnings**
 - [ ] `dotnet test` passes locally
-- [ ] New logic in `Services/` or `Models/` comes with tests in `NineLives.Tests`
+- [ ] New logic in `Services/` or `Models/` comes with tests
+- [ ] Any generated T-SQL goes through `Services/TSql.cs` (`QuoteName` / `EscapeLiteral`)
 - [ ] UI changes include a screenshot (dark theme)
 - [ ] No credentials, SAS tokens, or real server/database names in code, comments, or images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -1,0 +1,74 @@
+name: Check version bump
+
+# A dev -> main pull request is a release: main is meant to match the published binary, so the
+# version must move. Feature work targets dev and never reaches this check.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-version:
+    # Only the release PR is gated. A direct hotfix branch into main is rare enough to bump by
+    # hand, and gating it would block genuine emergency fixes.
+    if: github.head_ref == 'dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Deliberately one job that always runs and always reports, rather than paths-ignore:
+      # a required check that is skipped entirely sits pending forever and blocks the merge.
+      # Documentation-only release PRs pass without a bump.
+      - name: Compare versions against main
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          csproj='src/NineLives/NineLives.csproj'
+
+          changed=$(git diff --name-only "$BASE_SHA" HEAD)
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+
+          # Anything that is not markdown, the licence, gitignore, or a docs asset counts as a
+          # code change. A new file type defaults to being treated as code, which is the safe
+          # direction to be wrong in.
+          code_changes=$(echo "$changed" \
+            | grep -vE '(\.md$|^LICENSE$|^\.gitignore$|^\.gitattributes$|^docs/)' || true)
+
+          if [ -z "$code_changes" ]; then
+            echo "::notice title=Version bump not required::Only documentation changed in this release PR."
+            exit 0
+          fi
+
+          # POSIX sed rather than grep -oP: PCRE grep is not available on every platform a
+          # contributor might run this logic on, and the runner image should not be the only
+          # place it works.
+          extract_version() { sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' "$1" | head -1; }
+
+          pr_version=$(extract_version "$csproj")
+          git show "$BASE_SHA:$csproj" > /tmp/main.csproj
+          main_version=$(extract_version /tmp/main.csproj)
+
+          echo "main version: $main_version"
+          echo "PR version:   $pr_version"
+
+          if [ -z "$pr_version" ]; then
+            echo "::error::Could not read <Version> from $csproj."
+            exit 1
+          fi
+
+          if [ "$pr_version" = "$main_version" ]; then
+            echo "::error::Version in $csproj ($pr_version) is unchanged from main. Bump it before releasing."
+            exit 1
+          fi
+
+          echo "Version bumped: $main_version -> $pr_version"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to Nine Lives
+
+Thanks for taking an interest. This is a tool people point at production databases during
+incidents, so the bar for correctness is high — but the codebase is small and the setup is quick.
+
+## Branching model
+
+**`dev` is the default branch and where all work lands. `main` is the released code.**
+
+```
+feature branch  ──PR──►  dev  ──release PR──►  main  ──tag──►  GitHub Release
+```
+
+- **Work targets `dev`.** Branch from `dev`, open your PR against `dev`.
+- **`main` always matches the published release.** Anyone cloning `main` gets code that
+  corresponds to the executable on the Releases page — which matters for a restore tool, where
+  "which version am I actually running?" is a question people ask mid-incident.
+- **Releases are a `dev` → `main` pull request.** A version-bump check enforces that
+  `<Version>` in `src/NineLives/NineLives.csproj` has moved. Publishing a GitHub Release then
+  builds, tests, and attaches `NineLives.exe` with checksums automatically.
+
+Branch naming is loose, but `fix/<issue>-<slug>` and `feat/<issue>-<slug>` keep things scannable.
+
+## Building and testing
+
+```bash
+git clone https://github.com/jakemorgangit/NineLives.git
+cd NineLives
+dotnet build
+dotnet test
+```
+
+Requires the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) and Windows (it is a
+WPF app).
+
+### Live SQL Server tests
+
+Some tests exercise real SQL Server behaviour that cannot be mocked meaningfully — for example
+that a failed restore actually throws rather than reporting success, and that a credential name
+cannot break out of its quoting. They are skipped unless you point them at an instance:
+
+```powershell
+$env:NINELIVES_TEST_SQL = ".\SQLEXPRESS"    # or "(localdb)\MSSQLLocalDB"
+dotnet test
+```
+
+They create and drop only their own objects and clean up after themselves. CI starts LocalDB on
+a best-effort basis, so they run there too.
+
+## What CI checks
+
+Every PR runs on `windows-latest`:
+
+1. `dotnet build -warnaserror` — **the build is warning-free and must stay that way**
+2. the full test suite
+3. a self-contained single-file publish, proving the shipping artifact still builds
+
+## Expectations for a change
+
+- New logic in `Services/` or `Models/` comes with tests. These are the parts that decide which
+  backups form a restore chain, so they carry the most risk.
+- **All generated T-SQL goes through `Services/TSql.cs`.** Identifiers use `QuoteName`, string
+  literals use `EscapeLiteral`. Do not hand-roll escaping.
+- If you change restore-chain logic, say in the PR what a DBA would see differently.
+- No credentials, SAS tokens, or real server/database names in code, comments, tests, or
+  screenshots. Use `MyDb`, `SRV01`, `mycluster01$My-AG1`.
+
+## Reporting bugs
+
+Include the app version (Help → About), Windows and SQL Server versions, your backup layout
+(path pattern or Ola naming), and — where relevant — the generated script with identifying
+details replaced.
+
+For anything security-sensitive, please follow [SECURITY.md](SECURITY.md) rather than opening a
+public issue.

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Built with:
 ```
 NineLives/
 ├── .github/
-│   └── workflows/               # CI: PR build/test gate + release pipeline
+│   └── workflows/               # CI: PR build/test gate, version-bump gate, release pipeline
 ├── docs/
 │   └── screenshots/             # README screenshots
 ├── src/
@@ -352,10 +352,11 @@ NineLives/
 
 ## Contributing
 
-Contributions are welcome! Please:
-1. Fork the repository
-2. Create a feature branch
-3. Submit a pull request
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
+
+In short: **`dev` is the default branch and where work lands; `main` tracks the released code.**
+Fork, branch from `dev`, and open your pull request against `dev`. Releases are a `dev` → `main`
+pull request with a version bump.
 
 ## License
 


### PR DESCRIPTION
Sets up the `dev` / `main` model discussed — the same shape erikdarlingdata/PerformanceMonitor uses.

## Why

`main` now tracks **released** code; `dev` is where work lands.

This matters concretely right now: `main` is three behavioural fixes ahead of any published release, and one of them changed whether a failed restore reports success. Someone cloning `main` today gets something meaningfully different from the executable on the Releases page. After this, `main` and the latest release agree.

```
feature branch  --PR-->  dev  --release PR-->  main  --tag-->  GitHub Release
```

## Changes

- **`build.yml`** now runs on push and PR for both `main` and `dev`.
- **`check-version-bump.yml`** (new) gates the `dev` → `main` release PR on `<Version>` in `NineLives.csproj` having moved.
  - It **always runs and always reports** rather than using `paths-ignore` — a required check that gets skipped entirely sits pending forever and blocks the merge.
  - Documentation-only release PRs pass without a bump. Anything not markdown / LICENSE / gitignore / `docs/` counts as code, so a new file type defaults to requiring a bump — the safe direction to be wrong in.
  - Only gates `head_ref == 'dev'`, so a genuine emergency hotfix straight into `main` is not blocked.
  - Reads the version with POSIX `sed` rather than `grep -oP`, so the logic is not tied to the runner image having PCRE grep.
- **`CONTRIBUTING.md`** (new) documents the branching model, build/test commands, the live-SQL test gating (`NINELIVES_TEST_SQL`), and the standing expectation that all generated T-SQL goes through `Services/TSql.cs`.
- **PR template and README** point contributors at `dev`.

Partially addresses #39 (that issue also covers CHANGELOG, issue templates, ARM64, and publish-config drift).

## Verification

The version-check script body was exercised locally against the real csproj:

| Case | Result |
|---|---|
| Extract version from `NineLives.csproj` | `1.0.0` |
| Unchanged version | correctly fails |
| Bumped version | correctly passes |
| Missing `<Version>` tag | correctly errors |
| Docs-only change set | correctly skips the bump requirement |
| Code change set | correctly requires a bump |

Note it cannot run end-to-end until the first `dev` → `main` release PR, since that is its only trigger.

## After merge

`dev` gets branch protection with `build` as a required check, matching `main`.
