### PR TITLE
Add coloured tag pills for servers and containers

### DIFF
--- a/src/NineLives.Tests/TagPaletteTests.cs
+++ b/src/NineLives.Tests/TagPaletteTests.cs
@@ -1,0 +1,151 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+public class TagPaletteTests
+{
+    // GitHub's label swatches, which the palette draws from.
+    private const string GitHubRed = "#B60205";
+    private const string GitHubOrange = "#D93F0B";
+    private const string GitHubYellow = "#FBCA04";
+    private const string GitHubGreen = "#0E8A16";
+    private const string GitHubBlue = "#1D76DB";
+
+    private static readonly string[] AllSwatches =
+    [
+        "#B60205", "#D93F0B", "#FBCA04", "#0E8A16",
+        "#006B75", "#1D76DB", "#0052CC", "#5319E7"
+    ];
+
+    // ── semantic colours ─────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("prod")]
+    [InlineData("production")]
+    [InlineData("live")]
+    [InlineData("PROD")]
+    [InlineData("  Prod  ")]
+    public void ColorFor_ProductionNames_AreRed(string tag)
+        => Assert.Equal(GitHubRed, TagPalette.ColorFor(tag));
+
+    [Fact]
+    public void ColorFor_EnvironmentNames_UseTheirConventionalColours()
+    {
+        Assert.Equal(GitHubOrange, TagPalette.ColorFor("dr"));
+        Assert.Equal(GitHubYellow, TagPalette.ColorFor("uat"));
+        Assert.Equal(GitHubGreen, TagPalette.ColorFor("test"));
+        Assert.Equal(GitHubBlue, TagPalette.ColorFor("dev"));
+    }
+
+    [Fact]
+    public void IsProductionLike_OnlyTrueForProductionNames()
+    {
+        Assert.True(TagPalette.IsProductionLike("prod"));
+        Assert.True(TagPalette.IsProductionLike("PRODUCTION"));
+        Assert.True(TagPalette.IsProductionLike("live"));
+
+        Assert.False(TagPalette.IsProductionLike("test"));
+        Assert.False(TagPalette.IsProductionLike("prod-eu"));
+        Assert.False(TagPalette.IsProductionLike(null));
+    }
+
+    [Fact]
+    public void ColorFor_PartialEnvironmentName_FallsThroughToHashing()
+    {
+        // "prod-eu" is NOT matched semantically. Better to hash it than to imply a safety
+        // signal from a name that only resembles one.
+        Assert.NotEqual(GitHubRed, TagPalette.ColorFor("prod-eu"));
+        Assert.False(TagPalette.IsProductionLike("prod-eu"));
+    }
+
+    // ── hashed colours ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ColorFor_ArbitraryTag_IsFromTheGitHubPalette()
+        => Assert.Contains(TagPalette.ColorFor("client-acme"), AllSwatches);
+
+    [Fact]
+    public void ColorFor_IsStableAcrossCalls()
+    {
+        var first = TagPalette.ColorFor("finance-cluster");
+        for (int i = 0; i < 50; i++)
+            Assert.Equal(first, TagPalette.ColorFor("finance-cluster"));
+    }
+
+    [Fact]
+    public void ColorFor_IsCaseInsensitive()
+        => Assert.Equal(TagPalette.ColorFor("Reporting"), TagPalette.ColorFor("REPORTING"));
+
+    [Fact]
+    public void ColorFor_KnownValue_IsPinned()
+    {
+        // Pins the hash itself. If the algorithm is ever swapped, every existing tag silently
+        // changes colour - which users notice and dislike. This test makes that deliberate.
+        // The value is whatever FNV-1a currently produces; it is recorded, not chosen.
+        Assert.Equal("#0E8A16", TagPalette.ColorFor("client-acme"));
+    }
+
+    [Fact]
+    public void ColorFor_DistributesAcrossThePalette()
+    {
+        // A hash that collapsed onto one or two swatches would make every tag look the same.
+        var used = Enumerable.Range(0, 60)
+            .Select(i => TagPalette.ColorFor($"tag-{i}"))
+            .Distinct()
+            .ToList();
+
+        Assert.True(used.Count >= 6, $"Only {used.Count} of {AllSwatches.Length} swatches used.");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ColorFor_EmptyInput_StillReturnsAValidSwatch(string? tag)
+        => Assert.Contains(TagPalette.ColorFor(tag), AllSwatches);
+
+    // ── parsing ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseTags_SplitsTrimsAndDropsBlanks()
+        => Assert.Equal(["prod", "eu-west", "critical"],
+            TagPalette.ParseTags("  prod ,, eu-west ,  critical  "));
+
+    [Fact]
+    public void ParseTags_AcceptsSemicolonsToo()
+        => Assert.Equal(["a", "b"], TagPalette.ParseTags("a; b"));
+
+    [Fact]
+    public void ParseTags_RemovesDuplicatesKeepingTheFirstSpelling()
+        => Assert.Equal(["Prod"], TagPalette.ParseTags("Prod, prod, PROD"));
+
+    [Fact]
+    public void ParseTags_PreservesOrder()
+        => Assert.Equal(["zebra", "apple"], TagPalette.ParseTags("zebra, apple"));
+
+    [Fact]
+    public void ParseTags_TruncatesOverlongTags()
+    {
+        var tag = Assert.Single(TagPalette.ParseTags(new string('x', 100)));
+        Assert.Equal(32, tag.Length);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" , , ")]
+    public void ParseTags_NothingUsable_ReturnsEmpty(string? input)
+        => Assert.Empty(TagPalette.ParseTags(input));
+
+    [Fact]
+    public void FormatTags_RoundTripsThroughParse()
+    {
+        var original = new[] { "prod", "eu-west", "critical" };
+        Assert.Equal(original, TagPalette.ParseTags(TagPalette.FormatTags(original)));
+    }
+
+    [Fact]
+    public void FormatTags_Null_IsEmptyString()
+        => Assert.Equal(string.Empty, TagPalette.FormatTags(null));
+}

--- a/src/NineLives/Converters/ValueConverters.cs
+++ b/src/NineLives/Converters/ValueConverters.cs
@@ -5,6 +5,59 @@ using System.Windows.Media;
 
 namespace Blackcat.NineLives.Converters;
 
+/// <summary>
+/// Renders a tag name as a GitHub-style pill brush.
+///
+/// GitHub's LIGHT theme fills a label with the raw swatch and picks black or white text. Against
+/// this app's dark background a solid #B60205 is punishing to look at, so this follows GitHub's
+/// DARK theme treatment instead: a low-alpha fill of the colour, a coloured border, and a
+/// lightened version of the colour as the text. Same palette, appropriate rendering.
+///
+/// ConverterParameter selects which part: "fill", "border", or text (the default).
+/// </summary>
+public class TagBrushConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var hex = Services.TagPalette.ColorFor(value as string);
+        var baseColor = (Color)ColorConverter.ConvertFromString(hex);
+
+        return (parameter as string)?.ToLowerInvariant() switch
+        {
+            "fill" => new SolidColorBrush(Color.FromArgb(0x33, baseColor.R, baseColor.G, baseColor.B)),
+            "border" => new SolidColorBrush(Color.FromArgb(0x99, baseColor.R, baseColor.G, baseColor.B)),
+            _ => new SolidColorBrush(Lighten(baseColor, 0.55))
+        };
+    }
+
+    /// <summary>
+    /// Mixes toward white so the text clears a sensible contrast floor on a dark background. The
+    /// darker swatches (#0052CC, #5319E7) are close to unreadable at full saturation here.
+    /// </summary>
+    private static Color Lighten(Color c, double amount)
+        => Color.FromRgb(
+            (byte)(c.R + (255 - c.R) * amount),
+            (byte)(c.G + (255 - c.G) * amount),
+            (byte)(c.B + (255 - c.B) * amount));
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Turns the comma-separated tag text being typed into the parsed list, so the edit form can
+/// show a live preview of the actual pills. Uses the same parser as save, so what is previewed
+/// is exactly what is stored.
+/// </summary>
+public class TagPreviewConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => Services.TagPalette.ParseTags(value as string);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
 public class BoolToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -38,6 +38,12 @@ public class BlobContainerConfig
     public string? AgPathPattern { get; set; }
 
     /// <summary>
+    /// Free-text labels shown as coloured pills. Absent from older config files, which
+    /// deserialise to an empty list - no migration needed.
+    /// </summary>
+    public List<string> Tags { get; set; } = [];
+
+    /// <summary>
     /// Key used to look up SAS token in Windows Credential Manager.
     /// </summary>
     public string CredentialKey => $"NineLives:Blob:{Name}";

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -24,6 +24,15 @@ public class ServerConnection
     public EncryptMode Encrypt { get; set; } = EncryptMode.Yes;
 
     /// <summary>
+    /// Free-text labels shown as coloured pills. Absent from older config files, which
+    /// deserialise to an empty list - no migration needed.
+    /// </summary>
+    public List<string> Tags { get; set; } = [];
+
+    /// <summary>True when any tag marks this as a production-like environment.</summary>
+    public bool IsProductionTagged => Tags.Any(Services.TagPalette.IsProductionLike);
+
+    /// <summary>
     /// Key used to look up password in Windows Credential Manager.
     /// Only used when AuthMode is SqlAuth.
     /// </summary>

--- a/src/NineLives/Services/TagPalette.cs
+++ b/src/NineLives/Services/TagPalette.cs
@@ -1,0 +1,127 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Assigns a colour to a tag name, using GitHub's own label palette.
+///
+/// Two rules, in order:
+///
+/// 1. Well-known environment names get a SEMANTIC colour. This is the point of the feature:
+///    Nine Lives restores databases with WITH REPLACE on by default, and the worst mistake
+///    available is restoring into the wrong environment. A red "prod" pill is a pre-attentive
+///    warning; a pastel one hashed from the letters p-r-o-d is decoration. Hostnames are a poor
+///    signal on their own - blackcatsvr01 and blackcatsvr02 differ by one character.
+///
+/// 2. Everything else hashes deterministically into the palette, so a given tag is always the
+///    same colour on every machine and across restarts, with no colour picker to manage.
+///
+/// Colours are GitHub's label swatches. Rendering follows GitHub's DARK theme treatment rather
+/// than its light one - a solid #B60205 pill is punishing against this app's background, whereas
+/// a tinted fill with a lightened foreground reads cleanly and is what GitHub itself shows in
+/// dark mode.
+/// </summary>
+public static class TagPalette
+{
+    /// <summary>GitHub's label colour swatches (the saturated row).</summary>
+    private static readonly string[] Swatches =
+    [
+        "#B60205", // red
+        "#D93F0B", // orange
+        "#FBCA04", // yellow
+        "#0E8A16", // green
+        "#006B75", // teal
+        "#1D76DB", // blue
+        "#0052CC", // dark blue
+        "#5319E7"  // purple
+    ];
+
+    /// <summary>
+    /// Environment names that carry meaning. Matched case-insensitively on the whole tag, so a
+    /// tag like "prod-eu" falls through to hashing rather than being wrongly reassured about.
+    /// </summary>
+    private static readonly Dictionary<string, string> Semantic = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["prod"] = "#B60205",
+        ["production"] = "#B60205",
+        ["live"] = "#B60205",
+
+        ["dr"] = "#D93F0B",
+        ["disaster-recovery"] = "#D93F0B",
+
+        ["staging"] = "#FBCA04",
+        ["stage"] = "#FBCA04",
+        ["uat"] = "#FBCA04",
+        ["preprod"] = "#FBCA04",
+
+        ["test"] = "#0E8A16",
+        ["testing"] = "#0E8A16",
+        ["qa"] = "#0E8A16",
+
+        ["dev"] = "#1D76DB",
+        ["development"] = "#1D76DB",
+        ["sandbox"] = "#1D76DB"
+    };
+
+    /// <summary>Base colour for a tag name, as #RRGGBB.</summary>
+    public static string ColorFor(string? tag)
+    {
+        var name = (tag ?? string.Empty).Trim();
+        if (name.Length == 0) return Swatches[0];
+
+        if (Semantic.TryGetValue(name, out var semantic)) return semantic;
+
+        return Swatches[StableIndex(name, Swatches.Length)];
+    }
+
+    /// <summary>True when this tag denotes a production-like environment.</summary>
+    public static bool IsProductionLike(string? tag)
+    {
+        var name = (tag ?? string.Empty).Trim();
+        return Semantic.TryGetValue(name, out var c) && c == "#B60205";
+    }
+
+    /// <summary>
+    /// FNV-1a over the lowercased name. Deliberately not string.GetHashCode(), which is
+    /// randomised per process in .NET Core - a tag would change colour every launch.
+    /// </summary>
+    private static int StableIndex(string name, int buckets)
+    {
+        unchecked
+        {
+            const uint offset = 2166136261;
+            const uint prime = 16777619;
+
+            var hash = offset;
+            foreach (var c in name.ToLowerInvariant())
+            {
+                hash ^= c;
+                hash *= prime;
+            }
+            return (int)(hash % (uint)buckets);
+        }
+    }
+
+    /// <summary>
+    /// Splits and normalises a user-entered tag list. Trims, drops blanks, removes duplicates
+    /// case-insensitively while keeping the first spelling the user chose, and preserves order.
+    /// </summary>
+    public static List<string> ParseTags(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return [];
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+
+        foreach (var part in input.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var tag = part.Trim();
+            if (tag.Length == 0) continue;
+            if (tag.Length > 32) tag = tag[..32];
+            if (seen.Add(tag)) result.Add(tag);
+        }
+
+        return result;
+    }
+
+    public static string FormatTags(IEnumerable<string>? tags)
+        => tags == null ? string.Empty : string.Join(", ", tags);
+}

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
 
     <!-- Color Palette -->
     <Color x:Key="WindowBackgroundColor">#1B1E2B</Color>
@@ -647,6 +648,41 @@
         <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
+    </Style>
+
+    <!-- ==================== Tag Pills ====================
+         GitHub's label palette, rendered the way GitHub renders labels in ITS dark theme: a
+         low-alpha fill, a coloured border, and lightened text - rather than the solid swatch it
+         uses on a light background, which is punishing against this window. Defined once so
+         every surface showing a tag (lists, connection status, execute confirmation) matches. -->
+    <converters:TagBrushConverter x:Key="TagBrush" />
+    <converters:TagPreviewConverter x:Key="TagPreview" />
+
+    <DataTemplate x:Key="TagPillTemplate">
+        <Border CornerRadius="9"
+                Padding="7,1"
+                Margin="0,2,4,0"
+                BorderThickness="1"
+                Background="{Binding Converter={StaticResource TagBrush}, ConverterParameter=fill}"
+                BorderBrush="{Binding Converter={StaticResource TagBrush}, ConverterParameter=border}">
+            <TextBlock Text="{Binding}"
+                       FontFamily="Segoe UI"
+                       FontSize="10.5"
+                       FontWeight="SemiBold"
+                       Foreground="{Binding Converter={StaticResource TagBrush}}" />
+        </Border>
+    </DataTemplate>
+
+    <!-- Drop-in list of pills: set ItemsSource to a collection of tag names. -->
+    <Style x:Key="TagPillList" TargetType="ItemsControl">
+        <Setter Property="ItemTemplate" Value="{StaticResource TagPillTemplate}" />
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <WrapPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
 </ResourceDictionary>

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -20,6 +20,10 @@ public partial class BlobConfigViewModel : ViewModelBase
     [ObservableProperty]
     private string _editName = string.Empty;
 
+    /// <summary>Comma-separated tag list as typed by the user; parsed on save.</summary>
+    [ObservableProperty]
+    private string _editTags = string.Empty;
+
     [ObservableProperty]
     private string _editContainerUrl = string.Empty;
 
@@ -314,6 +318,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     private void AddNew()
     {
         EditName = string.Empty;
+        EditTags = string.Empty;
         EditContainerUrl = string.Empty;
         EditSasToken = string.Empty;
         EditPathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
@@ -335,6 +340,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     {
         if (SelectedContainer == null) return;
         EditName = SelectedContainer.Name;
+        EditTags = TagPalette.FormatTags(SelectedContainer.Tags);
         EditContainerUrl = SelectedContainer.ContainerUrl;
         var storedToken = _credentialStore.GetSasToken(SelectedContainer);
         HasStoredSasToken = !string.IsNullOrEmpty(storedToken);
@@ -390,7 +396,8 @@ public partial class BlobConfigViewModel : ViewModelBase
                 ContainerUrl = EditContainerUrl.TrimEnd('/'),
                 PathPattern = EditPathPattern,
                 BackupSourceType = EditBackupSourceType,
-                AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim()
+                AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim(),
+                Tags = TagPalette.ParseTags(EditTags)
             };
             Containers.Add(container);
         }
@@ -398,6 +405,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         {
             container = SelectedContainer!;
             container.Name = EditName;
+            container.Tags = TagPalette.ParseTags(EditTags);
             container.ContainerUrl = EditContainerUrl.TrimEnd('/');
             container.PathPattern = EditPathPattern;
             container.BackupSourceType = EditBackupSourceType;

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -184,6 +184,13 @@ public partial class RestoreViewModel : ViewModelBase
 
     public ServerConnection? ConnectedServer { get; set; }
 
+    /// <summary>Tags of the connected server, shown on the execute confirmation.</summary>
+    [ObservableProperty]
+    private ObservableCollection<string> _connectedServerTags = [];
+
+    [ObservableProperty]
+    private bool _hasConnectedServerTags;
+
     partial void OnUseWithMoveChanged(bool value)
     {
         OnPropertyChanged(nameof(ShowMoveOptions));
@@ -973,6 +980,10 @@ public partial class RestoreViewModel : ViewModelBase
 
     partial void OnIsConnectedToServerChanged(bool value)
     {
+        var tags = value ? ConnectedServer?.Tags ?? [] : [];
+        ConnectedServerTags = new ObservableCollection<string>(tags);
+        HasConnectedServerTags = ConnectedServerTags.Count > 0;
+
         ValidateChainCommand.NotifyCanExecuteChanged();
         FetchLogicalNamesCommand.NotifyCanExecuteChanged();
         InspectBackupMetadataCommand.NotifyCanExecuteChanged();

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -22,6 +22,10 @@ public partial class ServerManagerViewModel : ViewModelBase
     [ObservableProperty]
     private string _editName = string.Empty;
 
+    /// <summary>Comma-separated tag list as typed by the user; parsed on save.</summary>
+    [ObservableProperty]
+    private string _editTags = string.Empty;
+
     [ObservableProperty]
     private string _editServerName = string.Empty;
 
@@ -92,6 +96,7 @@ public partial class ServerManagerViewModel : ViewModelBase
     private void AddNew()
     {
         EditName = string.Empty;
+        EditTags = string.Empty;
         EditServerName = string.Empty;
         EditAuthMode = AuthMode.WindowsAuth;
         EditUsername = string.Empty;
@@ -109,6 +114,7 @@ public partial class ServerManagerViewModel : ViewModelBase
     {
         if (SelectedServer == null) return;
         EditName = SelectedServer.Name;
+        EditTags = TagPalette.FormatTags(SelectedServer.Tags);
         EditServerName = SelectedServer.ServerName;
         EditAuthMode = SelectedServer.AuthMode;
         EditUsername = SelectedServer.Username ?? string.Empty;
@@ -160,6 +166,7 @@ public partial class ServerManagerViewModel : ViewModelBase
         }
 
         server.Name = EditName;
+        server.Tags = TagPalette.ParseTags(EditTags);
         server.ServerName = EditServerName;
         server.AuthMode = EditAuthMode;
         server.Username = EditAuthMode == AuthMode.SqlAuth ? EditUsername : null;

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -72,6 +72,10 @@
                                                TextTrimming="CharacterEllipsis"
                                                Margin="16,2,0,0"
                                                MaxWidth="220" />
+                                    <ItemsControl ItemsSource="{Binding Tags}"
+                                                  Style="{StaticResource TagPillList}"
+                                                  Margin="16,2,0,0"
+                                                  MaxWidth="220" />
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
@@ -286,6 +290,17 @@
                             <TextBox Text="{Binding EditName, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,16" />
+
+                            <TextBlock Text="TAGS" Style="{StaticResource LabelText}" />
+                            <TextBlock Text="Comma separated. prod, test, dev, uat and dr get environment colours."
+                                       Style="{StaticResource SecondaryText}"
+                                       FontSize="11" Margin="0,0,0,4" />
+                            <TextBox Text="{Binding EditTags, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource DarkTextBox}"
+                                     Margin="0,0,0,8" />
+                            <ItemsControl ItemsSource="{Binding EditTags, Converter={StaticResource TagPreview}}"
+                                          Style="{StaticResource TagPillList}"
+                                          Margin="0,0,0,16" />
 
                             <TextBlock Text="CONTAINER URL" Style="{StaticResource LabelText}" />
                             <TextBlock Text="e.g. https://myaccount.blob.core.windows.net/backups"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -830,19 +830,28 @@
                                 MinWidth="140" />
                     </StackPanel>
 
-                    <!-- Execute armed warning -->
+                    <!-- Execute armed warning. The server's tags appear here deliberately: this is
+                         the last thing between the user and an irreversible overwrite, and a
+                         hostname alone is a weak signal - blackcatsvr01 and blackcatsvr02 differ
+                         by one character. A red PROD pill is read before the sentence is. -->
                     <Border Background="#30E74C3C" CornerRadius="4" Padding="12,8" Margin="0,0,0,12"
                             Visibility="{Binding IsExecuteArmed, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap">
-                            <Run Text="&#x26A0;" Foreground="{StaticResource ErrorBrush}" FontSize="14" />
-                            <Run Text=" Click again to execute restore against" />
-                            <Run Text="{Binding ConnectedServerName, Mode=OneWay}" FontWeight="SemiBold" Foreground="{StaticResource ErrorBrush}" />
-                            <Run Text=". Target:" />
-                            <Run Text="{Binding TargetDatabaseName, Mode=OneWay}" FontWeight="SemiBold" />
-                            <Run Text="(" />
-                            <Run Text="{Binding ChainSummary, Mode=OneWay}" />
-                            <Run Text="). This operation cannot be undone." Foreground="{StaticResource ErrorBrush}" />
-                        </TextBlock>
+                        <StackPanel>
+                            <ItemsControl ItemsSource="{Binding ConnectedServerTags}"
+                                          Style="{StaticResource TagPillList}"
+                                          Margin="0,0,0,6"
+                                          Visibility="{Binding HasConnectedServerTags, Converter={StaticResource BoolToVis}}" />
+                            <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap">
+                                <Run Text="&#x26A0;" Foreground="{StaticResource ErrorBrush}" FontSize="14" />
+                                <Run Text=" Click again to execute restore against" />
+                                <Run Text="{Binding ConnectedServerName, Mode=OneWay}" FontWeight="SemiBold" Foreground="{StaticResource ErrorBrush}" />
+                                <Run Text=". Target:" />
+                                <Run Text="{Binding TargetDatabaseName, Mode=OneWay}" FontWeight="SemiBold" />
+                                <Run Text="(" />
+                                <Run Text="{Binding ChainSummary, Mode=OneWay}" />
+                                <Run Text="). This operation cannot be undone." Foreground="{StaticResource ErrorBrush}" />
+                            </TextBlock>
+                        </StackPanel>
                     </Border>
 
                     <!-- Not connected warning -->

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -65,6 +65,9 @@
                                     <TextBlock Text="{Binding DisplayText}"
                                                Style="{StaticResource SecondaryText}"
                                                Margin="22,2,0,0" />
+                                    <ItemsControl ItemsSource="{Binding Tags}"
+                                                  Style="{StaticResource TagPillList}"
+                                                  Margin="22,2,0,0" />
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
@@ -197,6 +200,17 @@
                             <TextBox Text="{Binding EditName, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,16" />
+
+                            <TextBlock Text="TAGS" Style="{StaticResource LabelText}" />
+                            <TextBlock Text="Comma separated. prod, test, dev, uat and dr get environment colours."
+                                       Style="{StaticResource SecondaryText}"
+                                       FontSize="11" Margin="0,0,0,4" />
+                            <TextBox Text="{Binding EditTags, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource DarkTextBox}"
+                                     Margin="0,0,0,8" />
+                            <ItemsControl ItemsSource="{Binding EditTags, Converter={StaticResource TagPreview}}"
+                                          Style="{StaticResource TagPillList}"
+                                          Margin="0,0,0,16" />
 
                             <TextBlock Text="SERVER NAME / IP" Style="{StaticResource LabelText}" />
                             <TextBlock Text="e.g. myserver.database.windows.net or 10.0.0.1\SQLEXPRESS"


### PR DESCRIPTION
Closes #67. Uses **GitHub's own label palette**, as requested.

## Palette and rendering

Colours are GitHub's label swatches: `#B60205` `#D93F0B` `#FBCA04` `#0E8A16` `#006B75` `#1D76DB` `#0052CC` `#5319E7`.

Rendering follows GitHub's **dark theme** treatment rather than its light one — a low-alpha fill, a coloured border, and lightened text, instead of the solid swatch GitHub shows on white. Two reasons: a solid `#B60205` pill is punishing against this window, and the darker swatches (`#0052CC`, `#5319E7`) are close to unreadable at full saturation on a dark background. Same palette, appropriate rendering — and it is still GitHub's own treatment, just the one that matches a dark app.

## Colour assignment

**Semantic first.** Well-known environment names get a meaningful colour:

| Tag | Colour |
|---|---|
| `prod`, `production`, `live` | red `#B60205` |
| `dr`, `disaster-recovery` | orange `#D93F0B` |
| `staging`, `stage`, `uat`, `preprod` | yellow `#FBCA04` |
| `test`, `testing`, `qa` | green `#0E8A16` |
| `dev`, `development`, `sandbox` | blue `#1D76DB` |

This is the point of the feature rather than decoration. `WITH REPLACE` is on by default, so the worst mistake available in this app is restoring into the wrong environment — and the only signal today is a hostname. `blackcatsvr01` and `blackcatsvr02` differ by one character. A pastel pill hashed from the letters `p-r-o-d` would not help; a red one is read before the sentence next to it is.

**Everything else hashes** deterministically into the palette, so a tag is the same colour on every machine with no colour picker to manage. FNV-1a rather than `string.GetHashCode()`, which is randomised per process in .NET Core and would repaint every tag on each launch.

**Only whole-name matches are semantic.** `prod-eu` hashes rather than being treated as production — implying a safety signal from a name that merely *resembles* one is worse than not implying it at all. There is a test for this.

## Where pills appear

- Server list and container list
- A **live preview** next to the edit field, using the same parser as save, so what you see is what gets stored
- **The arm-to-execute confirmation banner** — the last thing between the user and an irreversible overwrite, and the reason the semantic colours exist

## Storage

A plain `List<string>` on `ServerConnection` and `BlobContainerConfig`. Absent from existing config files and defaulting to empty, so **no migration is needed** — verified by launching against the existing `config.json`, which has no `Tags` field.

## Tests

26 new, **291 total**: semantic colours, case-insensitivity, hash stability and distribution across the palette, the partial-name carve-out, parsing (dedupe keeping first spelling, trimming, truncation, order preservation), and a `Format`/`Parse` round-trip.

The hash is **pinned by a test**, so swapping the algorithm — which would silently repaint every tag a user has already created — has to be a deliberate act rather than an accident.

App smoke-launched to confirm the pills and converters load.

## Not included

The issue also proposed automatic tags (storage type, SAS expiry, auth mode) and right-click-to-add. This PR does manual tags end to end; the automatic ones are a clean follow-up now that the rendering and storage exist — SAS expiry in particular needs no new data, since `BlobContainerConfig` already computes it.
