### PR TITLE
Check GitHub for a newer release at startup

### DIFF
--- a/src/NineLives.Tests/UpdateCheckerTests.cs
+++ b/src/NineLives.Tests/UpdateCheckerTests.cs
@@ -1,0 +1,131 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+public class UpdateCheckerTests
+{
+    private static ReleaseInfo Release(string tag, string version) =>
+        new(Version.Parse(version), tag, "https://example.invalid/release");
+
+    // ── version parsing ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("v1.1.0", "1.1.0")]
+    [InlineData("1.1.0", "1.1.0")]
+    [InlineData("V2.0.0", "2.0.0")]
+    [InlineData("1.2.3.4", "1.2.3.4")]
+    [InlineData("1.1.0+abc123", "1.1.0")]
+    [InlineData("1.1.0-beta", "1.1.0")]
+    public void Parse_AcceptsTheTagFormsWeActuallyPublish(string tag, string expected)
+        => Assert.Equal(Version.Parse(expected), AppVersion.Parse(tag));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-version")]
+    [InlineData("latest")]
+    public void Parse_Rubbish_ReturnsNull(string? tag)
+        => Assert.Null(AppVersion.Parse(tag));
+
+    // ── release payload ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseRelease_NormalPayload_IsRead()
+    {
+        var json = """
+        { "tag_name": "v1.1.0", "html_url": "https://github.com/x/y/releases/tag/v1.1.0",
+          "draft": false, "prerelease": false }
+        """;
+
+        var release = UpdateChecker.ParseRelease(json);
+
+        Assert.NotNull(release);
+        Assert.Equal(new Version(1, 1, 0), release!.Version);
+        Assert.Equal("v1.1.0", release.Tag);
+        Assert.Equal("https://github.com/x/y/releases/tag/v1.1.0", release.Url);
+    }
+
+    [Fact]
+    public void ParseRelease_MissingUrl_FallsBackToTheReleasesPage()
+    {
+        var release = UpdateChecker.ParseRelease("""{ "tag_name": "v1.1.0" }""");
+        Assert.Equal(UpdateChecker.ReleasesPage, release!.Url);
+    }
+
+    [Theory]
+    [InlineData("""{ "tag_name": "v2.0.0", "draft": true }""")]
+    [InlineData("""{ "tag_name": "v2.0.0", "prerelease": true }""")]
+    public void ParseRelease_DraftOrPrerelease_IsIgnored(string json)
+    {
+        // Not something to nudge people towards.
+        Assert.Null(UpdateChecker.ParseRelease(json));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("[]")]
+    [InlineData("""{ "message": "API rate limit exceeded" }""")]
+    [InlineData("""{ "tag_name": "nightly" }""")]
+    public void ParseRelease_AnythingUnexpected_ReturnsNull(string? json)
+    {
+        // Rate limits and API changes must be silent no-ops, not errors.
+        Assert.Null(UpdateChecker.ParseRelease(json));
+    }
+
+    // ── notify decision ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ShouldNotify_NewerRelease_Yes()
+        => Assert.True(UpdateChecker.ShouldNotify(
+            new Version(1, 0, 0), Release("v1.1.0", "1.1.0"), null, enabled: true));
+
+    [Fact]
+    public void ShouldNotify_SameVersion_No()
+        => Assert.False(UpdateChecker.ShouldNotify(
+            new Version(1, 1, 0), Release("v1.1.0", "1.1.0"), null, enabled: true));
+
+    [Fact]
+    public void ShouldNotify_OlderRelease_No()
+    {
+        // A local build ahead of the last release is not an update.
+        Assert.False(UpdateChecker.ShouldNotify(
+            new Version(1, 2, 0), Release("v1.1.0", "1.1.0"), null, enabled: true));
+    }
+
+    [Fact]
+    public void ShouldNotify_AlreadyToldAboutThisTag_No()
+        => Assert.False(UpdateChecker.ShouldNotify(
+            new Version(1, 0, 0), Release("v1.1.0", "1.1.0"), "v1.1.0", enabled: true));
+
+    [Fact]
+    public void ShouldNotify_ToldAboutAnOlderTag_StillNotifiesForTheNewOne()
+        => Assert.True(UpdateChecker.ShouldNotify(
+            new Version(1, 0, 0), Release("v1.2.0", "1.2.0"), "v1.1.0", enabled: true));
+
+    [Fact]
+    public void ShouldNotify_Disabled_No()
+        => Assert.False(UpdateChecker.ShouldNotify(
+            new Version(1, 0, 0), Release("v1.1.0", "1.1.0"), null, enabled: false));
+
+    [Fact]
+    public void ShouldNotify_NoReleaseFound_No()
+        => Assert.False(UpdateChecker.ShouldNotify(
+            new Version(1, 0, 0), null, null, enabled: true));
+
+    [Fact]
+    public void ShouldNotify_TagComparisonIgnoresCase()
+        => Assert.False(UpdateChecker.ShouldNotify(
+            new Version(1, 0, 0), Release("V1.1.0", "1.1.0"), "v1.1.0", enabled: true));
+
+    // ── current version ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AppVersion_Current_IsRealAndMatchesTheCsproj()
+    {
+        Assert.NotEqual(new Version(0, 0, 0), AppVersion.Current);
+        Assert.StartsWith("v", AppVersion.Display);
+    }
+}

--- a/src/NineLives/App.xaml.cs
+++ b/src/NineLives/App.xaml.cs
@@ -6,7 +6,7 @@ namespace Blackcat.NineLives;
 public partial class App : Application
 {
     /// <summary>How long the splash stays up once the main window has been built.</summary>
-    private static readonly TimeSpan SplashDwell = TimeSpan.FromMilliseconds(1400);
+    private static readonly TimeSpan SplashDwell = TimeSpan.FromMilliseconds(2500);
 
     protected override async void OnStartup(StartupEventArgs e)
     {

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -37,11 +37,50 @@
 
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid Grid.Row="0">
+        <!-- Update banner. Non-modal and dismissible on purpose: the app may well be open
+             because something is on fire, and a popup between the DBA and the restore button
+             would be exactly wrong. -->
+        <Border Grid.Row="0"
+                Background="#1B2A44"
+                BorderBrush="#2E4468"
+                BorderThickness="0,0,0,1"
+                Padding="16,8"
+                Visibility="{Binding UpdateAvailable, Converter={StaticResource BoolToVis}}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Column="0"
+                           Text="{Binding UpdateMessage}"
+                           VerticalAlignment="Center"
+                           Foreground="{StaticResource PrimaryTextBrush}"
+                           FontFamily="Segoe UI"
+                           FontSize="12.5" />
+
+                <Button Grid.Column="1"
+                        Content="View release"
+                        Command="{Binding OpenReleasesPageCommand}"
+                        Style="{StaticResource SecondaryButton}"
+                        Padding="12,4"
+                        Margin="12,0,8,0" />
+
+                <Button Grid.Column="2"
+                        Content="Dismiss"
+                        Command="{Binding DismissUpdateCommand}"
+                        Style="{StaticResource SecondaryButton}"
+                        Padding="12,4" />
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="220" />
                 <ColumnDefinition Width="*" />
@@ -205,7 +244,7 @@
         </Grid>
 
         <!-- Status Bar -->
-        <Border Grid.Row="1"
+        <Border Grid.Row="2"
                 Background="{StaticResource StatusBarBackgroundBrush}"
                 Padding="16,6">
             <Grid>

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -31,4 +31,9 @@
     <Resource Include="Assets\app.ico" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Lets the tests reach pure decision helpers without widening the public API. -->
+    <InternalsVisibleTo Include="NineLives.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/NineLives/Services/AppVersion.cs
+++ b/src/NineLives/Services/AppVersion.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>The running app's version, read from the assembly rather than a hardcoded string.</summary>
+public static class AppVersion
+{
+    public static Version Current { get; } = Resolve();
+
+    /// <summary>e.g. "v1.1.0"</summary>
+    public static string Display => $"v{Current.ToString(3)}";
+
+    private static Version Resolve()
+    {
+        var assembly = Assembly.GetEntryAssembly() ?? typeof(AppVersion).Assembly;
+
+        // InformationalVersion carries what the csproj <Version> said. It can have a build
+        // suffix (+sha, -beta) that Version.Parse rejects, so trim before parsing.
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        if (Parse(informational) is { } parsed) return parsed;
+
+        return assembly.GetName().Version ?? new Version(0, 0, 0);
+    }
+
+    internal static Version? Parse(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+
+        var text = raw.Trim().TrimStart('v', 'V');
+        foreach (var separator in new[] { '+', '-' })
+        {
+            var index = text.IndexOf(separator);
+            if (index > 0) text = text[..index];
+        }
+
+        return Version.TryParse(text, out var version) ? version : null;
+    }
+}

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -222,4 +222,10 @@ public class AppConfig
     public List<ServerConnection> Servers { get; set; } = [];
     public string? LastSelectedContainer { get; set; }
     public string? LastSelectedServer { get; set; }
+
+    /// <summary>Check GitHub for a newer release at startup. Turn off for offline installs.</summary>
+    public bool CheckForUpdates { get; set; } = true;
+
+    /// <summary>Last release tag the user was told about, so the banner does not nag.</summary>
+    public string? LastNotifiedReleaseTag { get; set; }
 }

--- a/src/NineLives/Services/UpdateChecker.cs
+++ b/src/NineLives/Services/UpdateChecker.cs
@@ -1,0 +1,104 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Blackcat.NineLives.Services;
+
+public sealed record ReleaseInfo(Version Version, string Tag, string Url);
+
+/// <summary>
+/// Asks GitHub whether a newer release exists. Tells the user; never downloads or installs.
+///
+/// Every failure here is a no-op. No network, a proxy, a rate limit, GitHub down, a changed API
+/// shape - all of it must leave the app behaving exactly as if the check never ran. A restore
+/// tool must not be impeded by its own update check.
+/// </summary>
+public class UpdateChecker
+{
+    private const string LatestReleaseApi =
+        "https://api.github.com/repos/jakemorgangit/NineLives/releases/latest";
+
+    public const string ReleasesPage = "https://github.com/jakemorgangit/NineLives/releases";
+
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    private readonly HttpMessageHandler? _handler;
+
+    public UpdateChecker(HttpMessageHandler? handler = null) => _handler = handler;
+
+    /// <summary>Latest published release, or null if it could not be determined.</summary>
+    public async Task<ReleaseInfo?> FetchLatestAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            using var client = _handler == null ? new HttpClient() : new HttpClient(_handler, false);
+            client.Timeout = Timeout;
+
+            // GitHub rejects requests without a User-Agent.
+            client.DefaultRequestHeaders.UserAgent.Add(
+                new ProductInfoHeaderValue("NineLives", AppVersion.Current.ToString(3)));
+            client.DefaultRequestHeaders.Accept.Add(
+                new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+
+            var response = await client.GetAsync(LatestReleaseApi, ct);
+            if (!response.IsSuccessStatusCode) return null;
+
+            return ParseRelease(await response.Content.ReadAsStringAsync(ct));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Reads a releases API payload. Returns null for anything unexpected.</summary>
+    internal static ReleaseInfo? ParseRelease(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object) return null;
+
+            // A draft or prerelease is not something to nudge people towards.
+            if (root.TryGetProperty("draft", out var draft) && draft.ValueKind == JsonValueKind.True)
+                return null;
+            if (root.TryGetProperty("prerelease", out var pre) && pre.ValueKind == JsonValueKind.True)
+                return null;
+
+            if (!root.TryGetProperty("tag_name", out var tagElement)) return null;
+
+            var tag = tagElement.GetString();
+            if (AppVersion.Parse(tag) is not { } version) return null;
+
+            var url = root.TryGetProperty("html_url", out var urlElement)
+                ? urlElement.GetString() ?? ReleasesPage
+                : ReleasesPage;
+
+            return new ReleaseInfo(version, tag!, url);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Whether to show the banner. Separate from fetching so the rules are testable without
+    /// touching the network.
+    /// </summary>
+    internal static bool ShouldNotify(
+        Version current, ReleaseInfo? latest, string? alreadyNotifiedTag, bool enabled)
+    {
+        if (!enabled || latest == null) return false;
+
+        // Running a build newer than the latest release (a local build) is not an update.
+        if (latest.Version <= current) return false;
+
+        // Only mention a given release once.
+        return !string.Equals(latest.Tag, alreadyNotifiedTag, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -3,7 +3,7 @@ namespace Blackcat.NineLives.ViewModels;
 public partial class AboutViewModel : ViewModelBase
 {
     public string AppName => "Nine Lives";
-    public string Version => "v1.0.0";
+    public string Version => Services.AppVersion.Display;
     public string Year => "2026";
     public string Author => "Jake Morgan";
     public string Company => "Blackcat Data Solutions Ltd";

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Models;
@@ -28,6 +29,15 @@ public partial class MainViewModel : ViewModelBase
     [ObservableProperty]
     private string _connectedServerName = "Not connected";
 
+    [ObservableProperty]
+    private bool _updateAvailable;
+
+    [ObservableProperty]
+    private string _updateMessage = string.Empty;
+
+    private string _updateUrl = UpdateChecker.ReleasesPage;
+    private string? _updateTag;
+
     public BlobConfigViewModel BlobConfig { get; }
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }
@@ -51,6 +61,68 @@ public partial class MainViewModel : ViewModelBase
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
 
         CurrentView = BlobConfig;
+
+        // Fire and forget - startup must not wait on the network.
+        _ = CheckForUpdatesAsync();
+    }
+
+    private async Task CheckForUpdatesAsync()
+    {
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            if (!config.CheckForUpdates) return;
+
+            var latest = await new UpdateChecker().FetchLatestAsync();
+            if (!UpdateChecker.ShouldNotify(
+                    AppVersion.Current, latest, config.LastNotifiedReleaseTag, config.CheckForUpdates))
+                return;
+
+            _updateUrl = latest!.Url;
+            _updateTag = latest.Tag;
+            UpdateMessage = $"Nine Lives {latest.Tag} is available. You have {AppVersion.Display}.";
+            UpdateAvailable = true;
+        }
+        catch
+        {
+            // Never surface an update-check failure. The app works fine without it.
+        }
+    }
+
+    /// <summary>Opens the releases page. The app downloads nothing itself.</summary>
+    [RelayCommand]
+    private void OpenReleasesPage()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(_updateUrl) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            GlobalStatus = $"Could not open browser: {ex.Message}";
+        }
+
+        DismissUpdate();
+    }
+
+    /// <summary>Hides the banner and remembers the tag so it is not shown again.</summary>
+    [RelayCommand]
+    private void DismissUpdate()
+    {
+        UpdateAvailable = false;
+
+        if (string.IsNullOrWhiteSpace(_updateTag)) return;
+
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            config.LastNotifiedReleaseTag = _updateTag;
+            _credentialStore.SaveConfig(config);
+        }
+        catch
+        {
+            // Worst case the banner shows again next launch.
+        }
     }
 
     private void OnSqlConnectionChanged(object? sender, ServerConnectionChangedEventArgs e)


### PR DESCRIPTION
Closes #65. Also fixes #35 along the way.

On launch the app asks the GitHub releases API whether there's a newer version, and shows a dismissible banner if so. Clicking it opens the release page — the app downloads and installs nothing.

The About box version was the hardcoded string `"v1.0.0"`. It now comes from the assembly, which the update check needs anyway to have something reliable to compare against.

## Behaviour

- **Every failure is a no-op.** No network, corporate proxy, rate limit, GitHub down, changed API shape — all leave the app behaving exactly as if the check never ran. A restore tool shouldn't be impeded by its own update check.
- **Never blocks startup.** Fire-and-forget with a 5s timeout.
- **Doesn't nag.** Dismissing remembers the tag; it won't mention that release again.
- **Ignores drafts and prereleases.**
- **A local build ahead of the last release isn't an update** — no banner when you're running something newer than what's published.
- **`CheckForUpdates` in config.json** turns it off entirely for offline or air-gapped installs.

Banner is non-modal and dismissible on purpose — the app may well be open because something is on fire, and a popup between the DBA and the restore button would be exactly wrong.

## Tested against the live API

```
App version : v1.0.0  (1.0.0)     <- read from the assembly
Latest tag  : v1.0.0  (1.0.0)
Newer than the running app? False  <- no banner, correctly
```

So nothing shows today, and a v1.0.0 install will see v1.1.0 the moment it ships. That's the real test — worth watching for when we cut the next release.

29 new tests, **345 total**. Splash dwell bumped to 2.5s as asked.
