### PR TITLE
Survive unhandled errors, and say what a failed restore left behind (#13, #14)

### DIFF
--- a/src/NineLives.Tests/DatabaseRecoveryStateTests.cs
+++ b/src/NineLives.Tests/DatabaseRecoveryStateTests.cs
@@ -1,0 +1,225 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// What a failed restore left behind, and the statements that undo it (#14).
+///
+/// A chain that stops part-way leaves the target in RESTORING, and in SINGLE_USER too when
+/// Disconnect sessions was on, because the closing SET MULTI_USER never runs. Both block other
+/// connections, at the worst possible moment.
+/// </summary>
+public class DatabaseRecoveryStateTests
+{
+    private static DatabaseRecoveryState State(string? state, string? access = "MULTI_USER")
+        => new(true, state, access);
+
+    // ── reading the state ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnOnlineMultiUserDatabaseNeedsNothing()
+    {
+        Assert.False(State("ONLINE").NeedsAttention);
+        Assert.Empty(State("ONLINE").SuggestedActions("MyDb"));
+    }
+
+    [Fact]
+    public void AMissingDatabaseNeedsNothingAndSaysSo()
+    {
+        var missing = DatabaseRecoveryState.Missing;
+
+        Assert.False(missing.NeedsAttention);
+        Assert.Empty(missing.SuggestedActions("MyDb"));
+        Assert.Contains("not on the server", missing.Explain("MyDb"));
+    }
+
+    [Theory]
+    [InlineData("RESTORING")]
+    [InlineData("restoring")]
+    [InlineData("RECOVERY_PENDING")]
+    public void AnInterruptedRestoreNeedsAttention(string stateDesc)
+        => Assert.True(State(stateDesc).NeedsAttention);
+
+    [Fact]
+    public void SingleUserAloneNeedsAttention()
+    {
+        // The database came online but Disconnect sessions left it locked to one connection.
+        var state = State("ONLINE", "SINGLE_USER");
+
+        Assert.True(state.NeedsAttention);
+        Assert.True(state.IsSingleUser);
+    }
+
+    // ── the statements offered ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ARestoringDatabaseIsOfferedWithRecovery()
+    {
+        var action = Assert.Single(State("RESTORING").SuggestedActions("MyDb"));
+
+        Assert.Equal("RESTORE DATABASE [MyDb] WITH RECOVERY", action.Sql);
+        Assert.Contains("cannot be applied after this", action.Caution);
+    }
+
+    [Fact]
+    public void ASingleUserDatabaseIsOfferedMultiUser()
+    {
+        var action = Assert.Single(State("ONLINE", "SINGLE_USER").SuggestedActions("MyDb"));
+
+        Assert.Equal("ALTER DATABASE [MyDb] SET MULTI_USER", action.Sql);
+    }
+
+    [Fact]
+    public void BothProblemsAtOnceAreOfferedInOrder()
+    {
+        // The usual shape of a failed restore with Disconnect sessions on. Recovery first: there
+        // is no point restoring access to a database that is still mid-restore.
+        var actions = State("RESTORING", "SINGLE_USER").SuggestedActions("MyDb");
+
+        Assert.Equal(2, actions.Count);
+        Assert.Contains("WITH RECOVERY", actions[0].Sql);
+        Assert.Contains("SET MULTI_USER", actions[1].Sql);
+    }
+
+    [Fact]
+    public void TheDatabaseNameIsQuoted()
+    {
+        // Free text from the target-name box, so it goes through TSql like everything else.
+        var actions = State("RESTORING", "SINGLE_USER").SuggestedActions("My Db]with-bracket");
+
+        Assert.All(actions, a => Assert.Contains("[My Db]]with-bracket]", a.Sql));
+    }
+
+    // ── the explanation ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheExplanationNamesTheDatabaseAndTheCause()
+    {
+        var text = State("RESTORING", "SINGLE_USER").Explain("MyDb");
+
+        Assert.Contains("[MyDb] is in RESTORING state", text);
+        Assert.Contains("SINGLE_USER", text);
+        Assert.Contains("Disconnect sessions", text);
+    }
+
+    [Fact]
+    public void AnUnrecognisedStateStillGetsDescribed()
+    {
+        // Better a plain readout than an empty panel if SQL Server reports something unexpected.
+        var text = State("SUSPECT", "RESTRICTED_USER").Explain("MyDb");
+
+        Assert.Contains("SUSPECT", text);
+        Assert.Contains("RESTRICTED_USER", text);
+    }
+
+    // ── against a real server ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// The end-to-end version: put a database into the exact state a failed chain leaves, confirm
+    /// it is detected, run the suggested statement, and confirm it is fixed. A NORECOVERY restore
+    /// is what a mid-chain stop actually looks like, so this reproduces the situation rather than
+    /// simulating it.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ARealRestoringDatabaseIsDetectedAndRecovered()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test",
+            ServerName = Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL")!,
+            AuthMode = AuthMode.WindowsAuth,
+            Encrypt = EncryptMode.No,
+            TrustServerCertificate = true,
+            ConnectionTimeoutSeconds = 15
+        };
+
+        var service = new SqlServerService(new CredentialStore());
+        var dbName = "NineLives_RecoveryTest_" + Guid.NewGuid().ToString("n")[..8];
+
+        // The server's own data directory, not ours. SQL Server writes the backup as its service
+        // account, which has no business being able to reach a user's temp folder - and on this
+        // machine it cannot.
+        var (dataPath, _) = await service.GetDefaultPathsAsync(server);
+        var backupPath = Path.Combine(dataPath, dbName + ".bak");
+
+        try
+        {
+            await Exec(service, server, $"CREATE DATABASE {TSql.QuoteName(dbName)}");
+            await Exec(service, server,
+                $"BACKUP DATABASE {TSql.QuoteName(dbName)} TO DISK = '{TSql.EscapeLiteral(backupPath)}'");
+
+            // Leave it mid-restore, exactly as a chain that stopped part-way would.
+            await Exec(service, server,
+                $"RESTORE DATABASE {TSql.QuoteName(dbName)} FROM DISK = '{TSql.EscapeLiteral(backupPath)}' " +
+                "WITH NORECOVERY, REPLACE");
+
+            var state = await service.GetDatabaseRecoveryStateAsync(server, dbName);
+            Assert.True(state.Exists);
+            Assert.True(state.IsRestoring);
+            Assert.True(state.NeedsAttention);
+
+            var action = Assert.Single(state.SuggestedActions(dbName));
+            await service.ExecuteRecoveryActionAsync(server, action.Sql);
+
+            var after = await service.GetDatabaseRecoveryStateAsync(server, dbName);
+            Assert.Equal("ONLINE", after.StateDescription);
+            Assert.False(after.NeedsAttention);
+        }
+        finally
+        {
+            try
+            {
+                await Exec(service, server,
+                    $"IF DB_ID('{TSql.EscapeLiteral(dbName)}') IS NOT NULL BEGIN " +
+                    $"ALTER DATABASE {TSql.QuoteName(dbName)} SET SINGLE_USER WITH ROLLBACK IMMEDIATE; " +
+                    $"DROP DATABASE {TSql.QuoteName(dbName)}; END");
+            }
+            catch { /* cleanup */ }
+
+            // The backup lives on the server's filesystem, so remove it through the server rather
+            // than assuming this process can reach the path.
+            try
+            {
+                await Exec(service, server,
+                    $"EXEC master.dbo.xp_delete_files N'{TSql.EscapeLiteral(backupPath)}'");
+            }
+            catch
+            {
+                try { File.Delete(backupPath); } catch { /* cleanup */ }
+            }
+        }
+    }
+
+    [RequiresSqlFact]
+    public async Task ADatabaseThatDoesNotExistReportsMissing()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test",
+            ServerName = Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL")!,
+            AuthMode = AuthMode.WindowsAuth,
+            Encrypt = EncryptMode.No,
+            TrustServerCertificate = true,
+            ConnectionTimeoutSeconds = 15
+        };
+
+        var state = await new SqlServerService(new CredentialStore())
+            .GetDatabaseRecoveryStateAsync(server, "NineLives_NoSuchDatabase_" + Guid.NewGuid().ToString("n"));
+
+        Assert.False(state.Exists);
+        Assert.False(state.NeedsAttention);
+    }
+
+    private static async Task Exec(SqlServerService service, ServerConnection server, string sql)
+    {
+        await using var conn = service.CreateConnection(server);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandTimeout = 0;
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/NineLives/App.xaml.cs
+++ b/src/NineLives/App.xaml.cs
@@ -12,6 +12,14 @@ public partial class App : Application
     {
         base.OnStartup(e);
 
+        // Before anything else. An unhandled exception on the dispatcher thread otherwise takes
+        // the process down instantly, and the worst moment for that is mid-restore: the execution
+        // log is the only record of how far the chain got, and it exists only in the window that
+        // just vanished (#13).
+        DispatcherUnhandledException += OnDispatcherUnhandledException;
+        AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
+        TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+
         // Explicit for the whole startup sequence: while the splash is briefly the only window,
         // the default OnLastWindowClose would quit the app the moment it closed. Handed back to
         // the main window once that exists.
@@ -58,4 +66,48 @@ public partial class App : Application
             ShutdownMode = ShutdownMode.OnMainWindowClose;
         }
     }
+
+    /// <summary>
+    /// Keeps the app alive after an unhandled UI-thread exception.
+    ///
+    /// Staying up is the right call here specifically because of what this tool does. If a restore
+    /// has partially run, the execution log on screen is the only record of which statements
+    /// completed - and that is exactly what someone needs in order to work out what state the
+    /// target database is in. Killing the window to be tidy destroys it.
+    /// </summary>
+    private void OnDispatcherUnhandledException(
+        object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
+    {
+        e.Handled = true;
+
+        MessageBox.Show(
+            "Nine Lives hit an unexpected error.\n\n" +
+            $"{e.Exception.GetType().Name}: {e.Exception.Message}\n\n" +
+            "The app is still running. If a restore was in progress, the execution log on screen " +
+            "is still the record of how far it got - check the target database's state before " +
+            "retrying.",
+            "Nine Lives", MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+
+    /// <summary>
+    /// A non-UI-thread exception cannot be swallowed - the runtime is already tearing down - so
+    /// this only makes sure the user sees something rather than the window disappearing silently.
+    /// </summary>
+    private void OnAppDomainUnhandledException(object sender, UnhandledExceptionEventArgs e)
+    {
+        var message = e.ExceptionObject is Exception ex
+            ? $"{ex.GetType().Name}: {ex.Message}"
+            : "Unknown error.";
+
+        MessageBox.Show(
+            $"Nine Lives has to close.\n\n{message}",
+            "Nine Lives", MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+
+    /// <summary>
+    /// Fire-and-forget work - the update check, the arm countdown - should not be able to bring
+    /// the process down when its exception is finally collected. Observing it is enough.
+    /// </summary>
+    private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        => e.SetObserved();
 }

--- a/src/NineLives/Services/DatabaseRecoveryState.cs
+++ b/src/NineLives/Services/DatabaseRecoveryState.cs
@@ -1,0 +1,110 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// What a restore left behind, and what to do about it (#14).
+///
+/// When a chain fails partway through, the target database is still mid-restore - and if
+/// "Disconnect sessions" was on it is also stuck in SINGLE_USER, because the closing
+/// ALTER DATABASE ... SET MULTI_USER never ran. Both states block other connections.
+///
+/// This is the worst possible moment to leave someone guessing: a restore has just failed during
+/// an incident, and the database is now in a state that keeps everyone else out. A DBA who knows
+/// the remedy will type it into SSMS from memory. The people this tool is aimed at may not, and
+/// the app is already holding the connection that could fix it.
+/// </summary>
+/// <param name="Exists">False when the database is not on the server at all.</param>
+/// <param name="StateDescription">sys.databases.state_desc, e.g. ONLINE, RESTORING, RECOVERY_PENDING.</param>
+/// <param name="UserAccessDescription">sys.databases.user_access_desc, e.g. MULTI_USER, SINGLE_USER.</param>
+public sealed record DatabaseRecoveryState(
+    bool Exists,
+    string? StateDescription,
+    string? UserAccessDescription)
+{
+    public static DatabaseRecoveryState Missing => new(false, null, null);
+
+    /// <summary>Mid-restore: the database is not usable until it is recovered or restored further.</summary>
+    public bool IsRestoring =>
+        string.Equals(StateDescription, "RESTORING", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Restore ended badly enough that SQL Server could not bring the database up.</summary>
+    public bool IsRecoveryPending =>
+        string.Equals(StateDescription, "RECOVERY_PENDING", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Locked to one connection - usually a leftover from Disconnect sessions.</summary>
+    public bool IsSingleUser =>
+        string.Equals(UserAccessDescription, "SINGLE_USER", StringComparison.OrdinalIgnoreCase);
+
+    public bool NeedsAttention => Exists && (IsRestoring || IsRecoveryPending || IsSingleUser);
+
+    /// <summary>
+    /// Plain-language account of where the database is, written for someone reading it just after
+    /// a restore failed rather than someone browsing documentation.
+    /// </summary>
+    public string Explain(string databaseName)
+    {
+        if (!Exists)
+            return $"[{databaseName}] is not on the server. The restore failed before it was created, " +
+                   "so nothing has been left behind.";
+
+        var lines = new List<string>();
+
+        if (IsRestoring)
+            lines.Add(
+                $"[{databaseName}] is in RESTORING state. That is what a database looks like " +
+                "part-way through a chain: it is waiting for more log or differential backups and " +
+                "cannot be used until it is either restored further or brought online as-is.");
+
+        if (IsRecoveryPending)
+            lines.Add(
+                $"[{databaseName}] is in RECOVERY_PENDING. SQL Server could not finish recovery - " +
+                "usually the restore was interrupted. It will need attention before the database " +
+                "can be used.");
+
+        if (IsSingleUser)
+            lines.Add(
+                $"[{databaseName}] is in SINGLE_USER. \"Disconnect sessions\" set that before the " +
+                "restore, and the statement that puts it back never ran because the chain stopped " +
+                "first. Only one connection can reach the database until it is changed back.");
+
+        if (lines.Count == 0)
+            lines.Add($"[{databaseName}] is {StateDescription} / {UserAccessDescription}.");
+
+        return string.Join("\n\n", lines);
+    }
+
+    /// <summary>
+    /// The statements that would put this right, in the order they should be run. Empty when there
+    /// is nothing to do.
+    ///
+    /// WITH RECOVERY is offered rather than performed silently: it ends the restore sequence, so
+    /// any log backup not yet applied can never be applied afterwards. Whether that is the right
+    /// move depends on what the user was trying to reach, and only they know that.
+    /// </summary>
+    public IReadOnlyList<RecoveryAction> SuggestedActions(string databaseName)
+    {
+        var actions = new List<RecoveryAction>();
+        if (!Exists) return actions;
+
+        if (IsRestoring || IsRecoveryPending)
+            actions.Add(new RecoveryAction(
+                "Bring the database online",
+                $"RESTORE DATABASE {TSql.QuoteName(databaseName)} WITH RECOVERY",
+                "Finishes the restore with what has already been applied. Any remaining log " +
+                "backups cannot be applied after this - if you meant to reach a later point in " +
+                "time, fix the chain and restore again instead."));
+
+        if (IsSingleUser)
+            actions.Add(new RecoveryAction(
+                "Allow other connections again",
+                $"ALTER DATABASE {TSql.QuoteName(databaseName)} SET MULTI_USER",
+                "Undoes the SINGLE_USER that Disconnect sessions applied. Safe at any point."));
+
+        return actions;
+    }
+}
+
+/// <summary>One remediation the user can read, copy, or run.</summary>
+/// <param name="Title">Short label for the button.</param>
+/// <param name="Sql">The exact statement - shown before it is run, never hidden.</param>
+/// <param name="Caution">What running it commits them to.</param>
+public sealed record RecoveryAction(string Title, string Sql, string Caution);

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -150,6 +150,49 @@ public class SqlServerService
         return result?.ToString() ?? "Unknown";
     }
 
+    /// <summary>
+    /// Reads what state a database is in, so a failed restore can say what it left behind (#14).
+    /// Parameterised - the name comes from a text box.
+    /// </summary>
+    public async Task<DatabaseRecoveryState> GetDatabaseRecoveryStateAsync(
+        ServerConnection server, string databaseName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(databaseName))
+            return DatabaseRecoveryState.Missing;
+
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT state_desc, user_access_desc FROM sys.databases WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", databaseName);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        if (!await reader.ReadAsync(ct))
+            return DatabaseRecoveryState.Missing;
+
+        return new DatabaseRecoveryState(
+            true,
+            reader["state_desc"]?.ToString(),
+            reader["user_access_desc"]?.ToString());
+    }
+
+    /// <summary>
+    /// Runs a single remediation statement chosen by the user from
+    /// <see cref="DatabaseRecoveryState.SuggestedActions"/>. Deliberately takes the whole statement
+    /// rather than building one - the user has already been shown exactly what will run.
+    /// </summary>
+    public async Task ExecuteRecoveryActionAsync(
+        ServerConnection server, string sql, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandTimeout = 0;
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
     public async Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
     {
         await using var conn = CreateConnection(server);

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -256,16 +256,9 @@ public partial class BlobBrowserViewModel : ViewModelBase
     {
         var target = file ?? SelectedFile;
         if (target == null || SelectedContainer == null) return;
-        try
-        {
-            var url = BlobStorageService.BuildBlobUrl(SelectedContainer, target.BlobName);
-            Clipboard.SetText(url);
-            SetStatus("HTTPS path copied to clipboard (no SAS token).");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        TryCopyToClipboard(
+            BlobStorageService.BuildBlobUrl(SelectedContainer, target.BlobName),
+            "HTTPS path copied to clipboard (no SAS token).");
     }
 
     [RelayCommand]
@@ -273,16 +266,7 @@ public partial class BlobBrowserViewModel : ViewModelBase
     {
         var target = file ?? SelectedFile;
         if (target == null || SelectedContainer == null) return;
-        try
-        {
-            var containerName = SelectedContainer.ContainerName ?? "container";
-            var path = $"{containerName}/{target.BlobName}";
-            Clipboard.SetText(path);
-            SetStatus("Container path copied to clipboard.");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        var containerName = SelectedContainer.ContainerName ?? "container";
+        TryCopyToClipboard($"{containerName}/{target.BlobName}", "Container path copied to clipboard.");
     }
 }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -167,6 +167,20 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _hasInventoryIssues;
 
+    // ── Aftermath of a failed restore (#14) ─────────────────────────────────────
+    // A chain that stops part-way leaves the target in RESTORING, and in SINGLE_USER too if
+    // Disconnect sessions was on, because the closing SET MULTI_USER never ran. Both block other
+    // connections, at the worst possible moment.
+
+    [ObservableProperty]
+    private string _recoveryStateMessage = string.Empty;
+
+    [ObservableProperty]
+    private ObservableCollection<RecoveryAction> _recoveryActions = [];
+
+    [ObservableProperty]
+    private bool _hasRecoveryActions;
+
     /// <summary>True once the chain has been checked against RESTORE HEADERONLY metadata.</summary>
     [ObservableProperty]
     private bool _chainLsnVerified;
@@ -1126,45 +1140,23 @@ public partial class RestoreViewModel : ViewModelBase
 
     [RelayCommand]
     private void CopyScript()
-    {
-        if (!string.IsNullOrEmpty(GeneratedScript))
-        {
-            Clipboard.SetText(GeneratedScript);
-            SetStatus("Script copied to clipboard.");
-        }
-    }
+        => TryCopyToClipboard(GeneratedScript, "Script copied to clipboard.");
 
     [RelayCommand]
     private void CopyPathHttps(BackupFileInfo? file)
     {
         if (file == null || SelectedContainer == null) return;
-        try
-        {
-            var url = BlobStorageService.BuildBlobUrl(SelectedContainer, file.BlobName);
-            Clipboard.SetText(url);
-            SetStatus("HTTPS path copied to clipboard (no SAS token).");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        TryCopyToClipboard(
+            BlobStorageService.BuildBlobUrl(SelectedContainer, file.BlobName),
+            "HTTPS path copied to clipboard (no SAS token).");
     }
 
     [RelayCommand]
     private void CopyPathContainer(BackupFileInfo? file)
     {
         if (file == null || SelectedContainer == null) return;
-        try
-        {
-            var containerName = SelectedContainer.ContainerName ?? "container";
-            var path = $"{containerName}/{file.BlobName}";
-            Clipboard.SetText(path);
-            SetStatus("Container path copied to clipboard.");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        var containerName = SelectedContainer.ContainerName ?? "container";
+        TryCopyToClipboard($"{containerName}/{file.BlobName}", "Container path copied to clipboard.");
     }
 
     [RelayCommand(CanExecute = nameof(CanFetchLogicalNames))]
@@ -1270,15 +1262,7 @@ public partial class RestoreViewModel : ViewModelBase
         var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
         var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var sql = $"RESTORE FILELISTONLY FROM {urlClauses}";
-        try
-        {
-            Clipboard.SetText(sql);
-            SetStatus("RESTORE FILELISTONLY command copied to clipboard. Paste into SSMS to run.");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        TryCopyToClipboard(sql, "RESTORE FILELISTONLY command copied to clipboard. Paste into SSMS to run.");
     }
 
     /// <summary>Builds the exact T-SQL for RESTORE HEADERONLY (encoded URLs, no WITH CREDENTIAL) for pasting into SSMS.</summary>
@@ -1289,15 +1273,7 @@ public partial class RestoreViewModel : ViewModelBase
         var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
         var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var sql = $"RESTORE HEADERONLY FROM {urlClauses}";
-        try
-        {
-            Clipboard.SetText(sql);
-            SetStatus("RESTORE HEADERONLY command copied to clipboard. Paste into SSMS to run.");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        TryCopyToClipboard(sql, "RESTORE HEADERONLY command copied to clipboard. Paste into SSMS to run.");
     }
 
     [RelayCommand]
@@ -1312,10 +1288,18 @@ public partial class RestoreViewModel : ViewModelBase
             FileName = $"restore_{TargetDatabaseName}_{DateTime.Now:yyyyMMdd_HHmmss}.sql"
         };
 
-        if (dialog.ShowDialog() == true)
+        if (dialog.ShowDialog() != true) return;
+
+        try
         {
             File.WriteAllText(dialog.FileName, GeneratedScript);
             SetStatus($"Script saved to {dialog.FileName}");
+        }
+        catch (Exception ex)
+        {
+            // Read-only location, full disk, or a path the database name made invalid. Any of
+            // those used to take the whole app down from inside a synchronous command (#13).
+            SetError($"Could not save the script: {ex.Message}");
         }
     }
 
@@ -1432,12 +1416,89 @@ public partial class RestoreViewModel : ViewModelBase
             ExecutionSuccess = false;
             AppendLog($"\nERROR: {ex.Message}");
             SetError($"Restore failed: {ex.Message}");
+
+            // The restore has stopped part-way and the target is almost certainly not usable.
+            // Find out exactly how, and say so, while the connection is still open (#14).
+            if (ConnectedServer != null)
+                await ReportRecoveryStateAsync(ConnectedServer);
         }
         finally
         {
             IsExecuting = false;
             ExecutionComplete = true;
         }
+    }
+
+    /// <summary>
+    /// After a failed restore, works out what state the target database was left in and offers the
+    /// statements that put it right.
+    ///
+    /// This is the moment of maximum stress - a restore has failed mid-incident and the database is
+    /// now in a state that blocks other connections. Leaving someone to work that out from a raw
+    /// SQL error, when the app is still holding the connection that could tell them, is the wrong
+    /// place to stop.
+    /// </summary>
+    private async Task ReportRecoveryStateAsync(ServerConnection server)
+    {
+        RecoveryActions = [];
+        HasRecoveryActions = false;
+        RecoveryStateMessage = string.Empty;
+
+        try
+        {
+            var state = await _sqlService.GetDatabaseRecoveryStateAsync(server, TargetDatabaseName);
+            if (!state.NeedsAttention)
+            {
+                if (!state.Exists)
+                    AppendLog($"\n[{TargetDatabaseName}] is not on the server - nothing was left behind.");
+                return;
+            }
+
+            RecoveryStateMessage = state.Explain(TargetDatabaseName);
+            RecoveryActions = new ObservableCollection<RecoveryAction>(
+                state.SuggestedActions(TargetDatabaseName));
+            HasRecoveryActions = RecoveryActions.Count > 0;
+
+            AppendLog($"\n{RecoveryStateMessage}");
+            foreach (var action in RecoveryActions)
+                AppendLog($"\n  {action.Title}:  {action.Sql}");
+        }
+        catch (Exception ex)
+        {
+            // Best effort. The restore failure is the news; failing to describe the aftermath must
+            // not replace the error the user actually needs to read.
+            AppendLog($"\nCould not check the state of [{TargetDatabaseName}]: {ex.Message}");
+        }
+    }
+
+    /// <summary>Runs one remediation the user picked, then re-reads the state.</summary>
+    [RelayCommand]
+    private async Task RunRecoveryActionAsync(RecoveryAction? action)
+    {
+        if (action == null || ConnectedServer == null) return;
+
+        try
+        {
+            AppendLog($"\nRunning: {action.Sql}");
+            await _sqlService.ExecuteRecoveryActionAsync(ConnectedServer, action.Sql);
+            AppendLog("Completed.");
+            await ReportRecoveryStateAsync(ConnectedServer);
+
+            if (!HasRecoveryActions)
+                SetStatus($"[{TargetDatabaseName}] is back to a usable state.");
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"\nERROR: {ex.Message}");
+            SetError($"Recovery step failed: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    private void CopyRecoveryAction(RecoveryAction? action)
+    {
+        if (action != null)
+            TryCopyToClipboard(action.Sql, "Recovery statement copied to clipboard.");
     }
 
     private void AppendLog(string message)

--- a/src/NineLives/ViewModels/ViewModelBase.cs
+++ b/src/NineLives/ViewModels/ViewModelBase.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Blackcat.NineLives.ViewModels;
@@ -51,5 +52,33 @@ public abstract partial class ViewModelBase : ObservableObject
         StatusMessage = string.Empty;
         HasError = false;
         ErrorMessage = string.Empty;
+    }
+
+    /// <summary>
+    /// Puts text on the clipboard, reporting failure through the status surface instead of
+    /// throwing out of a synchronous command and taking the process with it (#13).
+    ///
+    /// Clipboard.SetText throwing is an ordinary Windows condition, not an exceptional one -
+    /// another process holding the clipboard lock is routine with remote desktop sessions and
+    /// clipboard managers, and it was reproduced while the issue was being written. A failed copy
+    /// deserves a line in the status bar, not a crash.
+    /// </summary>
+    protected bool TryCopyToClipboard(string? text, string successMessage)
+    {
+        if (string.IsNullOrEmpty(text)) return false;
+
+        try
+        {
+            Clipboard.SetText(text);
+            SetStatus(successMessage);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            SetError(
+                $"Could not copy to the clipboard: {ex.Message}. " +
+                "Another application may be holding it - try again in a moment.");
+            return false;
+        }
     }
 }

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -958,6 +958,60 @@
                                      TextChanged="ExecutionLogBox_TextChanged" />
                         </StackPanel>
                     </Border>
+
+                    <!-- What a failed restore left behind, and how to undo it (#14). A chain that
+                         stops part-way leaves the target in RESTORING, and in SINGLE_USER too if
+                         Disconnect sessions was on. Both block other connections, and this is the
+                         worst moment to be left working that out from a raw SQL error. Each action
+                         shows the exact statement before it runs. -->
+                    <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                            Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1"
+                            Visibility="{Binding HasRecoveryActions, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
+                                       Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                            <TextBlock Text="{Binding RecoveryStateMessage}"
+                                       Style="{StaticResource BodyText}"
+                                       TextWrapping="Wrap" Margin="0,0,0,12" />
+                            <ItemsControl ItemsSource="{Binding RecoveryActions}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="{StaticResource InputBackgroundBrush}"
+                                                CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Title}"
+                                                           FontWeight="SemiBold"
+                                                           Foreground="{StaticResource PrimaryTextBrush}"
+                                                           TextWrapping="Wrap" />
+                                                <TextBox Text="{Binding Sql, Mode=OneWay}"
+                                                         Style="{StaticResource DarkTextBox}"
+                                                         IsReadOnly="True" TextWrapping="Wrap"
+                                                         FontFamily="Cascadia Code, Consolas, Courier New"
+                                                         FontSize="12" Margin="0,6,0,6" />
+                                                <TextBlock Text="{Binding Caution}"
+                                                           Style="{StaticResource SecondaryText}"
+                                                           TextWrapping="Wrap" Margin="0,0,0,8" />
+                                                <StackPanel Orientation="Horizontal">
+                                                    <Button Content="Run this"
+                                                            Command="{Binding DataContext.RunRecoveryActionCommand,
+                                                                      RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                            CommandParameter="{Binding}"
+                                                            Style="{StaticResource SecondaryButton}"
+                                                            Padding="10,6" Margin="0,0,8,0" />
+                                                    <Button Content="Copy"
+                                                            Command="{Binding DataContext.CopyRecoveryActionCommand,
+                                                                      RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                            CommandParameter="{Binding}"
+                                                            Style="{StaticResource SecondaryButton}"
+                                                            Padding="10,6" />
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
                 </StackPanel>
             </Border>
 


### PR DESCRIPTION
Closes #13. Closes #14.

Both are about what happens when something goes wrong, which for this tool is the case that matters most.

## #13 — nothing caught unhandled exceptions

`App` registered no handler at all, so anything unhandled on the dispatcher thread terminated the process. The worst possible moment for that is mid-restore: **the execution log is the only record of which statements completed**, and it exists only in the window that just disappeared.

There's now a `DispatcherUnhandledException` handler that keeps the app alive and says explicitly that the log is still on screen and worth reading before retrying. Plus `AppDomain.UnhandledException` (can't be swallowed, but the user should see *something* rather than a window vanishing) and `TaskScheduler.UnobservedTaskException` (fire-and-forget work — the update check, the arm countdown — shouldn't be able to kill the process when its exception is finally collected).

**Guarded calls.** `Clipboard.SetText` was bare inside a synchronous command in `CopyScript`. It throwing is ordinary Windows behaviour, not an exceptional condition — another process holding the clipboard lock is routine with RDP sessions and clipboard managers, and the issue reports reproducing it. All copy paths now go through one helper on `ViewModelBase` with a message that says what to do about it. `File.WriteAllText` on Save Script is wrapped. `Process.Start` turned out to be guarded already.

## #14 — a failed restore left the database stuck, silently

When a chain fails part-way the target sits in `RESTORING`, and in `SINGLE_USER` too if **Disconnect sessions** was on, because the closing `SET MULTI_USER` never runs. Both block other connections. The app said nothing about any of it.

This is the moment of maximum stress — a restore has failed during an incident and the database is now locking everyone out. A DBA who knows the remedy types it into SSMS from memory; the audience this tool is aimed at may not, and **the app is still holding the connection that could fix it**.

On failure it now reads `sys.databases` while that connection is open, explains the state in plain language, and offers the statements that put it right:

- `RESTORE DATABASE [db] WITH RECOVERY`
- `ALTER DATABASE [db] SET MULTI_USER`

Each is shown in full, with what running it commits you to, and can be run or copied.

**`WITH RECOVERY` is offered, not performed automatically.** It ends the restore sequence, so any log backup not yet applied can never be applied afterwards. Whether that's the right move depends on what point in time the user was trying to reach — and only they know that. Recovery is listed before multi-user, since there's no point restoring access to a database that's still mid-restore.

## Tests

14 new. The one worth calling out is live and reproduces the situation rather than simulating it: it creates a database, backs it up, restores `WITH NORECOVERY` to leave it **genuinely mid-restore**, confirms the state is detected, runs the suggested statement, and confirms it comes back `ONLINE`.

Also covers both problems occurring together, the database name going through `TSql.QuoteName` (it's free text from the target box), and an unrecognised state still producing a readable explanation rather than an empty panel.

One thing that needed fixing during the work: the live test first wrote its backup to the user temp directory and got `Operating system error 5 (Access is denied)` — SQL Server writes as its service account. It now uses the server's own default data path.

**467 tests pass**, build clean at `-warnaserror`, and no test databases left behind on the instance.
