### PR TITLE
Validate the restore chain against backup headers

### DIFF
--- a/src/NineLives.Tests/BackupChainValidatorTests.cs
+++ b/src/NineLives.Tests/BackupChainValidatorTests.cs
@@ -211,7 +211,64 @@ public class BackupChainValidatorTests
             Set(BackupType.TransactionLog, T(1, 27))
         };
 
-        Assert.Empty(_validator.Validate(Chain(Set(BackupType.Full, T(0)), null, logs)));
+        // Full immediately before the first log, so this test isolates jitter between logs and
+        // does not accidentally describe a coverage gap after the full.
+        Assert.Empty(_validator.Validate(Chain(Set(BackupType.Full, T(0, 57)), null, logs)));
+    }
+
+    // ── log coverage reaching back to the data backup ────────────────────────────
+
+    [Fact]
+    public void Validate_FirstLogLongAfterTheDifferential_IsWarned()
+    {
+        // The retention shape found on real data: logs kept for days, fulls and differentials for
+        // weeks, so the oldest surviving log sits long after the differential and cannot connect
+        // to it. The chain looks complete - regular hourly logs - but will fail with 4305.
+        var chain = Chain(
+            Set(BackupType.Full, T(0)),
+            [Set(BackupType.Differential, T(1))],
+            [
+                Set(BackupType.TransactionLog, T(14)),
+                Set(BackupType.TransactionLog, T(15)),
+                Set(BackupType.TransactionLog, T(16)),
+                Set(BackupType.TransactionLog, T(17))
+            ]);
+
+        var issue = Assert.Single(_validator.Validate(chain));
+
+        Assert.False(issue.IsError);
+        Assert.Contains("may not reach back", issue.Title);
+        Assert.Contains("4305", issue.Detail);
+    }
+
+    [Fact]
+    public void Validate_FirstLogShortlyAfterTheFull_IsClean()
+    {
+        // A full at 00:00 with hourly logs starting at 01:00 is entirely normal.
+        var chain = Chain(
+            Set(BackupType.Full, T(0)),
+            null,
+            [
+                Set(BackupType.TransactionLog, T(1)),
+                Set(BackupType.TransactionLog, T(2)),
+                Set(BackupType.TransactionLog, T(3)),
+                Set(BackupType.TransactionLog, T(4))
+            ]);
+
+        Assert.Empty(_validator.Validate(chain));
+    }
+
+    [Fact]
+    public void Validate_TooFewLogsToJudgeCoverage_ProducesNoWarning()
+    {
+        // With one log there is no cadence to compare against - only the LSN check can tell,
+        // and claiming otherwise would be guessing.
+        var chain = Chain(
+            Set(BackupType.Full, T(0)),
+            [Set(BackupType.Differential, T(1))],
+            [Set(BackupType.TransactionLog, T(20))]);
+
+        Assert.Empty(_validator.Validate(chain));
     }
 
     // ── ordering ─────────────────────────────────────────────────────────────────

--- a/src/NineLives.Tests/LsnChainValidationTests.cs
+++ b/src/NineLives.Tests/LsnChainValidationTests.cs
@@ -1,0 +1,264 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// LSN-level chain validation — the authoritative check, against what SQL Server recorded inside
+/// each backup rather than what the filename suggests.
+///
+/// The LSN values and relationships here mirror those measured from a real backup set before the
+/// rules were written:
+///   diff.DatabaseBackupLSN == full.CheckpointLSN
+///   consecutive logs meet exactly: log[i].FirstLSN == log[i-1].LastLSN
+///   only the FIRST log spans the recovery point
+/// </summary>
+public class LsnChainValidationTests
+{
+    private readonly BackupChainValidator _validator = new();
+
+    private static DateTime T(int hour) => new(2026, 8, 4, hour, 0, 0);
+
+    private static BackupSet Set(BackupType type, DateTime timestamp, string? db = "Utility") => new()
+    {
+        SetId = timestamp.ToString("yyyyMMdd_HHmmss"),
+        Type = type,
+        Timestamp = timestamp,
+        DatabaseName = db,
+        Files = [new BackupFileInfo { BlobName = $"{timestamp:yyyyMMdd_HHmmss}.bak", Type = type, SizeBytes = 100 }]
+    };
+
+    private static BackupFileInfo Header(
+        BackupType type,
+        decimal firstLsn, decimal lastLsn,
+        decimal? checkpointLsn = null,
+        decimal? databaseBackupLsn = null,
+        string db = "Utility") => new()
+        {
+            Type = type,
+            DatabaseName = db,
+            FirstLsn = firstLsn,
+            LastLsn = lastLsn,
+            CheckpointLsn = checkpointLsn ?? firstLsn,
+            DatabaseBackupLsn = databaseBackupLsn
+        };
+
+    // A healthy full + diff + 3 logs, using realistic LSN spacing.
+    private const decimal FullFirst = 481000000008800001m;
+    private const decimal FullLast = 481000000011200001m;
+    private const decimal DiffFirst = 482000001412800001m;
+    private const decimal DiffLast = 482000001415200001m;
+    private const decimal Log1First = 482000001058400001m;
+    private const decimal Log1Last = 482000001946400001m;
+    private const decimal Log2Last = 482000001967200001m;
+    private const decimal Log3Last = 482000001986400001m;
+
+    private static (BackupChain chain, List<ChainHeader> headers) HealthyChain()
+    {
+        var full = Set(BackupType.Full, T(0));
+        var diff = Set(BackupType.Differential, T(4));
+        var log1 = Set(BackupType.TransactionLog, T(5));
+        var log2 = Set(BackupType.TransactionLog, T(6));
+        var log3 = Set(BackupType.TransactionLog, T(7));
+
+        var chain = new BackupChain { FullSet = full, DiffSets = [diff], LogSets = [log1, log2, log3] };
+
+        var headers = new List<ChainHeader>
+        {
+            new(full, Header(BackupType.Full, FullFirst, FullLast, checkpointLsn: FullFirst)),
+            new(diff, Header(BackupType.Differential, DiffFirst, DiffLast, databaseBackupLsn: FullFirst)),
+            new(log1, Header(BackupType.TransactionLog, Log1First, Log1Last)),
+            new(log2, Header(BackupType.TransactionLog, Log1Last, Log2Last)),
+            new(log3, Header(BackupType.TransactionLog, Log2Last, Log3Last))
+        };
+
+        return (chain, headers);
+    }
+
+    [Fact]
+    public void ValidateLsnChain_HealthyChain_IsClean()
+    {
+        var (chain, headers) = HealthyChain();
+        Assert.Empty(_validator.ValidateLsnChain(chain, headers));
+    }
+
+    [Fact]
+    public void ValidateLsnChain_NoHeaders_ProducesNothing()
+        => Assert.Empty(_validator.ValidateLsnChain(HealthyChain().chain, []));
+
+    [Fact]
+    public void ValidateLsnChain_LaterLogsNeedNotSpanTheRecoveryPoint()
+    {
+        // Measured behaviour: only the first log spans the base point; later logs start after it.
+        // Requiring all of them to span it would reject every valid chain.
+        var (chain, headers) = HealthyChain();
+
+        var issues = _validator.ValidateLsnChain(chain, headers);
+
+        Assert.DoesNotContain(issues, i => i.Title.Contains("starts too late"));
+    }
+
+    // ── differential base ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidateLsnChain_DifferentialFromADifferentFull_IsAnError()
+    {
+        // The copy-only scenario as SQL Server sees it: timestamps look fine, but the
+        // differential's DatabaseBackupLSN points at a full that is not the one in the chain.
+        var (chain, headers) = HealthyChain();
+        var diff = chain.DiffSets[0];
+        headers[1] = new ChainHeader(diff,
+            Header(BackupType.Differential, DiffFirst, DiffLast, databaseBackupLsn: 999000000000000001m));
+
+        var issue = Assert.Single(_validator.ValidateLsnChain(chain, headers), i => i.IsError);
+
+        Assert.Contains("not based on this full", issue.Title);
+        Assert.Contains("3136", issue.Detail);
+    }
+
+    [Fact]
+    public void ValidateLsnChain_DifferentialMatchingCheckpointLsn_IsAccepted()
+    {
+        // The rule is against CheckpointLSN specifically, not FirstLSN - they coincide on many
+        // fulls but are not the same field.
+        var full = Set(BackupType.Full, T(0));
+        var diff = Set(BackupType.Differential, T(4));
+        var chain = new BackupChain { FullSet = full, DiffSets = [diff] };
+
+        var headers = new List<ChainHeader>
+        {
+            new(full, Header(BackupType.Full, firstLsn: 100m, lastLsn: 200m, checkpointLsn: 150m)),
+            new(diff, Header(BackupType.Differential, 300m, 400m, databaseBackupLsn: 150m))
+        };
+
+        Assert.Empty(_validator.ValidateLsnChain(chain, headers));
+    }
+
+    [Fact]
+    public void ValidateLsnChain_DifferentialMatchingFirstLsnButNotCheckpoint_IsRejected()
+    {
+        var full = Set(BackupType.Full, T(0));
+        var diff = Set(BackupType.Differential, T(4));
+        var chain = new BackupChain { FullSet = full, DiffSets = [diff] };
+
+        var headers = new List<ChainHeader>
+        {
+            new(full, Header(BackupType.Full, firstLsn: 100m, lastLsn: 200m, checkpointLsn: 150m)),
+            new(diff, Header(BackupType.Differential, 300m, 400m, databaseBackupLsn: 100m))
+        };
+
+        Assert.Single(_validator.ValidateLsnChain(chain, headers), i => i.IsError);
+    }
+
+    // ── log continuity ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidateLsnChain_GapBetweenLogs_IsAnError()
+    {
+        // The break timestamps cannot see: a log taken by another job to another destination.
+        // The visible sequence stays perfectly regular; the LSN chain does not.
+        var (chain, headers) = HealthyChain();
+        headers[3] = new ChainHeader(chain.LogSets[1],
+            Header(BackupType.TransactionLog, Log1Last + 5000m, Log2Last));
+
+        var issue = Assert.Single(_validator.ValidateLsnChain(chain, headers), i => i.IsError);
+
+        Assert.Contains("Break in the log chain", issue.Title);
+        Assert.Contains("4305", issue.Detail);
+    }
+
+    [Fact]
+    public void ValidateLsnChain_OverlappingLogs_AreAccepted()
+    {
+        // An overlap is not a gap - it restores fine.
+        var (chain, headers) = HealthyChain();
+        headers[3] = new ChainHeader(chain.LogSets[1],
+            Header(BackupType.TransactionLog, Log1Last - 5000m, Log2Last));
+
+        Assert.Empty(_validator.ValidateLsnChain(chain, headers));
+    }
+
+    [Fact]
+    public void ValidateLsnChain_FirstLogStartsAfterTheRecoveryPoint_IsAnError()
+    {
+        var (chain, headers) = HealthyChain();
+        headers[2] = new ChainHeader(chain.LogSets[0],
+            Header(BackupType.TransactionLog, DiffLast + 1000m, Log1Last));
+
+        Assert.Single(_validator.ValidateLsnChain(chain, headers),
+            i => i.IsError && i.Title.Contains("starts too late"));
+    }
+
+    // ── identity and type ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidateLsnChain_ChainMixingTwoDatabases_IsAnError()
+    {
+        var (chain, headers) = HealthyChain();
+        headers[2] = new ChainHeader(chain.LogSets[0],
+            Header(BackupType.TransactionLog, Log1First, Log1Last, db: "SomeOtherDatabase"));
+
+        Assert.Single(_validator.ValidateLsnChain(chain, headers),
+            i => i.IsError && i.Title.Contains("different databases"));
+    }
+
+    [Fact]
+    public void ValidateLsnChain_HeaderDatabaseDiffersFromThePath_IsAWarning()
+    {
+        // Every header agrees, but the path pattern inferred a different name - the backups are
+        // consistent, the parsing is not.
+        var full = Set(BackupType.Full, T(0), db: "PathSaysThis");
+        var chain = new BackupChain { FullSet = full };
+        var headers = new List<ChainHeader>
+        {
+            new(full, Header(BackupType.Full, 100m, 200m, db: "HeaderSaysThat"))
+        };
+
+        var issue = Assert.Single(_validator.ValidateLsnChain(chain, headers));
+
+        Assert.False(issue.IsError);
+        Assert.Contains("different database than the path suggests", issue.Title);
+    }
+
+    [Fact]
+    public void ValidateLsnChain_FilenameTypeContradictsTheHeader_IsAnError()
+    {
+        // Catches a misparsed filename - e.g. a log backup written with a .bak extension and
+        // therefore classified as a full.
+        var set = Set(BackupType.Full, T(0));
+        var chain = new BackupChain { FullSet = set };
+        var headers = new List<ChainHeader>
+        {
+            new(set, Header(BackupType.TransactionLog, 100m, 200m))
+        };
+
+        Assert.Single(_validator.ValidateLsnChain(chain, headers),
+            i => i.IsError && i.Title.Contains("not the type its filename suggests"));
+    }
+
+    // ── partial reads ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ValidateLsnChain_UnreadableMember_WarnsAndKeepsCheckingTheRest()
+    {
+        var (chain, headers) = HealthyChain();
+        headers[3] = new ChainHeader(chain.LogSets[1], null);   // header read failed
+
+        var issues = _validator.ValidateLsnChain(chain, headers);
+
+        Assert.Contains(issues, i => !i.IsError && i.Title.Contains("Could not read"));
+        // The unreadable member is skipped rather than reported as a break.
+        Assert.DoesNotContain(issues, i => i.Title.Contains("Break in the log chain"));
+    }
+
+    [Fact]
+    public void ValidateLsnChain_MissingLsnValues_AreSkippedNotReportedAsBreaks()
+    {
+        var (chain, headers) = HealthyChain();
+        headers[3] = new ChainHeader(chain.LogSets[1],
+            new BackupFileInfo { Type = BackupType.TransactionLog, DatabaseName = "Utility" });
+
+        Assert.DoesNotContain(_validator.ValidateLsnChain(chain, headers), i => i.IsError);
+    }
+}

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -46,7 +46,19 @@ public class BackupFileInfo
     public int? BackupTypeCode { get; set; }
     public decimal? FirstLsn { get; set; }
     public decimal? LastLsn { get; set; }
+
+    /// <summary>
+    /// For a differential, the CheckpointLSN of the full backup it is based on. Comparing this
+    /// against a candidate full's CheckpointLSN is the authoritative test of whether the pair
+    /// actually belongs together - timestamps only suggest it.
+    /// </summary>
     public decimal? DatabaseBackupLsn { get; set; }
+
+    /// <summary>
+    /// LSN of the checkpoint taken during this backup. A differential's DatabaseBackupLSN must
+    /// equal its base full's CheckpointLSN.
+    /// </summary>
+    public decimal? CheckpointLsn { get; set; }
 
     public bool HasDetailedMetadata => BackupStartDate.HasValue;
 

--- a/src/NineLives/Services/BackupChainValidator.cs
+++ b/src/NineLives/Services/BackupChainValidator.cs
@@ -25,6 +25,12 @@ public sealed class ChainIssue(ChainIssueSeverity severity, string title, string
 }
 
 /// <summary>
+/// One member of a chain paired with what RESTORE HEADERONLY said about it.
+/// <paramref name="Header"/> is null when the read failed or was not attempted.
+/// </summary>
+public sealed record ChainHeader(BackupSet Set, BackupFileInfo? Header);
+
+/// <summary>
 /// Structural validation of a restore chain, using only what discovery already knows - no server
 /// connection required.
 ///
@@ -55,6 +61,15 @@ public class BackupChainValidator
     /// </summary>
     private static readonly TimeSpan MinimumReportableLogGap = TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// The interval between the data backup and the FIRST log is inherently looser than the
+    /// interval between logs: the full itself takes time to run, and the log schedule is
+    /// independent of it, so the first log often lands most of an interval later. A tighter
+    /// factor here would warn on healthy chains - a full finishing at 22:09 with hourly logs on
+    /// the hour leaves a perfectly normal 51 minute gap.
+    /// </summary>
+    private const double LogCoverageStartFactor = 3.0;
+
     public List<ChainIssue> Validate(BackupChain? chain)
     {
         var issues = new List<ChainIssue>();
@@ -67,6 +82,7 @@ public class BackupChainValidator
         }
 
         CheckLogCadence(chain, issues);
+        CheckLogCoverageStart(chain, issues);
         CheckOrdering(chain, issues);
 
         return issues;
@@ -175,13 +191,9 @@ public class BackupChainValidator
         var logs = chain.LogSets.OrderBy(s => s.Timestamp).ToList();
         if (logs.Count < 3) return; // too few to establish a cadence
 
-        var intervals = new List<TimeSpan>();
-        for (int i = 1; i < logs.Count; i++)
-            intervals.Add(logs[i].Timestamp - logs[i - 1].Timestamp);
-
-        var ordered = intervals.OrderBy(t => t).ToList();
-        var median = ordered[ordered.Count / 2];
-        if (median <= TimeSpan.Zero) return;
+        var medianOrNull = MedianLogInterval(logs);
+        if (medianOrNull == null) return;
+        var median = medianOrNull.Value;
 
         var threshold = TimeSpan.FromTicks((long)(median.Ticks * LogGapFactor));
         if (threshold < MinimumReportableLogGap) threshold = MinimumReportableLogGap;
@@ -197,6 +209,62 @@ public class BackupChainValidator
                 "If a log backup is missing the restore will stop there with error 4305. A schedule change or " +
                 "maintenance window is the other likely explanation."));
         }
+    }
+
+    /// <summary>
+    /// Checks the first log follows closely enough behind the data backup to continue from it.
+    ///
+    /// Retention is the usual cause of a failure here: log backups are commonly kept for days
+    /// while fulls and differentials are kept for weeks, so the oldest surviving log can sit long
+    /// after the differential that precedes it, with everything in between purged. The chain
+    /// looks complete - a full, a differential and a run of regularly spaced logs - but the logs
+    /// cannot connect to the data backup, and the restore fails with 4305.
+    ///
+    /// Found on real data: an offered restore point whose only log began nearly four days after
+    /// its differential. The cadence check could not see it, because it only ever compares logs
+    /// against each other.
+    ///
+    /// Needs at least three logs to establish a cadence. With fewer, only the LSN check can tell.
+    /// </summary>
+    private static void CheckLogCoverageStart(BackupChain chain, List<ChainIssue> issues)
+    {
+        var logs = chain.LogSets.OrderBy(s => s.Timestamp).ToList();
+        if (logs.Count < 3) return;
+
+        var median = MedianLogInterval(logs);
+        if (median == null) return;
+
+        var chainBase = chain.DiffSets.Count > 0
+            ? chain.DiffSets[^1]
+            : chain.FullSet;
+
+        var gap = logs[0].Timestamp - chainBase.Timestamp;
+        if (gap <= TimeSpan.Zero) return;
+
+        var threshold = TimeSpan.FromTicks((long)(median.Value.Ticks * LogCoverageStartFactor));
+        if (threshold < MinimumReportableLogGap) threshold = MinimumReportableLogGap;
+        if (gap <= threshold) return;
+
+        issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
+            "Log backups may not reach back to the data backup",
+            $"The first log is {FormatGap(gap)} after the {chainBase.TypeDisplay.ToLowerInvariant()} backup at " +
+            $"{chainBase.Timestamp:yyyy-MM-dd HH:mm}, against a typical log interval of {FormatGap(median.Value)}. " +
+            "Log backups covering that period appear to be missing - commonly because logs are kept for a " +
+            "shorter retention than fulls and differentials. The restore would fail with error 4305. " +
+            "Validate Chain will confirm against the backup headers."));
+    }
+
+    private static TimeSpan? MedianLogInterval(IReadOnlyList<BackupSet> logs)
+    {
+        if (logs.Count < 2) return null;
+
+        var intervals = new List<TimeSpan>();
+        for (int i = 1; i < logs.Count; i++)
+            intervals.Add(logs[i].Timestamp - logs[i - 1].Timestamp);
+
+        var ordered = intervals.OrderBy(t => t).ToList();
+        var median = ordered[ordered.Count / 2];
+        return median > TimeSpan.Zero ? median : null;
     }
 
     private static void CheckOrdering(BackupChain chain, List<ChainIssue> issues)
@@ -217,6 +285,141 @@ public class BackupChainValidator
                 "Log backup predates the base of the chain",
                 $"The log at {log.Timestamp:yyyy-MM-dd HH:mm} is older than the point the database is restored " +
                 $"to ({chainStart:yyyy-MM-dd HH:mm}) and cannot be applied."));
+    }
+
+    /// <summary>
+    /// Authoritative validation against RESTORE HEADERONLY metadata.
+    ///
+    /// The structural checks above reason about filenames and timestamps. This reasons about what
+    /// SQL Server itself recorded inside the backups, which catches breaks the others physically
+    /// cannot see - a log taken by a different job to a different destination leaves the visible
+    /// sequence looking perfectly regular while the LSN chain is broken.
+    ///
+    /// Rules were confirmed against a real backup set before being encoded:
+    ///   - a differential's DatabaseBackupLSN equals its base full's CheckpointLSN
+    ///   - consecutive logs meet exactly: log[i].FirstLSN == log[i-1].LastLSN
+    ///   - only the FIRST log spans the recovery point; later ones start after it, so requiring
+    ///     every log to span it would reject valid chains
+    /// </summary>
+    public List<ChainIssue> ValidateLsnChain(BackupChain? chain, IReadOnlyList<ChainHeader> headers)
+    {
+        var issues = new List<ChainIssue>();
+        if (chain == null || headers.Count == 0) return issues;
+
+        BackupFileInfo? HeaderFor(BackupSet set) =>
+            headers.FirstOrDefault(h => ReferenceEquals(h.Set, set))?.Header;
+
+        var unread = headers.Where(h => h.Header == null).ToList();
+        if (unread.Count > 0)
+            issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
+                $"Could not read {unread.Count} backup header(s)",
+                "Those members could not be verified. The blob may be unreadable, or the server's " +
+                "credential may not cover it. Validation below is incomplete."));
+
+        CheckDatabaseIdentity(chain, headers, issues);
+        CheckDeclaredTypes(headers, issues);
+
+        var fullHeader = HeaderFor(chain.FullSet);
+
+        // Differential base: the only authoritative test that a differential belongs to this full.
+        foreach (var diff in chain.DiffSets)
+        {
+            var diffHeader = HeaderFor(diff);
+            if (diffHeader?.DatabaseBackupLsn == null || fullHeader?.CheckpointLsn == null) continue;
+
+            if (diffHeader.DatabaseBackupLsn != fullHeader.CheckpointLsn)
+                issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                    $"Differential at {diff.Timestamp:yyyy-MM-dd HH:mm} is not based on this full backup",
+                    $"Its DatabaseBackupLSN ({diffHeader.DatabaseBackupLsn}) does not match the full backup's " +
+                    $"CheckpointLSN ({fullHeader.CheckpointLsn}). It belongs to a different full - most often " +
+                    "because a copy-only or ad-hoc full was taken in between. The restore would fail with " +
+                    "error 3136."));
+        }
+
+        CheckLogLsnContinuity(chain, HeaderFor, issues);
+
+        return issues;
+    }
+
+    private static void CheckDatabaseIdentity(
+        BackupChain chain, IReadOnlyList<ChainHeader> headers, List<ChainIssue> issues)
+    {
+        var names = headers
+            .Where(h => h.Header?.DatabaseName != null)
+            .Select(h => h.Header!.DatabaseName!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (names.Count > 1)
+            issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                "Chain mixes backups of different databases",
+                $"The headers report {string.Join(", ", names)}. This usually means the blob path pattern " +
+                "is parsing the folder structure incorrectly, so unrelated backups have been grouped " +
+                "together. Restoring this chain would fail, or restore the wrong data."));
+
+        // The name discovery inferred from the path should agree with what is inside the backup.
+        var expected = chain.FullSet.DatabaseName;
+        if (!string.IsNullOrWhiteSpace(expected) && names.Count == 1
+            && !string.Equals(expected, names[0], StringComparison.OrdinalIgnoreCase))
+            issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
+                "Backup contains a different database than the path suggests",
+                $"The path indicates '{expected}' but the backup header says '{names[0]}'. The restore will " +
+                "use the contents of the backup - check the blob path pattern is correct for this container."));
+    }
+
+    private static void CheckDeclaredTypes(IReadOnlyList<ChainHeader> headers, List<ChainIssue> issues)
+    {
+        // Catches a misparsed filename: a log written with a .bak extension, or a copy-only full
+        // classified as a regular one. The header is the truth; the filename is a guess.
+        foreach (var h in headers)
+        {
+            if (h.Header == null || h.Header.Type == BackupType.Unknown) continue;
+            if (h.Header.Type == h.Set.Type) continue;
+
+            issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                $"Backup at {h.Set.Timestamp:yyyy-MM-dd HH:mm} is not the type its filename suggests",
+                $"It was treated as a {h.Set.TypeDisplay} backup, but the header says it is a " +
+                $"{h.Header.TypeDisplay} backup. The chain was built on the wrong assumption."));
+        }
+    }
+
+    private static void CheckLogLsnContinuity(
+        BackupChain chain, Func<BackupSet, BackupFileInfo?> headerFor, List<ChainIssue> issues)
+    {
+        var logs = chain.LogSets.OrderBy(s => s.Timestamp).ToList();
+        if (logs.Count == 0) return;
+
+        // The point the database reaches after the data backups are restored.
+        var basePoint = chain.DiffSets.Count > 0
+            ? headerFor(chain.DiffSets[^1])?.LastLsn
+            : headerFor(chain.FullSet)?.LastLsn;
+
+        var firstHeader = headerFor(logs[0]);
+        if (basePoint != null && firstHeader?.FirstLsn != null && firstHeader.LastLsn != null)
+        {
+            // Only the first log must span the base point - later logs legitimately start after it.
+            if (firstHeader.FirstLsn > basePoint)
+                issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                    "The log chain starts too late to follow the data backup",
+                    $"The first log begins at LSN {firstHeader.FirstLsn}, after the restore point of " +
+                    $"{basePoint}. A log backup covering that point is missing, so the restore would fail " +
+                    "with error 4305."));
+        }
+
+        for (int i = 1; i < logs.Count; i++)
+        {
+            var previous = headerFor(logs[i - 1]);
+            var current = headerFor(logs[i]);
+            if (previous?.LastLsn == null || current?.FirstLsn == null) continue;
+
+            if (current.FirstLsn > previous.LastLsn)
+                issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                    $"Break in the log chain before {logs[i].Timestamp:yyyy-MM-dd HH:mm}",
+                    $"This log begins at LSN {current.FirstLsn} but the previous one ended at " +
+                    $"{previous.LastLsn}, leaving a gap. A log backup is missing from the container - " +
+                    "possibly taken by another job to a different destination. The restore would fail " +
+                    "with error 4305."));
+        }
     }
 
     private static string FormatGap(TimeSpan gap)

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -103,7 +103,8 @@ public class SqlServerService
                 },
                 FirstLsn = GetDecimalFromReader(reader, "FirstLSN"),
                 LastLsn = GetDecimalFromReader(reader, "LastLSN"),
-                DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN")
+                DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN"),
+            CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN")
             });
         }
         return results;
@@ -183,7 +184,8 @@ public class SqlServerService
             },
             FirstLsn = GetDecimalFromReader(reader, "FirstLSN"),
             LastLsn = GetDecimalFromReader(reader, "LastLSN"),
-            DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN")
+            DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN"),
+            CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN")
         };
     }
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -155,6 +155,13 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _chainIssueSummary = string.Empty;
 
+    /// <summary>True once the chain has been checked against RESTORE HEADERONLY metadata.</summary>
+    [ObservableProperty]
+    private bool _chainLsnVerified;
+
+    [ObservableProperty]
+    private bool _isValidatingChain;
+
     [ObservableProperty]
     private bool _disconnectSessions = true;
 
@@ -455,7 +462,11 @@ public partial class RestoreViewModel : ViewModelBase
         ChainSets = new ObservableCollection<BackupSet>(chain.AllSets);
         ChainSummary = $"{chain.Summary} | {chain.FileCount} files | Target: {value.Timestamp:yyyy-MM-dd HH:mm:ss}";
         UpdatePointInTimeWindow(value);
+        // Structural only at selection time; LSN verification is on demand since it costs a
+        // round trip per chain member.
+        ChainLsnVerified = false;
         UpdateChainIssues(chain);
+        ValidateChainCommand.NotifyCanExecuteChanged();
         UpdateRestoreSummary();
         FetchLogicalNamesCommand.NotifyCanExecuteChanged();
         InspectBackupMetadataCommand.NotifyCanExecuteChanged();
@@ -793,9 +804,65 @@ public partial class RestoreViewModel : ViewModelBase
         ValidatePointInTime();
     }
 
-    private void UpdateChainIssues(BackupChain? chain)
+    /// <summary>
+    /// Reads RESTORE HEADERONLY for every member of the selected chain and validates the LSN
+    /// relationships - the authoritative check that the chain actually restores, as opposed to
+    /// merely looking plausible by filename and timestamp.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanValidateChain))]
+    private async Task ValidateChainAsync()
+    {
+        if (RestoreChain == null || ConnectedServer == null) return;
+
+        IsValidatingChain = true;
+        ClearStatus();
+        try
+        {
+            var headers = new List<ChainHeader>();
+            foreach (var set in RestoreChain.AllSets)
+            {
+                var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+                try
+                {
+                    // credentialName is null on purpose: WITH CREDENTIAL is invalid for a SAS
+                    // credential, which is the only kind this app creates.
+                    var header = await _sqlService.RestoreHeaderOnlyMultiAsync(
+                        ConnectedServer, urls, credentialName: null);
+                    headers.Add(new ChainHeader(set, header));
+                }
+                catch (Exception)
+                {
+                    // One unreadable member must not abort the whole validation - the validator
+                    // reports it and carries on checking everything else.
+                    headers.Add(new ChainHeader(set, null));
+                }
+            }
+
+            UpdateChainIssues(RestoreChain, headers);
+            ChainLsnVerified = true;
+
+            SetStatus(HasChainIssues
+                ? $"Chain validation found problems - see the panel above."
+                : $"Chain validated: {headers.Count} backup(s) read, LSN chain is intact.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Chain validation failed: {ex.Message}");
+        }
+        finally
+        {
+            IsValidatingChain = false;
+        }
+    }
+
+    private bool CanValidateChain() =>
+        IsConnectedToServer && RestoreChain != null && !IsValidatingChain;
+
+    private void UpdateChainIssues(BackupChain? chain, IReadOnlyList<ChainHeader>? headers = null)
     {
         var issues = _chainValidator.Validate(chain);
+        if (headers != null)
+            issues.AddRange(_chainValidator.ValidateLsnChain(chain, headers));
 
         ChainIssues = new ObservableCollection<ChainIssue>(issues);
         HasChainIssues = issues.Count > 0;
@@ -906,6 +973,7 @@ public partial class RestoreViewModel : ViewModelBase
 
     partial void OnIsConnectedToServerChanged(bool value)
     {
+        ValidateChainCommand.NotifyCanExecuteChanged();
         FetchLogicalNamesCommand.NotifyCanExecuteChanged();
         InspectBackupMetadataCommand.NotifyCanExecuteChanged();
         CopyFileListOnlyCommandCommand.NotifyCanExecuteChanged();

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -310,6 +310,7 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
@@ -320,7 +321,37 @@
                             <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{StaticResource SecondaryTextBrush}" />
                         </TextBlock>
 
+                        <!-- On-demand LSN verification: one RESTORE HEADERONLY per chain member,
+                             so it is a deliberate action rather than automatic on selection. -->
                         <Button Grid.Column="1"
+                                Style="{StaticResource SecondaryButton}"
+                                Command="{Binding ValidateChainCommand}"
+                                Padding="12,6" Margin="0,0,8,0"
+                                ToolTip="Read each backup's header and verify the LSN chain is unbroken. Requires a connected server.">
+                            <Button.Content>
+                                <TextBlock>
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="Validate Chain" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsValidatingChain}" Value="True">
+                                                    <Setter Property="Text" Value="Validating..." />
+                                                </DataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding ChainLsnVerified}" Value="True" />
+                                                        <Condition Binding="{Binding HasChainIssues}" Value="False" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Text" Value="Chain Verified" />
+                                                </MultiDataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Button.Content>
+                        </Button>
+
+                        <Button Grid.Column="2"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding ToggleChainDetailsCommand}"
                                 Padding="12,6">


### PR DESCRIPTION
Closes #23. Phase 2 of gap detection, following #62.

The structural checks in #62 reason about filenames and timestamps. This reasons about what SQL Server recorded **inside** the backups — which catches breaks the others physically cannot see. A log taken by a different job to a different destination leaves the visible sequence looking perfectly regular while the LSN chain is broken.

## What it checks

A **Validate Chain** button reads `RESTORE HEADERONLY` for every member of the selected chain:

| Check | Why it matters |
|---|---|
| `diff.DatabaseBackupLSN == full.CheckpointLSN` | The only authoritative test that a differential belongs to this full. Fails with **3136** otherwise. |
| Consecutive logs meet | A later `FirstLSN` than the previous `LastLSN` is a gap → **4305** |
| First log spans the recovery point | The log chain must reach back to where the data backups finished |
| All members report the same database | Catches a path pattern grouping unrelated backups together |
| Header type matches the parsed type | Catches a log written with a `.bak` extension, a misclassified copy-only, etc. |

On demand rather than automatic — it costs a round trip per chain member. A member whose header cannot be read is **reported and skipped**, never mistaken for a break.

This also adds `CheckpointLSN` to the header read; it was required for the differential test and was not previously captured.

## Measuring before encoding changed a rule

I probed a real backup set before writing the rules, and one result contradicted the intuitive design:

```
recovery base point (last data backup LastLSN) = 482000001415200001

08-05 00:00 First=482000001058400001 Last=482000001946400001  spansBase=True
08-05 01:00 First=482000001946400001 Last=482000001967200001  spansBase=False
08-05 02:00 First=482000001967200001 Last=482000001986400001  spansBase=False
```

**Only the first log spans the recovery point** — later logs legitimately start after it. Requiring every log to span it, which is what "the chain must cover the restore point" naively suggests, would have rejected every valid chain. There is a test pinning this specifically.

Also confirmed empirically: `diff.DatabaseBackupLSN == full.CheckpointLSN` (True), and consecutive logs meet exactly.

## Running it on real data found a defect in #62's structural checks

Validating real chains surfaced an offered restore point that **cannot actually be restored**:

```
08-01 12:00 [Full + 1 Diff(s) + 1 Log(s)]
  [ERROR] The log chain starts too late to follow the data backup.
          The first log begins at LSN 480000003031200001, after the restore
          point of 480000002543200001.
```

The cause is retention shape, and it is not exotic: **logs are kept for days while fulls and differentials are kept for weeks**, so the oldest surviving log can sit long after the differential preceding it, with everything between purged. The chain looks complete — a full, a differential, and regularly spaced logs — and fails with 4305.

The cadence check from #62 could not see this, because it only ever compares logs *against each other*, never against the data backup they must follow.

So this PR also adds **`CheckLogCoverageStart`** — a structural check comparing the interval from the chain base to the first log against the log cadence. It gets its own, more generous factor: a full takes time to run and the log schedule is independent of it, so a full finishing at 22:09 with hourly logs on the hour leaves a perfectly normal 51-minute gap that a tighter threshold would flag.

Result on the real 24-day set, **with no server connection**:

```
restore points : 114
  clean        : 105
  warnings     : 9      <- exactly the points affected by the retention gap
  errors       : 0
```

All 9 sit before the 01 Aug full — precisely the ones whose logs cannot reach back past the retention boundary. LSN validation independently confirms one of them as a true positive.

## A test caught a false positive during development

`Validate_SchedulerJitter_DoesNotWarn` began failing when the coverage check landed. Its data — 5-minute logs with the full an hour earlier — accidentally described a genuine coverage gap. Fixed the test data to isolate jitter, and split the threshold as described above rather than loosening the cadence check.

## Tests

17 new, **265 total**. App smoke-launched to confirm the new button and panel load.
