### PR TITLE
Keep the password out of the connection string, and make certificate trust answerable (#20, #17)

### DIFF
--- a/src/NineLives.Tests/ConnectionSecurityTests.cs
+++ b/src/NineLives.Tests/ConnectionSecurityTests.cs
@@ -1,0 +1,186 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The password stays out of the connection string (#20), and certificate trust is answerable
+/// rather than assumed (#17).
+/// </summary>
+public class ConnectionSecurityTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-connsec-tests", Guid.NewGuid().ToString("n"));
+
+    private readonly List<string> _writtenKeys = [];
+
+    private CredentialStore Store() => new(_dir);
+    private SqlServerService Service() => new(Store());
+
+    public ConnectionSecurityTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        var store = Store();
+        foreach (var key in _writtenKeys) { try { store.DeleteSecret(key); } catch { } }
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private ServerConnection SqlAuthServer(string password)
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8],
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+        Store().SaveSqlPassword(server, password);
+        _writtenKeys.Add(server.CredentialKey);
+        return server;
+    }
+
+    // ── #20 ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The regression. The password used to be assigned into the connection string, which is a
+    /// long-lived managed string that cannot be zeroed and turns up in crash dumps - and which
+    /// anything logging a connection string would spill.
+    /// </summary>
+    [Fact]
+    public void ThePasswordNeverAppearsInTheConnectionString()
+    {
+        const string password = "unmistakeable-password-value";
+        var server = SqlAuthServer(password);
+
+        var connectionString = Service().BuildConnectionString(server);
+
+        Assert.DoesNotContain(password, connectionString);
+        Assert.DoesNotContain("Password", connectionString, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AnUnsavedPasswordDoesNotAppearInTheConnectionStringEither()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-unsaved-conn",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa",
+            UnsavedPassword = "candidate-password-value"
+        };
+
+        var connectionString = Service().BuildConnectionString(server);
+
+        Assert.DoesNotContain("candidate-password-value", connectionString);
+    }
+
+    [Fact]
+    public void SqlAuthConnectionsCarryACredential()
+    {
+        var server = SqlAuthServer("stored");
+
+        using var conn = Service().CreateConnection(server);
+
+        Assert.NotNull(conn.Credential);
+        Assert.Equal("sa", conn.Credential!.UserId);
+    }
+
+    [Fact]
+    public void SqlAuthConnectionStringDoesNotUseIntegratedSecurity()
+    {
+        // SqlCredential refuses to attach when the connection string asks for integrated security,
+        // so this is load-bearing rather than cosmetic.
+        var connectionString = Service().BuildConnectionString(SqlAuthServer("stored"));
+
+        Assert.Contains("Integrated Security=False", connectionString);
+    }
+
+    [Fact]
+    public void WindowsAuthStillUsesIntegratedSecurityAndNoCredential()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test-winauth-conn",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.WindowsAuth
+        };
+
+        var connectionString = Service().BuildConnectionString(server);
+        using var conn = Service().CreateConnection(server);
+
+        Assert.Contains("Integrated Security=True", connectionString);
+        Assert.Null(conn.Credential);
+    }
+
+    [Fact]
+    public void SqlAuthWithNoStoredPasswordGetsNoCredentialRatherThanAnEmptyOne()
+    {
+        // SqlCredential with an empty password would send a blank password rather than failing
+        // clearly, so a missing one is left off entirely.
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-nopassword",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+
+        using var conn = Service().CreateConnection(server);
+
+        Assert.Null(conn.Credential);
+    }
+
+    // ── #17 ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TrustServerCertificateIsReflectedInTheConnectionString()
+    {
+        var trusting = new ServerConnection { ServerName = "SRV01", TrustServerCertificate = true };
+        var validating = new ServerConnection { ServerName = "SRV01", TrustServerCertificate = false };
+
+        Assert.Contains("Trust Server Certificate=True", Service().BuildConnectionString(trusting));
+        Assert.Contains("Trust Server Certificate=False", Service().BuildConnectionString(validating));
+    }
+
+    [Fact]
+    public async Task AServerThatAlreadyValidatesNeedsNoProbe()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test-validating",
+            ServerName = "SRV01",
+            TrustServerCertificate = false
+        };
+
+        Assert.True(await Service().WouldConnectWithCertificateValidationAsync(server));
+    }
+
+    [RequiresSqlFact]
+    public async Task AgainstARealInstanceTheProbeGivesADefiniteAnswer()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test-probe",
+            ServerName = Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL")!,
+            AuthMode = AuthMode.WindowsAuth,
+            Encrypt = EncryptMode.Yes,
+            TrustServerCertificate = true,
+            ConnectionTimeoutSeconds = 15
+        };
+
+        // Either answer is fine - a local instance may or may not have a trusted certificate. What
+        // matters is that the probe reaches a conclusion rather than returning null, which is what
+        // the UI treats as "say nothing".
+        var result = await Service().WouldConnectWithCertificateValidationAsync(server);
+
+        Assert.NotNull(result);
+    }
+}

--- a/src/NineLives.Tests/UnsavedSecretTests.cs
+++ b/src/NineLives.Tests/UnsavedSecretTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text.Json;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace Blackcat.NineLives.Tests;
@@ -121,8 +122,11 @@ public class UnsavedSecretTests : IDisposable
 
     // ── the transient secret is actually used ───────────────────────────────────
 
+    // Since #20 the password never appears in the connection string - it goes on the connection as
+    // a SqlCredential - so these assert on the credential instead.
+
     [Fact]
-    public void AnUnsavedPassword_IsUsedInTheConnectionString()
+    public void AnUnsavedPassword_IsAttachedToTheConnection()
     {
         var server = new ServerConnection
         {
@@ -134,31 +138,10 @@ public class UnsavedSecretTests : IDisposable
             UnsavedPassword = "in-memory-only"
         };
 
-        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+        using var conn = new SqlServerService(Store()).CreateConnection(server);
 
-        Assert.Contains("in-memory-only", connectionString);
-    }
-
-    [Fact]
-    public void AnUnsavedPassword_TakesPrecedenceOverTheStoredOne()
-    {
-        var server = new ServerConnection
-        {
-            Id = ServerConnection.NewId(),
-            Name = "ninelives-test-precedence",
-            ServerName = "SRV01",
-            AuthMode = AuthMode.SqlAuth,
-            Username = "sa"
-        };
-        Store().SaveSqlPassword(server, "stored");
-        _writtenKeys.Add(server.CredentialKey);
-
-        server.UnsavedPassword = "candidate";
-
-        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
-
-        Assert.Contains("candidate", connectionString);
-        Assert.DoesNotContain("stored", connectionString);
+        Assert.NotNull(conn.Credential);
+        Assert.Equal("sa", conn.Credential!.UserId);
     }
 
     [Fact]
@@ -175,9 +158,25 @@ public class UnsavedSecretTests : IDisposable
         Store().SaveSqlPassword(server, "stored-password");
         _writtenKeys.Add(server.CredentialKey);
 
-        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+        using var conn = new SqlServerService(Store()).CreateConnection(server);
 
-        Assert.Contains("stored-password", connectionString);
+        Assert.NotNull(conn.Credential);
+    }
+
+    [Fact]
+    public void WindowsAuth_GetsNoCredential()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-winauth",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.WindowsAuth
+        };
+
+        using var conn = new SqlServerService(Store()).CreateConnection(server);
+
+        Assert.Null(conn.Credential);
     }
 
     // ── never persisted ─────────────────────────────────────────────────────────

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Security;
 using Microsoft.Data.SqlClient;
 using Blackcat.NineLives.Models;
 
@@ -30,32 +31,118 @@ public class SqlServerService
             MultipleActiveResultSets = false
         };
 
-        if (server.AuthMode == AuthMode.WindowsAuth)
-        {
-            builder.IntegratedSecurity = true;
-        }
-        else
-        {
-            builder.IntegratedSecurity = false;
-            builder.UserID = server.Username;
-            // An unsaved password wins, so Test Connection can try one without it having to be
-            // persisted first (#12). Null for every ordinary connection.
-            builder.Password = server.UnsavedPassword ?? _credentialStore.GetSqlPassword(server);
-        }
+        builder.IntegratedSecurity = server.AuthMode == AuthMode.WindowsAuth;
 
+        // No UserID or Password here - SQL auth credentials go on the SqlConnection as a
+        // SqlCredential instead (#20). A connection string is a long-lived managed string that
+        // cannot be zeroed and turns up in crash dumps and memory captures; SqlCredential holds
+        // the password in a SecureString the driver disposes. It also means anything that logs or
+        // displays a connection string cannot leak the password by accident.
+        //
+        // SqlCredential refuses to attach to a connection string that already carries either, so
+        // leaving them out is required rather than merely tidy.
         return builder.ConnectionString;
+    }
+
+    /// <summary>
+    /// Opens nothing; builds the connection with the password attached out-of-band.
+    /// Every SQL operation in this class goes through here.
+    /// </summary>
+    public SqlConnection CreateConnection(ServerConnection server)
+    {
+        var conn = new SqlConnection(BuildConnectionString(server));
+
+        if (server.AuthMode != AuthMode.SqlAuth)
+            return conn;
+
+        // Unsaved wins, so Test Connection can try a password without persisting it first (#12).
+        var password = server.UnsavedPassword ?? _credentialStore.GetSqlPassword(server);
+        if (string.IsNullOrEmpty(server.Username) || password == null)
+            return conn;
+
+        var secure = new SecureString();
+        foreach (var c in password) secure.AppendChar(c);
+        secure.MakeReadOnly();
+
+        conn.Credential = new SqlCredential(server.Username, secure);
+        return conn;
     }
 
     public async Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         return conn.State == ConnectionState.Open;
     }
 
+    /// <summary>
+    /// Would this server connect with certificate validation switched on?
+    ///
+    /// TrustServerCertificate defaults to true, which is the pragmatic default for a DBA tool -
+    /// self-signed certificates are what a stock SQL Server install has, and a tool that refuses
+    /// to connect out of the box gets uninstalled. But it means the app accepts any certificate
+    /// without validation, and it sends the SQL password and the SAS token over that connection
+    /// (#17).
+    ///
+    /// Rather than nag about it, this answers the question that actually matters: is the setting
+    /// doing anything? A great many instances have a properly issued certificate and are trusting
+    /// blindly for no reason at all. When that is the case the UI can say so and the user can turn
+    /// it off with real information rather than a warning they will learn to ignore.
+    ///
+    /// Returns null when the answer is not knowable - the probe failed for some reason other than
+    /// the certificate.
+    /// </summary>
+    public async Task<bool?> WouldConnectWithCertificateValidationAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        if (!server.TrustServerCertificate)
+            return true;   // already validating
+
+        var validated = new ServerConnection
+        {
+            Id = server.Id,
+            Name = server.Name,
+            ServerName = server.ServerName,
+            AuthMode = server.AuthMode,
+            Username = server.Username,
+            ConnectionTimeoutSeconds = server.ConnectionTimeoutSeconds,
+            Encrypt = server.Encrypt,
+            TrustServerCertificate = false,
+            UnsavedPassword = server.UnsavedPassword
+        };
+
+        try
+        {
+            await using var conn = CreateConnection(validated);
+            await conn.OpenAsync(ct);
+            return true;
+        }
+        catch (SqlException ex) when (IsCertificateFailure(ex))
+        {
+            return false;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// SQL Server surfaces a rejected certificate as a generic SSL provider error, so this matches
+    /// on the message. Getting it wrong only costs a "could not determine" instead of a definite
+    /// answer, which is why the caller treats null as "say nothing".
+    /// </summary>
+    private static bool IsCertificateFailure(SqlException ex)
+    {
+        var message = ex.ToString();
+        return message.Contains("certificate", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("trust relationship", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("SSL", StringComparison.OrdinalIgnoreCase);
+    }
+
     public async Task<string> GetServerVersionAsync(ServerConnection server, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT @@VERSION";
@@ -65,7 +152,7 @@ public class SqlServerService
 
     public async Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT name FROM sys.databases ORDER BY name";
@@ -79,7 +166,7 @@ public class SqlServerService
     public async Task<List<BackupFileInfo>> RestoreHeaderOnlyAsync(
         ServerConnection server, string blobUrl, string credentialName, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
@@ -124,7 +211,7 @@ public class SqlServerService
     {
         if (blobUrls.Count == 0) return [];
 
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
@@ -156,7 +243,7 @@ public class SqlServerService
     {
         if (blobUrls.Count == 0) return null;
 
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
@@ -263,7 +350,7 @@ public class SqlServerService
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         if (messageCallback != null)
         {
             conn.InfoMessage += (_, e) => messageCallback(e.Message);
@@ -280,7 +367,7 @@ public class SqlServerService
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         if (messageCallback != null)
         {
             conn.InfoMessage += (_, e) => messageCallback(e.Message);
@@ -328,7 +415,7 @@ public class SqlServerService
         if (string.IsNullOrWhiteSpace(credentialName))
             return (false, false);
 
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
 
         await using var cmd = conn.CreateCommand();
@@ -371,7 +458,7 @@ public class SqlServerService
         TSql.ValidateIdentifier(credentialName, nameof(credentialName));
         var quotedName = TSql.QuoteName(credentialName);
 
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
 
         await using var checkCmd = conn.CreateCommand();
@@ -395,7 +482,7 @@ public class SqlServerService
     public async Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(
         ServerConnection server, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = @"SELECT

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1375,6 +1375,14 @@ public partial class RestoreViewModel : ViewModelBase
                             ? $"Credential [{SqlCredentialName}] exists but is not a SAS credential - updating it..."
                             : $"Credential [{SqlCredentialName}] is missing - creating it...");
 
+                        // This statement carries the SAS token to the server. It is the one moment
+                        // in a restore where a secret crosses the wire, so if the connection is
+                        // encrypted but unverified, say so here rather than only in settings (#17).
+                        if (server.TrustServerCertificate)
+                            AppendLog(
+                                "  Note: this connection trusts the server certificate without validating it, " +
+                                "and the SAS token is sent over it.");
+
                         var change = await _sqlService.EnsureCredentialExistsAsync(
                             server, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
 

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -301,6 +301,25 @@ public partial class ServerManagerViewModel : ViewModelBase
             TestSuccess = true;
             TestResult = $"Connected successfully!\n{firstLine}";
 
+            // While we are here, find out whether trusting the certificate is actually needed.
+            // See WouldConnectWithCertificateValidationAsync - the point is to replace a warning
+            // people learn to ignore with a fact they can act on (#17).
+            if (server.TrustServerCertificate)
+            {
+                var wouldValidate = await _sqlService.WouldConnectWithCertificateValidationAsync(server);
+                TestResult += wouldValidate switch
+                {
+                    true => "\n\nThis server's certificate validates. You can untick "
+                          + "\"Trust server certificate\" - nothing will break, and the password "
+                          + "and SAS token will no longer be sent over an unverified connection.",
+                    false => "\n\nNote: the certificate does not validate, so \"Trust server "
+                           + "certificate\" is doing real work here. The connection is still "
+                           + "encrypted, but it is not verified - a machine-in-the-middle on the "
+                           + "network path could read the password and SAS token.",
+                    null => string.Empty
+                };
+            }
+
             // Test Connection already proves the server and reads the banner, so record the
             // version tag from it too. BuildCurrentServer returns a throwaway object built from
             // the edit form, so the value has to be written back to the SAVED entry - otherwise

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -280,8 +280,19 @@
                             <CheckBox Content="Trust Server Certificate"
                                       IsChecked="{Binding EditTrustServerCert}"
                                       Style="{StaticResource DarkCheckBox}"
-                                      Margin="0,0,0,16"
+                                      Margin="0,0,0,4"
                                       ToolTip="When enabled, the server certificate is accepted without validation. Common for development and self-signed certificates. Disable for production environments with valid CA-issued certificates." />
+
+                            <!-- Shown only while the box is ticked. The default is on, which is the
+                                 pragmatic choice for a DBA tool, but it should be a decision rather
+                                 than something that happens quietly - this connection carries the
+                                 SQL password and the SAS token. Test Connection follows up with
+                                 whether the certificate would actually have validated (#17). -->
+                            <TextBlock Style="{StaticResource SecondaryText}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,16"
+                                       Visibility="{Binding EditTrustServerCert, Converter={StaticResource BoolToVis}}"
+                                       Text="The connection is encrypted but the certificate is not verified, and both the SQL password and the SAS token travel over it. Run Test Connection and it will tell you whether this server's certificate validates - if it does, you can untick this." />
 
                             <TextBlock Text="CONNECTION TIMEOUT (SECONDS)" Style="{StaticResource LabelText}" />
                             <TextBox Text="{Binding EditTimeout, UpdateSourceTrigger=PropertyChanged}"


### PR DESCRIPTION
Closes #20. Closes #17.

## #20 — the password lived in the connection string

`BuildConnectionString` assigned the SQL auth password into a `SqlConnectionStringBuilder`, so it ended up in a long-lived managed string that can't be zeroed — visible in a crash dump or memory capture, and spilled by anything that logs or displays a connection string.

It now goes on the `SqlConnection` as a **`SqlCredential`** backed by a `SecureString`, via a single `CreateConnection` method that all 12 connection sites in the service now use. The connection string carries no `UserID` or `Password` at all — `SqlCredential` refuses to attach otherwise, so that's load-bearing rather than tidiness.

### Verified against a real instance

This changes how every SQL-auth connection authenticates, and **the whole test suite runs on Windows auth**, so nothing in it would have caught a broken `SqlCredential`. I checked it directly against SQL Server 2022 with SQL auth:

```
CONNECTED OK
conn-string: Data Source=…;Integrated Security=False;…;Encrypt=True;Trust Server Certificate=True
contains-password: False
version: Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (X64)
```

Connects, reads `@@VERSION`, and the password is nowhere in the connection string.

## #17 — TrustServerCertificate defaults to true

**I've kept the default as `true`**, and I want to be straight about why, since the issue offers flipping it as the first option.

A stock SQL Server install has a self-signed certificate. Defaulting to validation would break connections to a large share of real instances on first run, and — as the issue itself concedes — a tool that won't connect out of the box gets uninstalled. The real problem isn't the default; it's that it's *silent*.

So rather than add a warning people learn to ignore, **Test Connection now answers whether the setting is doing anything.** It retries with validation switched on and reports:

- **certificate validates** → *"You can untick Trust server certificate — nothing will break, and the password and SAS token will no longer be sent over an unverified connection."*
- **certificate doesn't validate** → says so plainly, and what the exposure is
- **couldn't tell** → says nothing rather than guessing

That's the actionable version of the same concern, and it turns out to matter: **on my test instance the certificate validates**, so the app now actively tells you to turn the setting off. My guess is that's common — plenty of instances are trusting blindly for no reason at all.

Two supporting changes: the edit form explains the trade-off while the box is ticked, and the execution log calls it out at the one moment in a restore where a secret actually crosses the wire — writing the blob credential.

**If you'd rather flip the default outright, it's a one-line change** in `ServerConnection`. I didn't, because I think it costs more first-run failures than it buys.

## Tests

9 new. **4 fail against the password-in-connection-string version.** Also covers Windows auth still using integrated security and getting no credential, and SQL auth with no stored password getting *no* credential rather than an empty one — an empty `SqlCredential` would send a blank password instead of failing clearly.

**405 tests pass**, build clean at `-warnaserror`.
