### PR TITLE
Show saved tags immediately, add automatic SQL version tag

### DIFF
--- a/src/NineLives.Tests/SqlVersionNameTests.cs
+++ b/src/NineLives.Tests/SqlVersionNameTests.cs
@@ -1,0 +1,65 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+public class SqlVersionNameTests
+{
+    // Real @@VERSION banner from SQL Server 2022, as returned by the test instance.
+    private const string Sql2022 =
+        "Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (X64) \n\tOct  8 2022 05:58:25 \n\t" +
+        "Copyright (C) 2022 Microsoft Corporation\n\tDeveloper Edition (64-bit) on Windows 10";
+
+    // Real banner from the local SQL Server 2025 Express instance.
+    private const string Sql2025 =
+        "Microsoft SQL Server 2025 (RTM-GDR) (KB5102333) - 17.0.1125.2 (X64) \n\tJun 18 2026 14:38:44 \n\t" +
+        "Copyright (C) 2025 Microsoft Corporation\n\tExpress Edition (64-bit) on Windows 11";
+
+    [Fact]
+    public void FromVersionBanner_Sql2022_IsNamed()
+        => Assert.Equal("SQL Server 2022", SqlVersionName.FromVersionBanner(Sql2022));
+
+    [Fact]
+    public void FromVersionBanner_Sql2025_IsNamed()
+        => Assert.Equal("SQL Server 2025", SqlVersionName.FromVersionBanner(Sql2025));
+
+    [Theory]
+    [InlineData("Microsoft SQL Server 2019 (RTM) - 15.0.2000.5 (X64)", "SQL Server 2019")]
+    [InlineData("Microsoft SQL Server 2017 (RTM) - 14.0.1000.169 (X64)", "SQL Server 2017")]
+    [InlineData("Microsoft SQL Server 2016 (SP3) - 13.0.6300.2 (X64)", "SQL Server 2016")]
+    public void FromVersionBanner_BoxedReleases_UseThePrintedYear(string banner, string expected)
+        => Assert.Equal(expected, SqlVersionName.FromVersionBanner(banner));
+
+    [Fact]
+    public void FromVersionBanner_NoPrintedYear_FallsBackToTheProductVersion()
+    {
+        // Some banners omit the year; the major version number is always present.
+        Assert.Equal("SQL Server 2022",
+            SqlVersionName.FromVersionBanner("Microsoft SQL Server (RTM) - 16.0.1000.6 (X64)"));
+    }
+
+    [Theory]
+    [InlineData("Microsoft SQL Azure (RTM) - 12.0.2000.8")]
+    [InlineData("Microsoft Azure SQL Edge Developer (RTM) - 15.0.2000.1552")]
+    public void FromVersionBanner_Azure_IsNamedAzure(string banner)
+    {
+        // The year in an Azure banner is a build lineage, not a product year - reporting
+        // "SQL Server 2014" for Azure SQL would be actively misleading.
+        Assert.Equal("Azure SQL", SqlVersionName.FromVersionBanner(banner));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("something that is not a version banner at all")]
+    public void FromVersionBanner_Unrecognised_ReturnsNull(string? banner)
+    {
+        // No tag is better than a wrong one on a screen used to decide what to overwrite.
+        Assert.Null(SqlVersionName.FromVersionBanner(banner));
+    }
+
+    [Fact]
+    public void FromVersionBanner_UnknownMajorVersion_ReturnsNull()
+        => Assert.Null(SqlVersionName.FromVersionBanner("Microsoft SQL Server (RTM) - 99.0.1000.6 (X64)"));
+}

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Web;
 
 namespace Blackcat.NineLives.Models;
@@ -39,9 +40,14 @@ public class BlobContainerConfig
 
     /// <summary>
     /// Free-text labels shown as coloured pills. Absent from older config files, which
-    /// deserialise to an empty list - no migration needed.
+    /// deserialise to an empty collection - no migration needed.
+    ///
+    /// ObservableCollection, and callers MUST mutate it in place rather than assigning a new
+    /// one: these models are plain serialised objects with no PropertyChanged, so a reassignment
+    /// is invisible to a bound ItemsControl and the pills only appear after navigating away and
+    /// back. Mutating in place raises CollectionChanged, which the binding does see.
     /// </summary>
-    public List<string> Tags { get; set; } = [];
+    public ObservableCollection<string> Tags { get; set; } = [];
 
     /// <summary>
     /// Key used to look up SAS token in Windows Credential Manager.

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -1,3 +1,6 @@
+using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
+
 namespace Blackcat.NineLives.Models;
 
 public enum AuthMode
@@ -25,11 +28,34 @@ public class ServerConnection
 
     /// <summary>
     /// Free-text labels shown as coloured pills. Absent from older config files, which
-    /// deserialise to an empty list - no migration needed.
+    /// deserialise to an empty collection - no migration needed.
+    ///
+    /// ObservableCollection, and callers MUST mutate it in place rather than assigning a new
+    /// one: these models are plain serialised objects with no PropertyChanged, so a reassignment
+    /// is invisible to a bound ItemsControl and the pills only appear after navigating away and
+    /// back. Mutating in place raises CollectionChanged, which the binding does see.
     /// </summary>
-    public List<string> Tags { get; set; } = [];
+    public ObservableCollection<string> Tags { get; set; } = [];
+
+    /// <summary>
+    /// Product name detected on the last successful connection, e.g. "SQL Server 2022". Shown as
+    /// an automatic tag. Persisted so it survives a restart and is available before reconnecting.
+    /// </summary>
+    public string? DetectedVersion { get; set; }
+
+    /// <summary>
+    /// Tags derived from observed facts rather than typed by the user. Rendered distinctly so a
+    /// derived fact is never mistaken for a human assertion.
+    /// </summary>
+    [JsonIgnore]
+    public IEnumerable<string> AutoTags =>
+        string.IsNullOrWhiteSpace(DetectedVersion) ? [] : [DetectedVersion];
+
+    [JsonIgnore]
+    public bool HasAutoTags => !string.IsNullOrWhiteSpace(DetectedVersion);
 
     /// <summary>True when any tag marks this as a production-like environment.</summary>
+    [JsonIgnore]
     public bool IsProductionTagged => Tags.Any(Services.TagPalette.IsProductionLike);
 
     /// <summary>

--- a/src/NineLives/Services/SqlVersionName.cs
+++ b/src/NineLives/Services/SqlVersionName.cs
@@ -1,0 +1,65 @@
+using System.Text.RegularExpressions;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Turns the sprawling <c>@@VERSION</c> banner into something short enough for a tag.
+///
+/// The banner looks like:
+///   Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (X64) \n Jun 18 2026 ... \n Copyright ...
+///
+/// Two routes to a name, because neither works alone:
+///   - the release year is printed for boxed versions but Azure SQL says "Azure SQL Edge" or
+///     similar with no year;
+///   - the major version number is always there, and maps to a year for boxed releases.
+/// </summary>
+public static class SqlVersionName
+{
+    private static readonly Regex YearRegex = new(
+        @"Microsoft SQL Server\s+(?<year>\d{4})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex ProductVersionRegex = new(
+        @"-\s*(?<major>\d{1,2})\.\d+\.\d+", RegexOptions.Compiled);
+
+    private static readonly Regex AzureRegex = new(
+        @"Microsoft SQL Azure|Azure SQL", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>Major version number to release year, for boxed SQL Server.</summary>
+    private static readonly Dictionary<int, string> MajorToYear = new()
+    {
+        [17] = "2025",
+        [16] = "2022",
+        [15] = "2019",
+        [14] = "2017",
+        [13] = "2016",
+        [12] = "2014",
+        [11] = "2012",
+        [10] = "2008",
+        [9] = "2005"
+    };
+
+    /// <summary>
+    /// A short label such as "SQL Server 2022", or null when the banner cannot be read - in
+    /// which case no tag is better than a misleading one.
+    /// </summary>
+    public static string? FromVersionBanner(string? banner)
+    {
+        if (string.IsNullOrWhiteSpace(banner)) return null;
+
+        if (AzureRegex.IsMatch(banner)) return "Azure SQL";
+
+        var year = YearRegex.Match(banner);
+        if (year.Success) return $"SQL Server {year.Groups["year"].Value}";
+
+        // No year printed - fall back to the product version number, which always is.
+        var product = ProductVersionRegex.Match(banner);
+        if (product.Success
+            && int.TryParse(product.Groups["major"].Value, out var major)
+            && MajorToYear.TryGetValue(major, out var mapped))
+        {
+            return $"SQL Server {mapped}";
+        }
+
+        return null;
+    }
+}

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -685,4 +685,32 @@
         </Setter>
     </Style>
 
+    <!-- Automatic tags: facts the app detected, not labels the user typed. Deliberately neutral
+         and outline-only so a derived value is never mistaken for a human assertion, and so it
+         cannot compete with a red PROD pill for attention. -->
+    <DataTemplate x:Key="AutoTagPillTemplate">
+        <Border CornerRadius="9"
+                Padding="7,1"
+                Margin="0,2,4,0"
+                BorderThickness="1"
+                Background="Transparent"
+                BorderBrush="{StaticResource InputBorderBrush}">
+            <TextBlock Text="{Binding}"
+                       FontFamily="Segoe UI"
+                       FontSize="10.5"
+                       Foreground="{StaticResource SecondaryTextBrush}" />
+        </Border>
+    </DataTemplate>
+
+    <Style x:Key="AutoTagPillList" TargetType="ItemsControl">
+        <Setter Property="ItemTemplate" Value="{StaticResource AutoTagPillTemplate}" />
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <WrapPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
 </ResourceDictionary>

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -397,7 +397,7 @@ public partial class BlobConfigViewModel : ViewModelBase
                 PathPattern = EditPathPattern,
                 BackupSourceType = EditBackupSourceType,
                 AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim(),
-                Tags = TagPalette.ParseTags(EditTags)
+                Tags = [.. TagPalette.ParseTags(EditTags)]
             };
             Containers.Add(container);
         }
@@ -405,7 +405,8 @@ public partial class BlobConfigViewModel : ViewModelBase
         {
             container = SelectedContainer!;
             container.Name = EditName;
-            container.Tags = TagPalette.ParseTags(EditTags);
+            // Mutate in place - see ReplaceTags.
+            ReplaceTags(container.Tags, TagPalette.ParseTags(EditTags));
             container.ContainerUrl = EditContainerUrl.TrimEnd('/');
             container.PathPattern = EditPathPattern;
             container.BackupSourceType = EditBackupSourceType;

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -92,6 +92,25 @@ public partial class ServerManagerViewModel : ViewModelBase
         _credentialStore.SaveConfig(config);
     }
 
+    /// <summary>
+    /// Forces one row to re-render after a non-observable property changed on it.
+    ///
+    /// DetectedVersion is a plain property on a serialised model, so setting it raises nothing a
+    /// binding can see. Tags avoid this by being an ObservableCollection mutated in place, but a
+    /// scalar has no such escape - so the item is re-seated in the collection, which re-renders
+    /// just that row. Selection is preserved because the instance is unchanged.
+    /// </summary>
+    private void RefreshServerRow(ServerConnection server)
+    {
+        var index = Servers.IndexOf(server);
+        if (index < 0) return;
+
+        var wasSelected = ReferenceEquals(SelectedServer, server);
+        Servers.RemoveAt(index);
+        Servers.Insert(index, server);
+        if (wasSelected) SelectedServer = server;
+    }
+
     [RelayCommand]
     private void AddNew()
     {
@@ -166,7 +185,9 @@ public partial class ServerManagerViewModel : ViewModelBase
         }
 
         server.Name = EditName;
-        server.Tags = TagPalette.ParseTags(EditTags);
+        // Mutate in place - assigning a new collection raises no notification on a POCO, so the
+        // pills would not appear until the user navigated away and back.
+        ReplaceTags(server.Tags, TagPalette.ParseTags(EditTags));
         server.ServerName = EditServerName;
         server.AuthMode = EditAuthMode;
         server.Username = EditAuthMode == AuthMode.SqlAuth ? EditUsername : null;
@@ -248,6 +269,25 @@ public partial class ServerManagerViewModel : ViewModelBase
         try
         {
             await _sqlService.TestConnectionAsync(SelectedServer);
+
+            // Derive the product-version tag from the connection we just proved works. Best
+            // effort: a server that connects but will not answer @@VERSION should still connect.
+            try
+            {
+                var banner = await _sqlService.GetServerVersionAsync(SelectedServer);
+                var detected = SqlVersionName.FromVersionBanner(banner);
+                if (detected != null && detected != SelectedServer.DetectedVersion)
+                {
+                    SelectedServer.DetectedVersion = detected;
+                    SaveServers();
+                    RefreshServerRow(SelectedServer);
+                }
+            }
+            catch
+            {
+                // Leave any previously detected value alone rather than clearing it.
+            }
+
             IsConnected = true;
             ConnectedServerDisplay = SelectedServer.DisplayText;
             ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs

--- a/src/NineLives/ViewModels/ViewModelBase.cs
+++ b/src/NineLives/ViewModels/ViewModelBase.cs
@@ -1,9 +1,25 @@
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Blackcat.NineLives.ViewModels;
 
 public abstract partial class ViewModelBase : ObservableObject
 {
+    /// <summary>
+    /// Replaces a bound collection's contents IN PLACE.
+    ///
+    /// The config models are plain serialised objects with no PropertyChanged, so assigning a
+    /// new collection to one of their properties is invisible to a bound ItemsControl - the UI
+    /// only catches up when the item is re-rendered for some other reason, which is why edited
+    /// tags appeared to need a navigate-away-and-back. Clearing and refilling the SAME instance
+    /// raises CollectionChanged, which the binding does observe.
+    /// </summary>
+    protected static void ReplaceTags(ObservableCollection<string> target, IEnumerable<string> values)
+    {
+        target.Clear();
+        foreach (var value in values) target.Add(value);
+    }
+
     [ObservableProperty]
     private bool _isBusy;
 

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -65,9 +65,12 @@
                                     <TextBlock Text="{Binding DisplayText}"
                                                Style="{StaticResource SecondaryText}"
                                                Margin="22,2,0,0" />
-                                    <ItemsControl ItemsSource="{Binding Tags}"
-                                                  Style="{StaticResource TagPillList}"
-                                                  Margin="22,2,0,0" />
+                                    <WrapPanel Orientation="Horizontal" Margin="22,2,0,0">
+                                        <ItemsControl ItemsSource="{Binding Tags}"
+                                                      Style="{StaticResource TagPillList}" />
+                                        <ItemsControl ItemsSource="{Binding AutoTags}"
+                                                      Style="{StaticResource AutoTagPillList}" />
+                                    </WrapPanel>
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>


### PR DESCRIPTION
Two follow-ups to #67: the refresh bug you spotted, and the automatic SQL version tag.

## Bug: saved tags only appeared after navigating away and back

**Root cause.** `Tags` was a `List<string>` on a plain serialised model, and `Save` assigned a **new list** to the property. Those models have no `PropertyChanged` — they are config POCOs — so a reassignment is completely invisible to a bound `ItemsControl`. The row only picked up the change when it happened to be re-rendered for some other reason, which is precisely what leaving and re-entering the view does.

**Fix.** `Tags` is now an `ObservableCollection<string>` mutated **in place** through a shared `ReplaceTags` helper:

```csharp
target.Clear();
foreach (var value in values) target.Add(value);
```

That raises `CollectionChanged`, which the binding does observe, so pills appear the moment you save.

I documented the requirement on **both** model properties, because the natural thing to write — assigning a fresh collection — silently reintroduces exactly this bug, and it fails in a way that looks like "works, just slowly".

## Feature: automatic SQL Server version tag

`SqlVersionName` turns the `@@VERSION` banner into something short enough for a pill:

| Input | Output |
|---|---|
| `Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (X64)…` | `SQL Server 2022` |
| `Microsoft SQL Server (RTM) - 16.0.1000.6 (X64)` (no year printed) | `SQL Server 2022` |
| `Microsoft SQL Azure (RTM) - 12.0.2000.8` | `Azure SQL` |
| unrecognised | **null** — no tag |

Three deliberate choices:

- **Azure is reported as Azure**, not translated. An Azure banner's version number is a build lineage, so mapping `12.0` would print "SQL Server 2014" for an Azure database — actively misleading.
- **An unrecognised banner produces no tag at all.** On a screen used to decide what to overwrite, no information beats wrong information.
- **Detection is best effort.** A server that connects but will not answer `@@VERSION` still connects, and a failed read leaves any previously detected value alone rather than clearing it.

`DetectedVersion` is captured on a successful **Connect** and persisted, so the tag survives a restart and is visible before reconnecting.

### Rendered distinctly

Automatic tags are outline-only in neutral grey, clearly different from the coloured manual pills. Two reasons: a derived fact should never be mistaken for something a human asserted, and an auto-tag must not compete with a red **PROD** pill for attention.

### One more notification wrinkle

`DetectedVersion` is a scalar, so it has no collection to observe and the `ReplaceTags` trick does not apply. `RefreshServerRow` re-seats the item in the collection to force just that row to re-render, preserving selection since the instance is unchanged.

## Tests

13 new, **304 total** — using the **real** `@@VERSION` banners captured from your SQL Server 2022 instance and the local 2025 Express, plus older boxed releases, the no-year fallback, Azure, and the unrecognised cases that must return null.

App smoke-launched to confirm both pill styles render.
