### PR TITLE
Stop a locked config.json from wiping every saved server and container (#7)

### DIFF
--- a/src/NineLives.Tests/ConfigPersistenceTests.cs
+++ b/src/NineLives.Tests/ConfigPersistenceTests.cs
@@ -1,0 +1,177 @@
+using System.IO;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Config load/save behaviour (#7).
+///
+/// LoadConfig used to catch everything and return empty defaults, and SaveConfig used to catch
+/// everything and return silently while the UI reported success. Together those turned a
+/// momentary file lock - antivirus, a backup agent, a sync client mid-upload - into permanent
+/// data loss: the app came up showing nothing, the user re-added one container, and the save
+/// wrote that single entry over every server and container they had.
+///
+/// These use a temp directory through the internal constructor, so they never touch the real
+/// %LOCALAPPDATA%\NineLives\config.json.
+/// </summary>
+public class ConfigPersistenceTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-config-tests", Guid.NewGuid().ToString("n"));
+
+    private string ConfigPath => Path.Combine(_dir, "config.json");
+    private CredentialStore Store() => new(_dir);
+
+    public ConfigPersistenceTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* temp dir */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private static AppConfig ConfigWith(params string[] containerNames)
+    {
+        var config = new AppConfig();
+        foreach (var name in containerNames)
+        {
+            config.BlobContainers.Add(new BlobContainerConfig
+            {
+                Name = name,
+                ContainerUrl = $"https://acct.blob.core.windows.net/{name}"
+            });
+        }
+        return config;
+    }
+
+    // ── the distinction that matters ────────────────────────────────────────────
+
+    [Fact]
+    public void MissingFile_IsAFreshInstall_NotAnError()
+    {
+        var config = Store().LoadConfig();
+
+        Assert.Null(config.LoadError);
+        Assert.Empty(config.BlobContainers);
+    }
+
+    [Fact]
+    public void UnreadableFile_ReportsLoadError()
+    {
+        Store().SaveConfig(ConfigWith("prod", "uat", "dev"));
+
+        // Hold the file open exclusively, the way a scanner or sync client briefly does.
+        using var _ = new FileStream(ConfigPath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var config = Store().LoadConfig();
+
+        Assert.NotNull(config.LoadError);
+        Assert.Empty(config.BlobContainers);
+    }
+
+    [Fact]
+    public void CorruptFile_ReportsLoadError()
+    {
+        File.WriteAllText(ConfigPath, "{ this is not json");
+
+        var config = Store().LoadConfig();
+
+        Assert.NotNull(config.LoadError);
+    }
+
+    // ── the data-loss regression ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The whole of #7 in one test: the file is briefly locked, the app comes up empty, the user
+    /// re-adds a container and saves. Before the fix that wrote one container over three. The
+    /// save must now refuse, and the file on disk must be untouched.
+    /// </summary>
+    [Fact]
+    public void SavingAConfigThatFailedToLoad_IsRefused_AndLeavesTheFileIntact()
+    {
+        Store().SaveConfig(ConfigWith("prod", "uat", "dev"));
+
+        AppConfig loaded;
+        using (var _ = new FileStream(ConfigPath, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            loaded = Store().LoadConfig();
+            Assert.NotNull(loaded.LoadError);
+        }
+
+        // The user, seeing an empty list, adds a container back.
+        loaded.BlobContainers.Add(new BlobContainerConfig { Name = "prod", ContainerUrl = "https://acct/prod" });
+
+        Assert.Throws<ConfigSaveRefusedException>(() => Store().SaveConfig(loaded));
+
+        var onDisk = Store().LoadConfig();
+        Assert.Null(onDisk.LoadError);
+        Assert.Equal(new[] { "prod", "uat", "dev" }, onDisk.BlobContainers.Select(c => c.Name));
+    }
+
+    [Fact]
+    public void SaveFailure_Propagates_RatherThanReportingSuccess()
+    {
+        Store().SaveConfig(ConfigWith("prod"));
+        var config = Store().LoadConfig();
+
+        // Something else holds the target open for writing; the swap cannot happen.
+        using var _ = new FileStream(ConfigPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        Assert.ThrowsAny<IOException>(() => Store().SaveConfig(config));
+    }
+
+    // ── ordinary behaviour that must keep working ───────────────────────────────
+
+    [Fact]
+    public void SaveThenLoad_RoundTrips()
+    {
+        Store().SaveConfig(ConfigWith("prod", "uat"));
+
+        var config = Store().LoadConfig();
+
+        Assert.Null(config.LoadError);
+        Assert.Equal(new[] { "prod", "uat" }, config.BlobContainers.Select(c => c.Name));
+    }
+
+    [Fact]
+    public void LoadError_IsNotWrittenToTheFile()
+    {
+        // It describes one load attempt, not the configuration. Persisting it would make a
+        // transient failure permanent, and every later save would be refused.
+        Store().SaveConfig(ConfigWith("prod"));
+
+        Assert.DoesNotContain("LoadError", File.ReadAllText(ConfigPath));
+    }
+
+    [Fact]
+    public void OverwritingAnExistingConfig_KeepsThePreviousContentsAsBak()
+    {
+        Store().SaveConfig(ConfigWith("prod", "uat"));
+        Store().SaveConfig(ConfigWith("prod"));
+
+        var backup = JsonSerializer.Deserialize<AppConfig>(File.ReadAllText(ConfigPath + ".bak"))!;
+        Assert.Equal(new[] { "prod", "uat" }, backup.BlobContainers.Select(c => c.Name));
+    }
+
+    [Fact]
+    public void SaveLeavesNoTempFileBehind()
+    {
+        Store().SaveConfig(ConfigWith("prod"));
+
+        Assert.False(File.Exists(ConfigPath + ".tmp"));
+    }
+
+    [Fact]
+    public void SaveCreatesTheDirectoryWhenItIsMissing()
+    {
+        Directory.Delete(_dir, recursive: true);
+
+        Store().SaveConfig(ConfigWith("prod"));
+
+        Assert.Single(Store().LoadConfig().BlobContainers);
+    }
+}

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
@@ -13,10 +14,21 @@ namespace Blackcat.NineLives.Services;
 public class CredentialStore
 {
     private const string AppPrefix = "NineLives";
-    private static readonly string ConfigDir = Path.Combine(
+    private static readonly string DefaultConfigDir = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "NineLives");
-    private static readonly string ConfigPath = Path.Combine(ConfigDir, "config.json");
+
+    private readonly string _configDir;
+    private readonly string _configPath;
+
+    public CredentialStore() : this(DefaultConfigDir) { }
+
+    /// <summary>Lets the tests point config persistence at a temp directory instead of the real profile.</summary>
+    internal CredentialStore(string configDir)
+    {
+        _configDir = configDir;
+        _configPath = Path.Combine(configDir, "config.json");
+    }
 
     #region Windows Credential Manager P/Invoke
 
@@ -182,38 +194,98 @@ public class CredentialStore
 
     #region Config Persistence (non-secret data)
 
+    /// <summary>
+    /// Reads config.json. Never throws, so startup cannot be bricked by a bad file - but a file
+    /// that exists and could not be read comes back carrying <see cref="AppConfig.LoadError"/>,
+    /// and <see cref="SaveConfig"/> refuses to overwrite anything in that state.
+    ///
+    /// The distinction matters. "No file" means a fresh install, where empty defaults are exactly
+    /// right. "File is there but I could not read it" used to produce the same empty defaults,
+    /// which is how a transient lock - antivirus, a backup agent, a sync client mid-upload -
+    /// turned into permanent data loss: the UI showed no containers, the user re-added one, and
+    /// the save wrote that single entry over everything they had.
+    /// </summary>
     public AppConfig LoadConfig()
     {
+        if (!File.Exists(_configPath))
+            return new AppConfig();
+
         try
         {
-            if (File.Exists(ConfigPath))
+            var json = File.ReadAllText(_configPath);
+            var config = JsonSerializer.Deserialize<AppConfig>(json);
+            if (config != null)
+                return config;
+
+            return new AppConfig
             {
-                var json = File.ReadAllText(ConfigPath);
-                return JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
-            }
+                LoadError = $"{_configPath} does not contain valid configuration."
+            };
         }
-        catch
+        catch (Exception ex)
         {
-            // Config corrupted, return defaults
+            return new AppConfig
+            {
+                LoadError = $"{_configPath} could not be read: {ex.Message}"
+            };
         }
-        return new AppConfig();
     }
 
+    /// <summary>
+    /// Writes config.json, or throws. Callers must report the failure rather than telling the
+    /// user their work was saved - the old version swallowed everything and the UI said
+    /// "saved successfully" regardless.
+    /// </summary>
+    /// <exception cref="ConfigSaveRefusedException">
+    /// The config being saved came from a failed load, so writing it would destroy whatever is
+    /// still on disk.
+    /// </exception>
     public void SaveConfig(AppConfig config)
     {
-        try
+        if (config.LoadError != null)
+            throw new ConfigSaveRefusedException(config.LoadError);
+
+        Directory.CreateDirectory(_configDir);
+        var json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
+
+        // Write beside the real file and swap it in, so a crash or a full disk part-way through
+        // cannot leave a truncated config.json where a complete one used to be. File.Replace is
+        // atomic and keeps the previous contents as .bak, which is a free undo for the case
+        // where something else has gone wrong.
+        var tempPath = _configPath + ".tmp";
+        File.WriteAllText(tempPath, json);
+
+        if (File.Exists(_configPath))
         {
-            Directory.CreateDirectory(ConfigDir);
-            var json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(ConfigPath, json);
+            try
+            {
+                File.Replace(tempPath, _configPath, _configPath + ".bak", ignoreMetadataErrors: true);
+                return;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Some filesystems (a few network shares) cannot do the atomic swap. Fall through
+                // to the plain move, which is still better than writing over the file in place.
+            }
+            File.Delete(_configPath);
         }
-        catch
-        {
-            // Silently fail config save
-        }
+
+        File.Move(tempPath, _configPath);
     }
 
     #endregion
+}
+
+/// <summary>
+/// Thrown when a save is refused because the configuration in hand was never successfully loaded.
+/// Writing it would replace real saved servers and containers with an empty list.
+/// </summary>
+public class ConfigSaveRefusedException(string loadError)
+    : InvalidOperationException(
+        $"Configuration was not saved, because it could not be read in the first place and " +
+        $"saving now would overwrite the copy on disk. {loadError}")
+{
+    public string LoadError { get; } = loadError;
 }
 
 public class AppConfig
@@ -228,4 +300,13 @@ public class AppConfig
 
     /// <summary>Last release tag the user was told about, so the banner does not nag.</summary>
     public string? LastNotifiedReleaseTag { get; set; }
+
+    /// <summary>
+    /// Set when config.json existed but could not be read or parsed. Not persisted - it describes
+    /// this load attempt, not the configuration. While it is set, this object holds empty defaults
+    /// that do NOT reflect what is on disk, so <see cref="CredentialStore.SaveConfig"/> will
+    /// refuse to write it.
+    /// </summary>
+    [JsonIgnore]
+    public string? LoadError { get; set; }
 }

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -122,11 +122,25 @@ public partial class BlobConfigViewModel : ViewModelBase
         }
     }
 
-    private void SaveContainers()
+    /// <summary>
+    /// Persists the container list. Returns false and sets the error when the write failed, so
+    /// callers do not go on to report success - the config save used to swallow everything and
+    /// the UI said "saved successfully" whether or not anything reached the disk.
+    /// </summary>
+    private bool SaveContainers()
     {
-        var config = _credentialStore.LoadConfig();
-        config.BlobContainers = [.. Containers];
-        _credentialStore.SaveConfig(config);
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            config.BlobContainers = [.. Containers];
+            _credentialStore.SaveConfig(config);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not save configuration: {ex.Message}");
+            return false;
+        }
     }
 
     partial void OnSelectedContainerChanged(BlobContainerConfig? value)
@@ -417,7 +431,14 @@ public partial class BlobConfigViewModel : ViewModelBase
         if (haveTokenToSave)
             _credentialStore.SaveSasToken(container, EditSasToken);
         // When editing and leaving SAS field empty, existing token is kept (never re-read or shown)
-        SaveContainers();
+        if (!SaveContainers())
+        {
+            // Nothing reached the disk, so do not leave the list showing a container that is not
+            // really there. Stay in the edit form so the save can be retried once whatever was
+            // holding the file has let go.
+            if (IsNew) Containers.Remove(container);
+            return;
+        }
 
         SelectedContainer = container;
         IsEditing = false;
@@ -430,9 +451,20 @@ public partial class BlobConfigViewModel : ViewModelBase
     private void Delete()
     {
         if (SelectedContainer == null) return;
-        _credentialStore.DeleteSecret(SelectedContainer.CredentialKey);
-        Containers.Remove(SelectedContainer);
-        SaveContainers();
+
+        // Remove from the config first and only destroy the secret once that write has actually
+        // landed. The other order threw the SAS token away and then, if the save failed, left the
+        // container in config.json pointing at a credential that no longer exists.
+        var removed = SelectedContainer;
+        Containers.Remove(removed);
+        if (!SaveContainers())
+        {
+            Containers.Add(removed);
+            SelectedContainer = removed;
+            return;
+        }
+
+        _credentialStore.DeleteSecret(removed.CredentialKey);
         SelectedContainer = Containers.FirstOrDefault();
         SetStatus("Container removed.");
     }

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -85,11 +85,25 @@ public partial class ServerManagerViewModel : ViewModelBase
         Servers = new ObservableCollection<ServerConnection>(config.Servers);
     }
 
-    private void SaveServers()
+    /// <summary>
+    /// Persists the server list. Returns false and sets the error when the write failed, so
+    /// callers do not go on to report success - the config save used to swallow everything and
+    /// the UI said "saved successfully" whether or not anything reached the disk.
+    /// </summary>
+    private bool SaveServers()
     {
-        var config = _credentialStore.LoadConfig();
-        config.Servers = [.. Servers];
-        _credentialStore.SaveConfig(config);
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            config.Servers = [.. Servers];
+            _credentialStore.SaveConfig(config);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not save configuration: {ex.Message}");
+            return false;
+        }
     }
 
     /// <summary>
@@ -220,7 +234,14 @@ public partial class ServerManagerViewModel : ViewModelBase
             _credentialStore.SaveSqlPassword(server, EditPassword);
         }
 
-        SaveServers();
+        if (!SaveServers())
+        {
+            // Nothing reached the disk, so do not leave the list showing a server that is not
+            // really there. Stay in the edit form so the save can be retried.
+            if (IsNew) Servers.Remove(server);
+            return;
+        }
+
         SelectedServer = server;
         IsEditing = false;
         SetStatus("Server saved successfully.");
@@ -231,10 +252,23 @@ public partial class ServerManagerViewModel : ViewModelBase
     {
         if (SelectedServer == null) return;
 
-        if (SelectedServer.AuthMode == AuthMode.SqlAuth)
-            _credentialStore.DeleteSecret(SelectedServer.CredentialKey);
+        // Take the server out of the config first and only destroy its stored password once that
+        // write has landed. The other order threw the password away and then, if the save failed,
+        // left the server in config.json with no credential behind it.
+        var removed = SelectedServer;
+        var index = Servers.IndexOf(removed);
+        Servers.Remove(removed);
+        if (!SaveServers())
+        {
+            Servers.Insert(Math.Clamp(index, 0, Servers.Count), removed);
+            SelectedServer = removed;
+            return;
+        }
 
-        if (IsConnected && ConnectedServerDisplay == SelectedServer.DisplayText)
+        if (removed.AuthMode == AuthMode.SqlAuth)
+            _credentialStore.DeleteSecret(removed.CredentialKey);
+
+        if (IsConnected && ConnectedServerDisplay == removed.DisplayText)
         {
             IsConnected = false;
             ConnectedServerDisplay = string.Empty;
@@ -245,8 +279,6 @@ public partial class ServerManagerViewModel : ViewModelBase
             });
         }
 
-        Servers.Remove(SelectedServer);
-        SaveServers();
         SelectedServer = Servers.FirstOrDefault();
         SetStatus("Server removed.");
     }


### PR DESCRIPTION
Closes #7.

`LoadConfig` caught **everything** — including an `IOException` from a file that was merely locked
— and returned empty defaults. `SaveConfig` caught everything and returned silently, while the UI
reported "Container saved successfully" regardless.

Put together, that is permanent data loss, and it needs nothing more exotic than a file being
briefly busy:

1. Antivirus, a backup agent or a sync client holds `config.json` open for a moment.
2. `LoadConfig` swallows the error and returns empty defaults. The app shows no containers.
3. The user re-adds one.
4. The save serialises that single-entry list over `config.json`.
5. **Every server and container is gone**, and their secrets are orphaned in Credential Manager
   under keys nothing now references.

## Changes

**`LoadConfig` distinguishes two cases that are not the same thing.** "No file" is a fresh install
and empty defaults are correct. "File exists but I could not read or parse it" now comes back
carrying `LoadError`, and the returned object explicitly does not describe what's on disk.

**`SaveConfig` refuses to write a config that failed to load** (`ConfigSaveRefusedException`), and
otherwise throws rather than swallowing. A save that didn't happen is now something the caller has
to deal with.

**Writes are atomic.** Serialise to `config.json.tmp`, then `File.Replace` it in. A crash or a full
disk part-way through can no longer leave a truncated file where a complete one was. `File.Replace`
also keeps the previous contents as `config.json.bak`, which is a free undo.

**Both viewmodels report failures** instead of claiming success. They also roll back the row they'd
optimistically added to the list and stay in the edit form so the save can be retried.

**Delete ordering fixed** on both screens. It used to destroy the secret and *then* save; if the
save failed, the entry stayed in `config.json` pointing at a credential that no longer existed. Now
the config write has to land before the secret is removed.

## Tests

`CredentialStore`'s config paths were hardcoded to `%LOCALAPPDATA%`, so none of this could be
tested without writing to the real profile. Added an internal constructor taking a directory; the
public one is unchanged.

10 new tests. **3 fail against the old implementation**, including the one that reproduces the
whole bug — write three containers, lock the file, load, add one back, save:

```
Assert.NotNull() Failure: Value is null
```

Under the old code the load reported no problem, the save went ahead, and the file ended up with
one container. Now the save is refused and the assertion at the end confirms all three survive.

**359 tests pass**, build clean at `-warnaserror`.

## Note

This doesn't address the orphaned-secret half of the story — a secret whose config entry has gone
still sits in Credential Manager. That's #8's territory (keys derived from mutable display names)
and is next.
