### PR TITLE
Key secrets by stable id, and stop Test Connection persisting them (#8, #12)

### DIFF
--- a/src/NineLives.Tests/SecretKeyMigrationTests.cs
+++ b/src/NineLives.Tests/SecretKeyMigrationTests.cs
@@ -1,0 +1,229 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Secrets keyed by stable id rather than display name (#8).
+///
+/// The credential key used to be derived from Name. Renaming a container or server therefore
+/// pointed every lookup at a key that did not exist, and the working token stayed under the old
+/// name with no UI to recover it - which bites hardest on containers, because the edit form
+/// deliberately never shows a stored SAS and so actively invites you to leave the field blank.
+///
+/// These write to the real Windows Credential Manager, so every key is namespaced under
+/// "ninelives-test-" plus a fresh Guid and removed in Dispose. Config goes to a temp directory.
+/// </summary>
+public class SecretKeyMigrationTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-migration-tests", Guid.NewGuid().ToString("n"));
+
+    private readonly string _prefix = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8];
+    private readonly List<string> _writtenKeys = [];
+
+    private string ConfigPath => Path.Combine(_dir, "config.json");
+    private CredentialStore Store() => new(_dir);
+
+    public SecretKeyMigrationTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        var store = Store();
+        foreach (var key in _writtenKeys)
+        {
+            try { store.DeleteSecret(key); } catch { /* best effort */ }
+        }
+        try { Directory.Delete(_dir, recursive: true); } catch { /* temp dir */ }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Writes a secret under a legacy name-derived key, as a pre-#8 config would have.</summary>
+    private void GiveLegacySecret(string key, string username, string secret)
+    {
+        Store().SaveSecret(key, username, secret);
+        _writtenKeys.Add(key);
+    }
+
+    private BlobContainerConfig LegacyContainer(string name) => new()
+    {
+        Name = $"{_prefix}-{name}",
+        ContainerUrl = $"https://acct.blob.core.windows.net/{name}"
+        // No Id: this is what an entry written before #8 looks like.
+    };
+
+    private ServerConnection LegacyServer(string name) => new()
+    {
+        Name = $"{_prefix}-{name}",
+        ServerName = "SRV01",
+        AuthMode = AuthMode.SqlAuth,
+        Username = "sa"
+    };
+
+    private void TrackNewKey(string key) => _writtenKeys.Add(key);
+
+    // ── migration ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LegacyContainer_GetsAnId_AndItsTokenMovesToTheNewKey()
+    {
+        var container = LegacyContainer("prod");
+        GiveLegacySecret(container.LegacyCredentialKey, "acct", "sv=2026&sig=the-real-token");
+
+        var config = new AppConfig { BlobContainers = { container } };
+        var result = new ConfigMigrator(Store()).Migrate(config);
+        TrackNewKey(container.CredentialKey);
+
+        Assert.Null(result.Error);
+        Assert.Equal(1, result.ContainersMigrated);
+        Assert.False(string.IsNullOrEmpty(container.Id));
+        Assert.Equal("sv=2026&sig=the-real-token", Store().GetSasToken(container));
+    }
+
+    [Fact]
+    public void LegacyServer_GetsAnId_AndItsPasswordMovesToTheNewKey()
+    {
+        var server = LegacyServer("sql01");
+        GiveLegacySecret(server.LegacyCredentialKey, "sa", "correct horse battery staple");
+
+        var config = new AppConfig { Servers = { server } };
+        var result = new ConfigMigrator(Store()).Migrate(config);
+        TrackNewKey(server.CredentialKey);
+
+        Assert.Null(result.Error);
+        Assert.Equal(1, result.ServersMigrated);
+        Assert.Equal("correct horse battery staple", Store().GetSqlPassword(server));
+    }
+
+    [Fact]
+    public void Migration_RemovesTheOldKey()
+    {
+        var container = LegacyContainer("prod");
+        var legacyKey = container.LegacyCredentialKey;
+        GiveLegacySecret(legacyKey, "acct", "token");
+
+        new ConfigMigrator(Store()).Migrate(new AppConfig { BlobContainers = { container } });
+        TrackNewKey(container.CredentialKey);
+
+        Assert.Null(Store().ReadSecret(legacyKey).secret);
+    }
+
+    [Fact]
+    public void Migration_IsIdempotent()
+    {
+        var container = LegacyContainer("prod");
+        GiveLegacySecret(container.LegacyCredentialKey, "acct", "token");
+        var config = new AppConfig { BlobContainers = { container } };
+
+        new ConfigMigrator(Store()).Migrate(config);
+        TrackNewKey(container.CredentialKey);
+        var idAfterFirst = container.Id;
+
+        var second = new ConfigMigrator(Store()).Migrate(config);
+
+        Assert.Equal(0, second.ContainersMigrated);
+        Assert.Equal(idAfterFirst, container.Id);
+        Assert.Equal("token", Store().GetSasToken(container));
+    }
+
+    [Fact]
+    public void LegacyEntryWithNoStoredSecret_StillGetsAnId()
+    {
+        var container = LegacyContainer("no-token-yet");
+
+        new ConfigMigrator(Store()).Migrate(new AppConfig { BlobContainers = { container } });
+
+        Assert.False(string.IsNullOrEmpty(container.Id));
+    }
+
+    // ── the actual bug ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// #8 itself. Rename a container and the token must still be found. Before the fix the key
+    /// moved with the name and the lookup came back empty.
+    /// </summary>
+    [Fact]
+    public void RenamingAContainer_KeepsItsToken()
+    {
+        var container = LegacyContainer("prod");
+        GiveLegacySecret(container.LegacyCredentialKey, "acct", "sv=2026&sig=still-here");
+        new ConfigMigrator(Store()).Migrate(new AppConfig { BlobContainers = { container } });
+        TrackNewKey(container.CredentialKey);
+
+        container.Name = $"{_prefix}-prod-backups";
+
+        Assert.Equal("sv=2026&sig=still-here", Store().GetSasToken(container));
+    }
+
+    [Fact]
+    public void RenamingAServer_KeepsItsPassword()
+    {
+        var server = LegacyServer("sql01");
+        GiveLegacySecret(server.LegacyCredentialKey, "sa", "hunter2");
+        new ConfigMigrator(Store()).Migrate(new AppConfig { Servers = { server } });
+        TrackNewKey(server.CredentialKey);
+
+        server.Name = $"{_prefix}-sql01-renamed";
+
+        Assert.Equal("hunter2", Store().GetSqlPassword(server));
+    }
+
+    [Fact]
+    public void TwoEntriesSharingAName_DoNotShareASecret()
+    {
+        // The other half of keying on a display name: two entries called the same thing collided
+        // on one credential key, so whichever saved last silently owned both.
+        var first = new BlobContainerConfig { Id = BlobContainerConfig.NewId(), Name = $"{_prefix}-dup" };
+        var second = new BlobContainerConfig { Id = BlobContainerConfig.NewId(), Name = $"{_prefix}-dup" };
+
+        Store().SaveSasToken(first, "token-one");
+        Store().SaveSasToken(second, "token-two");
+        TrackNewKey(first.CredentialKey);
+        TrackNewKey(second.CredentialKey);
+
+        Assert.Equal("token-one", Store().GetSasToken(first));
+        Assert.Equal("token-two", Store().GetSasToken(second));
+    }
+
+    // ── failure handling ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// If the config write fails, the migration must not be half-applied: the old key has to
+    /// survive, because it is still the only thing the on-disk config points at.
+    /// </summary>
+    [Fact]
+    public void WhenTheConfigCannotBeSaved_TheOldKeySurvives_AndNoIdIsKept()
+    {
+        var container = LegacyContainer("prod");
+        var legacyKey = container.LegacyCredentialKey;
+        GiveLegacySecret(legacyKey, "acct", "token");
+
+        var config = new AppConfig { BlobContainers = { container } };
+        Store().SaveConfig(new AppConfig());
+
+        ConfigMigrator.Result result;
+        using (var _ = new FileStream(ConfigPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            result = new ConfigMigrator(Store()).Migrate(config);
+        }
+
+        Assert.NotNull(result.Error);
+        Assert.True(string.IsNullOrEmpty(container.Id));
+        Assert.Equal("token", Store().ReadSecret(legacyKey).secret);
+    }
+
+    [Fact]
+    public void AConfigThatFailedToLoad_IsNotMigrated()
+    {
+        // It holds empty defaults rather than anything real, and saving it would be refused.
+        var config = new AppConfig { LoadError = "locked" };
+
+        var result = new ConfigMigrator(Store()).Migrate(config);
+
+        Assert.Null(result.Error);
+        Assert.False(result.DidWork);
+    }
+
+}

--- a/src/NineLives.Tests/UnsavedSecretTests.cs
+++ b/src/NineLives.Tests/UnsavedSecretTests.cs
@@ -1,0 +1,227 @@
+using System.IO;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Test Connection must not persist anything (#12).
+///
+/// Testing a newly typed SAS token used to write it to Credential Manager first, with
+/// CRED_PERSIST_LOCAL_MACHINE - before Save, with no undo. So: edit a container whose token works,
+/// paste one that turns out to be typo'd or expired, click Test Connection because that is exactly
+/// what the button invites, watch it fail, click Cancel expecting nothing to have changed, and the
+/// working token is gone. The form never displays stored tokens, so there is no way to get it back.
+/// Same shape on the SQL side for passwords.
+///
+/// The fix is a transient in-memory secret the services prefer over the stored one. These tests
+/// pin both halves: the transient value is used, and it never reaches disk.
+/// </summary>
+public class UnsavedSecretTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-unsaved-tests", Guid.NewGuid().ToString("n"));
+
+    private readonly List<string> _writtenKeys = [];
+
+    private CredentialStore Store() => new(_dir);
+
+    public UnsavedSecretTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        var store = Store();
+        foreach (var key in _writtenKeys)
+        {
+            try { store.DeleteSecret(key); } catch { /* best effort */ }
+        }
+        try { Directory.Delete(_dir, recursive: true); } catch { /* temp dir */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private BlobContainerConfig SavedContainer(string storedToken)
+    {
+        var container = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8],
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        };
+        Store().SaveSasToken(container, storedToken);
+        _writtenKeys.Add(container.CredentialKey);
+        return container;
+    }
+
+    // ── the stored secret survives a test ───────────────────────────────────────
+
+    /// <summary>
+    /// The regression. A throwaway config built from the edit form, carrying a candidate token,
+    /// must leave the saved container's token exactly where it was.
+    /// </summary>
+    [Fact]
+    public void TryingACandidateToken_LeavesTheStoredOneUntouched()
+    {
+        var saved = SavedContainer("sv=2026&sig=the-working-token");
+
+        // What TestConnection now builds: same name and URL, token held in memory only.
+        var candidate = new BlobContainerConfig
+        {
+            Name = saved.Name,
+            ContainerUrl = saved.ContainerUrl,
+            UnsavedSasToken = "sv=2026&sig=typo"
+        };
+
+        Assert.Equal("sv=2026&sig=typo", candidate.UnsavedSasToken);
+        Assert.Equal("sv=2026&sig=the-working-token", Store().GetSasToken(saved));
+    }
+
+    [Fact]
+    public void ACandidateTokenIsNotWrittenUnderTheLegacyKeyEither()
+    {
+        // The throwaway object has no Id, so its CredentialKey falls back to the name-derived one.
+        // Nothing should have been written there.
+        var candidate = new BlobContainerConfig
+        {
+            Name = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8],
+            UnsavedSasToken = "sv=2026&sig=candidate"
+        };
+
+        Assert.Null(Store().ReadSecret(candidate.CredentialKey).secret);
+        Assert.Null(Store().ReadSecret(candidate.LegacyCredentialKey).secret);
+    }
+
+    [Fact]
+    public void TryingACandidatePassword_LeavesTheStoredOneUntouched()
+    {
+        var saved = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8],
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+        Store().SaveSqlPassword(saved, "the-working-password");
+        _writtenKeys.Add(saved.CredentialKey);
+
+        var candidate = new ServerConnection
+        {
+            Name = saved.Name,
+            ServerName = saved.ServerName,
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa",
+            UnsavedPassword = "typo"
+        };
+
+        Assert.Null(Store().ReadSecret(candidate.LegacyCredentialKey).secret);
+        Assert.Equal("the-working-password", Store().GetSqlPassword(saved));
+    }
+
+    // ── the transient secret is actually used ───────────────────────────────────
+
+    [Fact]
+    public void AnUnsavedPassword_IsUsedInTheConnectionString()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-unsaved",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa",
+            UnsavedPassword = "in-memory-only"
+        };
+
+        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+
+        Assert.Contains("in-memory-only", connectionString);
+    }
+
+    [Fact]
+    public void AnUnsavedPassword_TakesPrecedenceOverTheStoredOne()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-precedence",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+        Store().SaveSqlPassword(server, "stored");
+        _writtenKeys.Add(server.CredentialKey);
+
+        server.UnsavedPassword = "candidate";
+
+        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+
+        Assert.Contains("candidate", connectionString);
+        Assert.DoesNotContain("stored", connectionString);
+    }
+
+    [Fact]
+    public void WithoutAnUnsavedPassword_TheStoredOneIsStillUsed()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-fallback",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+        Store().SaveSqlPassword(server, "stored-password");
+        _writtenKeys.Add(server.CredentialKey);
+
+        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+
+        Assert.Contains("stored-password", connectionString);
+    }
+
+    // ── never persisted ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TransientSecrets_AreNotSerialisedIntoConfigJson()
+    {
+        var config = new AppConfig
+        {
+            BlobContainers =
+            {
+                new BlobContainerConfig { Id = "c1", Name = "prod", UnsavedSasToken = "sv=2026&sig=secret" }
+            },
+            Servers =
+            {
+                new ServerConnection { Id = "s1", Name = "sql01", UnsavedPassword = "hunter2" }
+            }
+        };
+
+        Store().SaveConfig(config);
+        var json = File.ReadAllText(Path.Combine(_dir, "config.json"));
+
+        Assert.DoesNotContain("sv=2026&sig=secret", json);
+        Assert.DoesNotContain("hunter2", json);
+        Assert.DoesNotContain("UnsavedSasToken", json);
+        Assert.DoesNotContain("UnsavedPassword", json);
+    }
+
+    [Fact]
+    public void CredentialKeys_AreNotSerialisedIntoConfigJson()
+    {
+        // Derived, and now that they contain the id they are pure noise in the file.
+        var config = new AppConfig
+        {
+            BlobContainers = { new BlobContainerConfig { Id = "c1", Name = "prod" } }
+        };
+
+        Store().SaveConfig(config);
+        var json = File.ReadAllText(Path.Combine(_dir, "config.json"));
+
+        Assert.DoesNotContain("CredentialKey", json);
+
+        // ...and the round trip still works.
+        var reloaded = JsonSerializer.Deserialize<AppConfig>(json)!;
+        Assert.Equal("c1", reloaded.BlobContainers[0].Id);
+    }
+}

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -24,6 +24,22 @@ public enum BackupSourceType
 /// </summary>
 public class BlobContainerConfig : INotifyPropertyChanged
 {
+    /// <summary>
+    /// Stable identity for the stored SAS token, assigned once and never changed.
+    ///
+    /// The credential key used to derive from Name, so renaming a container pointed it at a key
+    /// that did not exist and the working token was stranded under the old one with no way to get
+    /// it back (#8).
+    ///
+    /// Null on entries written before this existed. It is deliberately NOT defaulted to a new Guid:
+    /// an absent value in JSON leaves the property at its initialiser, so defaulting would hand
+    /// every legacy entry a fresh id on load and lose its secret immediately. ConfigMigrator
+    /// assigns ids and moves the secrets; NewId() is what callers creating a container use.
+    /// </summary>
+    public string? Id { get; set; }
+
+    public static string NewId() => Guid.NewGuid().ToString("n");
+
     public string Name { get; set; } = string.Empty;
     public string ContainerUrl { get; set; } = string.Empty;
 
@@ -95,9 +111,17 @@ public class BlobContainerConfig : INotifyPropertyChanged
         => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     /// <summary>
-    /// Key used to look up SAS token in Windows Credential Manager.
+    /// Key used to look up the SAS token in Windows Credential Manager. Keyed on the immutable
+    /// <see cref="Id"/> so renaming the container does not strand its token; falls back to the
+    /// old name-derived key only for entries that have not been migrated yet.
     /// </summary>
-    public string CredentialKey => $"NineLives:Blob:{Name}";
+    [JsonIgnore]
+    public string CredentialKey =>
+        string.IsNullOrEmpty(Id) ? LegacyCredentialKey : $"NineLives:Blob:{Id}";
+
+    /// <summary>The pre-#8 name-derived key. Only ConfigMigrator should need this.</summary>
+    [JsonIgnore]
+    public string LegacyCredentialKey => $"NineLives:Blob:{Name}";
 
     public bool IsExpired => GetSasExpiry() is DateTime expiry && expiry < DateTime.UtcNow;
 

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -123,6 +123,18 @@ public class BlobContainerConfig : INotifyPropertyChanged
     [JsonIgnore]
     public string LegacyCredentialKey => $"NineLives:Blob:{Name}";
 
+    /// <summary>
+    /// A SAS token held in memory for this object only, never written anywhere. When set, the
+    /// blob service uses it in place of the stored one.
+    ///
+    /// This exists for Test Connection (#12). Testing a newly typed token used to persist it to
+    /// Credential Manager first - so pasting a typo'd or expired token, testing it, watching it
+    /// fail and clicking Cancel destroyed the working token that was there before, with no way
+    /// to get it back because the form never displays stored tokens.
+    /// </summary>
+    [JsonIgnore]
+    public string? UnsavedSasToken { get; set; }
+
     public bool IsExpired => GetSasExpiry() is DateTime expiry && expiry < DateTime.UtcNow;
 
     public DateTime? SasExpiry => GetSasExpiry();

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -146,6 +146,14 @@ public class ServerConnection : INotifyPropertyChanged
     [JsonIgnore]
     public string LegacyCredentialKey => $"NineLives:SQL:{Name}";
 
+    /// <summary>
+    /// A password held in memory for this object only, never written anywhere. When set, the
+    /// connection string uses it in place of the stored one. Same purpose as
+    /// <see cref="BlobContainerConfig.UnsavedSasToken"/> - see the note there (#12).
+    /// </summary>
+    [JsonIgnore]
+    public string? UnsavedPassword { get; set; }
+
     public string DisplayText => AuthMode == AuthMode.WindowsAuth
         ? $"{ServerName} (Windows Auth)"
         : $"{ServerName} ({Username})";

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -30,6 +30,15 @@ public enum EncryptMode
 /// </summary>
 public class ServerConnection : INotifyPropertyChanged
 {
+    /// <summary>
+    /// Stable identity for the stored password, assigned once and never changed. See the note on
+    /// <see cref="BlobContainerConfig.Id"/> - same bug (#8), same reason it is not defaulted to a
+    /// new Guid, same migration.
+    /// </summary>
+    public string? Id { get; set; }
+
+    public static string NewId() => Guid.NewGuid().ToString("n");
+
     public string Name { get; set; } = string.Empty;
     public string ServerName { get; set; } = string.Empty;
     public AuthMode AuthMode { get; set; } = AuthMode.WindowsAuth;
@@ -129,7 +138,13 @@ public class ServerConnection : INotifyPropertyChanged
     /// Key used to look up password in Windows Credential Manager.
     /// Only used when AuthMode is SqlAuth.
     /// </summary>
-    public string CredentialKey => $"NineLives:SQL:{Name}";
+    [JsonIgnore]
+    public string CredentialKey =>
+        string.IsNullOrEmpty(Id) ? LegacyCredentialKey : $"NineLives:SQL:{Id}";
+
+    /// <summary>The pre-#8 name-derived key. Only ConfigMigrator should need this.</summary>
+    [JsonIgnore]
+    public string LegacyCredentialKey => $"NineLives:SQL:{Name}";
 
     public string DisplayText => AuthMode == AuthMode.WindowsAuth
         ? $"{ServerName} (Windows Auth)"

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -16,7 +16,9 @@ public class BlobStorageService
 
     private BlobContainerClient CreateClient(BlobContainerConfig config)
     {
-        var sasToken = _credentialStore.GetSasToken(config);
+        // An unsaved token wins, so Test Connection can try one without it having to be persisted
+        // first (#12). Null for every ordinary operation, which falls through to the stored token.
+        var sasToken = config.UnsavedSasToken ?? _credentialStore.GetSasToken(config);
         if (string.IsNullOrEmpty(sasToken))
             throw new InvalidOperationException(
                 "No SAS token found. Please configure the SAS token for this container.");

--- a/src/NineLives/Services/ConfigMigrator.cs
+++ b/src/NineLives/Services/ConfigMigrator.cs
@@ -1,0 +1,117 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Moves stored secrets off name-derived keys and onto stable per-entry ids (#8).
+///
+/// Runs once at startup. Entries saved before ids existed have no <c>Id</c>, and their SAS token
+/// or password sits under <c>NineLives:Blob:{Name}</c> / <c>NineLives:SQL:{Name}</c>. This assigns
+/// an id, copies the secret to the new key, saves the config, and only then removes the old key.
+///
+/// The ordering is the whole point, because this runs against the only copy of someone's
+/// credentials and can be interrupted by a crash, a power cut or a refused config write:
+///
+///   1. copy secrets to the new keys, leaving the old ones in place
+///   2. save the config carrying the new ids
+///   3. delete the old keys
+///
+/// Interrupted after 1, the config still has no ids, so the next run reads the same old keys and
+/// starts over - the stray new-key entries are orphans, not losses. Interrupted after 2, the
+/// secrets are already where the ids point. There is no window in which a secret exists only under
+/// a key nothing references.
+/// </summary>
+public class ConfigMigrator(CredentialStore store)
+{
+    public record Result(int ContainersMigrated, int ServersMigrated, string? Error)
+    {
+        public bool DidWork => ContainersMigrated > 0 || ServersMigrated > 0;
+    }
+
+    /// <summary>
+    /// Assigns ids to any entry lacking one and relocates its secret. Returns what happened rather
+    /// than throwing: a migration that cannot complete must not stop the app from starting, since
+    /// everything still works off the old keys until it succeeds.
+    /// </summary>
+    public Result Migrate(AppConfig config)
+    {
+        // A config that failed to load holds empty defaults, so there is nothing to migrate and
+        // saving it would be refused anyway.
+        if (config.LoadError != null)
+            return new Result(0, 0, null);
+
+        var containers = config.BlobContainers.Where(c => string.IsNullOrEmpty(c.Id)).ToList();
+        var servers = config.Servers.Where(s => string.IsNullOrEmpty(s.Id)).ToList();
+
+        if (containers.Count == 0 && servers.Count == 0)
+            return new Result(0, 0, null);
+
+        // Step 1: copy each secret to its new key while the old key still exists.
+        var oldKeys = new List<string>();
+        var newKeys = new List<string>();
+        try
+        {
+            foreach (var container in containers)
+            {
+                var legacyKey = container.LegacyCredentialKey;
+                var (username, secret) = store.ReadSecret(legacyKey);
+                container.Id = BlobContainerConfig.NewId();
+
+                if (secret == null) continue;   // nothing stored; the id alone is the migration
+                store.SaveSecret(container.CredentialKey, username ?? "azure", secret);
+                oldKeys.Add(legacyKey);
+                newKeys.Add(container.CredentialKey);
+            }
+
+            foreach (var server in servers)
+            {
+                var legacyKey = server.LegacyCredentialKey;
+                var (username, secret) = store.ReadSecret(legacyKey);
+                server.Id = ServerConnection.NewId();
+
+                if (secret == null) continue;
+                store.SaveSecret(server.CredentialKey, username ?? server.Username ?? "sa", secret);
+                oldKeys.Add(legacyKey);
+                newKeys.Add(server.CredentialKey);
+            }
+        }
+        catch (Exception ex)
+        {
+            return Abandon($"Could not copy stored secrets: {ex.Message}");
+        }
+
+        // Step 2: persist the ids. Until this lands the migration has not really happened.
+        try
+        {
+            store.SaveConfig(config);
+        }
+        catch (Exception ex)
+        {
+            return Abandon($"Could not save the updated configuration: {ex.Message}");
+        }
+
+        // Step 3: the old keys are now unreferenced. Failing to remove one leaves a harmless
+        // orphan in Credential Manager, which is not worth failing a completed migration over.
+        foreach (var key in oldKeys)
+        {
+            try { store.DeleteSecret(key); } catch { /* orphan, not a failure */ }
+        }
+
+        return new Result(containers.Count, servers.Count, null);
+
+        // Give up cleanly: put the in-memory objects back to matching what is on disk, and remove
+        // the new-key copies written before the failure. Those ids are freshly generated and were
+        // never persisted, so nothing else can be referring to them. The old keys are untouched
+        // throughout and remain the ones the saved config points at.
+        Result Abandon(string error)
+        {
+            foreach (var key in newKeys)
+            {
+                try { store.DeleteSecret(key); } catch { /* orphan, not a failure */ }
+            }
+            foreach (var container in containers) container.Id = null;
+            foreach (var server in servers) server.Id = null;
+            return new Result(0, 0, error);
+        }
+    }
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -38,7 +38,9 @@ public class SqlServerService
         {
             builder.IntegratedSecurity = false;
             builder.UserID = server.Username;
-            builder.Password = _credentialStore.GetSqlPassword(server);
+            // An unsaved password wins, so Test Connection can try one without it having to be
+            // persisted first (#12). Null for every ordinary connection.
+            builder.Password = server.UnsavedPassword ?? _credentialStore.GetSqlPassword(server);
         }
 
         return builder.ConnectionString;

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -500,9 +500,16 @@ public partial class BlobConfigViewModel : ViewModelBase
                 config = SelectedContainer; // Use stored token for test
             else
             {
-                config = new BlobContainerConfig { Name = EditName, ContainerUrl = EditContainerUrl };
-                if (!string.IsNullOrWhiteSpace(EditSasToken))
-                    _credentialStore.SaveSasToken(config, EditSasToken);
+                // In memory only. This used to call SaveSasToken, which is a durable write to
+                // Credential Manager - so pasting a typo'd or expired token, testing it, and
+                // clicking Cancel destroyed the working token that was there before, with no way
+                // to get it back because the form never displays stored tokens (#12).
+                config = new BlobContainerConfig
+                {
+                    Name = EditName,
+                    ContainerUrl = EditContainerUrl,
+                    UnsavedSasToken = string.IsNullOrWhiteSpace(EditSasToken) ? null : EditSasToken
+                };
             }
         }
         else

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -406,6 +406,8 @@ public partial class BlobConfigViewModel : ViewModelBase
             var agPattern = IsAgPathSectionVisible ? PathElement.BuildPattern(AgActivePathElements) : null;
             container = new BlobContainerConfig
             {
+                // Assigned here rather than defaulted on the model - see the note on Id.
+                Id = BlobContainerConfig.NewId(),
                 Name = EditName,
                 ContainerUrl = EditContainerUrl.TrimEnd('/'),
                 PathPattern = EditPathPattern,

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -47,6 +47,12 @@ public partial class MainViewModel : ViewModelBase
     public MainViewModel()
     {
         _credentialStore = new CredentialStore();
+
+        // Before anything reads the config: move secrets from name-derived keys onto stable ids
+        // (#8). Must happen ahead of the child viewmodels, which load containers and servers in
+        // their constructors and would otherwise look up keys the migration is about to change.
+        MigrateSecretKeys();
+
         _blobService = new BlobStorageService(_credentialStore);
         _sqlService = new SqlServerService(_credentialStore);
         _chainBuilder = new BackupChainBuilder();
@@ -64,6 +70,29 @@ public partial class MainViewModel : ViewModelBase
 
         // Fire and forget - startup must not wait on the network.
         _ = CheckForUpdatesAsync();
+    }
+
+    /// <summary>
+    /// One-off relocation of stored secrets onto stable ids. A no-op on every launch after the
+    /// first, and never fatal - if it cannot complete, the old keys are untouched and everything
+    /// still works, so the app starts normally and tries again next time.
+    /// </summary>
+    private void MigrateSecretKeys()
+    {
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            var result = new ConfigMigrator(_credentialStore).Migrate(config);
+
+            if (result.Error != null)
+                GlobalStatus = $"Stored credentials could not be updated: {result.Error}";
+            else if (result.DidWork)
+                GlobalStatus = "Ready";
+        }
+        catch
+        {
+            // Startup must not depend on this.
+        }
     }
 
     private async Task CheckForUpdatesAsync()

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -387,8 +387,15 @@ public partial class ServerManagerViewModel : ViewModelBase
                 TrustServerCertificate = EditTrustServerCert,
                 Encrypt = EditEncrypt
             };
+            // In memory only. This used to call SaveSqlPassword, which is a durable write to
+            // Credential Manager - so testing a mistyped password overwrote the working one
+            // before the user had agreed to anything, and Cancel could not undo it (#12).
             if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
-                _credentialStore.SaveSqlPassword(server, EditPassword);
+                server.UnsavedPassword = EditPassword;
+            else if (EditAuthMode == AuthMode.SqlAuth && !IsNew)
+                // No new password typed: test against the one already saved for this entry.
+                server.Id = SelectedServer?.Id;
+
             return server;
         }
         return SelectedServer;

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -210,7 +210,8 @@ public partial class ServerManagerViewModel : ViewModelBase
                 SetError("A server with this name already exists.");
                 return;
             }
-            server = new ServerConnection();
+            // Id assigned here rather than defaulted on the model - see the note on it.
+            server = new ServerConnection { Id = ServerConnection.NewId() };
             Servers.Add(server);
         }
         else


### PR DESCRIPTION
Closes #8. Closes #12.

Two bugs about where secrets live. They're together because they interact, and I had to measure
that interaction to describe either one honestly.

---

# #8 — renaming an entry stranded its secret

`CredentialKey` was derived from `Name`:

```csharp
public string CredentialKey => $"NineLives:Blob:{Name}";
```

Rename a container and every lookup pointed at a key that had never been written. The working token
stayed under the old name with nothing in the UI to get it back — and since the edit form
deliberately never displays a stored SAS, leaving that field blank during a rename is exactly what
you'd do. Same on the SQL side: after a rename `GetSqlPassword` returned null and the connection
string was built with an empty password.

## Stable ids

Both models now carry an `Id`, assigned once at creation, and the credential key derives from that.
Renaming is just a rename.

`Id` is deliberately **not** defaulted to a new Guid on the model. An absent value in JSON leaves a
property at its initialiser, so defaulting would hand every existing entry a fresh id the moment it
loaded and lose its secret on the spot. It's null for legacy entries, set explicitly when the
viewmodels create one, and filled in by the migrator for anything already saved.

## Migration, ordered so an interruption cannot lose a secret

This runs against the only copy of someone's credentials and can be cut short by a crash, a power
cut, or the config write being refused. So:

1. copy each secret to its new key, **leaving the old one in place**
2. save the config carrying the new ids
3. delete the old keys

Interrupted after 1, the saved config still has no ids, so the next launch reads the same old keys
and starts over — the stray new-key entries are orphans, not losses. Interrupted after 2, the
secrets are already where the ids point. **There is no window in which a secret exists only under a
key nothing references.**

If it can't finish it removes the copies it made, puts the in-memory ids back to null so the object
still matches the disk, and returns the error. The app starts normally on the old keys and retries
next launch — a migration failing is not a reason to be unable to run a restore.

---

# #12 — Test Connection wrote secrets to disk before you'd saved anything

Testing a newly typed SAS token persisted it to Credential Manager first, with
`CRED_PERSIST_LOCAL_MACHINE`. Paste a token that turns out to be typo'd or expired, click **Test
Connection** because that is precisely what the button invites, watch it fail, click **Cancel**
expecting nothing to have changed — and the working token is already gone, unrecoverable, because
the form never displays stored tokens.

Both models now carry a transient secret (`JsonIgnore`, so it cannot reach `config.json`) which the
services prefer over the stored one. Test Connection sets that and writes nothing.

## What #8 changes about this, measured rather than assumed

I ran the old Test Connection code against both states:

| Saved entry | Result |
|---|---|
| Migrated (has an id) | stored token **survives**, but a stray credential is written under the name-derived key and left there — one per name tested |
| Unmigrated — i.e. **every v1.1.0 install** | `TYPO` overwrites the working token outright |

So #8 alone would downgrade #12 from data loss to orphan-creation. #12 removes the unconsented
durable write entirely, and closes the data-loss path for anyone upgrading before migration runs.

---

## Tests

**18 new.** For #8, **5 fail against name-derived keys**, including the two that are the bug:

- `RenamingAContainer_KeepsItsToken` / `RenamingAServer_KeepsItsPassword`
- `TwoEntriesSharingAName_DoNotShareASecret` — the other half of keying on a display name, where
  two entries called the same thing collided on one key and whichever saved last silently owned
  both

Plus migration correctness, idempotency, an entry with no secret yet, and the failed-save path
asserting the old key survives and no id is kept.

For #12: the transient secret is used and takes precedence over a stored one, the stored one is
untouched by a test, nothing is written under the legacy key either, and neither transient value
is serialised into `config.json`.

These write to the real Windows Credential Manager, so every key is namespaced under
`ninelives-test-<guid>` and removed in `Dispose`.

**377 tests pass**, build clean at `-warnaserror`.

## Worth knowing

Migration runs in the `MainViewModel` constructor, ahead of the child viewmodels — they load
containers and servers in *their* constructors and would otherwise look up keys the migration is
about to change.

Old keys orphaned by an interrupted run stay in Credential Manager. They're harmless and
unreferenced, but there's no tidy-up UI; `ListCredentialKeys` already exists if we ever want one.

`CredentialKey` was also being serialised into `config.json` as a derived read-only property. It's
`JsonIgnore`d now — it was noise before and would be misleading noise with an id in it.
