### PR TITLE
Consolidate the size formatter, and confirm before deleting (#42, partial)

### DIFF
--- a/src/NineLives.Tests/ByteSizeTests.cs
+++ b/src/NineLives.Tests/ByteSizeTests.cs
@@ -1,0 +1,45 @@
+using Blackcat.NineLives.Models;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The single byte formatter (#42). The same loop had been copied into four SizeDisplay
+/// properties across three files - nothing had gone wrong with it yet, but four copies is four
+/// chances to drift and start disagreeing about the size of the same backup on different screens.
+/// </summary>
+public class ByteSizeTests
+{
+    [Theory]
+    [InlineData(0, "0.0 B")]
+    [InlineData(512, "512.0 B")]
+    [InlineData(1024, "1.0 KB")]
+    [InlineData(1536, "1.5 KB")]
+    [InlineData(1024L * 1024, "1.0 MB")]
+    [InlineData(1024L * 1024 * 1024, "1.0 GB")]
+    [InlineData(1024L * 1024 * 1024 * 1024, "1.0 TB")]
+    public void SizesFormatInBinaryUnits(long bytes, string expected)
+        => Assert.Equal(expected, ByteSize.Format(bytes));
+
+    [Fact]
+    public void VeryLargeSizesStopAtTerabytes()
+    {
+        // The loop is bounded by the unit list, so a petabyte-scale container reads as thousands
+        // of TB rather than running off the end of the array.
+        Assert.Equal("2048.0 TB", ByteSize.Format(2048L * 1024 * 1024 * 1024 * 1024));
+    }
+
+    [Fact]
+    public void ANegativeSizeIsShownAsIsRatherThanLoopingOrPrintingNonsense()
+    {
+        // Not physically meaningful, but a subtraction bug upstream should look odd rather than
+        // print "-0.0 B".
+        Assert.Equal("-5 B", ByteSize.Format(-5));
+    }
+
+    [Fact]
+    public void TheBoundaryBelowAUnitDoesNotRoundUpIntoIt()
+    {
+        Assert.Equal("1023.0 B", ByteSize.Format(1023));
+    }
+}

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -79,21 +79,7 @@ public class BackupFileInfo
         _ => "Unknown"
     };
 
-    public string SizeDisplay
-    {
-        get
-        {
-            string[] units = ["B", "KB", "MB", "GB", "TB"];
-            double size = SizeBytes;
-            int unit = 0;
-            while (size >= 1024 && unit < units.Length - 1)
-            {
-                size /= 1024;
-                unit++;
-            }
-            return $"{size:F1} {units[unit]}";
-        }
-    }
+    public string SizeDisplay => ByteSize.Format(SizeBytes);
 
     public override string ToString()
         => $"[{TypeDisplay}] {BlobName} ({SizeDisplay}) - {EffectiveDate:yyyy-MM-dd HH:mm:ss}";
@@ -137,21 +123,7 @@ public class BackupSet
     public int FileCount => Files.Count;
     public bool IsStriped => Files.Count > 1;
 
-    public string SizeDisplay
-    {
-        get
-        {
-            string[] units = ["B", "KB", "MB", "GB", "TB"];
-            double size = TotalSizeBytes;
-            int unit = 0;
-            while (size >= 1024 && unit < units.Length - 1)
-            {
-                size /= 1024;
-                unit++;
-            }
-            return $"{size:F1} {units[unit]}";
-        }
-    }
+    public string SizeDisplay => ByteSize.Format(TotalSizeBytes);
 
     public string TypeDisplay => Type switch
     {
@@ -261,21 +233,7 @@ public class RestorePoint
         }
     }
 
-    public string SizeDisplay
-    {
-        get
-        {
-            string[] units = ["B", "KB", "MB", "GB", "TB"];
-            double size = TotalSizeBytes;
-            int unit = 0;
-            while (size >= 1024 && unit < units.Length - 1)
-            {
-                size /= 1024;
-                unit++;
-            }
-            return $"{size:F1} {units[unit]}";
-        }
-    }
+    public string SizeDisplay => ByteSize.Format(TotalSizeBytes);
 
     public string ChainDescription
     {

--- a/src/NineLives/Models/ByteSize.cs
+++ b/src/NineLives/Models/ByteSize.cs
@@ -1,0 +1,31 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// One place that turns a byte count into something readable (#42).
+///
+/// The same while-loop was copied into four SizeDisplay properties across three files. Nothing had
+/// gone wrong with it yet, but four copies is four chances for them to drift and start disagreeing
+/// about the size of the same backup on different screens.
+/// </summary>
+public static class ByteSize
+{
+    private static readonly string[] Units = ["B", "KB", "MB", "GB", "TB"];
+
+    /// <summary>e.g. 1536 becomes "1.5 KB". Binary units, matching what SSMS and Explorer show.</summary>
+    public static string Format(long bytes)
+    {
+        // Negative sizes are not physically meaningful, but a subtraction bug upstream should show
+        // as an odd number rather than looping forever or printing "-0.0 B".
+        if (bytes < 0) return $"{bytes} B";
+
+        double size = bytes;
+        var unit = 0;
+        while (size >= 1024 && unit < Units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+
+        return $"{size:F1} {Units[unit]}";
+    }
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -478,19 +478,5 @@ public class ContainerSummary
     public DateTimeOffset? EarliestBackup { get; set; }
     public DateTimeOffset? LatestBackup { get; set; }
 
-    public string TotalSizeDisplay
-    {
-        get
-        {
-            string[] units = ["B", "KB", "MB", "GB", "TB"];
-            double size = TotalSizeBytes;
-            int unit = 0;
-            while (size >= 1024 && unit < units.Length - 1)
-            {
-                size /= 1024;
-                unit++;
-            }
-            return $"{size:F1} {units[unit]}";
-        }
-    }
+    public string TotalSizeDisplay => ByteSize.Format(TotalSizeBytes);
 }

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Models;
@@ -463,6 +464,18 @@ public partial class BlobConfigViewModel : ViewModelBase
     private void Delete()
     {
         if (SelectedContainer == null) return;
+
+        // Deleting takes the SAS token out of Credential Manager, and the token is never displayed
+        // anywhere in the app - so if it was the only copy, it is gone for good. That deserves a
+        // question rather than a single click (#42).
+        var confirm = MessageBox.Show(
+            $"Remove the container \"{SelectedContainer.Name}\"?\n\n" +
+            "Its stored SAS token will be deleted from Windows Credential Manager. The app never " +
+            "displays stored tokens, so if this is the only copy you will need to obtain a new one.\n\n" +
+            "Nothing in Azure is affected - no backups are deleted.",
+            "Nine Lives", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
+
+        if (confirm != MessageBoxResult.Yes) return;
 
         // Remove from the config first and only destroy the secret once that write has actually
         // landed. The other order threw the SAS token away and then, if the save failed, left the

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Models;
@@ -252,6 +253,19 @@ public partial class ServerManagerViewModel : ViewModelBase
     private void Delete()
     {
         if (SelectedServer == null) return;
+
+        // Same reasoning as deleting a container: a stored SQL password is removed from Credential
+        // Manager and the app never displays it, so a single click should not be enough (#42).
+        var secretNote = SelectedServer.AuthMode == AuthMode.SqlAuth
+            ? "\n\nIts stored SQL password will be deleted from Windows Credential Manager."
+            : string.Empty;
+
+        var confirm = MessageBox.Show(
+            $"Remove the server \"{SelectedServer.Name}\"?{secretNote}\n\n" +
+            "Nothing on the SQL Server itself is affected.",
+            "Nine Lives", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
+
+        if (confirm != MessageBoxResult.Yes) return;
 
         // Take the server out of the config first and only destroy its stored password once that
         // write has landed. The other order threw the password away and then, if the save failed,


### PR DESCRIPTION
Partial for #42 — two items with real user impact, rather than the whole tidy-up sweep. **Leaving the issue open** for the rest.

## Size formatter consolidated

The bytes-to-KB/MB/GB loop was copied into **four** `SizeDisplay` properties across three files. Nothing had gone wrong with it, but four copies is four chances to drift and start disagreeing about the size of the same backup on different screens. Now one `ByteSize.Format`.

## Delete now asks first

Neither Delete button had a confirmation. Both remove the stored SAS token or SQL password from Credential Manager — and **the app never displays stored secrets**, so if that was the only copy of a token it's gone with one click and no undo.

Both now confirm, defaulting to No, and say what is *not* affected — no backups in Azure, nothing on the SQL Server itself. That second part matters: "delete container" is an alarming phrase if you're not sure whether it means the Azure container.

## Three items were already done

Worth noting so they can be ticked off:

- **Dead single-URL `RestoreFileListOnlyAsync` overload** — removed with #60
- **Surface config corruption** — done in #7; `LoadConfig` reports it and the UI shows it
- **`MatchesServerSet` ignoring the instance** — fixed with #43/#48, with a comment explaining what it used to do

## Deliberately not done

The remaining items are pure refactors, and doing them unattended adds risk without giving you anything: path-builder dedupe, magic strings to constants, nullable annotations on the `null!` chain members, shared viewmodel commands, and the WITH MOVE guessed-logical-names warning. That last one is a real UX gap and probably deserves its own issue rather than a checkbox.

**498 tests pass**, build clean at `-warnaserror`.
