### PR TITLE
Never use a copy-only full as a differential base

### DIFF
--- a/src/NineLives.Tests/BlobStorageServiceTests.cs
+++ b/src/NineLives.Tests/BlobStorageServiceTests.cs
@@ -22,10 +22,12 @@ public class BlobStorageServiceTests
         string? instance = null,
         long size = 100,
         DateTime? lastModified = null,
-        string? agSetId = null)
+        string? agSetId = null,
+        bool copyOnly = false)
     {
         return new BackupFileInfo
         {
+            IsCopyOnly = copyOnly,
             BlobName = blobName,
             BlobUrl = $"https://acct.blob.core.windows.net/backups/{blobName}",
             Type = type,
@@ -300,6 +302,51 @@ public class BlobStorageServiceTests
         Assert.Equal(@"SQLHOST\PROD", set.ServerDisplay);
         Assert.True(set.MatchesServer(@"SQLHOST\PROD"));
         Assert.False(set.MatchesServer(@"SQLHOST\TEST"));
+    }
+
+    [Theory]
+    // Ola's shape, and common hand-rolled variants.
+    [InlineData("Sales_FULL_COPY_ONLY_20260804_120000_1.bak", true)]
+    [InlineData("Sales_FULL_COPY_ONLY_20260804_120000.bak", true)]
+    [InlineData("Sales-full-copy-only-20260804.bak", true)]
+    [InlineData("Sales_copyonly_20260804_120000.bak", true)]
+    [InlineData("Sales_FULL_20260804_120000_1.bak", false)]
+    // The false-positive trap that bit ContainsDiffIndicator, where a bare "diff" substring
+    // classified DiffusionDb's full backups as differentials. A database whose NAME contains
+    // the words must not be treated as copy-only.
+    [InlineData("CopyOnlyArchive_FULL_20260804_120000_1.bak", false)]
+    [InlineData("Copy_Only_Archive_FULL_20260804_120000_1.bak", false)]
+    public void IsCopyOnlyFileName_DetectsDelimitedMarkerOnly(string fileName, bool expectedCopyOnly)
+        => Assert.Equal(expectedCopyOnly, BlobStorageService.IsCopyOnlyFileName(fileName));
+
+    [Fact]
+    public void GroupIntoBackupSets_CarriesCopyOnlyOntoTheSet()
+    {
+        var files = new List<BackupFileInfo>
+        {
+            File("FULL/SRV01/Sales/Sales_FULL_COPY_ONLY_20260804_120000_1.bak",
+                 db: "Sales", server: "SRV01", copyOnly: true)
+        };
+
+        Assert.True(Assert.Single(_service.GroupIntoBackupSets(files)).IsCopyOnly);
+    }
+
+    [Fact]
+    public void GroupIntoBackupSets_CopyOnlyAndRegularAtSameTimestamp_StaySeparate()
+    {
+        // AG naming derives the setId from the timestamp alone, so without the copy-only
+        // component in the key these would merge into one mixed set.
+        var files = new List<BackupFileInfo>
+        {
+            File("Sales_FULL_20260804_120000_1.bak", db: "Sales", server: "SRV01", agSetId: "20260804_120000"),
+            File("Sales_FULL_COPY_ONLY_20260804_120000_1.bak", db: "Sales", server: "SRV01", agSetId: "20260804_120000", copyOnly: true),
+        };
+
+        var sets = _service.GroupIntoBackupSets(files);
+
+        Assert.Equal(2, sets.Count);
+        Assert.Contains(sets, s => s.IsCopyOnly);
+        Assert.Contains(sets, s => !s.IsCopyOnly);
     }
 
     [Fact]

--- a/src/NineLives.Tests/CopyOnlyChainTests.cs
+++ b/src/NineLives.Tests/CopyOnlyChainTests.cs
@@ -1,0 +1,152 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A copy-only full backup does NOT reset the differential base — the base LSN stays with the
+/// last regular full — so a differential restored on top of a copy-only full fails with
+/// error 3136.
+///
+/// Ola writes copy-only backups into the same FULL folder with the same naming, so an ad-hoc
+/// copy-only taken mid-week silently became the base for every later differential, and through
+/// the log-chain code broke every restore point from that differential onward until the next
+/// regular full — the entire recent end of the timeline.
+///
+/// Copy-only sets stay first-class everywhere else: valid Full restore points, and valid anchors
+/// for a log chain.
+/// </summary>
+public class CopyOnlyChainTests
+{
+    private readonly BackupChainBuilder _builder = new();
+
+    private static DateTime T(int day, int hour = 0) => new(2026, 8, day, hour, 0, 0);
+
+    private static BackupSet Set(BackupType type, DateTime timestamp, bool copyOnly = false) => new()
+    {
+        SetId = timestamp.ToString("yyyyMMdd_HHmmss"),
+        Type = type,
+        Timestamp = timestamp,
+        IsCopyOnly = copyOnly,
+        DatabaseName = "Sales",
+        Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = $"{timestamp:yyyyMMdd_HHmmss}.bak",
+                Type = type,
+                IsCopyOnly = copyOnly,
+                SizeBytes = 100
+            }
+        ]
+    };
+
+    [Fact]
+    public void Differential_SkipsCopyOnlyFull_AndUsesTheLastRegularFull()
+    {
+        // Sunday full, Wednesday ad-hoc copy-only, Thursday differential.
+        var sundayFull = Set(BackupType.Full, T(2));
+        var wedCopyOnly = Set(BackupType.Full, T(5), copyOnly: true);
+        var thuDiff = Set(BackupType.Differential, T(6));
+
+        var points = _builder.ComputeRestorePoints([sundayFull, wedCopyOnly, thuDiff]);
+        var diffPoint = Assert.Single(points, p => p.Type == BackupType.Differential);
+
+        Assert.Same(sundayFull, diffPoint.RequiredFullSet);
+        Assert.NotSame(wedCopyOnly, diffPoint.RequiredFullSet);
+    }
+
+    [Fact]
+    public void CopyOnlyFull_IsStillOfferedAsItsOwnRestorePoint()
+    {
+        // Excluding it from differential bases must not remove it from the timeline: restoring
+        // a copy-only full on its own is perfectly valid.
+        var full = Set(BackupType.Full, T(2));
+        var copyOnly = Set(BackupType.Full, T(5), copyOnly: true);
+
+        var points = _builder.ComputeRestorePoints([full, copyOnly]);
+
+        Assert.Equal(2, points.Count(p => p.Type == BackupType.Full));
+        Assert.Contains(points, p => ReferenceEquals(p.PrimarySet, copyOnly));
+    }
+
+    [Fact]
+    public void CopyOnlyFull_CanAnchorALogChain()
+    {
+        // Copy-only backups do not break the log chain, so copy-only + logs is a valid restore.
+        var copyOnly = Set(BackupType.Full, T(5), copyOnly: true);
+        var log = Set(BackupType.TransactionLog, T(5, 6));
+
+        var points = _builder.ComputeRestorePoints([copyOnly, log]);
+        var logPoint = Assert.Single(points, p => p.Type == BackupType.TransactionLog);
+
+        Assert.Same(copyOnly, logPoint.RequiredFullSet);
+        Assert.Empty(logPoint.RequiredDiffSets);
+    }
+
+    [Fact]
+    public void LogChainAnchoredOnCopyOnly_NeverPullsInADifferential()
+    {
+        // The defect that broke the whole recent timeline: the differential fell inside the
+        // copy-only full's range and was picked up as latestDiff, producing
+        // copy-only + diff + logs — which SQL Server rejects with 3136.
+        var sundayFull = Set(BackupType.Full, T(2));
+        var wedCopyOnly = Set(BackupType.Full, T(5), copyOnly: true);
+        var thuDiff = Set(BackupType.Differential, T(6));
+        var friLog = Set(BackupType.TransactionLog, T(7));
+
+        var points = _builder.ComputeRestorePoints([sundayFull, wedCopyOnly, thuDiff, friLog]);
+        var logPoint = Assert.Single(points, p => p.Type == BackupType.TransactionLog);
+
+        Assert.Empty(logPoint.RequiredDiffSets);
+        Assert.Same(wedCopyOnly, logPoint.RequiredFullSet);
+    }
+
+    [Fact]
+    public void DifferentialStillJoinsALogChainAnchoredOnItsOwnBase()
+    {
+        // The rule must not over-correct: with no copy-only involved, the differential still
+        // belongs to the chain exactly as before.
+        var full = Set(BackupType.Full, T(2));
+        var diff = Set(BackupType.Differential, T(4));
+        var log = Set(BackupType.TransactionLog, T(5));
+
+        var points = _builder.ComputeRestorePoints([full, diff, log]);
+        var logPoint = Assert.Single(points, p => p.Type == BackupType.TransactionLog);
+
+        Assert.Same(full, logPoint.RequiredFullSet);
+        Assert.Same(diff, Assert.Single(logPoint.RequiredDiffSets));
+    }
+
+    [Fact]
+    public void DifferentialWithOnlyCopyOnlyFullsAvailable_GetsNoRestorePoint()
+    {
+        // There is no valid base, so offering the differential at all would generate a script
+        // that cannot succeed.
+        var copyOnly = Set(BackupType.Full, T(2), copyOnly: true);
+        var diff = Set(BackupType.Differential, T(4));
+
+        var points = _builder.ComputeRestorePoints([copyOnly, diff]);
+
+        Assert.DoesNotContain(points, p => p.Type == BackupType.Differential);
+        Assert.Single(points); // just the copy-only full
+    }
+
+    [Fact]
+    public void CopyOnlyBetweenFullAndDiff_DoesNotStrandTheDifferential()
+    {
+        // End-to-end shape from the issue: the differential must still be restorable, and its
+        // chain must name the Sunday full.
+        var sundayFull = Set(BackupType.Full, T(2));
+        var wedCopyOnly = Set(BackupType.Full, T(5), copyOnly: true);
+        var thuDiff = Set(BackupType.Differential, T(6));
+
+        var points = _builder.ComputeRestorePoints([sundayFull, wedCopyOnly, thuDiff]);
+        var diffPoint = points.Single(p => p.Type == BackupType.Differential);
+        var chain = _builder.BuildChainFromRestorePoint(diffPoint);
+
+        Assert.Same(sundayFull, chain.FullSet);
+        Assert.Same(thuDiff, Assert.Single(chain.DiffSets));
+    }
+}

--- a/src/NineLives.Tests/OlaAgFileNameParserTests.cs
+++ b/src/NineLives.Tests/OlaAgFileNameParserTests.cs
@@ -11,6 +11,52 @@ namespace Blackcat.NineLives.Tests;
 /// </summary>
 public class OlaAgFileNameParserTests
 {
+    // ---- COPY_ONLY support ----------------------------------------
+
+    [Fact]
+    public void TryParse_CopyOnlyFull_IsParsedAndFlagged()
+    {
+        // Without the optional _COPY_ONLY group these did not match at all: they fell through to
+        // path parsing and, in a flat container, ended up with no database name - silently
+        // disappearing from the model rather than being offered as a restore point.
+        var parsed = OlaAgFileNameParser.TryParse(
+            "mycluster01$My-AG1_MyDatabase_FULL_COPY_ONLY_20260226_200032_1.bak");
+
+        Assert.NotNull(parsed);
+        Assert.True(parsed!.IsCopyOnly);
+        Assert.Equal("MyDatabase", parsed.DatabaseName);
+        Assert.Equal(BackupType.Full, parsed.BackupType);
+        Assert.Equal("20260226_200032", parsed.SetId);
+        Assert.Equal("mycluster01$My-AG1", parsed.ServerDisplay);
+        Assert.Equal(1, parsed.FileNumber);
+    }
+
+    [Fact]
+    public void TryParse_RegularFull_IsNotFlaggedCopyOnly()
+    {
+        var parsed = OlaAgFileNameParser.TryParse(
+            "mycluster01$My-AG1_MyDatabase_FULL_20260226_200032_1.bak");
+
+        Assert.NotNull(parsed);
+        Assert.False(parsed!.IsCopyOnly);
+    }
+
+    [Fact]
+    public void TryParse_CopyOnlyLog_IsParsedAndFlagged()
+    {
+        var parsed = OlaAgFileNameParser.TryParse(
+            "mycluster01$My-AG1_MyDatabase_LOG_COPY_ONLY_20260226_210500_1.trn");
+
+        Assert.NotNull(parsed);
+        Assert.True(parsed!.IsCopyOnly);
+        Assert.Equal(BackupType.TransactionLog, parsed.BackupType);
+    }
+
+    [Fact]
+    public void LooksLikeAgDefault_CopyOnlyName_IsRecognised()
+        => Assert.True(OlaAgFileNameParser.LooksLikeAgDefault(
+            "mycluster01$My-AG1_MyDatabase_FULL_COPY_ONLY_20260226_200032_1.bak"));
+
     // ---------------------------------------------------------------
     // TryParse — happy paths
     // ---------------------------------------------------------------

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -27,6 +27,12 @@ public class BackupFileInfo
     /// True when this file was identified using Ola Hallengren default AG naming (flat filename).
     /// </summary>
     public bool IsAgDefaultNaming { get; set; }
+
+    /// <summary>
+    /// True when this is a COPY_ONLY backup. Copy-only fulls do not reset the differential base,
+    /// so they can never serve as the base for a differential restore.
+    /// </summary>
+    public bool IsCopyOnly { get; set; }
     /// <summary>
     /// When IsAgDefaultNaming, the backup set id (e.g. 20260226_200032) used for grouping stripes.
     /// </summary>
@@ -100,6 +106,13 @@ public class BackupSet
     /// their backups interleave into a single restore timeline.
     /// </summary>
     public string? InstanceName { get; set; }
+
+    /// <summary>
+    /// True when this is a COPY_ONLY backup set. A copy-only full is a perfectly good restore
+    /// point on its own and a valid anchor for a log chain, but it does NOT reset the
+    /// differential base - so it can never be the base for a differential restore.
+    /// </summary>
+    public bool IsCopyOnly { get; set; }
 
     /// <summary>Server as the filter dropdowns present it: <c>HOST\INSTANCE</c> or <c>HOST</c>.</summary>
     public string? ServerDisplay => ServerIdentity.Format(ServerName, InstanceName);

--- a/src/NineLives/Services/BackupChainBuilder.cs
+++ b/src/NineLives/Services/BackupChainBuilder.cs
@@ -27,11 +27,26 @@ public class BackupChainBuilder
             });
         }
 
+        // A differential's base is the latest NON-copy-only full at or before it.
+        //
+        // A copy-only full does not reset the differential base: the base LSN stays with the last
+        // regular full, and SQL Server rejects a differential applied on top of a copy-only full
+        // with error 3136 ("the database has not been restored to the correct earlier state").
+        // Ola writes copy-only backups into the same FULL folder with the same naming, so before
+        // this an ad-hoc copy-only taken mid-week silently became the base for every subsequent
+        // differential - and, via the log-chain code below, broke every restore point from that
+        // differential onward until the next regular full.
+        //
+        // Copy-only sets remain first-class everywhere else: they are offered as Full restore
+        // points above, and they anchor log chains below, both of which are perfectly valid.
+        BackupSet? BaseFullFor(BackupSet diff) =>
+            fulls.LastOrDefault(f => !f.IsCopyOnly && f.Timestamp <= diff.Timestamp);
+
         // Each diff restore point: Full + that single diff only (differentials are cumulative
         // since the last full, so earlier diffs are never needed in the chain).
         foreach (var diff in diffs)
         {
-            var baseFull = fulls.LastOrDefault(f => f.Timestamp <= diff.Timestamp);
+            var baseFull = BaseFullFor(diff);
             if (baseFull == null) continue;
 
             points.Add(new RestorePoint
@@ -58,9 +73,13 @@ public class BackupChainBuilder
 
             if (applicableLogs.Count == 0) continue;
 
-            // At most one diff: the latest one before the log chain (differentials are cumulative since the last full).
+            // At most one diff: the latest one before the log chain (differentials are cumulative
+            // since the last full). Only diffs whose ACTUAL base is this full may join the chain -
+            // being inside the range is not enough. When the anchor is a copy-only full no diff
+            // ever qualifies, so the chain becomes copy-only full + logs, which is valid.
             var diffsInRange = diffs
-                .Where(d => d.Timestamp > full.Timestamp && d.Timestamp < upperBound)
+                .Where(d => d.Timestamp > full.Timestamp && d.Timestamp < upperBound
+                            && ReferenceEquals(BaseFullFor(d), full))
                 .OrderBy(d => d.Timestamp)
                 .ToList();
             var latestDiff = diffsInRange.Count > 0 ? diffsInRange.Last() : null;

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Blackcat.NineLives.Models;
@@ -74,6 +75,7 @@ public class BlobStorageService
                     file.Type = agParsed.BackupType;
                     file.InferredSetId = agParsed.SetId;
                     file.IsAgDefaultNaming = true;
+                    file.IsCopyOnly = agParsed.IsCopyOnly;
                 }
             }
 
@@ -103,6 +105,9 @@ public class BlobStorageService
 
             if (file.Type == BackupType.Unknown)
                 file.Type = InferBackupTypeFromExtension(blob.Name);
+
+            if (!file.IsCopyOnly)
+                file.IsCopyOnly = IsCopyOnlyFileName(file.FileName);
 
             files.Add(file);
         }
@@ -193,6 +198,9 @@ public class BlobStorageService
                 file.InferredInstanceName ?? "",
                 file.InferredDatabaseName ?? "",
                 BlobDirectory(file.BlobName),
+                // AG naming derives setId from the timestamp alone, so a copy-only and a regular
+                // full taken in the same second would otherwise merge into one mixed set.
+                file.IsCopyOnly ? "copyonly" : "",
                 setId);
 
             if (!groups.TryGetValue(key, out var list))
@@ -218,12 +226,29 @@ public class BlobStorageService
                 Timestamp = timestamp,
                 DatabaseName = first.InferredDatabaseName,
                 ServerName = first.InferredServerName,
-                InstanceName = first.InferredInstanceName
+                InstanceName = first.InferredInstanceName,
+                IsCopyOnly = first.IsCopyOnly
             });
         }
 
         return sets.OrderBy(s => s.Timestamp).ToList();
     }
+
+    // A COPY_ONLY marker delimited by _ - . and preceded by a delimiter, so a database whose
+    // name merely CONTAINS the words is not caught. Requiring a leading delimiter (rather than
+    // allowing start-of-string) keeps a database literally named "Copy_Only_Archive" safe.
+    // Deliberately not a bare substring match - see the ContainsDiffIndicator defect, where
+    // "diff" matched DiffusionDb and classified its full backups as differentials.
+    private static readonly Regex CopyOnlyRegex = new(
+        @"[_\-.]copy[_\-]?only(?:$|[_\-.])",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// True when a backup filename carries a COPY_ONLY marker. Public because it is pure logic
+    /// worth testing directly - the caller sits behind Azure IO.
+    /// </summary>
+    public static bool IsCopyOnlyFileName(string fileName)
+        => !string.IsNullOrEmpty(fileName) && CopyOnlyRegex.IsMatch(fileName);
 
     /// <summary>Parent folder of a blob name, or empty for a flat name. Scopes set grouping.</summary>
     private static string BlobDirectory(string blobName)

--- a/src/NineLives/Services/OlaAgFileNameParser.cs
+++ b/src/NineLives/Services/OlaAgFileNameParser.cs
@@ -10,10 +10,15 @@ namespace Blackcat.NineLives.Services;
 /// </summary>
 public static class OlaAgFileNameParser
 {
-    // Matches: clustername$AgName_DatabaseName_FULL|DIFF|LOG_YYYYMMDD_HHMMSS_N.ext
+    // Matches: clustername$AgName_DatabaseName_FULL|DIFF|LOG[_COPY_ONLY]_YYYYMMDD_HHMMSS_N.ext
     // DatabaseName is [^_]+ so no underscores in DB name; AG name can have hyphens (e.g. My-AG1).
+    //
+    // The optional _COPY_ONLY group matters: without it a copy-only backup does not match at all,
+    // falls through to path parsing, and in a flat container ends up with no inferred database -
+    // so it silently vanishes from the model instead of being offered as a restore point.
+    // Named groups, because an optional group would otherwise shift every positional index.
     private static readonly Regex AgDefaultRegex = new(
-        @"^(.+?)\$(.+)_([^_]+)_(FULL|DIFF|LOG)_(\d{8}_\d{6})_(\d+)\.(bak|trn|diff|log)$",
+        @"^(?<cluster>.+?)\$(?<ag>.+)_(?<db>[^_]+)_(?<type>FULL|DIFF|LOG)(?<copyonly>_COPY_ONLY)?_(?<setid>\d{8}_\d{6})_(?<file>\d+)\.(?<ext>bak|trn|diff|log)$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
@@ -29,7 +34,7 @@ public static class OlaAgFileNameParser
         if (!match.Success)
             return null;
 
-        var backupTypeStr = match.Groups[4].Value.ToUpperInvariant();
+        var backupTypeStr = match.Groups["type"].Value.ToUpperInvariant();
         var backupType = backupTypeStr switch
         {
             "FULL" => BackupType.Full,
@@ -40,13 +45,14 @@ public static class OlaAgFileNameParser
 
         return new OlaAgParsedName
         {
-            ClusterName = match.Groups[1].Value,
-            AgName = match.Groups[2].Value,
-            DatabaseName = match.Groups[3].Value,
+            ClusterName = match.Groups["cluster"].Value,
+            AgName = match.Groups["ag"].Value,
+            DatabaseName = match.Groups["db"].Value,
             BackupType = backupType,
-            SetId = match.Groups[5].Value, // YYYYMMDD_HHMMSS
-            FileNumber = int.TryParse(match.Groups[6].Value, out var n) ? n : 0,
-            FileExtension = match.Groups[7].Value
+            IsCopyOnly = match.Groups["copyonly"].Success,
+            SetId = match.Groups["setid"].Value, // YYYYMMDD_HHMMSS
+            FileNumber = int.TryParse(match.Groups["file"].Value, out var n) ? n : 0,
+            FileExtension = match.Groups["ext"].Value
         };
     }
 
@@ -66,6 +72,10 @@ public class OlaAgParsedName
     public string AgName { get; set; } = string.Empty;
     public string DatabaseName { get; set; } = string.Empty;
     public BackupType BackupType { get; set; }
+
+    /// <summary>True when the filename carries Ola's COPY_ONLY marker.</summary>
+    public bool IsCopyOnly { get; set; }
+
     public string SetId { get; set; } = string.Empty;
     public int FileNumber { get; set; }
     public string FileExtension { get; set; } = string.Empty;


### PR DESCRIPTION
Closes #49.

## The rule

A **copy-only full backup does not reset the differential base.** The base LSN stays with the last regular full, and SQL Server rejects a differential applied on top of a copy-only full with **error 3136** — *"the database has not been restored to the correct earlier state"*.

The app had no copy-only awareness whatsoever — a repo-wide grep found zero references.

## Why it broke more than one restore point

Ola writes copy-only backups into the same `FULL` folder with the same naming, so an ad-hoc copy-only taken mid-week became an ordinary full as far as the chain builder was concerned.

Take Sunday full → Wednesday copy-only → Thursday differential → logs:

| | Before |
|---|---|
| Thursday differential | based on **Wednesday's copy-only** → fails with 3136 |
| Every log point after it | anchored on the copy-only, and the differential was picked up as `latestDiff` → also fails |
| The correct pairing (Sunday full + Thursday diff) | offered **nowhere** |
| The safe alternative (copy-only + logs, no diff) | suppressed by the `>= baseTimestamp` filter |

So it wasn't one bad option among good ones — **the entire recent end of the timeline was unrestorable**, and (before #6 landed) it would have failed silently while reporting success.

## The fix

```csharp
// A differential's base is the latest NON-copy-only full at or before it.
BackupSet? BaseFullFor(BackupSet diff) =>
    fulls.LastOrDefault(f => !f.IsCopyOnly && f.Timestamp <= diff.Timestamp);
```

Used in **both** places that need it:

1. The differential restore point resolves its base through it.
2. A differential joins a log chain only when that chain's anchor **is** its base — being inside the range is no longer sufficient. When the anchor is copy-only, no differential ever qualifies, so the chain becomes copy-only + logs, which is valid.

### What deliberately did *not* change

Copy-only sets stay first-class: still offered as their **own Full restore points**, and still valid **log-chain anchors**. Restoring a copy-only full, or a copy-only full plus subsequent logs, is perfectly correct — only the differential pairing was ever invalid. Two tests pin that, so the fix cannot over-correct into removing them.

## Two supporting fixes

**`OlaAgFileNameParser` now accepts `_COPY_ONLY`.** Without it these filenames did not match *at all* — they fell through to path parsing and, in a flat container, ended up with no inferred database, so they **silently vanished from the model** rather than being offered as a restore point. That is a distinct defect from the one in the issue title. Switched to named groups so the optional group cannot shift positional indices.

**Detection matches a delimited marker, not a bare substring.** A database named `CopyOnlyArchive` must not be caught — that is exactly the false-positive shape that makes `ContainsDiffIndicator` classify `DiffusionDb`'s full backups as differentials today (#45, still open). Both false-positive names are covered by tests.

Copy-only is also part of the grouping key, because AG naming derives the setId from the timestamp alone — so a copy-only and a regular full taken in the same second would otherwise merge into one mixed set.

## Tests — 20 new, 227 total

`CopyOnlyChainTests` covers base resolution across a copy-only, copy-only still being its own restore point, copy-only anchoring a log chain, a log chain never pulling a differential across a copy-only, the unchanged non-copy-only path, and a differential with *no* valid base getting no restore point at all. Plus parser cases (copy-only full, copy-only log, regular full unflagged) and detection cases including the false-positive names.

**Verified against the old code**: the copy-only chain tests produce **4 failures of 7** on the previous builder and all pass after. The 3 that pass either way are the ones asserting behaviour that should not change — which is the point of including them.

| | Result |
|---|---|
| Full suite, live SQL | **227 passed** |
| Build | 0 warnings (`-warnaserror`) |

## Related

#45 (`ContainsDiffIndicator` substring matching) is the same class of bug and still open — worth fixing with the same delimited-token approach used here.
