### PR TITLE
Capture the SQL version tag on Test Connection as well as Connect

### DIFF
--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -93,6 +93,26 @@ public partial class ServerManagerViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Records the product version parsed from a @@VERSION banner against a saved server, and
+    /// refreshes its row so the automatic tag appears at once.
+    ///
+    /// Populated only when the user actually connects or tests - the app never probes saved
+    /// servers on its own. Reaching out to every configured instance at startup, some of which
+    /// are production, is not something a restore tool should do unasked.
+    /// </summary>
+    private void RecordDetectedVersion(ServerConnection? server, string? banner)
+    {
+        if (server == null) return;
+
+        var detected = SqlVersionName.FromVersionBanner(banner);
+        if (detected == null || detected == server.DetectedVersion) return;
+
+        server.DetectedVersion = detected;
+        SaveServers();
+        RefreshServerRow(server);
+    }
+
+    /// <summary>
     /// Forces one row to re-render after a non-observable property changed on it.
     ///
     /// DetectedVersion is a plain property on a serialised model, so setting it raises nothing a
@@ -247,6 +267,12 @@ public partial class ServerManagerViewModel : ViewModelBase
             ServerVersion = firstLine;
             TestSuccess = true;
             TestResult = $"Connected successfully!\n{firstLine}";
+
+            // Test Connection already proves the server and reads the banner, so record the
+            // version tag from it too. BuildCurrentServer returns a throwaway object built from
+            // the edit form, so the value has to be written back to the SAVED entry - otherwise
+            // testing an existing server tells us the version and then discards it.
+            RecordDetectedVersion(IsNew ? null : SelectedServer, version);
         }
         catch (Exception ex)
         {
@@ -274,14 +300,7 @@ public partial class ServerManagerViewModel : ViewModelBase
             // effort: a server that connects but will not answer @@VERSION should still connect.
             try
             {
-                var banner = await _sqlService.GetServerVersionAsync(SelectedServer);
-                var detected = SqlVersionName.FromVersionBanner(banner);
-                if (detected != null && detected != SelectedServer.DetectedVersion)
-                {
-                    SelectedServer.DetectedVersion = detected;
-                    SaveServers();
-                    RefreshServerRow(SelectedServer);
-                }
+                RecordDetectedVersion(SelectedServer, await _sqlService.GetServerVersionAsync(SelectedServer));
             }
             catch
             {


### PR DESCRIPTION
Follow-up to #67. Your saved servers showed no version tags — diagnosed and fixed.

## Why they were missing

`DetectedVersion` was only recorded on a successful **Connect**, and your existing entries had never been connected to since the feature landed. Confirmed by probing the real saved servers read-only:

| Server | Would resolve to | Stored value |
|---|---|---|
| SQLSERVEREXPRESS | `SQL Server 2025` | *(none yet)* |
| BlackcatSVR01 | `SQL Server 2022` | *(none yet)* |
| BlackcatSVR02 | `SQL Server 2022` | *(none yet)* |

So the detection logic was correct; nothing had ever triggered it. The manual pills in your screenshot rendering correctly confirmed the refresh fix was working.

## Fix

**Test Connection** already proved the server *and* read the `@@VERSION` banner — then threw the parsed version away. It now records it, which is the other natural way you exercise a saved entry.

One subtlety: Test Connection runs against `BuildCurrentServer()`, a throwaway object built from the edit form, so the value has to be written back to the **saved** entry to persist. For a brand-new unsaved server there is no entry to write to, so nothing is recorded until it is saved and connected.

Both paths now share `RecordDetectedVersion`, which skips no-op updates, persists, and refreshes just that row.

## Still on demand, deliberately

The app does not probe saved servers by itself. Reaching out to every configured instance at startup — some of them production — is not something a restore tool should do unasked. A version tag appears once you connect or test, and not before.

If you would rather it filled them in automatically, that is a small change, but I would want it to be an explicit opt-in setting rather than default behaviour.

**304 tests passing.**
