### PR TITLE
Match backup type indicators on delimited tokens, not substrings (#45, #44)

### DIFF
--- a/src/NineLives.Tests/BackupTypeInferenceTests.cs
+++ b/src/NineLives.Tests/BackupTypeInferenceTests.cs
@@ -1,0 +1,134 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Filename-based backup type inference (#45, #44).
+///
+/// This is the last resort, used when the path structure did not say what a file is. Getting it
+/// wrong is not a cosmetic mislabel:
+///
+///   - a full read as a differential never enters the fulls collection in BackupChainBuilder, so
+///     if it is the only full in the container that database gets no restore points at all (#45)
+///   - a log read as a full becomes a chain root, so the timeline offers a log file as a
+///     restorable Full point and drops every earlier log from the chain (#44)
+/// </summary>
+public class BackupTypeInferenceTests
+{
+    // ── #45: the substring match, live on the default path ──────────────────────
+
+    [Theory]
+    [InlineData("DiffusionDb_FULL_20260804_220000.bak")]
+    [InlineData("TrafficDiffusion_20260804_220000.bak")]
+    [InlineData("DiffEngineDb_20260804_220000.bak")]
+    [InlineData("diffusion_20260804.bak")]
+    public void ADatabaseWhoseNameContainsDiffIsStillAFullBackup(string fileName)
+    {
+        Assert.Equal(BackupType.Full, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    [Theory]
+    [InlineData("MyDb_DIFF_20260804_220000.bak")]
+    [InlineData("MyDb-diff-20260804.bak")]
+    [InlineData("MyDb.DIFF.20260804.bak")]
+    [InlineData("MyDb_DIFFERENTIAL_20260804.bak")]
+    [InlineData("MyDb_20260804.diff")]
+    public void ARealDifferentialMarkerIsStillDetected(string fileName)
+    {
+        Assert.Equal(BackupType.Differential, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    // ── #44: a log written as .bak ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("MyDb_LOG_20260804_120000.bak")]
+    [InlineData("MyDb-log-20260804.bak")]
+    [InlineData("MyDb_TLOG_20260804.bak")]
+    [InlineData("MyDb_TRN_20260804.bak")]
+    [InlineData("MyDb_TRANSACTIONLOG_20260804.bak")]
+    public void ALogWrittenAsBakIsNotAFullBackup(string fileName)
+    {
+        Assert.Equal(BackupType.TransactionLog, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    /// <summary>
+    /// The trap the issue calls out. A bare "log" substring would retype all of these, which is
+    /// exactly the mistake ContainsDiffIndicator was making with "diff".
+    /// </summary>
+    [Theory]
+    [InlineData("CatalogDb_FULL_20260804_220000.bak")]
+    [InlineData("BlogDb_20260804.bak")]
+    [InlineData("DialogDb_FULL_20260804.bak")]
+    [InlineData("AnalogData_20260804.bak")]
+    [InlineData("Catalog_20260804.bak")]
+    public void ADatabaseWhoseNameContainsLogIsStillAFullBackup(string fileName)
+    {
+        Assert.Equal(BackupType.Full, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    // ── extensions still win where they are unambiguous ─────────────────────────
+
+    [Theory]
+    [InlineData("MyDb_20260804.trn", BackupType.TransactionLog)]
+    [InlineData("MyDb_20260804.log", BackupType.TransactionLog)]
+    [InlineData("CatalogDb_20260804.trn", BackupType.TransactionLog)]
+    [InlineData("MyDb_20260804.bak", BackupType.Full)]
+    [InlineData("MyDb_20260804.bkp", BackupType.Full)]
+    [InlineData("MyDb_20260804.txt", BackupType.Unknown)]
+    [InlineData("MyDb_20260804", BackupType.Unknown)]
+    public void ExtensionDrivesTheAnswerWhenItIsUnambiguous(string fileName, BackupType expected)
+    {
+        Assert.Equal(expected, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    [Fact]
+    public void ADifferentialMarkerBeatsALogMarker()
+    {
+        // Ola-style names can carry both words; DIFF is the more specific claim.
+        Assert.Equal(
+            BackupType.Differential,
+            BlobStorageService.InferBackupTypeFromExtension("MyDb_DIFF_LOG_20260804.bak"));
+    }
+
+    // ── folders must not retype files ───────────────────────────────────────────
+
+    [Theory]
+    [InlineData("logs/MyDb_FULL_20260804.bak")]
+    [InlineData("log/MyDb_FULL_20260804.bak")]
+    [InlineData("diff/MyDb_FULL_20260804.bak")]
+    [InlineData("backups/LOG/CatalogDb_20260804.bak")]
+    public void IndicatorsAreReadFromTheFilenameNotTheFoldersAboveIt(string blobName)
+    {
+        // Folder-based typing is the primary path's job and runs before this. If this method also
+        // looked at the path, a container organised under a "logs/" prefix would have every file
+        // in it retyped regardless of what the file actually is.
+        Assert.Equal(BackupType.Full, BlobStorageService.InferBackupTypeFromExtension(blobName));
+    }
+
+    [Fact]
+    public void CaseDoesNotMatter()
+    {
+        Assert.Equal(BackupType.TransactionLog, BlobStorageService.InferBackupTypeFromExtension("MyDb_log_20260804.BAK"));
+        Assert.Equal(BackupType.Differential, BlobStorageService.InferBackupTypeFromExtension("MyDb_Diff_20260804.BAK"));
+    }
+
+    // ── the indicator helpers directly ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData("MyDb_DIFF_1.bak", true)]
+    [InlineData("DiffusionDb_FULL.bak", false)]
+    [InlineData("TariffData_FULL.bak", false)]
+    [InlineData("diff_20260804.bak", true)]
+    public void DiffIndicatorIsDelimited(string fileName, bool expected)
+        => Assert.Equal(expected, BlobStorageService.ContainsDiffIndicator(fileName));
+
+    [Theory]
+    [InlineData("MyDb_LOG_1.trn", true)]
+    [InlineData("CatalogDb_FULL.bak", false)]
+    [InlineData("BlogDb.bak", false)]
+    [InlineData("MyDb.log.bak", true)]
+    public void LogIndicatorIsDelimited(string fileName, bool expected)
+        => Assert.Equal(expected, BlobStorageService.ContainsLogIndicator(fileName));
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -385,31 +385,75 @@ public class BlobStorageService
         };
     }
 
-    private static BackupType InferBackupTypeFromExtension(string blobName)
+    /// <summary>
+    /// Last-resort type inference from the filename, reached only when the path structure did not
+    /// say what a backup is.
+    ///
+    /// Getting this wrong is not cosmetic. A log misread as a full enters the fulls collection in
+    /// BackupChainBuilder and becomes a chain root, so the timeline offers a log file as a
+    /// restorable Full point and every earlier log is dropped from the chain (#44). A full misread
+    /// as a differential never enters that collection at all, and if it is the only full in the
+    /// container the database gets no restore points whatsoever (#45).
+    /// </summary>
+    internal static BackupType InferBackupTypeFromExtension(string blobName)
     {
         var name = blobName.ToLowerInvariant();
 
         if (name.EndsWith(".trn") || name.EndsWith(".log"))
             return BackupType.TransactionLog;
 
-        if (name.EndsWith(".bak") || name.EndsWith(".bkp"))
-        {
-            if (ContainsDiffIndicator(name))
-                return BackupType.Differential;
-            return BackupType.Full;
-        }
-
         if (name.EndsWith(".diff"))
             return BackupType.Differential;
+
+        if (name.EndsWith(".bak") || name.EndsWith(".bkp"))
+        {
+            // Indicators are read from the filename only, never the folders above it - those are
+            // the primary path's job, and a container called "logs" should not retype every file
+            // underneath it.
+            var fileName = name[(name.LastIndexOf('/') + 1)..];
+
+            if (ContainsDiffIndicator(fileName))
+                return BackupType.Differential;
+
+            // A log written as .bak used to land here as Full. Ola and maintenance plans both emit
+            // .trn so this needs a hand-rolled job, but the failure was bad enough to be worth
+            // catching (#44).
+            if (ContainsLogIndicator(fileName))
+                return BackupType.TransactionLog;
+
+            return BackupType.Full;
+        }
 
         return BackupType.Unknown;
     }
 
-    private static bool ContainsDiffIndicator(string name)
-    {
-        string[] diffIndicators = ["diff", "differential", "_diff", "-diff", ".diff"];
-        return diffIndicators.Any(name.Contains);
-    }
+    // Delimited, not a bare substring. The old version tested name.Contains("diff"), which made
+    // every other entry in its list redundant and classified DiffusionDb's FULL backups as
+    // differentials (#45). Same anchoring as CopyOnlyRegex above.
+    private static readonly Regex DiffIndicatorRegex = new(
+        @"(?:^|[_\-.])(?:diff|differential)(?:$|[_\-.])",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // Deliberately delimited for the same reason, and more sharply here: a bare "log" substring
+    // would retype CatalogDb, BlogDb and DialogDb backups as transaction logs.
+    private static readonly Regex LogIndicatorRegex = new(
+        @"(?:^|[_\-.])(?:log|tlog|trn|translog|transactionlog)(?:$|[_\-.])",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>True when a filename carries a delimited differential marker. Public for testing.</summary>
+    public static bool ContainsDiffIndicator(string fileName)
+        => !string.IsNullOrEmpty(fileName) && DiffIndicatorRegex.IsMatch(fileName);
+
+    /// <summary>
+    /// True when a filename carries a delimited transaction-log marker. Public for testing.
+    ///
+    /// Known limitation: a database actually named "Log" or "Diff" would match on its own name.
+    /// Nothing in a filename can settle that, and the alternative - a bare substring - is the bug
+    /// being fixed. Path-based typing takes precedence anyway, so this only bites a flat container
+    /// holding a database with one of those names.
+    /// </summary>
+    public static bool ContainsLogIndicator(string fileName)
+        => !string.IsNullOrEmpty(fileName) && LogIndicatorRegex.IsMatch(fileName);
 
     /// <summary>
     /// For path-based AG files, extract backup set id from the filename segment (e.g. 20260226_200032_1.bak → 20260226_200032).


### PR DESCRIPTION
Closes #45. Closes #44.

Two halves of the same mistake in `InferBackupTypeFromExtension` — the last-resort path used when the folder structure didn't say what a file is.

## #45 — `"diff"` matched anywhere in the name

```csharp
string[] diffIndicators = ["diff", "differential", "_diff", "-diff", ".diff"];
return diffIndicators.Any(name.Contains);
```

The bare `"diff"` makes every other entry redundant and matches any substring. `DiffusionDb_FULL_20260804_220000.bak` was classified as a **differential**.

That's not a cosmetic mislabel. A misclassified full never enters the `fulls` collection in `BackupChainBuilder`, so it can't serve as a chain base — and if it's the only full in the container, that database gets **no restore points at all**. An empty timeline, no explanation. Live on the default path, no unusual configuration needed.

## #44 — a log written as `.bak` became a full

`.bak` fell through to `Full` unless it looked like a differential, so `MyDb_LOG_20260804_120000.bak` was a full backup.

Worse than a wrong label: the bogus full becomes a chain root, the timeline offers a **log file as a restorable Full point**, and every earlier log is dropped from that chain. SQL Server would reject the restore, but the damage — a silently shortened log chain — happens before anything is executed.

This one needs a hand-rolled backup job, since both Ola and maintenance plans emit `.trn`. Cheap to catch anyway.

## The fix, and the trap the issue flagged

Both indicators now match **delimited tokens** via regex, following the `CopyOnlyRegex` already in this file — whose comment already cited the `diff` defect as the reason it was written that way.

The log indicator needed the delimiting even more than the diff one. A bare `"log"` substring would have retyped:

`CatalogDb` · `BlogDb` · `DialogDb` · `AnalogData`

All of those are in the test file.

**Indicators are read from the filename only, never the folders above it.** Folder-based typing runs first and is more reliable, and a container organised under a `logs/` prefix shouldn't have every file underneath it retyped. Also tested.

### Known limitation, and it's commented in the code

A database *actually named* `Log` or `Diff` will match on its own name. Nothing in a filename can settle that, and the alternative is the substring matching being removed here. Path-based typing takes precedence anyway, so it only bites a flat container holding a database with one of those names.

### One judgement call

The issue suggests *"safer still: return `Unknown` for an ambiguous `.bak`"*. I didn't — an unmarked `.bak` in a flat container is overwhelmingly a genuine full backup, and returning `Unknown` would exclude it from chains and break the ordinary case to guard against a rare one. `Full` stays the default; the change is that log and diff markers are now detected properly first.

## Tests

40 new. **10 fail against the old implementation** — every `Diffusion`-style name and every `.bak` log.

**445 tests pass**, build clean at `-warnaserror`.
