### PR TITLE
Treat an unreadable SAS expiry as expired, and drop the token from copied URLs (#21, #18)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,81 @@
+# Security policy
+
+Nine Lives holds Azure SAS tokens and SQL Server passwords, and it generates and runs T-SQL against
+instances you point it at — usually with rights to drop and replace databases. Security reports are
+taken seriously here.
+
+## Reporting a vulnerability
+
+**Please don't open a public issue.** Use either:
+
+- **[Private vulnerability reporting](https://github.com/jakemorgangit/NineLives/security/advisories/new)**
+  — the Report a vulnerability button under the Security tab. Preferred, because the discussion and
+  the fix stay in one place until there's something to release.
+- **jake@blackcat.wales** if you'd rather use email.
+
+Useful things to include: the version (Help → About), what an attacker would gain, and the smallest
+set of steps that shows it. A proof of concept helps but is not required — a clear description of
+the flaw is enough.
+
+### What to expect
+
+This is maintained by one person alongside client work, so:
+
+- **Acknowledgement within 3 working days.** If you haven't heard back by then, please chase — it
+  means the message went astray.
+- An assessment, and either a fix or an explanation of why it isn't one, within 30 days.
+- Credit in the release notes if you'd like it, or none if you'd rather not.
+
+Please give a fix a reasonable chance to ship before disclosing publicly. If something is being
+actively exploited, say so and it'll jump the queue.
+
+## Supported versions
+
+Only the **latest release** is supported. There are no maintenance branches — fixes go into the
+next release. If you're running something older, upgrading is the fix.
+
+## What the tool assumes
+
+Worth stating plainly, because it determines whether a given finding is a bug or the design:
+
+- **It runs locally as you.** It has whatever access your Windows account has, and no privilege
+  boundary of its own.
+- **Secrets live in Windows Credential Manager**, per-user, under `NineLives:Blob:*` and
+  `NineLives:SQL:*`. They are never written to `config.json`, never included in generated scripts,
+  and never sent anywhere except the SQL Server you connect to.
+- **`config.json` is trusted input.** It sits in `%LOCALAPPDATA%\NineLives`, is plain text, and has
+  no integrity checking. Anything able to write it is already running as you. That said, values
+  read from it still get escaped properly before reaching T-SQL — someone who can write that file
+  should not thereby get a cleaner path to running arbitrary SQL as sysadmin.
+- **You choose the server.** The tool connects where you tell it to and runs the script you can
+  read before you run it.
+
+So: anything an attacker who is *already you, on your machine* can do is generally not a
+vulnerability. Anything that leaks a secret somewhere it shouldn't go, sends it somewhere
+unexpected, or turns untrusted data into executed T-SQL, is.
+
+### Particularly interested in
+
+- SAS tokens or SQL passwords ending up anywhere other than Credential Manager — logs, the
+  generated script, `config.json`, the clipboard, an error message, a crash dump.
+- Anything that reaches T-SQL without going through `Services/TSql.cs`, or a way past its quoting.
+- A restore being aimed at a server or database other than the one shown in the confirmation.
+- Credentials being sent over a connection that isn't validated the way the settings claim.
+
+### Known and already tracked
+
+Not vulnerabilities to report — they're on the list:
+
+- The released binary is **unsigned**, so SmartScreen warns on download
+  ([#33](https://github.com/jakemorgangit/NineLives/issues/33)). Releases carry a
+  [build provenance attestation](https://github.com/jakemorgangit/NineLives#windows-protected-your-pc)
+  you can verify in the meantime.
+- `TrustServerCertificate` defaults to true
+  ([#17](https://github.com/jakemorgangit/NineLives/issues/17)).
+- Entra ID / Managed Identity is not supported yet; SAS tokens only
+  ([#29](https://github.com/jakemorgangit/NineLives/issues/29)).
+
+## Thank you
+
+Genuinely — a private report is a favour, and it's the difference between fixing something quietly
+and finding out about it the hard way.

--- a/src/NineLives.Tests/SasExpiryTests.cs
+++ b/src/NineLives.Tests/SasExpiryTests.cs
@@ -1,0 +1,168 @@
+using System.Globalization;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// SAS expiry parsing (#21), and keeping the token off the clipboard (#18).
+///
+/// The expiry was parsed with DateTime.TryParse and no culture, and any failure returned null -
+/// which every caller reads as "not expired". So on a non-invariant locale an expired token could
+/// be presented as perfectly valid, and the user found out when the restore failed.
+/// </summary>
+public class SasExpiryTests
+{
+    private static BlobContainerConfig Container() => new()
+    {
+        Name = "prod",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups"
+    };
+
+    private static string TokenExpiring(string se) => $"sv=2024-11-04&se={se}&sr=c&sp=rl&sig=abc";
+
+    // ── culture ─────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("en-GB")]
+    [InlineData("en-US")]
+    [InlineData("de-DE")]
+    [InlineData("fr-FR")]
+    [InlineData("ar-SA")]   // non-Gregorian default calendar
+    [InlineData("th-TH")]   // Buddhist calendar: years land ~543 out under the ambient culture
+    public void ExpiryIsReadIdenticallyInEveryCulture(string culture)
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+
+            var expiry = Container().ReadSasExpiry(TokenExpiring("2026-03-09T17:45:00Z"));
+
+            Assert.Equal(new DateTime(2026, 3, 9, 17, 45, 0, DateTimeKind.Utc), expiry.ExpiresAt);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void AnExpiryWithNoZoneIsTreatedAsUtc()
+    {
+        // Azure writes UTC here. Reading it as local time would shift the answer by the machine's
+        // offset, so a token could look valid for another hour on one desk and not on the next.
+        var expiry = Container().ReadSasExpiry(TokenExpiring("2026-03-09T17:45:00"));
+
+        Assert.Equal(new DateTime(2026, 3, 9, 17, 45, 0, DateTimeKind.Utc), expiry.ExpiresAt);
+    }
+
+    // ── the three states ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AReadableFutureExpiryIsNotExpired()
+    {
+        var se = DateTime.UtcNow.AddHours(4).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        var expiry = Container().ReadSasExpiry(TokenExpiring(se));
+
+        Assert.False(expiry.IsExpired);
+        Assert.False(expiry.CouldNotParse);
+    }
+
+    [Fact]
+    public void AReadablePastExpiryIsExpired()
+    {
+        var se = DateTime.UtcNow.AddHours(-4).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        Assert.True(Container().ReadSasExpiry(TokenExpiring(se)).IsExpired);
+    }
+
+    /// <summary>
+    /// The regression. An se= we cannot read must not be reported as a valid token - we have no
+    /// basis for saying so, and the restore is the wrong place to find out.
+    /// </summary>
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("2026-13-45T99:99:99Z")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AnUnreadableExpiryCountsAsExpired(string se)
+    {
+        var expiry = Container().ReadSasExpiry($"sv=2024-11-04&se={Uri.EscapeDataString(se)}&sig=abc");
+
+        Assert.True(expiry.IsExpired);
+        Assert.Null(expiry.ExpiresAt);
+    }
+
+    [Fact]
+    public void NoExpiryAtAllIsUnknownRatherThanExpired()
+    {
+        // A SAS built on a stored access policy legitimately carries no se= of its own. Calling
+        // that expired would condemn a perfectly good token.
+        var expiry = Container().ReadSasExpiry("sv=2024-11-04&sr=c&si=my-policy&sig=abc");
+
+        Assert.False(expiry.IsExpired);
+        Assert.False(expiry.CouldNotParse);
+        Assert.Null(expiry.ExpiresAt);
+    }
+
+    [Fact]
+    public void NoTokenAtAllIsUnknown()
+    {
+        var expiry = Container().ReadSasExpiry("");
+
+        Assert.False(expiry.IsExpired);
+        Assert.Null(expiry.ExpiresAt);
+    }
+
+    [Fact]
+    public void ALeadingQuestionMarkIsAccepted()
+    {
+        var expiry = Container().ReadSasExpiry("?sv=2024-11-04&se=2026-03-09T17:45:00Z&sig=abc");
+
+        Assert.Equal(new DateTime(2026, 3, 9, 17, 45, 0, DateTimeKind.Utc), expiry.ExpiresAt);
+    }
+
+    [Fact]
+    public void DisplayTextMarksAContainerWithAnUnreadableExpiryAsExpired()
+    {
+        var container = Container();
+        container.CacheSasToken("sv=2024-11-04&se=not-a-date&sig=abc");
+
+        Assert.True(container.IsExpired);
+        Assert.Contains("[EXPIRED]", container.DisplayText);
+    }
+
+    // ── #18: the copied URL carries no credential ───────────────────────────────
+
+    [Fact]
+    public void TheCopyableBlobUrlCarriesNoSasToken()
+    {
+        // Copying a SAS-bearing URL puts a live credential on the Windows clipboard, where
+        // clipboard history and cloud sync can keep it long after the app has closed. The
+        // token-free URL is what the generated scripts use anyway - RESTORE FROM URL
+        // authenticates with the server-side credential, not with anything in the URL.
+        var url = BlobStorageService.BuildBlobUrl(Container(), "FULL/SRV01/MyDb/MyDb_20260305.bak");
+
+        Assert.Equal(
+            "https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/MyDb_20260305.bak",
+            url);
+        Assert.DoesNotContain("?", url);
+        Assert.DoesNotContain("sig=", url);
+    }
+
+    [Fact]
+    public void TheCopyableBlobUrlDoesNotDoubleUpSlashes()
+    {
+        var container = new BlobContainerConfig
+        {
+            ContainerUrl = "https://acct.blob.core.windows.net/backups/"
+        };
+
+        Assert.Equal(
+            "https://acct.blob.core.windows.net/backups/FULL/MyDb.bak",
+            BlobStorageService.BuildBlobUrl(container, "FULL/MyDb.bak"));
+    }
+}

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Globalization;
 using System.Text.Json.Serialization;
 using System.Web;
 
@@ -135,7 +136,7 @@ public class BlobContainerConfig : INotifyPropertyChanged
     [JsonIgnore]
     public string? UnsavedSasToken { get; set; }
 
-    public bool IsExpired => GetSasExpiry() is DateTime expiry && expiry < DateTime.UtcNow;
+    public bool IsExpired => ReadSasExpiry().IsExpired;
 
     public DateTime? SasExpiry => GetSasExpiry();
 
@@ -172,26 +173,55 @@ public class BlobContainerConfig : INotifyPropertyChanged
 
     private string? _cachedSasTokenValue;
 
-    public DateTime? GetSasExpiry(string? sasToken = null)
+    public DateTime? GetSasExpiry(string? sasToken = null) => ReadSasExpiry(sasToken).ExpiresAt;
+
+    /// <summary>
+    /// Reads the SAS <c>se=</c> expiry, distinguishing "there isn't one" from "there is one and it
+    /// is not readable" (#21).
+    ///
+    /// That distinction is the point. The old version parsed with the ambient culture and returned
+    /// null on any failure, and every caller reads null as "not expired" - so on a non-invariant
+    /// locale an expired token could be presented as perfectly fine, and the user found out when
+    /// the restore failed. An se= that will not parse now counts as expired, because the honest
+    /// answer is "this token cannot be trusted to be valid".
+    ///
+    /// A token with no se= at all is a different case and stays "unknown, not expired": a SAS
+    /// built on a stored access policy legitimately has no expiry of its own.
+    /// </summary>
+    public SasExpiryInfo ReadSasExpiry(string? sasToken = null)
     {
         var token = sasToken ?? _cachedSasTokenValue;
         if (string.IsNullOrEmpty(token))
-            return null;
+            return SasExpiryInfo.None;
 
+        string? se;
         try
         {
             var query = token.StartsWith("?") ? token : "?" + token;
-            var parsed = HttpUtility.ParseQueryString(query);
-            var se = parsed["se"];
-            if (se != null && DateTime.TryParse(se, out var expiry))
-                return expiry.ToUniversalTime();
+            se = HttpUtility.ParseQueryString(query)["se"];
         }
         catch
         {
-            // Malformed token
+            return SasExpiryInfo.Unreadable;
         }
 
-        return null;
+        // No se= at all is "this token does not state an expiry". An se= that is present but empty
+        // is a different thing: it claims one and supplies nothing, which is unreadable, not absent.
+        if (se == null)
+            return SasExpiryInfo.None;
+
+        if (string.IsNullOrWhiteSpace(se))
+            return SasExpiryInfo.Unreadable;
+
+        // Invariant, and treating the value as UTC whether or not it carries a zone. Azure writes
+        // ISO-8601 here; the ambient culture has no business interpreting it.
+        var parsed = DateTime.TryParse(
+            se,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal,
+            out var expiry);
+
+        return parsed ? new SasExpiryInfo(expiry, false) : SasExpiryInfo.Unreadable;
     }
 
     public void CacheSasToken(string sasToken)
@@ -200,6 +230,29 @@ public class BlobContainerConfig : INotifyPropertyChanged
     }
 
     public override string ToString() => DisplayText;
+}
+
+/// <summary>
+/// What a SAS token says about its own expiry. Three states rather than a nullable DateTime,
+/// because "no expiry stated" and "expiry stated but unreadable" mean opposite things and both
+/// used to come back as null (#21).
+/// </summary>
+/// <param name="ExpiresAt">When the token expires, in UTC. Null if it does not say.</param>
+/// <param name="CouldNotParse">The token carries an se= value that could not be read.</param>
+public readonly record struct SasExpiryInfo(DateTime? ExpiresAt, bool CouldNotParse)
+{
+    /// <summary>No se= parameter. Legitimate for a SAS built on a stored access policy.</summary>
+    public static SasExpiryInfo None => new(null, false);
+
+    /// <summary>There is an se=, and it is not readable. Treated as expired.</summary>
+    public static SasExpiryInfo Unreadable => new(null, true);
+
+    /// <summary>
+    /// Unreadable counts as expired. The alternative is presenting a token we cannot vouch for as
+    /// valid, and finding out mid-restore.
+    /// </summary>
+    public bool IsExpired =>
+        CouldNotParse || (ExpiresAt.HasValue && ExpiresAt.Value < DateTime.UtcNow);
 }
 
 /// <summary>

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -259,11 +259,17 @@ public class BlobStorageService
         return idx >= 0 ? blobName[..idx] : string.Empty;
     }
 
-    public string BuildBlobUrlWithSas(BlobContainerConfig config, string blobName)
-    {
-        var sasToken = _credentialStore.GetSasToken(config);
-        return $"{config.ContainerUrl.TrimEnd('/')}/{blobName}?{sasToken?.TrimStart('?')}";
-    }
+    /// <summary>
+    /// The plain HTTPS URL of a blob, with no SAS token on it.
+    ///
+    /// This replaced BuildBlobUrlWithSas, which existed only to feed the two "copy HTTPS path"
+    /// buttons and put a live credential on the Windows clipboard - where clipboard history
+    /// (Win+V) and cloud clipboard sync can keep it long after the app has closed (#18). The
+    /// token-free URL is what the generated scripts use anyway, since RESTORE FROM URL
+    /// authenticates with the server-side credential rather than anything in the URL.
+    /// </summary>
+    public static string BuildBlobUrl(BlobContainerConfig config, string blobName)
+        => $"{config.ContainerUrl.TrimEnd('/')}/{blobName}";
 
     private static void ParseBlobPath(BackupFileInfo file, string pathPattern)
     {

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -165,14 +165,17 @@ public class CredentialStore
     {
         var sasToken = GetSasToken(config);
         if (sasToken == null) return true;
-        var expiry = config.GetSasExpiry(sasToken);
-        return expiry.HasValue && expiry.Value < DateTime.UtcNow;
+        return config.ReadSasExpiry(sasToken).IsExpired;
     }
 
     public DateTime? GetSasTokenExpiry(BlobContainerConfig config)
+        => ReadSasTokenExpiry(config).ExpiresAt;
+
+    /// <summary>Full expiry state, so callers can tell "no expiry" from "unreadable" (#21).</summary>
+    public SasExpiryInfo ReadSasTokenExpiry(BlobContainerConfig config)
     {
         var sasToken = GetSasToken(config);
-        return sasToken != null ? config.GetSasExpiry(sasToken) : null;
+        return sasToken != null ? config.ReadSasExpiry(sasToken) : SasExpiryInfo.None;
     }
 
     #endregion

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -258,9 +258,9 @@ public partial class BlobBrowserViewModel : ViewModelBase
         if (target == null || SelectedContainer == null) return;
         try
         {
-            var url = _blobService.BuildBlobUrlWithSas(SelectedContainer, target.BlobName);
+            var url = BlobStorageService.BuildBlobUrl(SelectedContainer, target.BlobName);
             Clipboard.SetText(url);
-            SetStatus("HTTPS path copied to clipboard.");
+            SetStatus("HTTPS path copied to clipboard (no SAS token).");
         }
         catch (Exception ex)
         {

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -189,18 +189,28 @@ public partial class BlobConfigViewModel : ViewModelBase
 
     private void UpdateSasExpiryStatus(BlobContainerConfig container)
     {
-        var expiry = _credentialStore.GetSasTokenExpiry(container);
-        if (expiry.HasValue)
+        var expiry = _credentialStore.ReadSasTokenExpiry(container);
+
+        if (expiry.CouldNotParse)
         {
-            IsSasExpired = expiry.Value < DateTime.UtcNow;
-            var remaining = expiry.Value - DateTime.UtcNow;
+            // The token states an expiry we cannot read, so we cannot say it is still valid.
+            // Showing this as "unknown" alongside everything else that is fine would be a lie of
+            // omission - the restore is the wrong place to discover it (#21).
+            SasExpiryText = "SAS token expiry could not be read - treat this token as expired and replace it";
+            IsSasExpired = true;
+        }
+        else if (expiry.ExpiresAt is { } expiresAt)
+        {
+            IsSasExpired = expiresAt < DateTime.UtcNow;
+            var remaining = expiresAt - DateTime.UtcNow;
             SasExpiryText = IsSasExpired
                 ? $"SAS token expired {-remaining.TotalHours:F0}h ago"
-                : $"SAS token expires in {remaining.TotalHours:F0}h ({expiry.Value:yyyy-MM-dd HH:mm} UTC)";
+                : $"SAS token expires in {remaining.TotalHours:F0}h ({expiresAt:yyyy-MM-dd HH:mm} UTC)";
         }
         else
         {
-            SasExpiryText = "SAS token expiry unknown";
+            // No se= at all, which is legitimate for a SAS built on a stored access policy.
+            SasExpiryText = "SAS token states no expiry";
             IsSasExpired = false;
         }
     }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1117,9 +1117,9 @@ public partial class RestoreViewModel : ViewModelBase
         if (file == null || SelectedContainer == null) return;
         try
         {
-            var url = _blobService.BuildBlobUrlWithSas(SelectedContainer, file.BlobName);
+            var url = BlobStorageService.BuildBlobUrl(SelectedContainer, file.BlobName);
             Clipboard.SetText(url);
-            SetStatus("HTTPS path copied to clipboard.");
+            SetStatus("HTTPS path copied to clipboard (no SAS token).");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Closes #21. Closes #18.

## #21 — an unreadable expiry was reported as a valid token

`GetSasExpiry` returned `null` on any parse failure, and every caller reads `null` as *not expired*. So a token whose `se=` couldn't be read was presented as perfectly fine, and you found out when the restore failed.

Expiry is now a three-state answer rather than a nullable date:

| State | Meaning | Treated as |
|---|---|---|
| readable `se=` | a real expiry | expired iff it's in the past |
| no `se=` at all | token states no expiry | **not** expired |
| `se=` present, unreadable | claims an expiry, won't parse | **expired** |

Both edges matter. A SAS built on a stored access policy legitimately carries no `se=` of its own — calling that expired would condemn a perfectly good token. An `se=` that's present but *empty* claims an expiry and supplies nothing, so it's unreadable rather than absent. **A test caught that second case; my first cut had it filed under "no expiry".**

The UI now says so plainly — *"SAS token expiry could not be read — treat this token as expired and replace it"* — rather than showing "unknown" next to everything that's actually fine.

### One claim in the issue that doesn't hold

The issue says the ambient culture can misread the ISO-8601 value. **I couldn't reproduce that.** `DateTime.TryParse` reads `2026-03-09T17:45:00Z` identically under `en-GB`, `en-US`, `de-DE`, `fr-FR`, `ar-SA` and `th-TH` — including the non-Gregorian default calendars, which were my best bet for breaking it. Those cases are in the test file and they passed against the old code too.

Parsing is invariant now anyway, as defensive practice that costs nothing. `AssumeUniversal` **is** a real fix though: an `se=` with no zone suffix used to be read as local time and shifted by the machine's offset.

## #18 — copied URLs carried a live credential

Both "copy HTTPS path" buttons built a URL with the SAS token in the query string. That puts a working credential on the Windows clipboard, where **clipboard history (Win+V) and cloud clipboard sync can retain it** well after the app has closed.

They now copy the token-free URL. That's what the generated scripts use anyway — `RESTORE FROM URL` authenticates with the server-side credential, not with anything in the URL — so nothing is lost. `BuildBlobUrlWithSas` is deleted rather than left sitting there as a footgun; it had no other callers.

The status line says "(no SAS token)" so the change is visible rather than silent.

## Tests

19 new. **5 fail against the old expiry semantics** — every unparsable-`se=` case plus the container display marking.

**396 tests pass**, build clean at `-warnaserror`.
