### PR TITLE
Report log backups that reach no restore point (#46)

### DIFF
--- a/src/NineLives.Tests/ChainReachabilityTests.cs
+++ b/src/NineLives.Tests/ChainReachabilityTests.cs
@@ -1,0 +1,157 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Backups that exist but reach no restore point (#46).
+///
+/// The chain builder bounds each full's log range with strict inequalities at both ends, so a log
+/// whose timestamp exactly equals a full's belongs to neither the earlier full's range nor the
+/// colliding full's own. It vanishes from the timeline while still being counted in the header.
+///
+/// The collision is not exotic: timestamps come from filenames and the seconds group is optional,
+/// so under HHMM naming any full and log starting in the same minute collide - a nightly full plus
+/// quarter-hourly logs does it every day.
+///
+/// These tests pin the reporting, not a repair. Widening the bound would force the log to restore
+/// after the full always, which is wrong whenever the log job fired first and finished before the
+/// full's checkpoint. Only the LSNs can tell those apart.
+/// </summary>
+public class ChainReachabilityTests
+{
+    private static readonly DateTime Day = new(2026, 8, 4, 0, 0, 0, DateTimeKind.Unspecified);
+
+    private static BackupSet Set(BackupType type, DateTime timestamp, string name) => new()
+    {
+        Type = type,
+        Timestamp = timestamp,
+        SetId = name,
+        DatabaseName = "MyDb",
+        Files = [new BackupFileInfo { BlobName = name, SizeBytes = 1024, Type = type }]
+    };
+
+    private static (List<BackupSet> Sets, List<RestorePoint> Points) Build(params BackupSet[] sets)
+    {
+        var list = sets.ToList();
+        return (list, new BackupChainBuilder().ComputeRestorePoints(list));
+    }
+
+    // ── the defect ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ALogAtAFullsExactTimestampReachesNoRestorePoint()
+    {
+        // Establishes the behaviour the warning exists for. If this ever starts failing because
+        // the builder learned to place the log, the warning below should go with it.
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL_20260804_2200.bak");
+        var collide = Set(BackupType.TransactionLog, Day.AddHours(22), "MyDb_LOG_20260804_2200.trn");
+        var later = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_20260804_2230.trn");
+
+        var (_, points) = Build(full, collide, later);
+
+        var reached = points.Any(p => ReferenceEquals(p.PrimarySet, collide))
+                   || points.Any(p => p.RequiredLogSets.Contains(collide));
+        Assert.False(reached);
+
+        // ...while the log that does not collide is fine, so this is about the collision and not
+        // about logs generally.
+        Assert.Contains(points, p => ReferenceEquals(p.PrimarySet, later));
+    }
+
+    [Fact]
+    public void TheUnreachableLogIsReported()
+    {
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL_20260804_2200.bak");
+        var collide = Set(BackupType.TransactionLog, Day.AddHours(22), "MyDb_LOG_20260804_2200.trn");
+        var later = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_20260804_2230.trn");
+
+        var (sets, points) = Build(full, collide, later);
+        var issues = new BackupChainValidator().ValidateReachability(sets, points);
+
+        var issue = Assert.Single(issues);
+        Assert.Equal(ChainIssueSeverity.Warning, issue.Severity);
+        Assert.Contains("1 log backup(s) are not reachable", issue.Title);
+        Assert.Contains("share an exact timestamp with a full backup", issue.Detail);
+    }
+
+    [Fact]
+    public void TheReportNamesTheEarliestAffectedTime()
+    {
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL_20260804_2200.bak");
+        var collide = Set(BackupType.TransactionLog, Day.AddHours(22), "MyDb_LOG_20260804_2200.trn");
+        var later = Set(BackupType.TransactionLog, Day.AddHours(23), "MyDb_LOG_20260804_2300.trn");
+
+        var (sets, points) = Build(full, collide, later);
+        var issue = Assert.Single(new BackupChainValidator().ValidateReachability(sets, points));
+
+        Assert.Contains("2026-08-04 22:00:00", issue.Detail);
+    }
+
+    [Fact]
+    public void CollisionsAtASecondFullAreAlsoCaught()
+    {
+        // The issue's boundary sweep found the same behaviour at the later full, not just the first.
+        var first = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL_20260804_2200.bak");
+        var between = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_20260804_2230.trn");
+        var second = Set(BackupType.Full, Day.AddHours(23), "MyDb_FULL_20260804_2300.bak");
+        var collide = Set(BackupType.TransactionLog, Day.AddHours(23), "MyDb_LOG_20260804_2300.trn");
+
+        var (sets, points) = Build(first, between, second, collide);
+        var issue = Assert.Single(new BackupChainValidator().ValidateReachability(sets, points));
+
+        Assert.Contains("1 log backup(s) are not reachable", issue.Title);
+    }
+
+    // ── no false positives ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnOrdinaryChainReportsNothing()
+    {
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL.bak");
+        var log1 = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(15), "MyDb_LOG_2215.trn");
+        var log2 = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_2230.trn");
+
+        var (sets, points) = Build(full, log1, log2);
+
+        Assert.Empty(new BackupChainValidator().ValidateReachability(sets, points));
+    }
+
+    [Fact]
+    public void LogsBeforeTheFirstFullAreLeftToTheInventoryCheck()
+    {
+        // ValidateInventory already explains these. Reporting them twice in different words makes
+        // both messages easier to ignore.
+        var early = Set(BackupType.TransactionLog, Day.AddHours(20), "MyDb_LOG_2000.trn");
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL.bak");
+        var after = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_2230.trn");
+
+        var (sets, points) = Build(early, full, after);
+
+        Assert.Empty(new BackupChainValidator().ValidateReachability(sets, points));
+        Assert.Contains(
+            new BackupChainValidator().ValidateInventory(sets),
+            i => i.Title.Contains("predate the earliest full"));
+    }
+
+    [Fact]
+    public void NothingIsReportedWhenThereAreNoLogs()
+    {
+        var (sets, points) = Build(Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL.bak"));
+
+        Assert.Empty(new BackupChainValidator().ValidateReachability(sets, points));
+    }
+
+    [Fact]
+    public void NothingIsReportedWhenThereAreNoRestorePointsAtAll()
+    {
+        // A container with only logs produces no points; ValidateInventory reports the missing
+        // full, and this check must not pile on with a second warning about all of them.
+        var (sets, points) = Build(
+            Set(BackupType.TransactionLog, Day.AddHours(22), "MyDb_LOG_2200.trn"));
+
+        Assert.Empty(points);
+        Assert.Empty(new BackupChainValidator().ValidateReachability(sets, points));
+    }
+}

--- a/src/NineLives/Services/BackupChainValidator.cs
+++ b/src/NineLives/Services/BackupChainValidator.cs
@@ -125,14 +125,86 @@ public class BackupChainValidator
                 "restored and are not offered as restore points. Usually means the full they belong to has " +
                 "been removed by retention."));
 
+        // Strictly before, not at. A log sharing the earliest full's exact timestamp has not
+        // "predated" anything - it is the same-timestamp collision, which ValidateReachability
+        // describes accurately instead of filing it under retention.
         var orphanedLogs = sets
-            .Where(s => s.Type == BackupType.TransactionLog && s.Timestamp <= earliestFull)
+            .Where(s => s.Type == BackupType.TransactionLog && s.Timestamp < earliestFull)
             .ToList();
         if (orphanedLogs.Count > 0)
             issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
                 $"{orphanedLogs.Count} log backup(s) predate the earliest full",
                 $"Log backups at or before {earliestFull:yyyy-MM-dd HH:mm} have nothing to roll forward from " +
                 "and are not offered as restore points."));
+
+        return issues;
+    }
+
+    /// <summary>
+    /// Reports log backups that were discovered but reach no chain at all - present in the browse
+    /// list, counted in the header, and absent from every restore point (#46).
+    ///
+    /// The known cause is a log whose timestamp exactly equals a full's. The chain builder bounds
+    /// each full's log range with strict inequalities at both ends, so such a log falls outside the
+    /// earlier full's range and outside the colliding full's own, and belongs to neither.
+    ///
+    /// Timestamps come from filenames, and the seconds group is optional - so under HHMM naming
+    /// any full and log starting in the same minute collide, which a nightly full plus
+    /// quarter-hourly logs manages every single day.
+    ///
+    /// This reports rather than repairs, deliberately. Simply widening the bound to include the
+    /// log would force it to restore after the full always, and that is wrong whenever the log job
+    /// fired first and completed before the full's checkpoint - SQL Server rejects a log whose
+    /// range ends before the restore point. A filename timestamp cannot tell those two apart; only
+    /// the LSNs can, which needs RESTORE HEADERONLY. Until then the honest move is to stop the
+    /// omission being silent, so the header count and the timeline cannot disagree without saying
+    /// why.
+    /// </summary>
+    public List<ChainIssue> ValidateReachability(
+        IReadOnlyList<BackupSet> sets, IReadOnlyList<RestorePoint> restorePoints)
+    {
+        var issues = new List<ChainIssue>();
+
+        var logs = sets.Where(s => s.Type == BackupType.TransactionLog).ToList();
+        if (logs.Count == 0 || restorePoints.Count == 0) return issues;
+
+        var reachable = new HashSet<BackupSet>();
+        foreach (var point in restorePoints)
+        {
+            if (point.PrimarySet != null) reachable.Add(point.PrimarySet);
+            foreach (var log in point.RequiredLogSets) reachable.Add(log);
+        }
+
+        // Logs strictly before the first full are already explained by ValidateInventory; saying it
+        // twice in different words would just make both messages easier to ignore. A log AT the
+        // earliest full is this check's business, not that one's - it is the collision.
+        var fulls = sets.Where(s => s.Type == BackupType.Full).OrderBy(s => s.Timestamp).ToList();
+        var earliestFull = fulls.Count > 0 ? fulls[0].Timestamp : DateTime.MaxValue;
+
+        var unreachable = logs
+            .Where(l => !reachable.Contains(l) && l.Timestamp >= earliestFull)
+            .OrderBy(l => l.Timestamp)
+            .ToList();
+
+        if (unreachable.Count == 0) return issues;
+
+        var collisions = unreachable
+            .Where(l => fulls.Any(f => f.Timestamp == l.Timestamp))
+            .ToList();
+
+        var detail =
+            $"These log backups were found but appear in no restore point, so the timeline offers " +
+            $"fewer recovery points than the backup count suggests. Earliest: " +
+            $"{unreachable[0].Timestamp:yyyy-MM-dd HH:mm:ss}.";
+
+        if (collisions.Count > 0)
+            detail +=
+                $" {collisions.Count} of them share an exact timestamp with a full backup, which is " +
+                "usually a log job and a full job starting in the same minute. Verify Chain will " +
+                "read the LSNs and tell you whether the log is genuinely needed.";
+
+        issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
+            $"{unreachable.Count} log backup(s) are not reachable by any restore point", detail));
 
         return issues;
     }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -155,6 +155,18 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _chainIssueSummary = string.Empty;
 
+    /// <summary>
+    /// Findings about the discovered backups as a whole rather than the selected chain - backups
+    /// that exist but can never be offered as a restore point. Kept apart from ChainIssues because
+    /// they do not change when the selection does, and because they explain a gap between what the
+    /// browse list shows and what the timeline offers.
+    /// </summary>
+    [ObservableProperty]
+    private ObservableCollection<ChainIssue> _inventoryIssues = [];
+
+    [ObservableProperty]
+    private bool _hasInventoryIssues;
+
     /// <summary>True once the chain has been checked against RESTORE HEADERONLY metadata.</summary>
     [ObservableProperty]
     private bool _chainLsnVerified;
@@ -542,6 +554,17 @@ public partial class RestoreViewModel : ViewModelBase
     private void ComputeAndDisplayRestorePoints()
     {
         var points = _chainBuilder.ComputeRestorePoints(_dbSets);
+
+        // Inventory-level findings: backups that exist but can never be offered. These belong to
+        // the discovered set rather than to any one chain, so they are held separately and survive
+        // changing the selected restore point.
+        //
+        // ValidateInventory was written for #62 and then never called, so orphaned differentials,
+        // orphaned logs and "no full backup at all" were being computed nowhere and shown nowhere.
+        InventoryIssues = new ObservableCollection<ChainIssue>(
+            _chainValidator.ValidateInventory(_dbSets)
+                .Concat(_chainValidator.ValidateReachability(_dbSets, points)));
+        HasInventoryIssues = InventoryIssues.Count > 0;
 
         // Compute timeline positions (0-1)
         if (points.Count > 1)

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -416,6 +416,39 @@
                         </StackPanel>
                     </Border>
 
+                    <!-- Findings about the discovered backups rather than the selected chain:
+                         things that exist in the container but can never be offered as a restore
+                         point. Shown whether or not a point is selected, because they explain why
+                         the timeline has fewer entries than the browse list has files (#46). -->
+                    <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                            Background="#332B1A" BorderBrush="#8A6D2F" BorderThickness="1"
+                            Visibility="{Binding HasInventoryIssues, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <TextBlock Text="About the backups found in this container"
+                                       FontWeight="SemiBold"
+                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8" />
+                            <ItemsControl ItemsSource="{Binding InventoryIssues}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Margin="0,0,0,8">
+                                            <TextBlock TextWrapping="Wrap" FontWeight="SemiBold">
+                                                <Run Text="{Binding SeverityDisplay, Mode=OneWay}" />
+                                                <Run Text="  " />
+                                                <Run Text="{Binding Title, Mode=OneWay}" />
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Detail}"
+                                                       Style="{StaticResource SecondaryText}"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,2,0,0" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
                     <!-- Restore Chain Detail (togglable) -->
                     <Border Background="{StaticResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="12" Margin="0,12,0,0"


### PR DESCRIPTION
Closes #46.

A log whose timestamp exactly equals a full's belongs to **neither** range. `BackupChainBuilder` bounds each full's logs with strict inequalities at both ends, so the log falls outside the earlier full's range (`< upperBound`) and outside the colliding full's own (`> full.Timestamp`). It disappears from the timeline while still being counted in the header — and nothing says so.

Not an exotic scenario. Timestamps come from filenames and the seconds group is optional, so **under `HHMM` naming any full and log starting in the same minute collide**. A nightly full plus quarter-hourly logs manages it every day.

## This reports rather than repairs, deliberately

Widening the bound to `>=` looks like the obvious fix and isn't safe. It forces the log to restore *after* the full always, which is wrong whenever the log job fired first and completed before the full's checkpoint — SQL Server rejects a log whose range ends before the restore point. That case works correctly today.

A filename timestamp cannot distinguish "log finished before the checkpoint" from "log covers transactions after it". Only the LSNs can, and those need `RESTORE HEADERONLY`. So the warning says what happened and points at **Verify Chain**, which already reads them.

The check itself is general — any log appearing in no restore point is reported, whatever the cause — so it also catches the header count and the timeline disagreeing for reasons nobody's thought of yet.

## A dead-code find along the way

`BackupChainValidator.ValidateInventory` was written for #62 and **never called from anywhere**. Orphaned differentials, orphaned logs, and "no full backup at all" were being computed nowhere and shown nowhere — the last of those being the difference between an empty timeline and an empty timeline that tells you your full backups aren't where the path pattern expects.

Now surfaced in the restore view, in its own panel separate from chain issues: these describe the container rather than the selection, so they shouldn't vanish when you click a different restore point.

## A boundary I had to correct mid-way

My first cut filtered unreachable logs to `> earliestFull`, to avoid duplicating the inventory message. That silently swallowed the collision at the *first* full — a test caught it.

The two checks now split cleanly: `ValidateInventory` reports logs **strictly before** the earliest full ("predate the earliest full", a retention story), and this check owns everything from the earliest full onward. A log sharing that full's exact timestamp hasn't predated anything, and filing it under retention was the wrong explanation.

## Tests

8 new, including one that pins the underlying builder behaviour directly — if the builder ever learns to place these logs, that test fails and this warning should be removed with it.

Also covers: collisions at a *second* full (the issue's boundary sweep found it there too), and four no-false-positive cases — ordinary chains, logs before the first full, no logs, and no restore points at all.

**453 tests pass**, build clean at `-warnaserror`.
