### PR TITLE
Gate releases on the version not already being published

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -25,10 +25,11 @@ jobs:
       # Deliberately one job that always runs and always reports, rather than paths-ignore:
       # a required check that is skipped entirely sits pending forever and blocks the merge.
       # Documentation-only release PRs pass without a bump.
-      - name: Compare versions against main
+      - name: Check the version being released is not already published
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -66,9 +67,23 @@ jobs:
             exit 1
           fi
 
-          if [ "$pr_version" = "$main_version" ]; then
-            echo "::error::Version in $csproj ($pr_version) is unchanged from main. Bump it before releasing."
+          # The rule this gate actually enforces is "never publish two different builds under one
+          # version number". Comparing against main is only a proxy for that, and it gets the
+          # first release wrong: main can carry an unreleased version marker, in which case
+          # shipping it is legitimate because nothing was ever published under it.
+          #
+          # So the authoritative check is whether a release already exists for the version being
+          # shipped. That is stricter where it matters (it also catches re-releasing a version
+          # that main has since moved past) and correct on the first release.
+          if gh release view "v$pr_version" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::v$pr_version has already been published. Bump <Version> in $csproj before releasing again."
             exit 1
           fi
 
-          echo "Version bumped: $main_version -> $pr_version"
+          if [ "$pr_version" = "$main_version" ]; then
+            echo "::notice title=Version unchanged from main::main is also at $pr_version, but v$pr_version has never been published - shipping it is safe."
+          else
+            echo "Version bumped: $main_version -> $pr_version"
+          fi
+
+          echo "OK to release v$pr_version"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ feature branch  ──PR──►  dev  ──release PR──►  main  ──t
 - **`main` always matches the published release.** Anyone cloning `main` gets code that
   corresponds to the executable on the Releases page — which matters for a restore tool, where
   "which version am I actually running?" is a question people ask mid-incident.
-- **Releases are a `dev` → `main` pull request.** A version-bump check enforces that
-  `<Version>` in `src/NineLives/NineLives.csproj` has moved. Publishing a GitHub Release then
-  builds, tests, and attaches `NineLives.exe` with checksums automatically.
+- **Releases are a `dev` → `main` pull request.** A check enforces that `<Version>` in
+  `src/NineLives/NineLives.csproj` has not already been published as a release — so a version
+  number can never cover two different builds. Publishing a GitHub Release then builds, tests,
+  and attaches `NineLives.exe` with checksums automatically.
 
 Branch naming is loose, but `fix/<issue>-<slug>` and `feat/<issue>-<slug>` keep things scannable.
 


### PR DESCRIPTION
The release gate compared the PR version against `main`, which is only a proxy for the rule that actually matters: **never publish two different builds under one version number**.

That proxy gets the first release wrong. `main` can carry an unreleased version marker — which is exactly the situation now: `dev` and `main` both say `1.0.0` and **no release or tag exists**. Shipping it is legitimate, but the gate would have blocked it, and bypassing a required check to cut a first release is a bad precedent to set on day one.

Now the gate asks the authoritative question: does a release already exist for the version being shipped?

- Stricter where it matters — it also catches re-releasing a version `main` has since moved past, which the `main` comparison would have waved through.
- Correct on a first release.
- The `main` comparison is kept, but as an informational note rather than a failure.

Unblocks cutting v1.0.0.