### PR TITLE
Detect and surface gaps in the backup chain

### DIFF
--- a/src/NineLives.Tests/BackupChainValidatorTests.cs
+++ b/src/NineLives.Tests/BackupChainValidatorTests.cs
@@ -1,0 +1,297 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+public class BackupChainValidatorTests
+{
+    private readonly BackupChainValidator _validator = new();
+
+    private static DateTime T(int hour, int minute = 0) => new(2026, 8, 4, hour, minute, 0);
+
+    private static BackupSet Set(
+        BackupType type, DateTime timestamp, int fileCount = 1,
+        int[]? stripeNumbers = null, long sizePerFile = 100)
+    {
+        var files = new List<BackupFileInfo>();
+        var stamp = timestamp.ToString("yyyyMMdd_HHmmss");
+
+        if (stripeNumbers != null)
+        {
+            foreach (var n in stripeNumbers)
+                files.Add(new BackupFileInfo
+                {
+                    BlobName = $"{stamp}_{n}.bak",
+                    Type = type,
+                    SizeBytes = sizePerFile
+                });
+        }
+        else
+        {
+            for (int i = 0; i < fileCount; i++)
+                files.Add(new BackupFileInfo
+                {
+                    BlobName = fileCount == 1 ? $"{stamp}.bak" : $"{stamp}_{i + 1}.bak",
+                    Type = type,
+                    SizeBytes = sizePerFile
+                });
+        }
+
+        return new BackupSet
+        {
+            SetId = stamp,
+            Type = type,
+            Timestamp = timestamp,
+            Files = files
+        };
+    }
+
+    private static BackupChain Chain(BackupSet full, BackupSet[]? diffs = null, BackupSet[]? logs = null) => new()
+    {
+        FullSet = full,
+        DiffSets = diffs?.ToList() ?? [],
+        LogSets = logs?.ToList() ?? []
+    };
+
+    // ── clean chains produce nothing ─────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_NullChain_NoIssues()
+        => Assert.Empty(_validator.Validate(null));
+
+    [Fact]
+    public void Validate_HealthyChain_NoIssues()
+    {
+        var chain = Chain(
+            Set(BackupType.Full, T(0), fileCount: 4),
+            [Set(BackupType.Differential, T(4))],
+            [Set(BackupType.TransactionLog, T(5)), Set(BackupType.TransactionLog, T(6)), Set(BackupType.TransactionLog, T(7))]);
+
+        Assert.Empty(_validator.Validate(chain));
+    }
+
+    // ── missing stripes ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_MissingStripe_IsAnError()
+    {
+        // Stripes 1, 2, 4 - number 3 never arrived. SQL Server cannot restore a partial set.
+        var chain = Chain(Set(BackupType.Full, T(0), stripeNumbers: [1, 2, 4]));
+
+        var issue = Assert.Single(_validator.Validate(chain));
+
+        Assert.True(issue.IsError);
+        Assert.Contains("missing stripe", issue.Title, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("3", issue.Title);
+    }
+
+    [Fact]
+    public void Validate_MultipleMissingStripes_AreAllNamed()
+    {
+        var chain = Chain(Set(BackupType.Full, T(0), stripeNumbers: [1, 5]));
+
+        var issue = Assert.Single(_validator.Validate(chain));
+
+        Assert.Contains("2", issue.Title);
+        Assert.Contains("3", issue.Title);
+        Assert.Contains("4", issue.Title);
+    }
+
+    [Fact]
+    public void Validate_CompleteStripeSet_IsClean()
+        => Assert.Empty(_validator.Validate(Chain(Set(BackupType.Full, T(0), stripeNumbers: [1, 2, 3, 4]))));
+
+    [Fact]
+    public void Validate_SingleFileBackup_IsNotTreatedAsAStripeSet()
+        => Assert.Empty(_validator.Validate(Chain(Set(BackupType.Full, T(0)))));
+
+    [Fact]
+    public void Validate_MissingStripeInALogSet_IsAlsoCaught()
+    {
+        var chain = Chain(
+            Set(BackupType.Full, T(0)),
+            null,
+            [Set(BackupType.TransactionLog, T(1), stripeNumbers: [1, 3])]);
+
+        Assert.Single(_validator.Validate(chain), i => i.IsError);
+    }
+
+    // ── empty files ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_ZeroByteFile_IsAnError()
+    {
+        var chain = Chain(Set(BackupType.Full, T(0), sizePerFile: 0));
+
+        var issue = Assert.Single(_validator.Validate(chain));
+
+        Assert.True(issue.IsError);
+        Assert.Contains("empty file", issue.Title, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── log cadence ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_HoleInHourlyLogSequence_IsAWarning()
+    {
+        // Hourly logs with 03:00 and 04:00 absent - a 3 hour hole against a 1 hour cadence.
+        var logs = new[]
+        {
+            Set(BackupType.TransactionLog, T(1)),
+            Set(BackupType.TransactionLog, T(2)),
+            Set(BackupType.TransactionLog, T(5)),
+            Set(BackupType.TransactionLog, T(6)),
+            Set(BackupType.TransactionLog, T(7))
+        };
+        var chain = Chain(Set(BackupType.Full, T(0)), null, logs);
+
+        var issue = Assert.Single(_validator.Validate(chain));
+
+        Assert.False(issue.IsError);           // a schedule change is a legitimate cause
+        Assert.Contains("missing log backup", issue.Title, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("4305", issue.Detail); // tells the user how it will fail
+    }
+
+    [Fact]
+    public void Validate_EvenlySpacedLogs_ProduceNoCadenceWarning()
+    {
+        var logs = Enumerable.Range(1, 8)
+            .Select(i => Set(BackupType.TransactionLog, T(i)))
+            .ToArray();
+
+        Assert.Empty(_validator.Validate(Chain(Set(BackupType.Full, T(0)), null, logs)));
+    }
+
+    [Fact]
+    public void Validate_TooFewLogsToEstablishCadence_ProducesNoWarning()
+    {
+        // Two logs cannot define a "normal" interval, so any gap between them is unremarkable.
+        var logs = new[]
+        {
+            Set(BackupType.TransactionLog, T(1)),
+            Set(BackupType.TransactionLog, T(20))
+        };
+
+        Assert.Empty(_validator.Validate(Chain(Set(BackupType.Full, T(0)), null, logs)));
+    }
+
+    [Fact]
+    public void Validate_SingleMissingLog_IsWarned()
+    {
+        // The most common break and the one most worth catching: exactly one hourly log absent,
+        // showing up as a single 2 hour interval. A laxer threshold would miss this entirely.
+        var logs = new[]
+        {
+            Set(BackupType.TransactionLog, T(1)),
+            Set(BackupType.TransactionLog, T(2)),
+            Set(BackupType.TransactionLog, T(3)),
+            Set(BackupType.TransactionLog, T(5)),   // 04:00 missing
+            Set(BackupType.TransactionLog, T(6))
+        };
+
+        var issue = Assert.Single(_validator.Validate(Chain(Set(BackupType.Full, T(0)), null, logs)));
+
+        Assert.False(issue.IsError);
+        Assert.Contains("missing log backup", issue.Title, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_SchedulerJitter_DoesNotWarn()
+    {
+        // 5-minute logs drifting by a minute or two. Real schedules do this constantly, and
+        // warning on it would train the user to ignore the panel.
+        var logs = new[]
+        {
+            Set(BackupType.TransactionLog, T(1, 0)),
+            Set(BackupType.TransactionLog, T(1, 5)),
+            Set(BackupType.TransactionLog, T(1, 11)),
+            Set(BackupType.TransactionLog, T(1, 16)),
+            Set(BackupType.TransactionLog, T(1, 22)),
+            Set(BackupType.TransactionLog, T(1, 27))
+        };
+
+        Assert.Empty(_validator.Validate(Chain(Set(BackupType.Full, T(0)), null, logs)));
+    }
+
+    // ── ordering ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_DifferentialOlderThanItsFull_IsAnError()
+    {
+        var chain = Chain(Set(BackupType.Full, T(5)), [Set(BackupType.Differential, T(2))]);
+
+        Assert.Single(_validator.Validate(chain), i => i.IsError);
+    }
+
+    [Fact]
+    public void Validate_LogOlderThanTheChainBase_IsAnError()
+    {
+        var chain = Chain(
+            Set(BackupType.Full, T(0)),
+            [Set(BackupType.Differential, T(5))],
+            [Set(BackupType.TransactionLog, T(2))]);
+
+        Assert.Single(_validator.Validate(chain), i => i.IsError);
+    }
+
+    // ── inventory-level ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidateInventory_NoFullAtAll_IsAnError()
+    {
+        var sets = new List<BackupSet>
+        {
+            Set(BackupType.Differential, T(2)),
+            Set(BackupType.TransactionLog, T(3))
+        };
+
+        var issue = Assert.Single(_validator.ValidateInventory(sets));
+
+        Assert.True(issue.IsError);
+        Assert.Contains("No full backup", issue.Title);
+    }
+
+    [Fact]
+    public void ValidateInventory_DifferentialBeforeEarliestFull_IsFlagged()
+    {
+        var sets = new List<BackupSet>
+        {
+            Set(BackupType.Differential, T(1)),
+            Set(BackupType.Full, T(5))
+        };
+
+        Assert.Single(_validator.ValidateInventory(sets),
+            i => i.Title.Contains("no base full", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ValidateInventory_CopyOnlyFullDoesNotCountAsABase()
+    {
+        // A copy-only full cannot base a differential (#49), so a differential preceded only by
+        // a copy-only full is still orphaned.
+        var copyOnly = Set(BackupType.Full, T(1));
+        copyOnly.IsCopyOnly = true;
+
+        var sets = new List<BackupSet> { copyOnly, Set(BackupType.Differential, T(2)) };
+
+        Assert.Contains(_validator.ValidateInventory(sets), i => i.IsError);
+    }
+
+    [Fact]
+    public void ValidateInventory_HealthyInventory_IsClean()
+    {
+        var sets = new List<BackupSet>
+        {
+            Set(BackupType.Full, T(0)),
+            Set(BackupType.Differential, T(4)),
+            Set(BackupType.TransactionLog, T(5))
+        };
+
+        Assert.Empty(_validator.ValidateInventory(sets));
+    }
+
+    [Fact]
+    public void ValidateInventory_Empty_IsClean()
+        => Assert.Empty(_validator.ValidateInventory([]));
+}

--- a/src/NineLives/Services/BackupChainValidator.cs
+++ b/src/NineLives/Services/BackupChainValidator.cs
@@ -1,0 +1,226 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+public enum ChainIssueSeverity
+{
+    /// <summary>Worth knowing about, but the restore may still succeed.</summary>
+    Warning,
+
+    /// <summary>The restore cannot succeed as generated.</summary>
+    Error
+}
+
+/// <summary>A problem found in a restore chain or in the discovered backup inventory.</summary>
+public sealed class ChainIssue(ChainIssueSeverity severity, string title, string detail)
+{
+    public ChainIssueSeverity Severity { get; } = severity;
+    public string Title { get; } = title;
+    public string Detail { get; } = detail;
+
+    public bool IsError => Severity == ChainIssueSeverity.Error;
+    public string SeverityDisplay => Severity == ChainIssueSeverity.Error ? "ERROR" : "WARNING";
+
+    public override string ToString() => $"[{SeverityDisplay}] {Title} - {Detail}";
+}
+
+/// <summary>
+/// Structural validation of a restore chain, using only what discovery already knows - no server
+/// connection required.
+///
+/// The app otherwise assumes every backup it finds is present and intact. When something is
+/// missing - purged by retention, never uploaded, written elsewhere by a second job - the user
+/// finds out mid-restore, after WITH REPLACE has already dropped the target. These checks move
+/// that discovery to before the script is generated.
+///
+/// LSN-level validation (the authoritative kind, which catches breaks these checks cannot see)
+/// needs RESTORE HEADERONLY and is tracked separately.
+/// </summary>
+public class BackupChainValidator
+{
+    /// <summary>
+    /// A log interval this many times the chain's median counts as a suspected missing backup.
+    ///
+    /// 1.5 rather than something rounder: ONE missing backup on a regular schedule shows up as a
+    /// 2x interval, and a single missing log is both the most common break and the one most worth
+    /// catching. A higher factor would only ever flag two or more consecutive misses. It still
+    /// sits well clear of ordinary scheduler jitter, which is seconds against intervals of
+    /// minutes.
+    /// </summary>
+    private const double LogGapFactor = 1.5;
+
+    /// <summary>
+    /// Absolute floor for reporting a log gap, so a very frequent schedule does not generate
+    /// noise from sub-minute drift.
+    /// </summary>
+    private static readonly TimeSpan MinimumReportableLogGap = TimeSpan.FromMinutes(5);
+
+    public List<ChainIssue> Validate(BackupChain? chain)
+    {
+        var issues = new List<ChainIssue>();
+        if (chain == null) return issues;
+
+        foreach (var set in chain.AllSets)
+        {
+            CheckStripes(set, issues);
+            CheckEmptyFiles(set, issues);
+        }
+
+        CheckLogCadence(chain, issues);
+        CheckOrdering(chain, issues);
+
+        return issues;
+    }
+
+    /// <summary>
+    /// Checks the discovered inventory for a database, independent of any selected chain. Explains
+    /// backups that exist but can never be offered - otherwise they simply appear in the browse
+    /// list and silently never show up on the timeline.
+    /// </summary>
+    public List<ChainIssue> ValidateInventory(IReadOnlyList<BackupSet> sets)
+    {
+        var issues = new List<ChainIssue>();
+        if (sets.Count == 0) return issues;
+
+        var fulls = sets.Where(s => s.Type == BackupType.Full && !s.IsCopyOnly)
+            .OrderBy(s => s.Timestamp).ToList();
+
+        if (fulls.Count == 0)
+        {
+            var others = sets.Count(s => s.Type != BackupType.Full);
+            if (others > 0)
+                issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                    "No full backup found",
+                    $"{others} differential/log backup(s) were discovered but no full backup to base them on. " +
+                    "A restore must start from a full backup - check retention, or whether the full backups " +
+                    "are under a different path than the configured pattern expects."));
+            return issues;
+        }
+
+        var earliestFull = fulls[0].Timestamp;
+
+        var orphanedDiffs = sets
+            .Where(s => s.Type == BackupType.Differential && s.Timestamp < earliestFull)
+            .ToList();
+        if (orphanedDiffs.Count > 0)
+            issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
+                $"{orphanedDiffs.Count} differential backup(s) have no base full",
+                $"They predate the earliest full backup ({earliestFull:yyyy-MM-dd HH:mm}), so they cannot be " +
+                "restored and are not offered as restore points. Usually means the full they belong to has " +
+                "been removed by retention."));
+
+        var orphanedLogs = sets
+            .Where(s => s.Type == BackupType.TransactionLog && s.Timestamp <= earliestFull)
+            .ToList();
+        if (orphanedLogs.Count > 0)
+            issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
+                $"{orphanedLogs.Count} log backup(s) predate the earliest full",
+                $"Log backups at or before {earliestFull:yyyy-MM-dd HH:mm} have nothing to roll forward from " +
+                "and are not offered as restore points."));
+
+        return issues;
+    }
+
+    /// <summary>
+    /// A striped set is only restorable with EVERY stripe present - SQL Server rejects a partial
+    /// set. Stripe numbers should run 1..N with no holes.
+    ///
+    /// Note this cannot detect a uniformly truncated set (stripes 1 and 2 of an original 4), since
+    /// nothing in the filename records how many there were. It catches holes, which is the common
+    /// shape of a failed or partial upload.
+    /// </summary>
+    private static void CheckStripes(BackupSet set, List<ChainIssue> issues)
+    {
+        if (set.FileCount <= 1) return;
+
+        var stripes = set.Files
+            .Select(f => BackupSet.ParseFileName(f.FileName).stripe)
+            .Where(n => n > 0)
+            .OrderBy(n => n)
+            .ToList();
+
+        // Not a numbered stripe set - nothing to verify.
+        if (stripes.Count != set.FileCount) return;
+
+        var missing = Enumerable.Range(1, stripes[^1])
+            .Where(n => !stripes.Contains(n))
+            .ToList();
+
+        if (missing.Count > 0)
+            issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                $"{set.TypeDisplay} backup at {set.Timestamp:yyyy-MM-dd HH:mm} is missing stripe(s) " +
+                string.Join(", ", missing),
+                $"The set has {set.FileCount} file(s) numbered up to {stripes[^1]}. A striped backup cannot be " +
+                "restored unless every file is present, so this restore will fail."));
+    }
+
+    private static void CheckEmptyFiles(BackupSet set, List<ChainIssue> issues)
+    {
+        var empty = set.Files.Where(f => f.SizeBytes == 0).ToList();
+        if (empty.Count == 0) return;
+
+        issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+            $"{set.TypeDisplay} backup at {set.Timestamp:yyyy-MM-dd HH:mm} contains {empty.Count} empty file(s)",
+            $"Zero-byte blob(s): {string.Join(", ", empty.Select(f => f.FileName))}. Usually an interrupted or " +
+            "failed upload. SQL Server cannot read these."));
+    }
+
+    /// <summary>
+    /// Looks for a hole in the log sequence. A missing .trn is invisible to timestamp-based chain
+    /// building - the surrounding logs still look perfectly regular - but the restore fails at
+    /// that point with error 4305.
+    /// </summary>
+    private static void CheckLogCadence(BackupChain chain, List<ChainIssue> issues)
+    {
+        var logs = chain.LogSets.OrderBy(s => s.Timestamp).ToList();
+        if (logs.Count < 3) return; // too few to establish a cadence
+
+        var intervals = new List<TimeSpan>();
+        for (int i = 1; i < logs.Count; i++)
+            intervals.Add(logs[i].Timestamp - logs[i - 1].Timestamp);
+
+        var ordered = intervals.OrderBy(t => t).ToList();
+        var median = ordered[ordered.Count / 2];
+        if (median <= TimeSpan.Zero) return;
+
+        var threshold = TimeSpan.FromTicks((long)(median.Ticks * LogGapFactor));
+        if (threshold < MinimumReportableLogGap) threshold = MinimumReportableLogGap;
+
+        for (int i = 1; i < logs.Count; i++)
+        {
+            var gap = logs[i].Timestamp - logs[i - 1].Timestamp;
+            if (gap <= threshold) continue;
+
+            issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
+                $"Possible missing log backup around {logs[i - 1].Timestamp:yyyy-MM-dd HH:mm}",
+                $"A {FormatGap(gap)} gap between log backups, against a typical interval of {FormatGap(median)}. " +
+                "If a log backup is missing the restore will stop there with error 4305. A schedule change or " +
+                "maintenance window is the other likely explanation."));
+        }
+    }
+
+    private static void CheckOrdering(BackupChain chain, List<ChainIssue> issues)
+    {
+        foreach (var diff in chain.DiffSets.Where(d => d.Timestamp < chain.FullSet.Timestamp))
+            issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                "Differential predates its full backup",
+                $"The differential at {diff.Timestamp:yyyy-MM-dd HH:mm} is older than the full at " +
+                $"{chain.FullSet.Timestamp:yyyy-MM-dd HH:mm}, so it cannot be applied to it."));
+
+        var logs = chain.LogSets.OrderBy(s => s.Timestamp).ToList();
+        var chainStart = chain.DiffSets.Count > 0
+            ? chain.DiffSets[^1].Timestamp
+            : chain.FullSet.Timestamp;
+
+        foreach (var log in logs.Where(l => l.Timestamp < chainStart))
+            issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                "Log backup predates the base of the chain",
+                $"The log at {log.Timestamp:yyyy-MM-dd HH:mm} is older than the point the database is restored " +
+                $"to ({chainStart:yyyy-MM-dd HH:mm}) and cannot be applied."));
+    }
+
+    private static string FormatGap(TimeSpan gap)
+        => gap.TotalHours >= 1
+            ? $"{gap.TotalHours:F1} hour"
+            : $"{gap.TotalMinutes:F0} minute";
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -16,6 +16,7 @@ public partial class RestoreViewModel : ViewModelBase
     private readonly SqlServerService _sqlService;
     private readonly BackupChainBuilder _chainBuilder;
     private readonly RestoreScriptGenerator _scriptGenerator;
+    private readonly BackupChainValidator _chainValidator = new();
     private readonly CredentialStore _credentialStore;
 
     private List<BackupFileInfo> _allBackups = [];
@@ -135,6 +136,24 @@ public partial class RestoreViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _hasPointInTimeError;
+
+    // ── Chain gap detection ──────────────────────────────────────────────────────
+    // Structural validation of the selected chain, run at selection time. The app otherwise
+    // assumes every discovered backup is present and intact, so a missing stripe or a hole in
+    // the log sequence only surfaces mid-restore - after WITH REPLACE has dropped the target.
+
+    [ObservableProperty]
+    private ObservableCollection<ChainIssue> _chainIssues = [];
+
+    [ObservableProperty]
+    private bool _hasChainIssues;
+
+    /// <summary>True when at least one issue makes the restore impossible as generated.</summary>
+    [ObservableProperty]
+    private bool _hasChainErrors;
+
+    [ObservableProperty]
+    private string _chainIssueSummary = string.Empty;
 
     [ObservableProperty]
     private bool _disconnectSessions = true;
@@ -418,6 +437,7 @@ public partial class RestoreViewModel : ViewModelBase
             ChainSets.Clear();
             ChainSummary = string.Empty;
             UpdatePointInTimeWindow(null);
+            UpdateChainIssues(null);
             FetchedFileMoves = [];
             HasFetchedFileMoves = false;
             BackupMetadataSummary = null;
@@ -435,6 +455,7 @@ public partial class RestoreViewModel : ViewModelBase
         ChainSets = new ObservableCollection<BackupSet>(chain.AllSets);
         ChainSummary = $"{chain.Summary} | {chain.FileCount} files | Target: {value.Timestamp:yyyy-MM-dd HH:mm:ss}";
         UpdatePointInTimeWindow(value);
+        UpdateChainIssues(chain);
         UpdateRestoreSummary();
         FetchLogicalNamesCommand.NotifyCanExecuteChanged();
         InspectBackupMetadataCommand.NotifyCanExecuteChanged();
@@ -770,6 +791,30 @@ public partial class RestoreViewModel : ViewModelBase
         UsePointInTime = false;
         StopAtText = window.Value.Latest.ToString(StopAtFormat);
         ValidatePointInTime();
+    }
+
+    private void UpdateChainIssues(BackupChain? chain)
+    {
+        var issues = _chainValidator.Validate(chain);
+
+        ChainIssues = new ObservableCollection<ChainIssue>(issues);
+        HasChainIssues = issues.Count > 0;
+        HasChainErrors = issues.Any(i => i.IsError);
+
+        if (issues.Count == 0)
+        {
+            ChainIssueSummary = string.Empty;
+            return;
+        }
+
+        var errors = issues.Count(i => i.IsError);
+        var warnings = issues.Count - errors;
+
+        ChainIssueSummary = errors > 0 && warnings > 0
+            ? $"{errors} problem(s) will prevent this restore, and {warnings} warning(s)"
+            : errors > 0
+                ? $"{errors} problem(s) will prevent this restore"
+                : $"{warnings} warning(s) about this chain";
     }
 
     private const string StopAtFormat = "yyyy-MM-dd HH:mm:ss";
@@ -1166,6 +1211,17 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (string.IsNullOrEmpty(GeneratedScript) || !IsConnectedToServer)
             return;
+
+        // Refuse to arm when the chain cannot possibly restore. This is the last safe moment:
+        // once execution starts, WITH REPLACE drops the target database, and a chain that fails
+        // partway leaves nothing usable behind. Failing here costs the user a few seconds;
+        // failing mid-restore costs them the database they were restoring over.
+        if (HasChainErrors && !IsExecuteArmed)
+        {
+            var first = ChainIssues.First(i => i.IsError);
+            SetError($"Cannot execute: {first.Title}. {first.Detail}");
+            return;
+        }
 
         if (!IsExecuteArmed)
         {

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -341,6 +341,50 @@
                         </Button>
                     </Grid>
 
+                    <!-- Chain gap detection: always visible when something is wrong, so a missing
+                         stripe or a hole in the log sequence is seen BEFORE the script is run,
+                         not after WITH REPLACE has already dropped the target database. -->
+                    <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                            Visibility="{Binding HasChainIssues, Converter={StaticResource BoolToVis}}">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Background" Value="#332B1A" />
+                                <Setter Property="BorderBrush" Value="#8A6D2F" />
+                                <Setter Property="BorderThickness" Value="1" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasChainErrors}" Value="True">
+                                        <Setter Property="Background" Value="#3A1E1E" />
+                                        <Setter Property="BorderBrush" Value="#A33F3F" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="{Binding ChainIssueSummary}"
+                                       FontWeight="SemiBold"
+                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8" />
+                            <ItemsControl ItemsSource="{Binding ChainIssues}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Margin="0,0,0,8">
+                                            <TextBlock TextWrapping="Wrap" FontWeight="SemiBold">
+                                                <Run Text="{Binding SeverityDisplay, Mode=OneWay}" />
+                                                <Run Text="  " />
+                                                <Run Text="{Binding Title, Mode=OneWay}" />
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Detail}"
+                                                       Style="{StaticResource SecondaryText}"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,2,0,0" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
                     <!-- Restore Chain Detail (togglable) -->
                     <Border Background="{StaticResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="12" Margin="0,12,0,0"


### PR DESCRIPTION
Closes #62 (phase 1 — structural detection, no server connection required).

## Why

The app assumed every backup it discovered was present and intact. When one was missing — purged by retention, never uploaded, written elsewhere by a second job — nothing said so, and the user found out **mid-restore**.

That is the worst failure this tool can produce. `WITH REPLACE` is on by default, so a chain that fails partway has *already dropped the database it was restoring over*. The information needed to predict it was sitting in the discovery data the whole time.

## What it checks

| Check | Severity | Why |
|---|---|---|
| Missing stripes in a set | **Error** | SQL Server cannot restore a partial striped set |
| Zero-byte files | **Error** | Signature of an interrupted upload |
| Hole in the log sequence | Warning | A missing `.trn` fails the restore at that point with 4305 |
| Differential older than its full | **Error** | Cannot be applied to it |
| Log older than the chain base | **Error** | Cannot be applied |
| No full backup at all *(inventory)* | **Error** | Nothing to restore from |
| Differentials/logs predating the earliest full *(inventory)* | Warning | Explains backups that appear in browse but are never offered |

The stripe check honestly cannot detect a *uniformly truncated* set — stripes 1 and 2 of an original 4 — because nothing in the filename records how many there were. It catches **holes**, which is the common shape of a partial upload.

## Surfacing

A panel above the chain detail, amber for warnings and red for errors, visible whenever there is something to say. Errors additionally **refuse to arm Execute** — that is the last moment before `WITH REPLACE` runs, and failing there costs seconds where failing mid-restore costs the database.

## A test drove a real design change

I first wrote the log-cadence threshold at **3× the median**. A test with one hourly log missing then failed — and it was right to. A 3× factor only ever flags *two or more consecutive* misses; a single missing log shows up as a 2× interval and would have sailed through. Since a single missing log is both the most common break and the most important to catch, the factor is now **1.5×**, with a 5-minute absolute floor so frequent schedules do not generate noise from drift.

Both behaviours are now pinned: `Validate_SingleMissingLog_IsWarned` and `Validate_SchedulerJitter_DoesNotWarn`.

## Validated against real backups

A detector that fires on healthy data is worse than none — the user learns to ignore the panel. So I ran it against a live 24-day production-shaped backup set:

```
=== INVENTORY VALIDATION ===
  clean

=== CHAIN VALIDATION ACROSS ALL RESTORE POINTS ===
  clean          : 114/114
  with warnings  : 0
  with errors    : 0
```

**Zero false positives.** Then I broke real chains synthetically to confirm it actually fires:

```
real chain (11 logs)                              : 0 issue(s)
same chain with 1 log removed                     : 1 issue(s)
  -> Possible missing log backup around 2026-08-05 04:00

real 4-file striped full with stripe 2 removed    : 1 issue(s)
  -> [ERROR] Full backup at 2026-07-11 22:09 is missing stripe(s) 2
```

## Tests

20 new, **248 total**. App smoke-launched to confirm the new panel loads.

## Phase 2

Authoritative **LSN validation** via `RESTORE HEADERONLY` — which catches breaks timestamps cannot see, such as a log taken by a different job to a different destination — is #23, and is the natural next step. The structural checks here are deliberately independent of it so they work with no server connected.
