### PR TITLE
Identify backup sets by server and instance

### DIFF
--- a/src/NineLives.Tests/BlobStorageServiceTests.cs
+++ b/src/NineLives.Tests/BlobStorageServiceTests.cs
@@ -197,6 +197,112 @@ public class BlobStorageServiceTests
     }
 
     [Fact]
+    public void GroupIntoBackupSets_SameDatabaseAndTimestampOnDifferentServers_StaySeparate()
+    {
+        // The defect: the key was Type|Database|SetId, so two servers backing up a same-named
+        // database to one container in the same second collapsed into ONE "striped" set - which
+        // would generate a single RESTORE ... FROM URL = a, URL = b spanning both servers, and
+        // silently drop the second server's backup from its own timeline.
+        var files = new List<BackupFileInfo>
+        {
+            File("FULL/SRV01/Sales/20260201_020000.bak", db: "Sales", server: "SRV01"),
+            File("FULL/SRV02/Sales/20260201_020000.bak", db: "Sales", server: "SRV02"),
+        };
+
+        var sets = _service.GroupIntoBackupSets(files);
+
+        Assert.Equal(2, sets.Count);
+        Assert.All(sets, s => Assert.False(s.IsStriped));
+        Assert.Contains(sets, s => s.ServerName == "SRV01");
+        Assert.Contains(sets, s => s.ServerName == "SRV02");
+    }
+
+    [Fact]
+    public void GroupIntoBackupSets_LogBackupsCollidingAcrossServers_StaySeparate()
+    {
+        // Logs are the realistic trigger: every 5-15 minutes across two servers is hundreds of
+        // chances a day for a same-second collision.
+        var files = new List<BackupFileInfo>
+        {
+            File("LOG/SRV01/Sales/20260805_121500.trn", BackupType.TransactionLog, db: "Sales", server: "SRV01"),
+            File("LOG/SRV02/Sales/20260805_121500.trn", BackupType.TransactionLog, db: "Sales", server: "SRV02"),
+        };
+
+        var sets = _service.GroupIntoBackupSets(files);
+
+        Assert.Equal(2, sets.Count);
+        Assert.All(sets, s => Assert.Equal(1, s.FileCount));
+    }
+
+    [Fact]
+    public void GroupIntoBackupSets_DifferentInstancesOnOneHost_StaySeparate()
+    {
+        var files = new List<BackupFileInfo>
+        {
+            File("FULL/SQLHOST/PROD/Sales/20260201_020000.bak", db: "Sales", server: "SQLHOST", instance: "PROD"),
+            File("FULL/SQLHOST/TEST/Sales/20260201_020000.bak", db: "Sales", server: "SQLHOST", instance: "TEST"),
+        };
+
+        var sets = _service.GroupIntoBackupSets(files);
+
+        Assert.Equal(2, sets.Count);
+        Assert.Contains(sets, s => s.InstanceName == "PROD");
+        Assert.Contains(sets, s => s.InstanceName == "TEST");
+    }
+
+    [Fact]
+    public void GroupIntoBackupSets_SeparatesByDirectoryEvenWithNoInferredServer()
+    {
+        // With an unconfigured or partial path pattern the server is null on both sides, so
+        // server/instance alone would not separate them - the parent directory still does.
+        var files = new List<BackupFileInfo>
+        {
+            File("SRV01/Sales/20260201_020000.bak"),
+            File("SRV02/Sales/20260201_020000.bak"),
+        };
+
+        var sets = _service.GroupIntoBackupSets(files);
+
+        Assert.Equal(2, sets.Count);
+    }
+
+    [Fact]
+    public void GroupIntoBackupSets_StripesOfOneBackup_StillGroupTogether()
+    {
+        // The stricter key must not break the case it exists to serve: every stripe of one
+        // backup shares server, instance, database and directory.
+        var files = new List<BackupFileInfo>
+        {
+            File("FULL/SQLHOST/PROD/Sales/20260201_020000_1.bak", db: "Sales", server: "SQLHOST", instance: "PROD"),
+            File("FULL/SQLHOST/PROD/Sales/20260201_020000_2.bak", db: "Sales", server: "SQLHOST", instance: "PROD"),
+            File("FULL/SQLHOST/PROD/Sales/20260201_020000_3.bak", db: "Sales", server: "SQLHOST", instance: "PROD"),
+        };
+
+        var set = Assert.Single(_service.GroupIntoBackupSets(files));
+
+        Assert.Equal(3, set.FileCount);
+        Assert.True(set.IsStriped);
+        Assert.Equal("PROD", set.InstanceName);
+    }
+
+    [Fact]
+    public void GroupIntoBackupSets_CarriesInstanceOntoTheSet()
+    {
+        var files = new List<BackupFileInfo>
+        {
+            File("FULL/SQLHOST/PROD/Sales/20260201_020000.bak", db: "Sales", server: "SQLHOST", instance: "PROD")
+        };
+
+        var set = Assert.Single(_service.GroupIntoBackupSets(files));
+
+        Assert.Equal("SQLHOST", set.ServerName);
+        Assert.Equal("PROD", set.InstanceName);
+        Assert.Equal(@"SQLHOST\PROD", set.ServerDisplay);
+        Assert.True(set.MatchesServer(@"SQLHOST\PROD"));
+        Assert.False(set.MatchesServer(@"SQLHOST\TEST"));
+    }
+
+    [Fact]
     public void GetDiscoveredDatabases_DistinctCaseInsensitive_Sorted()
     {
         var files = new List<BackupFileInfo>

--- a/src/NineLives.Tests/ServerIdentityTests.cs
+++ b/src/NineLives.Tests/ServerIdentityTests.cs
@@ -1,0 +1,100 @@
+using Blackcat.NineLives.Models;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+public class ServerIdentityTests
+{
+    // ── Format ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Format_ServerAndInstance_JoinsWithBackslash()
+        => Assert.Equal(@"SQLHOST\PROD", ServerIdentity.Format("SQLHOST", "PROD"));
+
+    [Fact]
+    public void Format_ServerOnly_ReturnsBareServer()
+        => Assert.Equal("SQLHOST", ServerIdentity.Format("SQLHOST", null));
+
+    [Fact]
+    public void Format_ServerWithEmptyInstance_ReturnsBareServer()
+        => Assert.Equal("SQLHOST", ServerIdentity.Format("SQLHOST", "   "));
+
+    [Fact]
+    public void Format_NeitherPresent_ReturnsNull()
+        => Assert.Null(ServerIdentity.Format(null, null));
+
+    [Fact]
+    public void Format_AgClusterName_PassesThroughUnchanged()
+        => Assert.Equal("mycluster01$My-AG1", ServerIdentity.Format("mycluster01$My-AG1", null));
+
+    // ── Matches: the defect this exists to prevent ───────────────────────────────
+
+    [Fact]
+    public void Matches_DifferentInstanceOnSameHost_DoesNotMatch()
+    {
+        // The bug: comparing only the host meant selecting SQLHOST\PROD also matched
+        // SQLHOST\TEST, so both instances' backups landed in one restore timeline.
+        Assert.False(ServerIdentity.Matches("SQLHOST", "TEST", @"SQLHOST\PROD"));
+    }
+
+    [Fact]
+    public void Matches_SameHostAndInstance_Matches()
+        => Assert.True(ServerIdentity.Matches("SQLHOST", "PROD", @"SQLHOST\PROD"));
+
+    [Fact]
+    public void Matches_IsCaseInsensitive()
+        => Assert.True(ServerIdentity.Matches("sqlhost", "prod", @"SQLHOST\PROD"));
+
+    [Fact]
+    public void Matches_BareHostFilter_MatchesOnlyBackupsWithNoInstance()
+    {
+        // A container that mixes both shapes lists SQLHOST and SQLHOST\PROD as separate
+        // dropdown entries, so a bare host must not silently swallow every instance under it.
+        Assert.True(ServerIdentity.Matches("SQLHOST", null, "SQLHOST"));
+        Assert.False(ServerIdentity.Matches("SQLHOST", "PROD", "SQLHOST"));
+    }
+
+    [Fact]
+    public void Matches_BareHostFilter_TreatsEmptyInstanceAsNoInstance()
+    {
+        // Path parsing can yield either null or empty; they must behave identically.
+        Assert.True(ServerIdentity.Matches("SQLHOST", "", "SQLHOST"));
+        Assert.True(ServerIdentity.Matches("SQLHOST", "  ", "SQLHOST"));
+    }
+
+    [Fact]
+    public void Matches_InstanceFilter_DoesNotMatchBackupWithoutInstance()
+        => Assert.False(ServerIdentity.Matches("SQLHOST", null, @"SQLHOST\PROD"));
+
+    [Fact]
+    public void Matches_DifferentHost_DoesNotMatch()
+        => Assert.False(ServerIdentity.Matches("OTHERHOST", "PROD", @"SQLHOST\PROD"));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Matches_EmptyFilter_MatchesEverything(string? filter)
+    {
+        Assert.True(ServerIdentity.Matches("SQLHOST", "PROD", filter));
+        Assert.True(ServerIdentity.Matches(null, null, filter));
+    }
+
+    [Fact]
+    public void Matches_RoundTripsWithFormat()
+    {
+        // Whatever Format produces for the dropdown must match the pair it came from -
+        // producer and matcher cannot be allowed to drift.
+        foreach (var (server, instance) in new[]
+        {
+            ("SQLHOST", "PROD"),
+            ("SQLHOST", (string?)null),
+            ("mycluster01$My-AG1", null)
+        })
+        {
+            var display = ServerIdentity.Format(server, instance);
+            Assert.True(ServerIdentity.Matches(server, instance, display),
+                $"Format produced '{display}' which does not match its own source pair.");
+        }
+    }
+}

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -44,6 +44,13 @@ public class BackupFileInfo
 
     public bool HasDetailedMetadata => BackupStartDate.HasValue;
 
+    /// <summary>Server as the filter dropdowns present it: <c>HOST\INSTANCE</c> or <c>HOST</c>.</summary>
+    public string? ServerDisplay => ServerIdentity.Format(InferredServerName, InferredInstanceName);
+
+    /// <summary>True when this file belongs to the given server filter (empty filter matches all).</summary>
+    public bool MatchesServer(string? serverFilter)
+        => ServerIdentity.Matches(InferredServerName, InferredInstanceName, serverFilter);
+
     public DateTime EffectiveDate => BackupStartDate ?? LastModified.DateTime;
 
     public string TypeDisplay => Type switch
@@ -86,6 +93,20 @@ public class BackupSet
     public DateTime Timestamp { get; set; }
     public string? DatabaseName { get; set; }
     public string? ServerName { get; set; }
+
+    /// <summary>
+    /// Named instance this set came from, when the path pattern supplies one. Without it, two
+    /// instances of the same host are indistinguishable once files are grouped into sets, and
+    /// their backups interleave into a single restore timeline.
+    /// </summary>
+    public string? InstanceName { get; set; }
+
+    /// <summary>Server as the filter dropdowns present it: <c>HOST\INSTANCE</c> or <c>HOST</c>.</summary>
+    public string? ServerDisplay => ServerIdentity.Format(ServerName, InstanceName);
+
+    /// <summary>True when this set belongs to the given server filter (empty filter matches all).</summary>
+    public bool MatchesServer(string? serverFilter)
+        => ServerIdentity.Matches(ServerName, InstanceName, serverFilter);
 
     public long TotalSizeBytes => Files.Sum(f => f.SizeBytes);
     public int FileCount => Files.Count;

--- a/src/NineLives/Models/ServerIdentity.cs
+++ b/src/NineLives/Models/ServerIdentity.cs
@@ -1,0 +1,56 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// Formatting and matching for the "which SQL Server did this backup come from" identity.
+///
+/// A host can run several named instances, and two instances of one host routinely hold
+/// same-named databases. Comparing only the host part therefore merges them: selecting
+/// SQLHOST\PROD would also match SQLHOST\TEST, and the restore timeline would interleave both.
+///
+/// This lived as four separate hand-rolled comparisons across two ViewModels, two of which
+/// silently ignored the instance. One implementation, used everywhere.
+/// </summary>
+public static class ServerIdentity
+{
+    /// <summary>
+    /// Renders a server/instance pair the way the filter dropdowns present it:
+    /// <c>HOST\INSTANCE</c>, or bare <c>HOST</c> when there is no instance.
+    /// Returns null when there is no server information at all.
+    /// </summary>
+    public static string? Format(string? server, string? instance)
+    {
+        if (string.IsNullOrWhiteSpace(server))
+            return string.IsNullOrWhiteSpace(instance) ? null : instance;
+
+        return string.IsNullOrWhiteSpace(instance) ? server : $@"{server}\{instance}";
+    }
+
+    /// <summary>
+    /// True when a server/instance pair matches a filter value taken from the dropdown.
+    ///
+    /// An empty filter matches everything. A <c>HOST\INSTANCE</c> filter requires both to match.
+    /// A bare <c>HOST</c> filter matches only backups with NO instance, because a container that
+    /// mixes both shapes lists them as separate entries - so a bare host must not silently
+    /// swallow every instance under it.
+    /// </summary>
+    public static bool Matches(string? server, string? instance, string? filter)
+    {
+        if (string.IsNullOrWhiteSpace(filter)) return true;
+
+        var parts = filter.Split('\\', 2);
+        var filterServer = parts[0];
+        var filterInstance = parts.Length == 2 ? parts[1] : null;
+
+        if (!string.Equals(server, filterServer, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        // Treat null and empty as the same "no instance" state - path parsing can produce either.
+        var hasInstance = !string.IsNullOrWhiteSpace(instance);
+        var filterHasInstance = !string.IsNullOrWhiteSpace(filterInstance);
+
+        if (!filterHasInstance) return !hasInstance;
+
+        return hasInstance
+            && string.Equals(instance, filterInstance, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -137,14 +137,10 @@ public class BlobStorageService
 
     public List<string> GetDiscoveredServers(List<BackupFileInfo> files)
     {
+        // Same formatter the filters match against, so the values offered in the dropdown and
+        // the values compared against a set can never drift apart.
         return files
-            .Select(f =>
-            {
-                var parts = new List<string>();
-                if (!string.IsNullOrEmpty(f.InferredServerName)) parts.Add(f.InferredServerName);
-                if (!string.IsNullOrEmpty(f.InferredInstanceName)) parts.Add(f.InferredInstanceName);
-                return parts.Count > 0 ? string.Join("\\", parts) : null;
-            })
+            .Select(f => f.ServerDisplay)
             .Where(s => s != null)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
@@ -179,7 +175,25 @@ public class BlobStorageService
             var (setId, _) = file.IsAgDefaultNaming && !string.IsNullOrEmpty(file.InferredSetId)
                 ? (file.InferredSetId!, 0)
                 : BackupSet.ParseFileName(file.FileName);
-            var key = $"{file.Type}|{file.InferredDatabaseName ?? ""}|{setId}";
+
+            // The key must identify ONE backup operation on ONE server. Type + database + setId
+            // alone does not: two servers writing a same-named database to one container in the
+            // same second collapse into a single "striped" set, which would generate one
+            // RESTORE ... FROM URL = a, URL = b spanning both - and silently drop the second
+            // server's backup from its own timeline. Log backups make this realistic: every
+            // 5-15 minutes across two servers is hundreds of chances a day.
+            //
+            // The parent directory is included as well as server/instance because it survives an
+            // unconfigured or partial path pattern: with no pattern InferredServerName is null on
+            // both sides and would not separate them, whereas FULL/SRV01/Sales and
+            // FULL/SRV02/Sales still differ. Every stripe of one backup shares both.
+            var key = string.Join("|",
+                file.Type,
+                file.InferredServerName ?? "",
+                file.InferredInstanceName ?? "",
+                file.InferredDatabaseName ?? "",
+                BlobDirectory(file.BlobName),
+                setId);
 
             if (!groups.TryGetValue(key, out var list))
             {
@@ -203,11 +217,19 @@ public class BlobStorageService
                 Files = groupFiles.OrderBy(f => f.FileName).ToList(),
                 Timestamp = timestamp,
                 DatabaseName = first.InferredDatabaseName,
-                ServerName = first.InferredServerName
+                ServerName = first.InferredServerName,
+                InstanceName = first.InferredInstanceName
             });
         }
 
         return sets.OrderBy(s => s.Timestamp).ToList();
+    }
+
+    /// <summary>Parent folder of a blob name, or empty for a flat name. Scopes set grouping.</summary>
+    private static string BlobDirectory(string blobName)
+    {
+        var idx = blobName.LastIndexOf('/');
+        return idx >= 0 ? blobName[..idx] : string.Empty;
     }
 
     public string BuildBlobUrlWithSas(BlobContainerConfig config, string blobName)

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -242,22 +242,14 @@ public partial class BlobBrowserViewModel : ViewModelBase
         }
     }
 
+    // Both delegate to the shared identity comparison. MatchesServerSet previously had a
+    // parts.Length == 2 branch that was byte-identical to its fallback and never compared the
+    // instance, so set-based summary counts silently included other instances of the same host.
     private static bool MatchesServer(BackupFileInfo file, string serverFilter)
-    {
-        var parts = serverFilter.Split('\\', 2);
-        if (parts.Length == 2)
-            return string.Equals(file.InferredServerName, parts[0], StringComparison.OrdinalIgnoreCase)
-                && string.Equals(file.InferredInstanceName, parts[1], StringComparison.OrdinalIgnoreCase);
-        return string.Equals(file.InferredServerName, parts[0], StringComparison.OrdinalIgnoreCase);
-    }
+        => file.MatchesServer(serverFilter);
 
     private static bool MatchesServerSet(BackupSet set, string serverFilter)
-    {
-        var parts = serverFilter.Split('\\', 2);
-        if (parts.Length == 2)
-            return string.Equals(set.ServerName, parts[0], StringComparison.OrdinalIgnoreCase);
-        return string.Equals(set.ServerName, parts[0], StringComparison.OrdinalIgnoreCase);
-    }
+        => set.MatchesServer(serverFilter);
 
     [RelayCommand]
     private void CopyPathHttps(BackupFileInfo? file)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -352,13 +352,10 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (_allSets.Count == 0) return;
 
-        var filtered = _allSets.AsEnumerable();
-        if (!string.IsNullOrEmpty(value))
-            filtered = filtered.Where(s =>
-            {
-                var parts = value.Split('\\', 2);
-                return string.Equals(s.ServerName, parts[0], StringComparison.OrdinalIgnoreCase);
-            });
+        // Compare the FULL server identity. Matching on the host alone made selecting
+        // SQLHOST\PROD also match SQLHOST\TEST, so the database list offered databases that
+        // only exist on the other instance.
+        var filtered = _allSets.Where(s => s.MatchesServer(value));
 
         var dbs = filtered
             .Where(s => !string.IsNullOrEmpty(s.DatabaseName))
@@ -380,12 +377,11 @@ public partial class RestoreViewModel : ViewModelBase
             .Where(s => string.Equals(s.DatabaseName, value, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
+        // Full server identity again - this is the filter that decides which sets reach
+        // BackupChainBuilder, so a host-only match let one instance's full pair with another
+        // instance's differentials and logs.
         if (!string.IsNullOrEmpty(SelectedServerName))
-        {
-            var parts = SelectedServerName.Split('\\', 2);
-            _dbSets = _dbSets.Where(s =>
-                string.Equals(s.ServerName, parts[0], StringComparison.OrdinalIgnoreCase)).ToList();
-        }
+            _dbSets = _dbSets.Where(s => s.MatchesServer(SelectedServerName)).ToList();
 
         FullCount = _dbSets.Count(s => s.Type == BackupType.Full);
         DiffCount = _dbSets.Count(s => s.Type == BackupType.Differential);


### PR DESCRIPTION
Closes #43. Closes #48.

Two defects, one root cause: **a backup set carried no notion of which server it came from** beyond a bare host name.

## #48 - two servers' backups merged into one striped set

The grouping key was `Type|Database|SetId` - no server, no instance, no directory. Two servers writing a same-named database (`master`, `msdb`, or any shared application name) to one container **in the same second** collapsed into a single set.

That would generate one `RESTORE ... FROM URL = a, URL = b` spanning **both servers** - and, more quietly, silently drop the second server's backup from its own timeline with nothing in the UI to say so.

Log backups make this realistic rather than theoretical: every 5-15 minutes across two servers is hundreds of chances a day. And this is the layout the README documents (`FULL/SQLSERVER01/AdventureWorks/20240115_220000_1.bak`).

## #43 - two instances of one host merged into one timeline

`BackupSet` had no `InstanceName`, and the filters compared only the host part of a `HOST\INSTANCE` selection - so choosing `SQLHOST\PROD` also matched `SQLHOST\TEST`. `BackupChainBuilder` is entirely server-agnostic, so a full from one instance could pair with logs from another.

A mixed chain at least fails loudly on an LSN mismatch. The quieter case is worse: the plain **Full** restore point restores perfectly cleanly, `WITH REPLACE` is on by default, and it is simply the **wrong instance's data**.

## The fix

One identity concept instead of four hand-rolled comparisons:

- **`Models/ServerIdentity`** - a single `Format` and a single `Matches`. It replaces four separate implementations across two ViewModels, **two of which ignored the instance entirely** - including `BlobBrowserViewModel.MatchesServerSet`, whose two-part branch was byte-identical to its fallback and never looked at `parts[1]`.
- `BackupSet` gains `InstanceName`, `ServerDisplay` and `MatchesServer`. `BackupFileInfo` gains the same two members, so file-level and set-level filtering agree by construction.
- The grouping key now includes server, instance **and the blob's parent directory**. The directory matters because it survives an unconfigured or partial path pattern - with no pattern the inferred server is null on both sides and would not separate them, whereas `FULL/SRV01/Sales` and `FULL/SRV02/Sales` still differ.
- `GetDiscoveredServers` now formats via the same helper the filters match against, so the dropdown values and the comparison **cannot drift apart**.

### One deliberate semantic

A bare `HOST` filter matches only backups with **no** instance. A container mixing both shapes lists `SQLHOST` and `SQLHOST\PROD` as separate dropdown entries, so a bare host must not silently swallow every instance beneath it.

## Tests - 22 new, 207 total

- **`ServerIdentityTests`** - formatting, matching, case-insensitivity, the no-instance case, empty-vs-null instance equivalence, and a `Format`/`Matches` round-trip so the producer and matcher are pinned together.
- **`BlobStorageServiceTests`** - cross-server separation, cross-instance separation, colliding log backups, directory-only separation (no inferred server), and that **genuine stripes still group** - the case the stricter key must not break.

**Verified against the old code**: the new grouping tests produce **4 failures** on the previous key and pass after the fix.