### PR TITLE
Execute against the connected server, and stop churning the credential (#11, #10)

### DIFF
--- a/src/NineLives.Tests/CredentialInjectionTests.cs
+++ b/src/NineLives.Tests/CredentialInjectionTests.cs
@@ -98,7 +98,7 @@ public class CredentialInjectionTests
     [RequiresSqlFact]
     public async Task EnsureCredentialExists_IsIdempotentForAwkwardNames()
     {
-        // Second call takes the DROP-then-CREATE path, which is the other interpolation site.
+        // Second call takes the ALTER path, which is the other interpolation site.
         const string name = "ninelives-test]awkward]name";
         try
         {

--- a/src/NineLives.Tests/CredentialLifecycleTests.cs
+++ b/src/NineLives.Tests/CredentialLifecycleTests.cs
@@ -1,0 +1,185 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Live proof of how <see cref="SqlServerService.EnsureCredentialExistsAsync"/> touches server
+/// state (#10).
+///
+/// It used to unconditionally DROP and re-CREATE the credential. A credential is server-scoped,
+/// so that momentarily removed something other sessions may have been mid-way through using - a
+/// backup job writing to the same container being the obvious one - and it happened on every
+/// single Execute, whether or not anything needed changing.
+///
+/// The tell is <c>sys.credentials.create_date</c>: ALTER leaves it alone, DROP-then-CREATE resets
+/// it. Asserting on it is what makes these tests fail against the old implementation rather than
+/// just describing the new one.
+///
+/// Gated on NINELIVES_TEST_SQL like the other live tests; each cleans up after itself.
+/// </summary>
+public class CredentialLifecycleTests
+{
+    private static string? TestServerName =>
+        Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL");
+
+    private static ServerConnection TestServer() => new()
+    {
+        Name = "ninelives-test",
+        ServerName = TestServerName!,
+        AuthMode = AuthMode.WindowsAuth,
+        Encrypt = EncryptMode.No,
+        TrustServerCertificate = true,
+        ConnectionTimeoutSeconds = 15
+    };
+
+    private static SqlServerService Service() => new(new CredentialStore());
+
+    private const string Url = "https://acct.blob.core.windows.net/backups";
+    private const string FirstSas = "sv=2026-01-01&sig=first-token";
+    private const string SecondSas = "sv=2026-01-01&sig=second-token";
+
+    [RequiresSqlFact]
+    public async Task FirstCall_CreatesTheCredential_AndSaysSo()
+    {
+        const string name = "ninelives-test-lifecycle-create";
+        try
+        {
+            await DropCredentialIfExists(name);
+
+            var change = await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, FirstSas);
+
+            Assert.Equal(CredentialChange.Created, change);
+            Assert.True(await CredentialExists(name));
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    /// <summary>
+    /// The regression test for #10. Under the old DROP-then-CREATE the credential came back as a
+    /// brand new object with a fresh create_date, and for the moment between the two statements
+    /// it did not exist at all.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task SecondCall_AltersInPlace_AndDoesNotRecreateTheCredential()
+    {
+        const string name = "ninelives-test-lifecycle-alter";
+        try
+        {
+            await DropCredentialIfExists(name);
+            await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, FirstSas);
+            var createdAt = await CreateDate(name);
+
+            // A second later, so a recreate would land on a visibly different timestamp.
+            await Task.Delay(1100);
+            var change = await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, SecondSas);
+
+            Assert.Equal(CredentialChange.Updated, change);
+            Assert.Equal(createdAt, await CreateDate(name));
+            Assert.True(await ModifyDate(name) > createdAt, "The secret should actually have been rewritten.");
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    /// <summary>
+    /// A credential sitting there under some other identity cannot serve a RESTORE FROM URL, so
+    /// ALTER resets IDENTITY too rather than leaving a broken credential to fail the restore.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task NonSasCredential_IsConvertedToSharedAccessSignature()
+    {
+        const string name = "ninelives-test-lifecycle-identity";
+        try
+        {
+            await DropCredentialIfExists(name);
+            await CreateNonSasCredential(name);
+
+            Assert.False((await Service().CredentialExistsAsync(TestServer(), name)).IsSharedAccessSignature);
+
+            var change = await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, FirstSas);
+
+            Assert.Equal(CredentialChange.Updated, change);
+            var (exists, isSas) = await Service().CredentialExistsAsync(TestServer(), name);
+            Assert.True(exists);
+            Assert.True(isSas);
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    [RequiresSqlFact]
+    public async Task CredentialExists_ReportsAbsenceWithoutCreatingAnything()
+    {
+        // Execute now asks this question before deciding whether to write. If the check itself
+        // had a side effect, the "don't touch the server" path would not be true.
+        const string name = "ninelives-test-lifecycle-absent";
+        await DropCredentialIfExists(name);
+
+        var (exists, isSas) = await Service().CredentialExistsAsync(TestServer(), name);
+
+        Assert.False(exists);
+        Assert.False(isSas);
+        Assert.False(await CredentialExists(name));
+    }
+
+    // ── helpers (parameterised) ──────────────────────────────────────────────────
+
+    private static async Task<SqlConnection> OpenAsync()
+    {
+        var conn = new SqlConnection(Service().BuildConnectionString(TestServer()));
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private static async Task<bool> CredentialExists(string name)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM sys.credentials WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", name);
+        return (int)(await cmd.ExecuteScalarAsync())! > 0;
+    }
+
+    private static Task<DateTime> CreateDate(string name) => DateColumn(name, "create_date");
+    private static Task<DateTime> ModifyDate(string name) => DateColumn(name, "modify_date");
+
+    private static async Task<DateTime> DateColumn(string name, string column)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        // The column name is a compile-time constant from the two callers above, never user input.
+        cmd.CommandText = $"SELECT {column} FROM sys.credentials WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", name);
+        var value = await cmd.ExecuteScalarAsync();
+        Assert.NotNull(value);
+        return (DateTime)value!;
+    }
+
+    private static async Task CreateNonSasCredential(string name)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"CREATE CREDENTIAL {TSql.QuoteName(name)} WITH IDENTITY = 'ninelives-test-identity', SECRET = 'not-a-sas'";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task DropCredentialIfExists(string name)
+    {
+        if (!await CredentialExists(name)) return;
+
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DROP CREDENTIAL {TSql.QuoteName(name)}";
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/NineLives/Services/CredentialChange.cs
+++ b/src/NineLives/Services/CredentialChange.cs
@@ -1,0 +1,20 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// What <see cref="SqlServerService.EnsureCredentialExistsAsync"/> actually did to the server.
+///
+/// Callers report this in the execution log. Modifying a server-scoped credential is a change to
+/// shared state on someone's production instance, made by a tool that was only asked to run a
+/// restore - so it should never happen without a line saying it happened.
+/// </summary>
+public enum CredentialChange
+{
+    /// <summary>Nothing was sent to the server; a usable credential was already there.</summary>
+    None,
+
+    /// <summary>The credential did not exist and was created.</summary>
+    Created,
+
+    /// <summary>The credential existed and its secret (and identity) were updated in place.</summary>
+    Updated
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -356,7 +356,13 @@ public class SqlServerService
     //
     // It also broke benignly: an IPv6-literal endpoint such as https://[fe80::1]:10000/... is a
     // legal URL containing ']' and failed with an opaque syntax error.
-    public async Task EnsureCredentialExistsAsync(
+    //
+    // An existing credential is now ALTERed rather than dropped and recreated. A credential is
+    // server-scoped shared state: dropping it, even for the moment between two statements,
+    // breaks anything else relying on it at that instant - a backup job writing to the same
+    // container, most obviously. ALTER updates the secret in place with no such window, and
+    // leaves create_date intact, which is how the tests tell the two apart.
+    public async Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
         CancellationToken ct = default)
     {
@@ -371,20 +377,17 @@ public class SqlServerService
         checkCmd.Parameters.AddWithValue("@name", credentialName);
         var exists = (int)(await checkCmd.ExecuteScalarAsync(ct))! > 0;
 
-        if (exists)
-        {
-            await using var dropCmd = conn.CreateCommand();
-            dropCmd.CommandText = $"DROP CREDENTIAL {quotedName}";
-            await dropCmd.ExecuteNonQueryAsync(ct);
-        }
-
+        // ALTER also resets IDENTITY, so a credential that exists under some other identity is
+        // converted rather than left in place to fail the restore later.
         var cleanSas = sasToken.TrimStart('?');
-        await using var createCmd = conn.CreateCommand();
-        createCmd.CommandText = $@"
-            CREATE CREDENTIAL {quotedName}
+        await using var writeCmd = conn.CreateCommand();
+        writeCmd.CommandText = $@"
+            {(exists ? "ALTER" : "CREATE")} CREDENTIAL {quotedName}
             WITH IDENTITY = 'SHARED ACCESS SIGNATURE',
             SECRET = '{TSql.EscapeLiteral(cleanSas)}'";
-        await createCmd.ExecuteNonQueryAsync(ct);
+        await writeCmd.ExecuteNonQueryAsync(ct);
+
+        return exists ? CredentialChange.Updated : CredentialChange.Created;
     }
 
     public async Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1081,10 +1081,12 @@ public partial class RestoreViewModel : ViewModelBase
 
         try
         {
-            await _sqlService.EnsureCredentialExistsAsync(
+            var change = await _sqlService.EnsureCredentialExistsAsync(
                 ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
             await RefreshCredentialStatusAsync();
-            SetStatus("Credential created or updated on server.");
+            SetStatus(change == CredentialChange.Created
+                ? "Credential created on server."
+                : "Credential updated on server with the stored SAS token.");
         }
         catch (Exception ex)
         {
@@ -1092,9 +1094,12 @@ public partial class RestoreViewModel : ViewModelBase
         }
     }
 
-    private bool CanCreateCredential() =>
-        IsConnectedToServer && SelectedContainer != null &&
-        (CredentialExistsOnServer != true || !CredentialIsValidSas);
+    // Deliberately available even when the credential is present and valid. SQL Server will not
+    // hand back a credential's secret, so "present and SAS" says nothing about whether the token
+    // inside it still works - a SAS that was rotated or has expired looks identical from here.
+    // Since Execute no longer rewrites the credential on every run, this button is the only way
+    // to push a fresh token, and hiding it left users with no route at all.
+    private bool CanCreateCredential() => IsConnectedToServer && SelectedContainer != null;
 
     [RelayCommand]
     private void CopyScript()
@@ -1331,11 +1336,16 @@ public partial class RestoreViewModel : ViewModelBase
 
         try
         {
-            var config = _credentialStore.LoadConfig();
-            var server = config.Servers.FirstOrDefault(s => s.ServerName == ConnectedServerName);
+            // Execute against the server we are actually connected to, not one looked up by name.
+            // This used to re-read config.json and take the first entry whose ServerName matched,
+            // which is a different object whenever two entries share a host and differ in auth,
+            // port or encryption - a Windows-auth and a SQL-auth entry for the same box, say. The
+            // restore would then run under credentials the user never connected with or tested.
+            // Every other server call on this screen already uses ConnectedServer.
+            var server = ConnectedServer;
             if (server == null)
             {
-                SetError("Connected server not found in config.");
+                SetError("Not connected to a server.");
                 return;
             }
 
@@ -1344,10 +1354,34 @@ public partial class RestoreViewModel : ViewModelBase
                 var sasToken = _credentialStore.GetSasToken(SelectedContainer);
                 if (!string.IsNullOrEmpty(sasToken))
                 {
-                    AppendLog("Creating SQL Server credential for blob access...");
-                    await _sqlService.EnsureCredentialExistsAsync(
-                        server, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
-                    AppendLog("Credential created successfully.");
+                    // Only write to the server when the credential is genuinely missing or is not
+                    // a SAS credential. This used to drop and recreate on every single execute,
+                    // regardless of the status the panel above was displaying, which contradicted
+                    // the UI's own "creating it is optional" wording and briefly removed a
+                    // credential that other sessions may have been using.
+                    //
+                    // A credential that exists and is SAS is left alone. Its secret could still be
+                    // a rotated SAS that no longer works - that is unknowable from here, since the
+                    // secret cannot be read back - so the fix for that case is the explicit
+                    // refresh button, not silently rewriting server state on every run.
+                    var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
+                    if (exists && isSas)
+                    {
+                        AppendLog($"Using the existing SQL credential [{SqlCredentialName}]. Server state not modified.");
+                    }
+                    else
+                    {
+                        AppendLog(exists
+                            ? $"Credential [{SqlCredentialName}] exists but is not a SAS credential - updating it..."
+                            : $"Credential [{SqlCredentialName}] is missing - creating it...");
+
+                        var change = await _sqlService.EnsureCredentialExistsAsync(
+                            server, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
+
+                        AppendLog(change == CredentialChange.Created
+                            ? "Credential created on the server."
+                            : "Credential updated on the server.");
+                    }
                 }
             }
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -766,15 +766,31 @@
                                         </Border>
                                         <TextBlock Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
-                                            <Run Text="Restore from URL requires a SQL credential (SHARED ACCESS SIGNATURE) for the container. Creating it is optional: you can create it from here or ensure it exists on the server before running the script. The SAS token is never included in the generated script." />
+                                            <Run Text="Restore from URL requires a SQL credential (SHARED ACCESS SIGNATURE) for the container. You can create it from here, or create it on the server yourself before running the script. Execute will create it for you if it is missing. The SAS token is never included in the generated script." />
                                         </TextBlock>
-                                        <Button Content="Create credential on server"
-                                                Command="{Binding CreateCredentialOnServerCommand}"
-                                                Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                        <!-- Stays available once the credential is valid, because "valid" only means a SAS
+                                             credential of that name exists. SQL Server will not return its secret, so a
+                                             rotated or expired token is indistinguishable from a working one, and this is
+                                             the only way to push a fresh one. -->
+                                        <TextBlock Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}}"
+                                                   Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
+                                            <Run Text="Execute will leave this credential alone. If the SAS token has been rotated or has expired since the credential was created, the restore will fail on blob access - refresh it below to push the token currently stored for this container." />
+                                        </TextBlock>
+                                        <Button Command="{Binding CreateCredentialOnServerCommand}"
                                                 Margin="0,0,0,0" Padding="10,6"
-                                                Style="{StaticResource SecondaryButton}"
-                                                ToolTip="Creates or updates a SQL Server credential for this blob container URL so that RESTORE FROM URL can access the backups. Optional; the credential can also be created manually on the server. The SAS token is not included in the generated script."
-                                                HorizontalAlignment="Left" />
+                                                ToolTip="Creates the SQL Server credential for this blob container URL, or updates an existing one with the SAS token currently stored for the container, so that RESTORE FROM URL can access the backups. An existing credential is altered in place, never dropped. The SAS token is not included in the generated script."
+                                                HorizontalAlignment="Left">
+                                            <Button.Style>
+                                                <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
+                                                    <Setter Property="Content" Value="Create credential on server" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding CredentialIsValidSas}" Value="True">
+                                                            <Setter Property="Content" Value="Refresh credential with stored SAS token" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Button.Style>
+                                        </Button>
                                     </StackPanel>
                                 </StackPanel>
                             </Border>


### PR DESCRIPTION
Closes #11. Closes #10.

Two bugs sat in the same twenty lines of `ExecuteScriptAsync`, both about doing something to a
server other than the one you asked for.

## #11 — the restore could run against a different server entry than the one you connected with

`ExecuteScriptAsync` was the only server operation that re-read `config.json` and re-resolved the
target by name:

```csharp
config.Servers.FirstOrDefault(s => s.ServerName == ConnectedServerName)
```

Every peer call — credential status, default paths, `FILELISTONLY`, `HEADERONLY` — uses the held
`ConnectedServer` object.

Two saved entries for the same host that differ in authentication, port or encryption is an
ordinary setup; a Windows-auth entry and a SQL-auth entry for the same box is the obvious one.
`FirstOrDefault` returns whichever was saved first, so the restore could execute under credentials
and connection settings you never connected with and never tested. Now it uses `ConnectedServer`,
like everything else.

## #10 — every Execute dropped and recreated the blob credential

Whenever a SAS was stored for the container, Execute called `EnsureCredentialExistsAsync`, which
unconditionally did `DROP CREDENTIAL` then `CREATE CREDENTIAL` — regardless of the credential
status the panel directly above had **already checked and was displaying**.

Two problems with that:

- A credential is server-scoped shared state. Dropping it, even for the instant between two
  statements, breaks anything else relying on it right then — a backup job writing to the same
  container being the obvious casualty.
- The UI calls creating the credential optional and offers it as a button you opt into. It was
  happening on every run either way.

Execute now checks first, and only writes when the credential is actually missing or is not a SAS
credential. It logs which of those it did, or says plainly that it left the server alone —
modifying a credential on someone's production instance should never happen without a line saying
it happened.

`EnsureCredentialExistsAsync` also uses **`ALTER`** rather than drop-and-recreate, so there is no
window where the credential does not exist, and returns whether it created or updated.

## Knock-on fix: a rotated SAS had become unfixable

The "create credential on server" button was hidden once `CredentialIsValidSas` was true. But
"valid" only means *a SAS credential of that name exists* — SQL Server will not hand back the
secret, so a token that has been rotated or has expired looks exactly like a working one.

Previously that was survivable by accident, because Execute rewrote the credential every time. With
#10 fixed, a stale credential would have had no route to repair at all. The button now stays
visible and relabels itself to **"Refresh credential with stored SAS token"**, with a line
explaining when you'd want it.

## Tests

4 new live tests in `CredentialLifecycleTests`. The one that matters is the #10 regression:

```
Assert.Equal() Failure: Values differ
Expected: 2026-08-05T13:18:38.4000000
Actual:   2026-08-05T13:18:39.8970000
```

That's it failing against the **old** implementation. `sys.credentials.create_date` survives an
`ALTER` and resets on a `DROP`/`CREATE`, so asserting on it is what makes the test detect the real
behaviour rather than just describe the new code. Also covers the create/update return value, the
non-SAS conversion path, and that the existence check has no side effect of its own.

**349 tests pass**, build clean at `-warnaserror`.

## One thing not covered by a test

#11 is a ViewModel change, and `RestoreViewModel` takes concrete services, so there's no seam to
inject a fake through. Verified by code inspection — it now uses the same object as its five peer
call sites. #41 (extract interfaces for the I/O services) is what would make this testable, and
this is a good argument for doing it.
