### PR TITLE
Attest build provenance on releases, and document the signing options (#33)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
 
 permissions:
   contents: write
+  # Build provenance attestation: id-token mints the short-lived Sigstore identity that
+  # proves the signature came from this workflow, attestations stores the result.
+  id-token: write
+  attestations: write
 
 # Release runs are never cancelled and never share a concurrency group — each one must
 # finish and attach its assets to the release that triggered it.
@@ -65,6 +69,22 @@ jobs:
           $checksums | Out-File -FilePath releases/SHA256SUMS.txt -Encoding utf8
           Write-Host "Checksums:"
           $checksums | ForEach-Object { Write-Host $_ }
+
+      # Signed, tamper-evident proof of where this exe came from: which repo, which commit,
+      # which workflow run. Anyone can check it with
+      #     gh attestation verify NineLives.exe --repo jakemorgangit/NineLives
+      # and get a hard answer, rather than trusting that the file on the Releases page is
+      # the one this workflow built. A checksum only proves the file matches a number
+      # published next to it; provenance ties it back to source.
+      #
+      # This is NOT code signing and does nothing for SmartScreen - see #33 and
+      # docs/code-signing.md. It is the part that can be done without a certificate.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            releases/NineLives.exe
+            releases/NineLives-${{ steps.version.outputs.VERSION }}-win-x64.zip
 
       - name: Upload release assets
         env:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,37 @@ Download the latest release from the [Releases page](https://github.com/jakemorg
 - Windows 10/11 (x64)
 - No .NET runtime installation required (self-contained)
 
+### "Windows protected your PC"
+
+The executable is not yet code-signed, so SmartScreen will stop it the first time you run it.
+Click **More info** → **Run anyway**.
+
+That warning means Windows has not seen this file before — not that anything is wrong with it. But
+you shouldn't have to take that on faith for a tool you're about to point at production with
+sysadmin rights, so there are two ways to check.
+
+**Checksum** — confirms the file matches what the release page publishes:
+
+```powershell
+Get-FileHash NineLives.exe -Algorithm SHA256
+```
+
+Compare against `SHA256SUMS.txt` on the release.
+
+**Build provenance** — confirms the file was built by this repository's release workflow, from a
+specific commit, and has not been altered since. Needs the [GitHub CLI](https://cli.github.com):
+
+```powershell
+gh attestation verify NineLives.exe --repo jakemorgangit/NineLives
+```
+
+A pass prints the commit and workflow that produced it. This is a stronger guarantee than the
+checksum, which only proves the file matches a number published beside it.
+
+Getting the exe signed properly is tracked in
+[#33](https://github.com/jakemorgangit/NineLives/issues/33); the options are written up in
+[docs/code-signing.md](docs/code-signing.md).
+
 ### Build from Source
 
 #### Prerequisites

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -1,0 +1,86 @@
+# Code signing
+
+Tracking issue: [#33](https://github.com/jakemorgangit/NineLives/issues/33).
+
+`NineLives.exe` is unsigned. Every person who downloads it meets **"Windows protected your PC —
+Microsoft Defender SmartScreen prevented an unrecognised app from starting"** and has to click
+through *More info → Run anyway*.
+
+For most tools that is a papercut. For this one it is the first impression made by software that
+asks to be pointed at a production SQL Server with rights to drop and replace databases. A fair
+number of DBAs will stop there, and plenty of corporate policies will stop for them.
+
+## What is already in place
+
+Releases carry a **Sigstore build provenance attestation**, added in
+`.github/workflows/release.yml`. It is cryptographic proof that the exe on the release page was
+built by this repo's release workflow from a named commit:
+
+```powershell
+gh attestation verify NineLives.exe --repo jakemorgangit/NineLives
+```
+
+That is a real guarantee and it costs nothing. **It does not touch SmartScreen.** Windows does not
+consult Sigstore; it looks for an Authenticode signature. Provenance answers "did this come from
+the source I think it did", which is the question a careful reviewer asks. SmartScreen asks "does
+Windows recognise the publisher", and only a certificate answers that.
+
+## Options for the certificate
+
+### SignPath — free for open source
+
+The route the issue proposed, and what several OSS .NET projects use. SignPath issues the
+certificate; there is nothing to buy or store.
+
+- **Cost:** free, subject to their OSS eligibility review.
+- **Effort:** register the project, define a signing policy and an artifact configuration, add
+  `signpath/github-action-submit-signing-request@v2` to the release job, store the API token as a
+  repository secret.
+- **Catch:** signing is a submit-and-poll round trip through their service, so the release job gets
+  slower. Worth confirming their upload size limit up front — `NineLives.exe` is ~166 MB, which is
+  large for a signing submission.
+
+### Azure Trusted Signing — ~$10/month
+
+Microsoft's managed signing service. Short-lived certificates, no private key to look after, and
+because it is Microsoft's own CA it carries SmartScreen reputation well.
+
+- **Cost:** Basic tier, around $9.99/month.
+- **Effort:** likely the least of the three — there is already an Azure tenant here, and
+  `azure/trusted-signing-action` is a single step.
+- **Catch:** identity validation, and eligibility rules that have included a minimum trading
+  history for organisations. **Check whether Blackcat Data Solutions Ltd qualifies before
+  committing to this route** — that is the deciding factor, not the price.
+
+### A traditional OV certificate — £200–400/year
+
+Buy from a CA, keep it on a hardware token or in a KMS. Full control, most work, and an OV
+certificate builds SmartScreen reputation slowly by download volume. Hard to recommend over the
+other two.
+
+## Recommendation
+
+Try **Azure Trusted Signing** first — the tenant already exists, the wiring is one action, and it
+gives the best SmartScreen outcome. Fall back to **SignPath** if the eligibility check fails.
+
+## What still needs a human
+
+Both routes need an account created and an identity verified by the project owner. That part
+cannot be automated or delegated. Once the account exists, wiring it up is a small PR:
+
+```yaml
+# after "Package release assets", before "Attest build provenance"
+- name: Sign
+  uses: azure/trusted-signing-action@v0   # or signpath/github-action-submit-signing-request@v2
+  with:
+    files-folder: releases
+    files-folder-filter: exe
+    # ...plus the account/profile inputs from the service
+```
+
+Attestation should stay, and should run **after** signing so it covers the signed bytes. Repackage
+the zip and regenerate `SHA256SUMS.txt` after signing too, or the published checksums will describe
+the unsigned file.
+
+Until then the README tells people plainly why the warning appears and how to verify the download
+themselves.


### PR DESCRIPTION
Part of #33 — the part that doesn't need a certificate. **The exe is still unsigned and SmartScreen
will still warn**, so the issue stays open.

## What this adds

**Build provenance attestation.** `release.yml` now attaches a Sigstore attestation to the exe and
the zip. Anyone can check where the file came from:

```powershell
gh attestation verify NineLives.exe --repo jakemorgangit/NineLives
```

A pass names the commit and the workflow run that built it. That's a stronger statement than the
checksum, which only proves the file matches a number published next to it on the same page — if
someone could replace the exe there, they could replace the number too. Provenance ties the bytes
back to source, and it's free on public repos.

**README** now says why the warning appears and shows both checks, instead of leaving people to
guess whether *Run anyway* is safe. That matters more here than for most tools: the warning is the
first thing a DBA sees from software that's about to ask for rights to drop and replace databases.

**[docs/code-signing.md](docs/code-signing.md)** weighs the options for the actual certificate.

## To be clear about what this does not do

Provenance does nothing for SmartScreen. Windows looks for an Authenticode signature; it doesn't
consult Sigstore. The two answer different questions — "did this come from the source I think it
did" versus "does Windows recognise the publisher" — and only a certificate answers the second.

## What's left on #33, and it needs you

Both routes need an account created and an identity verified by the project owner, which I can't do:

- **Azure Trusted Signing** (~$10/mo) — probably the best fit, since the Azure tenant already
  exists and it's one action in the workflow. Microsoft's own CA, so SmartScreen reputation lands
  well. **Worth checking Blackcat Data Solutions Ltd meets the eligibility rules first** — those
  have included a minimum trading history for organisations, and that's the deciding factor rather
  than the price.
- **SignPath** — free for OSS, which is what the issue originally proposed. Good fallback. Worth
  confirming their upload size limit, because 166 MB is large for a signing submission.

Once an account exists, wiring it is a small PR. One thing for whoever does it: signing must run
**before** packaging, and the zip and `SHA256SUMS.txt` have to be regenerated afterwards, or the
published checksums will describe the unsigned file. Attestation should move after signing so it
covers the signed bytes.

## Verified

Workflow YAML parses. The attestation step itself only runs on a real release, so it gets its first
live exercise at v1.2.0 — flagging that rather than claiming it's proven.
