### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,14 @@
 
 <!-- A short description of the change and the motivation for it. -->
 
+<!-- Target `dev`, not `main` — see CONTRIBUTING.md. `main` only receives release PRs from `dev`. -->
+
 ## Checklist
 
+- [ ] Targets `dev` (release PRs from `dev` → `main` are the exception)
 - [ ] `dotnet build NineLives.sln -c Release` succeeds with **no new warnings**
 - [ ] `dotnet test` passes locally
-- [ ] New logic in `Services/` or `Models/` comes with tests in `NineLives.Tests`
+- [ ] New logic in `Services/` or `Models/` comes with tests
+- [ ] Any generated T-SQL goes through `Services/TSql.cs` (`QuoteName` / `EscapeLiteral`)
 - [ ] UI changes include a screenshot (dark theme)
 - [ ] No credentials, SAS tokens, or real server/database names in code, comments, or images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -1,0 +1,74 @@
+name: Check version bump
+
+# A dev -> main pull request is a release: main is meant to match the published binary, so the
+# version must move. Feature work targets dev and never reaches this check.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-version:
+    # Only the release PR is gated. A direct hotfix branch into main is rare enough to bump by
+    # hand, and gating it would block genuine emergency fixes.
+    if: github.head_ref == 'dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Deliberately one job that always runs and always reports, rather than paths-ignore:
+      # a required check that is skipped entirely sits pending forever and blocks the merge.
+      # Documentation-only release PRs pass without a bump.
+      - name: Compare versions against main
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          csproj='src/NineLives/NineLives.csproj'
+
+          changed=$(git diff --name-only "$BASE_SHA" HEAD)
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+
+          # Anything that is not markdown, the licence, gitignore, or a docs asset counts as a
+          # code change. A new file type defaults to being treated as code, which is the safe
+          # direction to be wrong in.
+          code_changes=$(echo "$changed" \
+            | grep -vE '(\.md$|^LICENSE$|^\.gitignore$|^\.gitattributes$|^docs/)' || true)
+
+          if [ -z "$code_changes" ]; then
+            echo "::notice title=Version bump not required::Only documentation changed in this release PR."
+            exit 0
+          fi
+
+          # POSIX sed rather than grep -oP: PCRE grep is not available on every platform a
+          # contributor might run this logic on, and the runner image should not be the only
+          # place it works.
+          extract_version() { sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' "$1" | head -1; }
+
+          pr_version=$(extract_version "$csproj")
+          git show "$BASE_SHA:$csproj" > /tmp/main.csproj
+          main_version=$(extract_version /tmp/main.csproj)
+
+          echo "main version: $main_version"
+          echo "PR version:   $pr_version"
+
+          if [ -z "$pr_version" ]; then
+            echo "::error::Could not read <Version> from $csproj."
+            exit 1
+          fi
+
+          if [ "$pr_version" = "$main_version" ]; then
+            echo "::error::Version in $csproj ($pr_version) is unchanged from main. Bump it before releasing."
+            exit 1
+          fi
+
+          echo "Version bumped: $main_version -> $pr_version"

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -25,10 +25,11 @@ jobs:
       # Deliberately one job that always runs and always reports, rather than paths-ignore:
       # a required check that is skipped entirely sits pending forever and blocks the merge.
       # Documentation-only release PRs pass without a bump.
-      - name: Compare versions against main
+      - name: Check the version being released is not already published
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -66,9 +67,23 @@ jobs:
             exit 1
           fi
 
-          if [ "$pr_version" = "$main_version" ]; then
-            echo "::error::Version in $csproj ($pr_version) is unchanged from main. Bump it before releasing."
+          # The rule this gate actually enforces is "never publish two different builds under one
+          # version number". Comparing against main is only a proxy for that, and it gets the
+          # first release wrong: main can carry an unreleased version marker, in which case
+          # shipping it is legitimate because nothing was ever published under it.
+          #
+          # So the authoritative check is whether a release already exists for the version being
+          # shipped. That is stricter where it matters (it also catches re-releasing a version
+          # that main has since moved past) and correct on the first release.
+          if gh release view "v$pr_version" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::v$pr_version has already been published. Bump <Version> in $csproj before releasing again."
             exit 1
           fi
 
-          echo "Version bumped: $main_version -> $pr_version"
+          if [ "$pr_version" = "$main_version" ]; then
+            echo "::notice title=Version unchanged from main::main is also at $pr_version, but v$pr_version has never been published - shipping it is safe."
+          else
+            echo "Version bumped: $main_version -> $pr_version"
+          fi
+
+          echo "OK to release v$pr_version"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ feature branch  ──PR──►  dev  ──release PR──►  main  ──t
 - **`main` always matches the published release.** Anyone cloning `main` gets code that
   corresponds to the executable on the Releases page — which matters for a restore tool, where
   "which version am I actually running?" is a question people ask mid-incident.
-- **Releases are a `dev` → `main` pull request.** A version-bump check enforces that
-  `<Version>` in `src/NineLives/NineLives.csproj` has moved. Publishing a GitHub Release then
-  builds, tests, and attaches `NineLives.exe` with checksums automatically.
+- **Releases are a `dev` → `main` pull request.** A check enforces that `<Version>` in
+  `src/NineLives/NineLives.csproj` has not already been published as a release — so a version
+  number can never cover two different builds. Publishing a GitHub Release then builds, tests,
+  and attaches `NineLives.exe` with checksums automatically.
 
 Branch naming is loose, but `fix/<issue>-<slug>` and `feat/<issue>-<slug>` keep things scannable.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to Nine Lives
+
+Thanks for taking an interest. This is a tool people point at production databases during
+incidents, so the bar for correctness is high — but the codebase is small and the setup is quick.
+
+## Branching model
+
+**`dev` is the default branch and where all work lands. `main` is the released code.**
+
+```
+feature branch  ──PR──►  dev  ──release PR──►  main  ──tag──►  GitHub Release
+```
+
+- **Work targets `dev`.** Branch from `dev`, open your PR against `dev`.
+- **`main` always matches the published release.** Anyone cloning `main` gets code that
+  corresponds to the executable on the Releases page — which matters for a restore tool, where
+  "which version am I actually running?" is a question people ask mid-incident.
+- **Releases are a `dev` → `main` pull request.** A version-bump check enforces that
+  `<Version>` in `src/NineLives/NineLives.csproj` has moved. Publishing a GitHub Release then
+  builds, tests, and attaches `NineLives.exe` with checksums automatically.
+
+Branch naming is loose, but `fix/<issue>-<slug>` and `feat/<issue>-<slug>` keep things scannable.
+
+## Building and testing
+
+```bash
+git clone https://github.com/jakemorgangit/NineLives.git
+cd NineLives
+dotnet build
+dotnet test
+```
+
+Requires the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) and Windows (it is a
+WPF app).
+
+### Live SQL Server tests
+
+Some tests exercise real SQL Server behaviour that cannot be mocked meaningfully — for example
+that a failed restore actually throws rather than reporting success, and that a credential name
+cannot break out of its quoting. They are skipped unless you point them at an instance:
+
+```powershell
+$env:NINELIVES_TEST_SQL = ".\SQLEXPRESS"    # or "(localdb)\MSSQLLocalDB"
+dotnet test
+```
+
+They create and drop only their own objects and clean up after themselves. CI starts LocalDB on
+a best-effort basis, so they run there too.
+
+## What CI checks
+
+Every PR runs on `windows-latest`:
+
+1. `dotnet build -warnaserror` — **the build is warning-free and must stay that way**
+2. the full test suite
+3. a self-contained single-file publish, proving the shipping artifact still builds
+
+## Expectations for a change
+
+- New logic in `Services/` or `Models/` comes with tests. These are the parts that decide which
+  backups form a restore chain, so they carry the most risk.
+- **All generated T-SQL goes through `Services/TSql.cs`.** Identifiers use `QuoteName`, string
+  literals use `EscapeLiteral`. Do not hand-roll escaping.
+- If you change restore-chain logic, say in the PR what a DBA would see differently.
+- No credentials, SAS tokens, or real server/database names in code, comments, tests, or
+  screenshots. Use `MyDb`, `SRV01`, `mycluster01$My-AG1`.
+
+## Reporting bugs
+
+Include the app version (Help → About), Windows and SQL Server versions, your backup layout
+(path pattern or Ola naming), and — where relevant — the generated script with identifying
+details replaced.
+
+For anything security-sensitive, please follow [SECURITY.md](SECURITY.md) rather than opening a
+public issue.

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Built with:
 ```
 NineLives/
 ├── .github/
-│   └── workflows/               # CI: PR build/test gate + release pipeline
+│   └── workflows/               # CI: PR build/test gate, version-bump gate, release pipeline
 ├── docs/
 │   └── screenshots/             # README screenshots
 ├── src/
@@ -352,10 +352,11 @@ NineLives/
 
 ## Contributing
 
-Contributions are welcome! Please:
-1. Fork the repository
-2. Create a feature branch
-3. Submit a pull request
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
+
+In short: **`dev` is the default branch and where work lands; `main` tracks the released code.**
+Fork, branch from `dev`, and open your pull request against `dev`. Releases are a `dev` → `main`
+pull request with a version bump.
 
 ## License
 


### PR DESCRIPTION
Release **v1.0.0** — the first published release of Nine Lives.

Promotes `dev` to `main`. After this, `main` matches the executable on the Releases page.

## What ships

### 🔴 Failed restores no longer report success (#6)

`FireInfoMessageEventOnUserErrors = true` routed every error of severity ≤ 16 to the InfoMessage event instead of throwing — and severity 16 is where SQL Server reports essentially every real restore failure (3201 bad/expired SAS, 3013, 4305, 3136, 3154).

So a restore could fail completely — expired token, wrong base, missing file — while the app logged **"Restore completed successfully!"**. Fixed, with 7 live-SQL regression tests that also pin that execution stops at the first failure instead of running the rest of the chain against a database that was never created.

### 🔒 T-SQL injection in credential creation (#15) and identifier escaping (#9)

`CREATE`/`DROP CREDENTIAL` interpolated the credential name raw between brackets without doubling `]`, so the brackets did not delimit anything. The name is auto-populated from the container URL in plain-text `config.json`, making it reachable via a single local file write, on a connection that must already hold `CONTROL SERVER`.

Demonstrated against SQL Server 2025: the pre-fix shape created **two** credentials — the intended one plus an injected decoy. All identifiers and string literals now route through a single `TSql` helper. Also fixes the benign half: an IPv6-literal endpoint (`https://[fe80::1]:10000/...`) is a legal URL containing `]` and previously failed with an opaque syntax error.

### ⏱️ True point-in-time restore (#22)

`STOPAT` was supported by the generator and covered by tests, but **nothing in the app ever set it** — so "point-in-time recovery" actually meant "restore to the end of whichever log backup you picked". Recovering from a bad `DELETE` at 14:23:41 with 15-minute logs could only land on 14:15 or 14:30.

Now a log restore point offers a precise target time, bounded to that log's window, and `STOPAT` is emitted on **every** `RESTORE LOG` in the chain per Microsoft's guidance — emitting it only on the last statement overshoots when the target falls in an earlier log.

### 🐛 Blob URL double-encoding

`Uri.AbsolutePath` is already percent-encoded, so re-escaping turned a space into `%2520` and Azure looked for a blob literally named `%20`. Any backup path containing a space failed to restore.

## Project setup

- **CI**: build with `-warnaserror`, full test suite, and a self-contained single-file publish smoke test on every PR. Live SQL tests run against LocalDB on the runner.
- **185 tests**, up from zero at the rebrand.
- `dev`/`main` branching, Dependabot, PR template, `CONTRIBUTING.md`.

## Known limitations shipping with 1.0.0

Filed and tracked, not fixed here:

- Backups from different instances on one host can merge into a single timeline (#43) and same-named databases on different servers can merge into one striped set (#48) — both need an instance-aware grouping key.
- Copy-only full backups are treated as valid differential bases (#49).
- `Microsoft.Data.SqlClient` was auto-bumped 5.x → 7.x and has not been smoke-tested against a real server (#16) — **worth doing before announcing this anywhere**.
- The binary is unsigned, so SmartScreen will warn on download (#33).

## After merge

Publishing the GitHub Release for tag `v1.0.0` triggers `release.yml`, which builds, tests, and attaches `NineLives.exe`, a versioned zip, and `SHA256SUMS.txt`.
