### PR TITLE
Add an operation log on disk (#40)

### DIFF
--- a/src/NineLives.Tests/OperationLogTests.cs
+++ b/src/NineLives.Tests/OperationLogTests.cs
@@ -1,0 +1,233 @@
+using System.IO;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The log must never contain a secret (#40).
+///
+/// Redaction happens at the logging boundary rather than at the call sites, so these tests are the
+/// guarantee for every current and future caller. A log line that is over-redacted is a mild
+/// annoyance; a log line with a working SAS token in it is a credential leak with a filename
+/// attached, sitting in the folder people are told to attach to bug reports.
+/// </summary>
+public class LogRedactorTests
+{
+    private const string RealisticSas =
+        "sv=2024-11-04&ss=b&srt=sco&sp=rl&se=2026-09-01T18:00:00Z&st=2026-08-01T10:00:00Z&spr=https&sig=aBcD1234%2FefGh%2BijKl%3D";
+
+    [Fact]
+    public void ASasSignatureIsRemoved()
+    {
+        var redacted = LogRedactor.Redact($"listing https://acct.blob.core.windows.net/backups?{RealisticSas}");
+
+        Assert.DoesNotContain("aBcD1234", redacted);
+        Assert.Contains("sig=[redacted]", redacted);
+    }
+
+    [Fact]
+    public void EverySasParameterIsRemoved()
+    {
+        // Not just sig. The whole token is the credential - se and sp alone tell an attacker what
+        // a leaked signature would be good for, and there is no diagnostic value in any of it.
+        var redacted = LogRedactor.Redact(RealisticSas);
+
+        foreach (var fragment in new[] { "2024-11-04", "sco", "2026-09-01T18:00:00Z", "https", "aBcD1234" })
+            Assert.DoesNotContain(fragment, redacted);
+    }
+
+    [Fact]
+    public void TheUrlItselfSurvivesSoTheLineStaysUseful()
+    {
+        var redacted = LogRedactor.Redact($"GET https://acct.blob.core.windows.net/backups/FULL/MyDb.bak?{RealisticSas}");
+
+        Assert.Contains("https://acct.blob.core.windows.net/backups/FULL/MyDb.bak", redacted);
+    }
+
+    [Fact]
+    public void ATsqlCredentialSecretIsRemoved()
+    {
+        const string sql =
+            "CREATE CREDENTIAL [https://acct/backups] WITH IDENTITY = 'SHARED ACCESS SIGNATURE', SECRET = 'sv=2024&sig=verysecret'";
+
+        var redacted = LogRedactor.Redact(sql);
+
+        Assert.DoesNotContain("verysecret", redacted);
+        Assert.Contains("SECRET = '[redacted]'", redacted);
+        // The rest of the statement is what makes the line worth logging.
+        Assert.Contains("CREATE CREDENTIAL", redacted);
+        Assert.Contains("SHARED ACCESS SIGNATURE", redacted);
+    }
+
+    [Fact]
+    public void AnAlterCredentialSecretIsRemovedToo()
+    {
+        var redacted = LogRedactor.Redact("ALTER CREDENTIAL [x] WITH IDENTITY = 'SHARED ACCESS SIGNATURE', SECRET = N'token'");
+
+        Assert.DoesNotContain("token", redacted);
+    }
+
+    [Fact]
+    public void ASecretContainingDoubledQuotesIsStillFullyRemoved()
+    {
+        // TSql.EscapeLiteral doubles single quotes, so a naive "up to the next quote" match would
+        // stop early and leave the tail of the secret in the log.
+        var redacted = LogRedactor.Redact("SECRET = 'abc''def''ghi' AND something_else = 1");
+
+        Assert.DoesNotContain("abc", redacted);
+        Assert.DoesNotContain("ghi", redacted);
+        Assert.Contains("something_else", redacted);
+    }
+
+    [Theory]
+    [InlineData("Server=x;User ID=sa;Password=hunter2;Encrypt=True")]
+    [InlineData("Server=x;pwd=hunter2;Encrypt=True")]
+    [InlineData("Password = hunter2")]
+    public void AConnectionStringPasswordIsRemoved(string text)
+    {
+        var redacted = LogRedactor.Redact(text);
+
+        Assert.DoesNotContain("hunter2", redacted);
+    }
+
+    [Fact]
+    public void OrdinaryTextIsLeftAlone()
+    {
+        const string line = "Executing statement 3 of 12: RESTORE LOG [MyDb] FROM URL = N'https://acct/backups/x.trn'";
+
+        Assert.Equal(line, LogRedactor.Redact(line));
+    }
+
+    [Fact]
+    public void NullAndEmptyAreSafe()
+    {
+        Assert.Equal(string.Empty, LogRedactor.Redact(null));
+        Assert.Equal(string.Empty, LogRedactor.Redact(""));
+    }
+}
+
+/// <summary>The writer itself: it must record what it is given and must never throw.</summary>
+public class OperationLogTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-log-tests", Guid.NewGuid().ToString("n"));
+
+    private OperationLog Log() => new(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private string ReadLog() => File.ReadAllText(Log().CurrentFile);
+
+    [Fact]
+    public void WritingCreatesTheDirectoryAndTheFile()
+    {
+        var log = Log();
+        log.Info("hello");
+
+        Assert.True(File.Exists(log.CurrentFile));
+        Assert.Contains("hello", ReadLog());
+    }
+
+    [Fact]
+    public void EachLineCarriesATimestampAndLevel()
+    {
+        Log().Warn("something odd");
+
+        var line = File.ReadAllLines(Log().CurrentFile).Last();
+        Assert.Matches(@"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} WARN  something odd$", line);
+    }
+
+    [Fact]
+    public void EntriesAccumulateRatherThanOverwrite()
+    {
+        var log = Log();
+        log.Info("first");
+        log.Info("second");
+
+        var text = ReadLog();
+        Assert.Contains("first", text);
+        Assert.Contains("second", text);
+    }
+
+    /// <summary>The reason redaction lives in the writer: a caller cannot opt out of it.</summary>
+    [Fact]
+    public void SecretsAreRedactedOnTheWayToDisk()
+    {
+        Log().Info("CREATE CREDENTIAL [x] WITH IDENTITY = 'SHARED ACCESS SIGNATURE', SECRET = 'sig=leaked'");
+
+        var text = ReadLog();
+        Assert.DoesNotContain("leaked", text);
+        Assert.Contains("[redacted]", text);
+    }
+
+    [Fact]
+    public void ServerChangesAreMarkedSoTheyCanBeFound()
+    {
+        Log().ServerChange("SRV01", "credential [https://acct/backups] updated");
+
+        var text = ReadLog();
+        Assert.Contains("CHANGE", text);
+        Assert.Contains("[SRV01]", text);
+    }
+
+    [Fact]
+    public void AnExceptionIsRecordedWithItsTypeAndMessage()
+    {
+        Log().Error("while restoring", new InvalidOperationException("chain broken"));
+
+        var text = ReadLog();
+        Assert.Contains("InvalidOperationException", text);
+        Assert.Contains("chain broken", text);
+    }
+
+    /// <summary>
+    /// A logging failure must never break the operation being logged. An unusable directory is the
+    /// easiest way to prove the swallow works.
+    /// </summary>
+    [Fact]
+    public void AnUnwritableLocationDoesNotThrow()
+    {
+        var log = new OperationLog("\0:\\definitely\\not\\a\\path");
+
+        log.Info("this should vanish quietly");
+        log.Error("so should this", new Exception("boom"));
+        log.Prune();
+    }
+
+    [Fact]
+    public void PruningAnAbsentDirectoryDoesNotThrow() => new OperationLog(_dir).Prune();
+
+    [Fact]
+    public void PruningRemovesOldFilesAndKeepsRecentOnes()
+    {
+        var log = Log();
+        log.Info("today");
+
+        Directory.CreateDirectory(_dir);
+        var old = Path.Combine(_dir, "ninelives-20200101.log");
+        File.WriteAllText(old, "ancient");
+        File.SetLastWriteTime(old, DateTime.Now.AddDays(-60));
+
+        log.Prune();
+
+        Assert.False(File.Exists(old));
+        Assert.True(File.Exists(log.CurrentFile));
+    }
+
+    [Fact]
+    public void ConcurrentWritesDoNotLoseLines()
+    {
+        // The execution log appends from a progress callback while the UI thread is also writing.
+        var log = Log();
+
+        Parallel.For(0, 200, i => log.Info($"line-{i}"));
+
+        var lines = File.ReadAllLines(log.CurrentFile);
+        Assert.Equal(200, lines.Length);
+    }
+}

--- a/src/NineLives/App.xaml.cs
+++ b/src/NineLives/App.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Blackcat.NineLives.Services;
 using Blackcat.NineLives.Views;
 
 namespace Blackcat.NineLives;
@@ -7,6 +8,12 @@ public partial class App : Application
 {
     /// <summary>How long the splash stays up once the main window has been built.</summary>
     private static readonly TimeSpan SplashDwell = TimeSpan.FromMilliseconds(2500);
+
+    /// <summary>
+    /// One log for the whole app. Static because the exception handlers here and the viewmodels
+    /// both need it, and there is no container to resolve it from.
+    /// </summary>
+    public static OperationLog Log { get; } = new();
 
     protected override async void OnStartup(StartupEventArgs e)
     {
@@ -19,6 +26,9 @@ public partial class App : Application
         DispatcherUnhandledException += OnDispatcherUnhandledException;
         AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
         TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+
+        Log.Prune();
+        Log.Info($"Nine Lives {AppVersion.Display} starting on {Environment.OSVersion}");
 
         // Explicit for the whole startup sequence: while the splash is briefly the only window,
         // the default OnLastWindowClose would quit the app the moment it closed. Handed back to
@@ -79,6 +89,7 @@ public partial class App : Application
         object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
     {
         e.Handled = true;
+        Log.Error("Unhandled exception on the UI thread", e.Exception);
 
         MessageBox.Show(
             "Nine Lives hit an unexpected error.\n\n" +
@@ -98,6 +109,8 @@ public partial class App : Application
         var message = e.ExceptionObject is Exception ex
             ? $"{ex.GetType().Name}: {ex.Message}"
             : "Unknown error.";
+
+        Log.Error($"Fatal unhandled exception: {message}");
 
         MessageBox.Show(
             $"Nine Lives has to close.\n\n{message}",

--- a/src/NineLives/Services/LogRedactor.cs
+++ b/src/NineLives/Services/LogRedactor.cs
@@ -1,0 +1,55 @@
+using System.Text.RegularExpressions;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Strips secrets out of anything on its way to the log file (#40).
+///
+/// This runs at the logging boundary, not at the call sites, and that is the whole design. Asking
+/// every caller to remember to redact means it takes exactly one forgetful caller - or one new one
+/// - to write a live SAS token into a file that then gets attached to a bug report. Everything
+/// passes through here, so a new call site is safe by default.
+///
+/// The rule is deliberately blunt: if something looks like it might be a secret, it goes. A log
+/// line that is over-redacted is a mild annoyance. A log line with a working SAS token in it is a
+/// credential leak with a filename.
+/// </summary>
+public static class LogRedactor
+{
+    private const string Mask = "[redacted]";
+
+    // The SAS signature - the part that actually grants access. Matched first and on its own so a
+    // URL keeps enough shape to stay useful for diagnosis.
+    private static readonly Regex SasSignature = new(
+        @"(?<key>\b(?:sig|sv|se|st|sp|sr|si|skoid|sktid|ske|skt|sks|spr|srt|ss)=)(?<value>[^&\s'"";]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // T-SQL: CREATE/ALTER CREDENTIAL ... SECRET = 'the token'
+    private static readonly Regex TsqlSecret = new(
+        @"(?<key>\bSECRET\s*=\s*)(?<quote>N?')(?:[^']|'')*'",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // Connection-string style: Password=..., Pwd=...
+    private static readonly Regex ConnectionPassword = new(
+        @"(?<key>\b(?:password|pwd)\s*=\s*)(?<value>[^;\s]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>Returns the text with anything secret-shaped replaced. Never throws.</summary>
+    public static string Redact(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+
+        try
+        {
+            var result = TsqlSecret.Replace(text, m => $"{m.Groups["key"].Value}{m.Groups["quote"].Value}{Mask}'");
+            result = SasSignature.Replace(result, m => $"{m.Groups["key"].Value}{Mask}");
+            result = ConnectionPassword.Replace(result, m => $"{m.Groups["key"].Value}{Mask}");
+            return result;
+        }
+        catch
+        {
+            // A redaction failure must never let the raw text through.
+            return Mask;
+        }
+    }
+}

--- a/src/NineLives/Services/OperationLog.cs
+++ b/src/NineLives/Services/OperationLog.cs
@@ -1,0 +1,117 @@
+using System.IO;
+using System.Text;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// A small append-only log on disk (#40).
+///
+/// The app had no logging of any kind, which for a tool that executes restores against production
+/// databases means a bug report can contain nothing but a screenshot, and a server-state change -
+/// creating or altering a credential - leaves no trace whatsoever.
+///
+/// Hand-rolled rather than a logging framework: the requirement is a few lines of text per
+/// operation, and a self-contained single-file exe should not grow a dependency tree for that.
+///
+/// Two rules it must never break:
+///   - it never throws, because a logging failure must not break a restore
+///   - everything goes through LogRedactor, so a new call site cannot leak a token by forgetting
+/// </summary>
+public sealed class OperationLog
+{
+    /// <summary>Files older than this are removed on startup.</summary>
+    private const int RetentionDays = 30;
+
+    /// <summary>A single day's file is rolled once it passes this, so one runaway loop cannot fill the disk.</summary>
+    private const long MaxFileBytes = 5 * 1024 * 1024;
+
+    private readonly string _directory;
+    // Plain object rather than System.Threading.Lock, which is .NET 9+. Swap it when the .NET 10
+    // retarget lands (#34).
+    private readonly object _gate = new();
+
+    public OperationLog() : this(Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "NineLives", "logs"))
+    { }
+
+    /// <summary>Lets the tests write somewhere disposable instead of the real profile.</summary>
+    internal OperationLog(string directory) => _directory = directory;
+
+    public string Directory => _directory;
+
+    /// <summary>Today's log file. The name is stable within a day so it is easy to find and attach.</summary>
+    public string CurrentFile =>
+        Path.Combine(_directory, $"ninelives-{DateTime.Now:yyyyMMdd}.log");
+
+    public void Info(string message) => Write("INFO ", message);
+    public void Warn(string message) => Write("WARN ", message);
+    public void Error(string message) => Write("ERROR", message);
+
+    public void Error(string message, Exception ex)
+        => Write("ERROR", $"{message} | {ex.GetType().Name}: {ex.Message}");
+
+    /// <summary>
+    /// Records something the app changed on a server, as opposed to something it read. These are
+    /// the lines that matter when someone asks why a credential on their instance changed.
+    /// </summary>
+    public void ServerChange(string serverName, string what)
+        => Write("CHANGE", $"[{serverName}] {what}");
+
+    private void Write(string level, string message)
+    {
+        try
+        {
+            var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {level} {LogRedactor.Redact(message)}";
+
+            lock (_gate)
+            {
+                System.IO.Directory.CreateDirectory(_directory);
+                RollIfTooBig();
+                File.AppendAllText(CurrentFile, line + Environment.NewLine, Encoding.UTF8);
+            }
+        }
+        catch
+        {
+            // Logging is never worth failing an operation over. A locked file, a full disk or a
+            // redirected profile all end up here and are all survivable.
+        }
+    }
+
+    private void RollIfTooBig()
+    {
+        var current = CurrentFile;
+        if (!File.Exists(current) || new FileInfo(current).Length < MaxFileBytes) return;
+
+        for (var i = 1; i < 100; i++)
+        {
+            var rolled = Path.ChangeExtension(current, $".{i}.log");
+            if (File.Exists(rolled)) continue;
+            File.Move(current, rolled);
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Drops files past the retention window. Called once at startup rather than on every write -
+    /// enumerating a directory to append one line would be silly.
+    /// </summary>
+    public void Prune()
+    {
+        try
+        {
+            if (!System.IO.Directory.Exists(_directory)) return;
+
+            var cutoff = DateTime.Now.AddDays(-RetentionDays);
+            foreach (var file in System.IO.Directory.EnumerateFiles(_directory, "ninelives-*.log"))
+            {
+                if (File.GetLastWriteTime(file) < cutoff)
+                    File.Delete(file);
+            }
+        }
+        catch
+        {
+            // Same rule: never worth failing over.
+        }
+    }
+}

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -1,3 +1,7 @@
+using System.Diagnostics;
+using System.IO;
+using CommunityToolkit.Mvvm.Input;
+
 namespace Blackcat.NineLives.ViewModels;
 
 public partial class AboutViewModel : ViewModelBase
@@ -9,4 +13,25 @@ public partial class AboutViewModel : ViewModelBase
     public string Company => "Blackcat Data Solutions Ltd";
     public string Website => "https://blackcat.wales";
     public string Description => "Every database deserves nine lives. A production-ready utility for restoring SQL Server databases from Azure Blob Storage backups with full support for point-in-time recovery using Full, Differential, and Transaction Log backup chains.";
+
+    /// <summary>Shown so the path can be read even if opening the folder fails.</summary>
+    public string LogFolder => App.Log.Directory;
+
+    /// <summary>
+    /// Opens the log folder in Explorer. The logs are what someone attaches to a bug report, so
+    /// there needs to be a way to find them that is not "know where LocalAppData is" (#40).
+    /// </summary>
+    [RelayCommand]
+    private void OpenLogFolder()
+    {
+        try
+        {
+            Directory.CreateDirectory(App.Log.Directory);
+            Process.Start(new ProcessStartInfo(App.Log.Directory) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not open the log folder: {ex.Message}. It is at {App.Log.Directory}");
+        }
+    }
 }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1393,9 +1393,19 @@ public partial class RestoreViewModel : ViewModelBase
                         AppendLog(change == CredentialChange.Created
                             ? "Credential created on the server."
                             : "Credential updated on the server.");
+
+                        // Changing a credential is a change to shared state on someone's instance.
+                        // It belongs in the file, not only in a console that closes with the app.
+                        App.Log.ServerChange(server.ServerName,
+                            $"credential [{SqlCredentialName}] {change.ToString().ToLowerInvariant()}");
                     }
                 }
             }
+
+            App.Log.ServerChange(server.ServerName,
+                $"restore starting: target [{TargetDatabaseName}], " +
+                $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={WithReplace}, " +
+                $"recovery={RecoveryMode}, stopAt={EffectiveStopAt?.ToString("s") ?? "none"}");
 
             AppendLog("Beginning restore execution...\n");
 
@@ -1498,9 +1508,17 @@ public partial class RestoreViewModel : ViewModelBase
             TryCopyToClipboard(action.Sql, "Recovery statement copied to clipboard.");
     }
 
+    /// <summary>
+    /// Appends to the on-screen console and to the log file at the same time.
+    ///
+    /// One call rather than two so the file cannot drift from what the user was shown - and so a
+    /// restore that ends with the window being closed still leaves a record of how far it got.
+    /// Redaction happens inside the log, not here (#40).
+    /// </summary>
     private void AppendLog(string message)
     {
         ExecutionLog += message + "\n";
+        App.Log.Info($"[execute] {message.Trim()}");
     }
 
     private async Task RunArmCountdownAsync(CancellationToken ct)

--- a/src/NineLives/Views/AboutView.xaml
+++ b/src/NineLives/Views/AboutView.xaml
@@ -54,6 +54,23 @@
                     </Hyperlink>
                 </TextBlock>
 
+                <!-- The logs are what someone attaches to a bug report, so there has to be a way
+                     to find them that is not "know where LocalAppData lives" (#40). -->
+                <Button Content="Open log folder"
+                        Command="{Binding OpenLogFolderCommand}"
+                        Style="{StaticResource SecondaryButton}"
+                        Padding="10,6"
+                        HorizontalAlignment="Center"
+                        Margin="0,0,0,12"
+                        ToolTip="{Binding LogFolder}" />
+
+                <TextBlock Text="{Binding ErrorMessage}"
+                           Style="{StaticResource SecondaryText}"
+                           TextWrapping="Wrap"
+                           HorizontalAlignment="Center"
+                           Margin="0,0,0,12"
+                           Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}" />
+
                 <TextBlock HorizontalAlignment="Center"
                            Style="{StaticResource SecondaryText}">
                     <Run Text="&#x00A9; " />


### PR DESCRIPTION
Closes #40.

The app wrote **nothing** to disk. For a tool that executes restores against production databases, that means a bug report can contain nothing but a screenshot of a console — and changing a credential on someone's instance left no trace at all.

## The log

`OperationLog` appends to `%LOCALAPPDATA%\NineLives\logs\ninelives-yyyyMMdd.log`, with size-based rolling at 5 MB and 30-day retention pruned at startup.

Hand-rolled rather than `Microsoft.Extensions.Logging` plus a file provider. The requirement is a few lines of text per operation, and a self-contained single-file exe shouldn't grow a dependency tree for that — the issue asked for the light option and this is about 100 lines.

Two rules it doesn't break:

- **It never throws.** A locked file, a full disk, a redirected profile — all survivable, none of them worth failing a restore over.
- **Everything passes through `LogRedactor`.**

## Redaction is at the boundary, deliberately

Redacting at the call sites means it takes exactly one forgetful caller — or one new one — to write a live SAS token into the file people are told to attach to bug reports. Doing it in the writer makes new call sites safe by default.

It strips:

| | |
|---|---|
| SAS query parameters | `sig`, `sv`, `se`, `sp`, `sr`, `st`, and the rest — not just `sig`, because `se`/`sp` tell an attacker what a leaked signature is good for and none of it has diagnostic value |
| T-SQL `SECRET = '...'` | including secrets containing doubled quotes, which `TSql.EscapeLiteral` produces and a naive match would stop early on |
| Connection-string passwords | `Password=`, `pwd=` |

The URL and the surrounding statement survive, so the line is still worth reading:

```
GET https://acct.blob.core.windows.net/backups/FULL/MyDb.bak?sv=[redacted]&sig=[redacted]
CREATE CREDENTIAL [https://acct/backups] WITH IDENTITY = 'SHARED ACCESS SIGNATURE', SECRET = '[redacted]'
```

## What gets logged

- App start with version and OS
- **The whole execution stream** — `AppendLog` writes to the console and the file in one call, so the file can't drift from what the user was shown, and a restore that ends with the window closing still leaves a record of how far it got
- Restore start: target database, chain summary, `WITH REPLACE`, recovery mode, `STOPAT`
- **Credential creations and updates, marked `CHANGE`** — the lines that matter when someone asks why a credential on their instance changed
- Both unhandled-exception handlers

Plus an **Open log folder** button in About, with the path as its tooltip so it's readable even if opening fails.

## Tests

21 new. The ones I'd point at:

- a secret containing doubled quotes is fully removed, not truncated at the first `''`
- an unwritable path doesn't throw from `Info`, `Error` or `Prune`
- 200 concurrent writes produce exactly 200 lines — the execution log appends from a progress callback while the UI thread is also writing
- ordinary text passes through completely unchanged, so redaction isn't quietly mangling normal lines

**488 tests pass**, build clean at `-warnaserror`.

## Note

`OperationLog` uses a plain `object` lock rather than `System.Threading.Lock`, which is .NET 9+. There's a comment to swap it when #34 lands.
