### PR TITLE
Offer a restore point for every log backup

### DIFF
--- a/src/NineLives.Tests/BackupChainBuilderTests.cs
+++ b/src/NineLives.Tests/BackupChainBuilderTests.cs
@@ -195,8 +195,11 @@ public class BackupChainBuilderTests
     }
 
     [Fact]
-    public void ComputeRestorePoints_DiffWithinLogRange_UsesLatestDiffAndDropsEarlierLogs()
+    public void ComputeRestorePoints_DiffWithinLogRange_PicksTheDifferentialPerLog()
     {
+        // Rewritten for #24. This previously asserted that logs before the latest differential
+        // were DROPPED - the defect itself, faithfully characterized. Every log now yields a
+        // restore point, each using the shortest valid chain that reaches it.
         var full = Set(BackupType.Full, T(1));
         var logBeforeDiffs = Set(BackupType.TransactionLog, T(2));
         var diff1 = Set(BackupType.Differential, T(3));
@@ -208,21 +211,47 @@ public class BackupChainBuilderTests
         var points = _builder.ComputeRestorePoints(
             [full, logBeforeDiffs, diff1, logBetweenDiffs, diff2, logAfter1, logAfter2]);
 
-        // Full point, two diff points, and log points only for logs at/after the latest diff.
+        // Every backup is now a reachable point in time.
         Assert.Equal(
-            new[] { T(1), T(3), T(5), T(6), T(7) },
+            new[] { T(1), T(2), T(3), T(4), T(5), T(6), T(7) },
             points.Select(p => p.Timestamp).ToArray());
 
         var logPoints = points.Where(p => p.Type == BackupType.TransactionLog).ToList();
+        Assert.Equal(4, logPoints.Count);
+
+        // Before any differential: full + logs, no differential at all.
+        Assert.Empty(logPoints[0].RequiredDiffSets);
+        Assert.Equal([logBeforeDiffs], logPoints[0].RequiredLogSets);
+
+        // Between the two differentials: the EARLIER one is correct here, not the latest.
+        Assert.Equal([diff1], logPoints[1].RequiredDiffSets);
+        Assert.Equal([logBetweenDiffs], logPoints[1].RequiredLogSets);
+
+        // After the latest differential: unchanged from before the fix.
+        Assert.Equal([diff2], logPoints[2].RequiredDiffSets);
+        Assert.Equal([logAfter1], logPoints[2].RequiredLogSets);
+        Assert.Equal([diff2], logPoints[3].RequiredDiffSets);
+        Assert.Equal([logAfter1, logAfter2], logPoints[3].RequiredLogSets);
+    }
+
+    [Fact]
+    public void ComputeRestorePoints_LogsBeforeTheFirstDifferential_UseFullPlusLogsOnly()
+    {
+        // The chain the app could never generate: full + logs, skipping the differential
+        // entirely because it had not been taken yet.
+        var full = Set(BackupType.Full, T(1));
+        var log1 = Set(BackupType.TransactionLog, T(2));
+        var log2 = Set(BackupType.TransactionLog, T(3));
+        var diff = Set(BackupType.Differential, T(4));
+
+        var points = _builder.ComputeRestorePoints([full, log1, log2, diff]);
+        var logPoints = points.Where(p => p.Type == BackupType.TransactionLog).ToList();
+
         Assert.Equal(2, logPoints.Count);
-
-        // Only the latest diff is required, never earlier diffs.
-        Assert.Equal([diff2], logPoints[0].RequiredDiffSets);
-        Assert.Equal([diff2], logPoints[1].RequiredDiffSets);
-
-        // The log chain starts after the latest diff; earlier logs are not included.
-        Assert.Equal([logAfter1], logPoints[0].RequiredLogSets);
-        Assert.Equal([logAfter1, logAfter2], logPoints[1].RequiredLogSets);
+        Assert.All(logPoints, p => Assert.Empty(p.RequiredDiffSets));
+        Assert.All(logPoints, p => Assert.Same(full, p.RequiredFullSet));
+        Assert.Equal([log1], logPoints[0].RequiredLogSets);
+        Assert.Equal([log1, log2], logPoints[1].RequiredLogSets);
     }
 
     [Fact]
@@ -243,17 +272,23 @@ public class BackupChainBuilderTests
     }
 
     [Fact]
-    public void ComputeRestorePoints_AllLogsBeforeLatestDiff_ProducesNoLogPoints()
+    public void ComputeRestorePoints_LogBeforeTheOnlyDiff_IsStillOffered()
     {
+        // Rewritten for #24: this asserted the log produced NO restore point. It now gets one,
+        // restored as full + log with the differential skipped.
         var full = Set(BackupType.Full, T(1));
         var log = Set(BackupType.TransactionLog, T(2));
         var diff = Set(BackupType.Differential, T(3));
 
         var points = _builder.ComputeRestorePoints([full, log, diff]);
 
-        Assert.Equal(2, points.Count);
-        Assert.DoesNotContain(points, p => p.Type == BackupType.TransactionLog);
-        Assert.Equal(new[] { T(1), T(3) }, points.Select(p => p.Timestamp).ToArray());
+        Assert.Equal(3, points.Count);
+        Assert.Equal(new[] { T(1), T(2), T(3) }, points.Select(p => p.Timestamp).ToArray());
+
+        var logPoint = Assert.Single(points, p => p.Type == BackupType.TransactionLog);
+        Assert.Same(full, logPoint.RequiredFullSet);
+        Assert.Empty(logPoint.RequiredDiffSets);
+        Assert.Equal([log], logPoint.RequiredLogSets);
     }
 
     [Fact]
@@ -285,8 +320,9 @@ public class BackupChainBuilderTests
         var timestamps = points.Select(p => p.Timestamp).ToList();
         Assert.Equal(timestamps.OrderBy(t => t).ToList(), timestamps);
 
-        // full1, diff@3, log@4 (chain starts at the diff), full2, log@6.
-        Assert.Equal(new[] { T(1), T(3), T(4), T(5), T(6) }, timestamps.ToArray());
+        // Every backup is a point: full1, log@2 (full+log, pre-differential), diff@3,
+        // log@4 (full+diff+log), full2, log@6. log@2 was previously missing - see #24.
+        Assert.Equal(new[] { T(1), T(2), T(3), T(4), T(5), T(6) }, timestamps.ToArray());
     }
 
     // ---- GetRestoreWindow (BackupSet overload) ---------------------------

--- a/src/NineLives/Services/BackupChainBuilder.cs
+++ b/src/NineLives/Services/BackupChainBuilder.cs
@@ -59,8 +59,7 @@ public class BackupChainBuilder
             });
         }
 
-        // For transaction logs, build chains from each full forward.
-        // Includes all diffs in the full's range, then logs after the last diff.
+        // For transaction logs, build a chain from each full forward - one restore point per log.
         foreach (var full in fulls)
         {
             var nextFull = fulls.FirstOrDefault(f => f.Timestamp > full.Timestamp);
@@ -73,36 +72,44 @@ public class BackupChainBuilder
 
             if (applicableLogs.Count == 0) continue;
 
-            // At most one diff: the latest one before the log chain (differentials are cumulative
-            // since the last full). Only diffs whose ACTUAL base is this full may join the chain -
-            // being inside the range is not enough. When the anchor is a copy-only full no diff
-            // ever qualifies, so the chain becomes copy-only full + logs, which is valid.
-            var diffsInRange = diffs
+            // Only diffs whose ACTUAL base is this full may join a chain - being inside the range
+            // is not enough. When the anchor is a copy-only full no diff ever qualifies, so the
+            // chain becomes copy-only full + logs, which is valid.
+            var applicableDiffs = diffs
                 .Where(d => d.Timestamp > full.Timestamp && d.Timestamp < upperBound
                             && ReferenceEquals(BaseFullFor(d), full))
                 .OrderBy(d => d.Timestamp)
                 .ToList();
-            var latestDiff = diffsInRange.Count > 0 ? diffsInRange.Last() : null;
-            var baseTimestamp = latestDiff != null ? latestDiff.Timestamp : full.Timestamp;
 
-            var chainLogs = applicableLogs
-                .Where(l => l.Timestamp >= baseTimestamp)
-                .OrderBy(l => l.Timestamp)
-                .ToList();
-
-            var logChainSoFar = new List<BackupSet>();
-            for (int i = 0; i < chainLogs.Count; i++)
+            // The differential is chosen PER LOG: the latest one taken at or before that log.
+            //
+            // Previously a single latestDiff was picked for the whole range and the logs were then
+            // filtered to those at or after it - so every log between the full and the latest
+            // differential produced NO restore point at all. Measured against a real 24-day
+            // Ola-style set, that hid 73 of 94 log backups (78%), a 72-hour window in which no
+            // point-in-time recovery was offered even though every backup needed for it existed
+            // and was already listed in the browse view.
+            //
+            // Choosing per log restores the natural rule: use the shortest valid chain that
+            // reaches this point. Before the first differential that means full + logs, which is
+            // a chain SQL Server restores happily - it was simply never generated.
+            foreach (var log in applicableLogs)
             {
-                logChainSoFar.Add(chainLogs[i]);
+                var diff = applicableDiffs.LastOrDefault(d => d.Timestamp <= log.Timestamp);
+                var baseTimestamp = diff?.Timestamp ?? full.Timestamp;
+
+                var chainLogs = applicableLogs
+                    .Where(l => l.Timestamp >= baseTimestamp && l.Timestamp <= log.Timestamp)
+                    .ToList();
 
                 points.Add(new RestorePoint
                 {
-                    Timestamp = chainLogs[i].Timestamp,
+                    Timestamp = log.Timestamp,
                     Type = BackupType.TransactionLog,
-                    PrimarySet = chainLogs[i],
+                    PrimarySet = log,
                     RequiredFullSet = full,
-                    RequiredDiffSets = latestDiff != null ? [latestDiff] : [],
-                    RequiredLogSets = [.. logChainSoFar]
+                    RequiredDiffSets = diff != null ? [diff] : [],
+                    RequiredLogSets = chainLogs
                 });
             }
         }


### PR DESCRIPTION
Closes #24.

## The defect

The log-chain builder picked **one** differential for a full's entire range — the latest — and then filtered the logs to those at or after it. Every log between the full and that differential produced **no restore point at all**.

## Measured against real backups

I ran the current code against a live 24-day Ola-style backup set (production-shaped `Utility` database):

```
log backup sets      : 94
offered as a point   : 21
UNREACHABLE          : 73  (78% of log backups)
unreachable span     : 2026-08-01 23:00 .. 2026-08-04 23:00  (72 hours)
latest full          : 2026-08-01 22:09
latest differential  : 2026-08-04 23:01
```

**Three consecutive days** during which no point-in-time recovery was offered — even though every backup needed for it existed, was discovered, was correctly classified, and was already listed in the browse view.

Two things make this worse than an edge case:

1. **It scales with the backup schedule.** The gap sits between the last full and the last differential and grows with the interval between fulls. The standard "weekly full + daily differential + frequent logs" configuration this tool is built around puts the *majority* of log backups inside it.
2. **It hides the most recent history.** That window is precisely the region a DBA reaches for during an incident.

## The fix

Choose the differential **per log** — the latest one taken at or before that log, or none when the log precedes the first differential.

That restores the natural rule: *use the shortest valid chain that reaches this point*. Before the first differential, that means `full + logs`, which SQL Server restores happily; the app simply never generated it.

**Strictly additive** — no previously-offered restore point changes shape.

| Against the same real data | Before | After |
|---|---|---|
| Restore points | 40 | **113** |
| Unreachable log backups | 73 (78%) | **0** |

## Verifying the new points actually restore

More points is not the same as *working* points, so I checked LSN continuity on a chain that was unreachable before the fix — a log at `2026-08-02 19:00`, sitting between the last full and the last differential:

```
chain : 1 Full (4 files) + 1 Diff(s) + 20 Log(s), 28 files

FULL  08-01 22:09  FirstLSN=481000000008800001  LastLSN=481000000011200001
DIFF  08-01 23:00  FirstLSN=481000000388000001  LastLSN=481000000390400001
                   DatabaseBackupLSN=481000000008800001   <- matches the full
LOG   08-02 00:00  FirstLSN=481000000232000001  LastLSN=481000000916800001  contiguous
LOG   08-02 01:00  FirstLSN=481000000916800001  LastLSN=481000000937600001  contiguous
...  (20 logs, every FirstLSN == the previous LastLSN)
LOG   08-02 19:00  FirstLSN=481000001264000001  LastLSN=481000001283200001  contiguous
```

The differential's `DatabaseBackupLSN` equals the full's `FirstLSN`, confirming it is correctly based, and the log chain is unbroken. SQL Server would accept this restore.

## Three characterization tests were rewritten

They asserted the old behaviour, and their names said so plainly:

- `ComputeRestorePoints_DiffWithinLogRange_UsesLatestDiffAndDrops**EarlierLogs**`
- `ComputeRestorePoints_AllLogsBeforeLatestDiff_**ProducesNoLogPoints**`
- the scrambled-input test, whose expected list simply omitted the dropped log

They did exactly what characterization tests are for — they made this change explicit rather than letting it happen silently. Each is rewritten to assert the corrected behaviour with a note explaining what changed and why.

New coverage added for logs before the first differential (full + logs, no differential) and for per-log selection picking the **earlier** of two differentials where that is the correct base.

**228 tests passing.**

## Not included

The issue also floats an optional "skip differential" toggle so a post-differential point could route around a *corrupt* differential. Left out deliberately: it means offering two different chains for the same timestamp, which needs a UI answer for how the timeline presents that choice. Worth its own issue if there is appetite — the underlying builder change would be small now.
