### PR TITLE
Remove the unusable credential-name parameter, and pin actions by SHA (#60, #19)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,14 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      # Actions are pinned by commit SHA rather than tag. A tag is mutable: whoever controls the
+      # action's repository can repoint v7 at different code, and that code then runs inside our
+      # workflows - the release one holds contents: write and a signing identity. The trailing
+      # comment is the human-readable version, and Dependabot updates both together.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 8.0.x
 
@@ -84,7 +88,7 @@ jobs:
       # smoke publish above already proved the shape, and fork PRs shouldn't mint artifacts.
       - name: Upload build artifact
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: NineLives-main-${{ github.sha }}
           path: publish/NineLives.exe

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 8.0.x
 
@@ -82,7 +82,7 @@ jobs:
       # This is NOT code signing and does nothing for SmartScreen - see #33 and
       # docs/code-signing.md. It is the part that can be done without a certificate.
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             releases/NineLives.exe

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -206,51 +206,31 @@ public class SqlServerService
         return databases;
     }
 
-    public async Task<List<BackupFileInfo>> RestoreHeaderOnlyAsync(
-        ServerConnection server, string blobUrl, string credentialName, CancellationToken ct = default)
-    {
-        await using var conn = CreateConnection(server);
-        await conn.OpenAsync(ct);
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandTimeout = 120;
-        cmd.CommandText = $"RESTORE HEADERONLY FROM URL = N'{TSql.EscapeLiteral(blobUrl)}' WITH CREDENTIAL = N'{TSql.EscapeLiteral(credentialName)}'";
+    // These two read backup metadata off blob URLs, and neither takes a credential name any more.
+    //
+    // They used to, and passing one could never work. SQL Server rejects WITH CREDENTIAL against a
+    // SAS-backed credential outright:
+    //
+    //     Msg 3225: Use of WITH CREDENTIAL syntax is not valid for credentials containing a
+    //     Shared Access Signature.
+    //
+    // A SAS credential is the only kind this app ever creates - EnsureCredentialExistsAsync
+    // hardcodes WITH IDENTITY = 'SHARED ACCESS SIGNATURE' - so the branch could not succeed in any
+    // configuration the app produces. Both production callers already passed null, which is why
+    // the shipping app worked, but the parameter was positional and required: a new caller had to
+    // pass something, and the obvious something failed with an error about syntax rather than
+    // about the real cause. Removing it makes the wrong call unrepresentable rather than merely
+    // unused (#60).
+    //
+    // The server-side credential still does the authenticating. It is matched by URL prefix, which
+    // is exactly how the generated restore script has always worked.
+    //
+    // If a non-SAS credential is ever supported (managed identity, #29), bring the option back
+    // keyed off the identity type that CredentialExistsAsync already reports - not off a flag.
 
-        var results = new List<BackupFileInfo>();
-        await using var reader = await cmd.ExecuteReaderAsync(ct);
-        while (await reader.ReadAsync(ct))
-        {
-            int? backupTypeCode = GetIntFromReader(reader, "BackupType");
-            results.Add(new BackupFileInfo
-            {
-                DatabaseName = GetStringFromReader(reader, "DatabaseName"),
-                BackupStartDate = GetDateTimeFromReader(reader, "BackupStartDate"),
-                BackupFinishDate = GetDateTimeFromReader(reader, "BackupFinishDate"),
-                BackupTypeCode = backupTypeCode,
-                Type = (backupTypeCode ?? 0) switch
-                {
-                    1 => BackupType.Full,
-                    5 => BackupType.Differential,
-                    2 => BackupType.TransactionLog,
-                    _ => BackupType.Unknown
-                },
-                FirstLsn = GetDecimalFromReader(reader, "FirstLSN"),
-                LastLsn = GetDecimalFromReader(reader, "LastLSN"),
-                DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN"),
-            CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN")
-            });
-        }
-        return results;
-    }
-
+    /// <summary>RESTORE FILELISTONLY across the files of one backup set, striped or not.</summary>
     public async Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
-        ServerConnection server, string blobUrl, string credentialName, CancellationToken ct = default)
-    {
-        return await RestoreFileListOnlyAsync(server, [blobUrl], credentialName, urlsContainSas: false, ct);
-    }
-
-    /// <summary>RESTORE FILELISTONLY for striped backup. When urlsContainSas is true, omit WITH CREDENTIAL (SQL Server does not allow WITH CREDENTIAL for SAS credentials).</summary>
-    public async Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
-        ServerConnection server, IReadOnlyList<string> blobUrls, string? credentialName, bool urlsContainSas = false, CancellationToken ct = default)
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
     {
         if (blobUrls.Count == 0) return [];
 
@@ -260,10 +240,7 @@ public class SqlServerService
         cmd.CommandTimeout = 120;
 
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
-        var withCredential = !urlsContainSas && !string.IsNullOrEmpty(credentialName)
-            ? $" WITH CREDENTIAL = N'{TSql.EscapeLiteral(credentialName)}'"
-            : "";
-        cmd.CommandText = $"RESTORE FILELISTONLY FROM {urlClauses}{withCredential}";
+        cmd.CommandText = $"RESTORE FILELISTONLY FROM {urlClauses}";
 
         var files = new List<FileMoveOption>();
         await using var reader = await cmd.ExecuteReaderAsync(ct);
@@ -280,9 +257,9 @@ public class SqlServerService
         return files;
     }
 
-    /// <summary>RESTORE HEADERONLY for striped backup. When urlsContainSas is true, omit WITH CREDENTIAL (SQL Server does not allow WITH CREDENTIAL for SAS credentials).</summary>
+    /// <summary>RESTORE HEADERONLY across the files of one backup set, striped or not.</summary>
     public async Task<BackupFileInfo?> RestoreHeaderOnlyMultiAsync(
-        ServerConnection server, IReadOnlyList<string> blobUrls, string? credentialName, bool urlsContainSas = false, CancellationToken ct = default)
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
     {
         if (blobUrls.Count == 0) return null;
 
@@ -292,10 +269,7 @@ public class SqlServerService
         cmd.CommandTimeout = 120;
 
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
-        var withCredential = !urlsContainSas && !string.IsNullOrEmpty(credentialName)
-            ? $" WITH CREDENTIAL = N'{TSql.EscapeLiteral(credentialName)}'"
-            : "";
-        cmd.CommandText = $"RESTORE HEADERONLY FROM {urlClauses}{withCredential}";
+        cmd.CommandText = $"RESTORE HEADERONLY FROM {urlClauses}";
 
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         if (!await reader.ReadAsync(ct)) return null;

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -872,10 +872,7 @@ public partial class RestoreViewModel : ViewModelBase
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 try
                 {
-                    // credentialName is null on purpose: WITH CREDENTIAL is invalid for a SAS
-                    // credential, which is the only kind this app creates.
-                    var header = await _sqlService.RestoreHeaderOnlyMultiAsync(
-                        ConnectedServer, urls, credentialName: null);
+                    var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls);
                     headers.Add(new ChainHeader(set, header));
                 }
                 catch (Exception)
@@ -1170,7 +1167,7 @@ public partial class RestoreViewModel : ViewModelBase
         {
             // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
             var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls, credentialName: null, urlsContainSas: false);
+            var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls);
 
             var dataDir = Path.GetDirectoryName(MoveDataFilePath) ?? @"C:\SQL\Data";
             var logDir = Path.GetDirectoryName(MoveLogFilePath) ?? dataDir;
@@ -1218,7 +1215,7 @@ public partial class RestoreViewModel : ViewModelBase
         {
             // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
             var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls, credentialName: null, urlsContainSas: false);
+            var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls);
 
             if (header == null)
             {


### PR DESCRIPTION
Closes #60. Closes #19.

Two small ones, both about removing a way to get it wrong rather than fixing a live failure.

## #60 — a parameter that could never be used correctly

`RestoreHeaderOnlyMultiAsync` and `RestoreFileListOnlyAsync` took a credential name and emitted `WITH CREDENTIAL` when it was non-null. SQL Server rejects that outright for a SAS-backed credential:

```
Msg 3225: Use of WITH CREDENTIAL syntax is not valid for credentials
containing a Shared Access Signature.
```

And a SAS credential is **the only kind this app ever creates** — `EnsureCredentialExistsAsync` hardcodes `WITH IDENTITY = 'SHARED ACCESS SIGNATURE'`. So the branch could not succeed in any configuration the app produces.

Not a user-facing bug: both callers already passed `null`. It was a **trap**. The parameter was positional and required, so a new caller had to pass *something*, and the obvious something — the credential the app had just created — failed with an error about syntax rather than about the cause. I walked into exactly this writing a harness against these services.

The guarding flag `urlsContainSas` was also misnamed for what it did. The real rule isn't "the URL carries a token", it's "the credential is a SAS credential" — always true here.

Both parameters are gone, which makes the wrong call unrepresentable rather than merely unused. Also removed the two unreferenced single-URL overloads; one of them always emitted `WITH CREDENTIAL` with no opt-out, so it could never have worked, and nothing calling it is the only reason nobody hit it.

The server-side credential still authenticates, matched by URL prefix — exactly as the generated restore script has always done.

**Confirmed against a real striped backup in blob storage:**

```
blob: FULL/SRV01/MyDb/20260801_220912_1.bak
HEADERONLY:   db=MyDb type=Full first=481000000008800001 checkpoint=481000000008800001
FILELISTONLY: 2 logical files -> MyDb(D), Utility_log(L)
```

No Msg 3225. Metadata only — nothing was restored.

## #19 — actions pinned by mutable tag

`actions/checkout@v7` and friends are tags, and a tag can be repointed by whoever controls the action's repository. That code then runs inside workflows holding `contents: write` and, on the release path, a signing identity.

All four are now pinned to a full commit SHA with the version in a trailing comment:

```yaml
- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
```

Dependabot updates SHA pins and their comments together, so this doesn't go stale. Verified no mutable tag references remain and all three workflows still parse.

The other half of #19 — build provenance attestation — already landed with #33.

**467 tests pass**, build clean at `-warnaserror`.

