### PR TITLE
Wrap tag pills instead of clipping them

### DIFF
--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -50,6 +50,12 @@ public class BlobContainerConfig
     public ObservableCollection<string> Tags { get; set; } = [];
 
     /// <summary>
+    /// Tags as chips, matching the server list. Containers have no automatic tags yet, but going
+    /// through the same shape keeps one rendering path.
+    /// </summary>
+    public IEnumerable<TagChip> TagChips => Tags.Select(TagChip.Manual);
+
+    /// <summary>
     /// Key used to look up SAS token in Windows Credential Manager.
     /// </summary>
     public string CredentialKey => $"NineLives:Blob:{Name}";

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -54,6 +54,15 @@ public class ServerConnection
     [JsonIgnore]
     public bool HasAutoTags => !string.IsNullOrWhiteSpace(DetectedVersion);
 
+    /// <summary>
+    /// Manual and automatic tags as one sequence, so the UI can render them from a SINGLE
+    /// wrapping panel. Two adjacent ItemsControls inside a WrapPanel cannot wrap - each is
+    /// measured with infinite width - and their pills get clipped by the row instead.
+    /// </summary>
+    [JsonIgnore]
+    public IEnumerable<TagChip> TagChips =>
+        Tags.Select(TagChip.Manual).Concat(AutoTags.Select(TagChip.Automatic));
+
     /// <summary>True when any tag marks this as a production-like environment.</summary>
     [JsonIgnore]
     public bool IsProductionTagged => Tags.Any(Services.TagPalette.IsProductionLike);

--- a/src/NineLives/Models/TagChip.cs
+++ b/src/NineLives/Models/TagChip.cs
@@ -1,0 +1,16 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// One pill to render: its text, and whether it was typed by a user or derived by the app.
+///
+/// Manual and automatic tags must share a SINGLE ItemsControl rather than sitting in two
+/// side-by-side ones. A WrapPanel measures each child with infinite width in the wrapping
+/// direction, so a nested ItemsControl never learns it should wrap - it lays its pills out on one
+/// endless line and the row simply clips them. Combining both kinds into one collection gives one
+/// WrapPanel that wraps where it should, with the template switching on <see cref="IsAutomatic"/>.
+/// </summary>
+public sealed record TagChip(string Text, bool IsAutomatic)
+{
+    public static TagChip Manual(string text) => new(text, false);
+    public static TagChip Automatic(string text) => new(text, true);
+}

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -658,6 +658,7 @@
     <converters:TagBrushConverter x:Key="TagBrush" />
     <converters:TagPreviewConverter x:Key="TagPreview" />
 
+    <!-- Plain-string pill, for the live preview beside the edit field. -->
     <DataTemplate x:Key="TagPillTemplate">
         <Border CornerRadius="9"
                 Padding="7,1"
@@ -673,6 +674,51 @@
         </Border>
     </DataTemplate>
 
+    <!-- TagChip pill: one template covering manual and automatic, switching on IsAutomatic.
+         Both kinds MUST come from a single ItemsControl - two adjacent ones inside a WrapPanel
+         are each measured with infinite width, so neither wraps and the row clips them. -->
+    <DataTemplate x:Key="TagChipTemplate">
+        <Border x:Name="chip"
+                CornerRadius="9"
+                Padding="7,1"
+                Margin="0,2,4,0"
+                BorderThickness="1"
+                Background="{Binding Text, Converter={StaticResource TagBrush}, ConverterParameter=fill}"
+                BorderBrush="{Binding Text, Converter={StaticResource TagBrush}, ConverterParameter=border}">
+            <TextBlock x:Name="chipText"
+                       Text="{Binding Text}"
+                       FontFamily="Segoe UI"
+                       FontSize="10.5"
+                       FontWeight="SemiBold"
+                       Foreground="{Binding Text, Converter={StaticResource TagBrush}}" />
+        </Border>
+        <DataTemplate.Triggers>
+            <!-- Automatic tags: neutral outline, so a derived fact never competes with a red
+                 PROD pill or reads as something a human asserted. -->
+            <DataTrigger Binding="{Binding IsAutomatic}" Value="True">
+                <Setter TargetName="chip" Property="Background" Value="Transparent" />
+                <Setter TargetName="chip" Property="BorderBrush" Value="{StaticResource InputBorderBrush}" />
+                <Setter TargetName="chipText" Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+                <Setter TargetName="chipText" Property="FontWeight" Value="Normal" />
+            </DataTrigger>
+        </DataTemplate.Triggers>
+    </DataTemplate>
+
+    <!-- Drop-in list of chips. HorizontalAlignment=Left keeps the panel from stretching past
+         its content, and the parent must constrain width for the WrapPanel to know where to
+         break - see HorizontalContentAlignment on the lists that use this. -->
+    <Style x:Key="TagChipList" TargetType="ItemsControl">
+        <Setter Property="ItemTemplate" Value="{StaticResource TagChipTemplate}" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <WrapPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Drop-in list of pills: set ItemsSource to a collection of tag names. -->
     <Style x:Key="TagPillList" TargetType="ItemsControl">
         <Setter Property="ItemTemplate" Value="{StaticResource TagPillTemplate}" />
@@ -685,32 +731,5 @@
         </Setter>
     </Style>
 
-    <!-- Automatic tags: facts the app detected, not labels the user typed. Deliberately neutral
-         and outline-only so a derived value is never mistaken for a human assertion, and so it
-         cannot compete with a red PROD pill for attention. -->
-    <DataTemplate x:Key="AutoTagPillTemplate">
-        <Border CornerRadius="9"
-                Padding="7,1"
-                Margin="0,2,4,0"
-                BorderThickness="1"
-                Background="Transparent"
-                BorderBrush="{StaticResource InputBorderBrush}">
-            <TextBlock Text="{Binding}"
-                       FontFamily="Segoe UI"
-                       FontSize="10.5"
-                       Foreground="{StaticResource SecondaryTextBrush}" />
-        </Border>
-    </DataTemplate>
-
-    <Style x:Key="AutoTagPillList" TargetType="ItemsControl">
-        <Setter Property="ItemTemplate" Value="{StaticResource AutoTagPillTemplate}" />
-        <Setter Property="ItemsPanel">
-            <Setter.Value>
-                <ItemsPanelTemplate>
-                    <WrapPanel Orientation="Horizontal" />
-                </ItemsPanelTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
 
 </ResourceDictionary>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -184,9 +184,13 @@ public partial class RestoreViewModel : ViewModelBase
 
     public ServerConnection? ConnectedServer { get; set; }
 
-    /// <summary>Tags of the connected server, shown on the execute confirmation.</summary>
+    /// <summary>
+    /// Tags of the connected server, shown on the execute confirmation. Chips rather than plain
+    /// strings so the detected version appears alongside the environment labels, and so this
+    /// renders through the same single wrapping template as the lists.
+    /// </summary>
     [ObservableProperty]
-    private ObservableCollection<string> _connectedServerTags = [];
+    private ObservableCollection<TagChip> _connectedServerTags = [];
 
     [ObservableProperty]
     private bool _hasConnectedServerTags;
@@ -980,8 +984,10 @@ public partial class RestoreViewModel : ViewModelBase
 
     partial void OnIsConnectedToServerChanged(bool value)
     {
-        var tags = value ? ConnectedServer?.Tags ?? [] : [];
-        ConnectedServerTags = new ObservableCollection<string>(tags);
+        var chips = value && ConnectedServer != null
+            ? ConnectedServer.TagChips
+            : [];
+        ConnectedServerTags = new ObservableCollection<TagChip>(chips);
         HasConnectedServerTags = ConnectedServerTags.Count > 0;
 
         ValidateChainCommand.NotifyCanExecuteChanged();

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -52,6 +52,7 @@
                              Background="Transparent"
                              BorderThickness="0"
                              Foreground="{StaticResource PrimaryTextBrush}"
+                             HorizontalContentAlignment="Stretch"
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                              FocusVisualStyle="{x:Null}">
@@ -72,10 +73,9 @@
                                                TextTrimming="CharacterEllipsis"
                                                Margin="16,2,0,0"
                                                MaxWidth="220" />
-                                    <ItemsControl ItemsSource="{Binding Tags}"
-                                                  Style="{StaticResource TagPillList}"
-                                                  Margin="16,2,0,0"
-                                                  MaxWidth="220" />
+                                    <ItemsControl ItemsSource="{Binding TagChips}"
+                                                  Style="{StaticResource TagChipList}"
+                                                  Margin="16,2,0,0" />
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -838,7 +838,7 @@
                             Visibility="{Binding IsExecuteArmed, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
                             <ItemsControl ItemsSource="{Binding ConnectedServerTags}"
-                                          Style="{StaticResource TagPillList}"
+                                          Style="{StaticResource TagChipList}"
                                           Margin="0,0,0,6"
                                           Visibility="{Binding HasConnectedServerTags, Converter={StaticResource BoolToVis}}" />
                             <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap">

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -46,10 +46,15 @@
                                 HorizontalAlignment="Stretch" />
                     </StackPanel>
 
+                    <!-- Stretch + no horizontal scrolling: without both, each row is measured
+                         with unbounded width and the tag WrapPanel never learns where to break,
+                         so pills run off the edge and are clipped. -->
                     <ListBox ItemsSource="{Binding Servers}"
                              SelectedItem="{Binding SelectedServer}"
                              Background="Transparent"
                              BorderThickness="0"
+                             HorizontalContentAlignment="Stretch"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                              Foreground="{StaticResource PrimaryTextBrush}">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
@@ -62,15 +67,16 @@
                                                    FontWeight="SemiBold"
                                                    Foreground="{StaticResource PrimaryTextBrush}" />
                                     </StackPanel>
+                                    <!-- Now that the row is width-constrained (no horizontal
+                                         scrolling), a long name would be cut mid-character
+                                         rather than scrolled - so trim it explicitly. -->
                                     <TextBlock Text="{Binding DisplayText}"
                                                Style="{StaticResource SecondaryText}"
+                                               TextTrimming="CharacterEllipsis"
                                                Margin="22,2,0,0" />
-                                    <WrapPanel Orientation="Horizontal" Margin="22,2,0,0">
-                                        <ItemsControl ItemsSource="{Binding Tags}"
-                                                      Style="{StaticResource TagPillList}" />
-                                        <ItemsControl ItemsSource="{Binding AutoTags}"
-                                                      Style="{StaticResource AutoTagPillList}" />
-                                    </WrapPanel>
+                                    <ItemsControl ItemsSource="{Binding TagChips}"
+                                                  Style="{StaticResource TagChipList}"
+                                                  Margin="22,2,0,0" />
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>


### PR DESCRIPTION
Fixes the clipped pills in #67.

## Two causes, both about width measurement

**1. Nested wrapping panels.** Manual and automatic tags were two adjacent `ItemsControl`s inside a `WrapPanel`. A `WrapPanel` measures each child with **infinite** width in the wrapping direction, so neither inner `ItemsControl` ever learned it should wrap — each laid its pills out on one endless line, and the row simply clipped them.

They are now a **single** `ItemsControl` over a combined `TagChip` sequence, so one `WrapPanel` wraps where it should. The template switches styling on `IsAutomatic`, so the layout fix and the visual distinction between manual and derived tags no longer pull against each other.

**2. The ListBox allowed unbounded width.** The server list left `ScrollViewer.HorizontalScrollBarVisibility` at its default of `Auto`, which also measures items with unbounded width — so even one panel would not have wrapped. Now `Disabled`, with `HorizontalContentAlignment="Stretch"` so rows fill the available width and the `WrapPanel` has a real boundary to break against.

Both were necessary; fixing either alone would have left it clipping.

## Also

- The execute confirmation banner renders chips too, so the detected version shows there alongside the environment labels.
- `DisplayText` on the server row is now trimmed with an ellipsis — with horizontal scrolling off, an overlong server name would otherwise be cut mid-character rather than scrolled.

## Verification — please eyeball this one

**304 tests pass and the app builds and launches**, but I could not screenshot the result myself: computer-use only resolves Start-menu-installed applications, and this is a locally built exe. So I have verified the code, not the pixels.

The diagnosis is the standard WPF cause and the remedy is the standard one, but a layout fix deserves a human eye — particularly `BlackcatSVR02`, which has the most tags and was the row that clipped. If anything still looks off, tell me what and I will iterate.
