### PR TITLE
Load every view in a test, and fix the three things it found

### DIFF
--- a/src/NineLives.Tests/WpfFixture.cs
+++ b/src/NineLives.Tests/WpfFixture.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows;
+using System.Windows.Diagnostics;
+using System.Windows.Threading;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Hosts a real WPF <see cref="Application"/> on a dedicated STA thread so the views can be loaded
+/// and laid out in a test.
+///
+/// One Application per process and it belongs to the thread that created it, so everything runs on
+/// this single thread and the fixture is shared by the whole class.
+/// </summary>
+public sealed class WpfFixture : IDisposable
+{
+    private readonly Thread _thread;
+    private Dispatcher _dispatcher = null!;
+
+    public WpfFixture()
+    {
+        using var ready = new ManualResetEventSlim();
+
+        _thread = new Thread(() =>
+        {
+            _dispatcher = Dispatcher.CurrentDispatcher;
+
+            // InitializeComponent is what loads App.xaml - and therefore Themes/DarkTheme.xaml and
+            // Themes/Logo.xaml - into Application.Resources. The generated Main calls it after the
+            // constructor, so constructing App alone leaves the resources empty and every
+            // {StaticResource} in every view fails. OnStartup only runs from Run(), which is not
+            // called here, so no splash window appears.
+            var app = new App();
+            app.InitializeComponent();
+
+            ready.Set();
+            Dispatcher.Run();
+        })
+        {
+            IsBackground = true,
+            Name = "wpf-test-ui"
+        };
+
+        _thread.SetApartmentState(ApartmentState.STA);
+        _thread.Start();
+        ready.Wait(TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>Runs on the UI thread and rethrows anything it threw, with its stack intact.</summary>
+    public void Invoke(Action action)
+    {
+        Exception? captured = null;
+
+        _dispatcher.Invoke(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { captured = ex; }
+        });
+
+        if (captured != null) ExceptionDispatchInfo.Capture(captured).Throw();
+    }
+
+    public void Dispose()
+    {
+        _dispatcher?.InvokeShutdown();
+        _thread.Join(TimeSpan.FromSeconds(5));
+    }
+}
+
+/// <summary>
+/// Collects WPF's own binding failures.
+///
+/// A broken binding does not throw - WPF writes it to a trace source and carries on with an empty
+/// value. That is why a wrong RelativeSource renders a button that simply does nothing when
+/// clicked, with no error anywhere. Listening to the trace source is the only way to see them.
+/// </summary>
+public sealed class BindingErrorListener : TraceListener
+{
+    private readonly List<string> _errors = [];
+
+    public IReadOnlyList<string> Errors => _errors;
+
+    public override void Write(string? message) { }
+
+    public override void WriteLine(string? message)
+    {
+        if (!string.IsNullOrWhiteSpace(message)) _errors.Add(message);
+    }
+
+    /// <summary>Starts listening, and stops when disposed. Binding failures trace at Warning.</summary>
+    public static BindingErrorListener Attach()
+    {
+        var listener = new BindingErrorListener();
+        PresentationTraceSources.Refresh();
+        PresentationTraceSources.DataBindingSource.Listeners.Add(listener);
+        PresentationTraceSources.DataBindingSource.Switch.Level = SourceLevels.Warning;
+        return listener;
+    }
+
+    public void Detach() => PresentationTraceSources.DataBindingSource.Listeners.Remove(this);
+
+    public void AssertNone(string what)
+    {
+        if (_errors.Count == 0) return;
+
+        Assert.Fail(
+            $"{what} produced {_errors.Count} binding failure(s):{Environment.NewLine}  " +
+            string.Join(Environment.NewLine + "  ", _errors));
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -1,0 +1,291 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Loads every view against a real viewmodel and lays it out, so the two failure modes that
+/// otherwise need a human looking at the running app get caught here instead.
+///
+/// 1. A XAML parse failure or a missing {StaticResource} key - throws, so any of these tests fail.
+/// 2. A broken binding - does NOT throw. WPF traces it and carries on with an empty value, which
+///    is why a wrong RelativeSource renders a perfectly normal-looking button that does nothing
+///    when clicked. BindingErrorListener is what makes those visible.
+///
+/// What this deliberately does not check is whether the result LOOKS right - colours, spacing,
+/// whether a panel is where you expect. That still needs eyes on the running app.
+/// </summary>
+public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private CredentialStore Store() => new(_dir);
+
+    /// <summary>Realises the visual tree. Bindings are not evaluated until something lays out.</summary>
+    private static void Realise(FrameworkElement element)
+    {
+        element.Measure(new Size(1600, 1200));
+        element.Arrange(new Rect(0, 0, 1600, 1200));
+        element.UpdateLayout();
+    }
+
+    private void Check(string what, Func<FrameworkElement> build)
+    {
+        wpf.Invoke(() =>
+        {
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(build());
+                listener.AssertNone(what);
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    // ── every view loads and binds ──────────────────────────────────────────────
+
+    [Fact]
+    public void AboutViewLoads()
+        => Check("AboutView", () => new AboutView { DataContext = new AboutViewModel() });
+
+    [Fact]
+    public void BlobConfigViewLoads()
+        => Check("BlobConfigView", () =>
+            new BlobConfigView { DataContext = new BlobConfigViewModel(Store(), new BlobStorageService(Store())) });
+
+    [Fact]
+    public void ServerManagerViewLoads()
+        => Check("ServerManagerView", () =>
+            new ServerManagerView { DataContext = new ServerManagerViewModel(Store(), new SqlServerService(Store())) });
+
+    [Fact]
+    public void BlobBrowserViewLoads()
+        => Check("BlobBrowserView", () =>
+            new BlobBrowserView { DataContext = new BlobBrowserViewModel(new BlobStorageService(Store()), Store()) });
+
+    [Fact]
+    public void RestoreViewLoads()
+        => Check("RestoreView", () => new RestoreView { DataContext = NewRestoreViewModel() });
+
+    [Fact]
+    public void SplashWindowLoads()
+    {
+        // Borderless, transparent and animated - the shape of window most likely to be affected by
+        // a runtime change. Constructed but never shown.
+        wpf.Invoke(() =>
+        {
+            var splash = new SplashWindow();
+            Realise(splash);
+        });
+    }
+
+    [Fact]
+    public void MainWindowLoads()
+    {
+        wpf.Invoke(() =>
+        {
+            var window = new MainWindow();
+            Realise(window);
+        });
+    }
+
+    // ── the panels that only appear in a particular state ───────────────────────
+
+    /// <summary>
+    /// The recovery panel after a failed restore (#14). Its buttons reach the viewmodel's commands
+    /// through RelativeSource AncestorType=ItemsControl from inside a DataTemplate - the exact
+    /// shape that renders fine and quietly does nothing when it is wrong.
+    ///
+    /// The items have to be present and the panel visible, because a collapsed element is never
+    /// laid out and its template is never realised, so the binding would never be evaluated.
+    /// </summary>
+    [Fact]
+    public void TheRecoveryPanelBindsItsCommands()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.RecoveryStateMessage = "[MyDb] is in RESTORING state.";
+            vm.RecoveryActions =
+            [
+                new RecoveryAction("Bring the database online", "RESTORE DATABASE [MyDb] WITH RECOVERY", "Ends the sequence."),
+                new RecoveryAction("Allow other connections again", "ALTER DATABASE [MyDb] SET MULTI_USER", "Safe at any point.")
+            ];
+            vm.HasRecoveryActions = true;
+            vm.ExecutionComplete = true;
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                // Both buttons must have found a command. A failed RelativeSource leaves Command
+                // null, which is exactly the silent failure this test exists for.
+                var buttons = FindAll<Button>(view)
+                    .Where(b => b.Content as string is "Run this" or "Copy")
+                    .ToList();
+
+                Assert.Equal(4, buttons.Count);   // two actions, two buttons each
+                Assert.All(buttons, b => Assert.NotNull(b.Command));
+                Assert.All(buttons, b => Assert.NotNull(b.CommandParameter));
+
+                listener.AssertNone("RestoreView recovery panel");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The credential button relabels itself through a DataTrigger once the credential is valid
+    /// (#78). If that trigger is wrong the button keeps saying "Create credential on server" when
+    /// what it would actually do is refresh an existing one.
+    /// </summary>
+    [Fact]
+    public void TheCredentialButtonRelabelsWhenTheCredentialIsValid()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.SelectedContainer = new BlobContainerConfig
+            {
+                Id = BlobContainerConfig.NewId(),
+                Name = "prod",
+                ContainerUrl = "https://acct.blob.core.windows.net/backups"
+            };
+            vm.IsConnectedToServer = true;
+            vm.CredentialSectionVisible = true;
+
+            var view = new RestoreView { DataContext = vm };
+
+            vm.CredentialExistsOnServer = false;
+            vm.CredentialIsValidSas = false;
+            Realise(view);
+            Assert.Contains(FindAll<Button>(view), b => (b.Content as string) == "Create credential on server");
+
+            vm.CredentialExistsOnServer = true;
+            vm.CredentialIsValidSas = true;
+            Realise(view);
+            Assert.Contains(FindAll<Button>(view),
+                b => (b.Content as string) == "Refresh credential with stored SAS token");
+        });
+    }
+
+    /// <summary>The inventory warnings panel added with #46 - separate from the chain issues one.</summary>
+    [Fact]
+    public void TheInventoryPanelShowsItsFindings()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.InventoryIssues =
+            [
+                new ChainIssue(ChainIssueSeverity.Warning, "2 log backup(s) are not reachable", "Detail here.")
+            ];
+            vm.HasInventoryIssues = true;
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.True(
+                    texts.Any(t => t.Contains("Detail here.", StringComparison.Ordinal)),
+                    "The inventory panel did not render its findings. TextBlocks found: " +
+                    string.Join(" | ", texts.Where(t => !string.IsNullOrWhiteSpace(t))));
+
+                listener.AssertNone("RestoreView inventory panel");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    /// <summary>Tag pills render through one wrapping template; they used to clip (#67).</summary>
+    [Fact]
+    public void TagPillsRenderForAServerRow()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new ServerManagerViewModel(Store(), new SqlServerService(Store()));
+            var server = new ServerConnection
+            {
+                Id = ServerConnection.NewId(),
+                Name = "SRV01",
+                ServerName = "SRV01",
+                DetectedVersion = "SQL Server 2022"
+            };
+            server.Tags.Add("prod");
+            server.Tags.Add("uk-south");
+            vm.Servers = [server];
+            vm.SelectedServer = server;
+
+            var view = new ServerManagerView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.Contains("prod", texts);
+                Assert.Contains("uk-south", texts);
+                Assert.Contains("SQL Server 2022", texts);
+
+                listener.AssertNone("ServerManagerView tag pills");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private RestoreViewModel NewRestoreViewModel()
+    {
+        var store = Store();
+        return new RestoreViewModel(
+            new BlobStorageService(store),
+            new SqlServerService(store),
+            new BackupChainBuilder(),
+            new RestoreScriptGenerator(),
+            store);
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is T match) yield return match;
+            foreach (var descendant in FindAll<T>(child)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -265,8 +265,11 @@
                            VerticalAlignment="Center"
                            Margin="0,0,24,0" />
 
+                <!-- From the assembly, not a literal. This said v1.0.0 while the About box read
+                     v1.1.0 from AppVersion - #35 fixed the About box and missed the status bar,
+                     which is the version most people would glance at. -->
                 <TextBlock Grid.Column="2"
-                           Text="v1.0.0"
+                           Text="{Binding VersionText, Mode=OneWay}"
                            Style="{StaticResource SecondaryText}"
                            VerticalAlignment="Center" />
             </Grid>

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -2,6 +2,12 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
 
+    <!-- Declared here rather than per-view. It was repeated in five views, and AboutView - the one
+         that did not have it - threw a XamlParseException the moment a {StaticResource BoolToVis}
+         was added to it. Views that still declare their own simply shadow this with an identical
+         instance, so both work. -->
+    <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+
     <!-- Color Palette -->
     <Color x:Key="WindowBackgroundColor">#1B1E2B</Color>
     <Color x:Key="SidebarBackgroundColor">#141722</Color>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -38,6 +38,12 @@ public partial class MainViewModel : ViewModelBase
     private string _updateUrl = UpdateChecker.ReleasesPage;
     private string? _updateTag;
 
+    /// <summary>
+    /// Shown in the status bar. Read from the assembly so it cannot go stale.
+    /// Not named AppVersion - that would shadow the class of the same name inside this type.
+    /// </summary>
+    public string VersionText => Services.AppVersion.Display;
+
     public BlobConfigViewModel BlobConfig { get; }
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -62,6 +62,14 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _restoreWindowText = string.Empty;
 
+    /// <summary>
+    /// Left-hand label under the timeline. A plain property rather than the old
+    /// {Binding RestorePoints[0].Timestamp}, which threw an index error into WPF's binding trace
+    /// on every layout while the collection was empty.
+    /// </summary>
+    [ObservableProperty]
+    private string _timelineStartText = string.Empty;
+
     [ObservableProperty]
     private ObservableCollection<TimelineTick> _timelineTicks = [];
 
@@ -605,6 +613,7 @@ public partial class RestoreViewModel : ViewModelBase
             var first = points.First().Timestamp;
             var last = points.Last().Timestamp;
             RestoreWindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
+            TimelineStartText = $"{first:yyyy-MM-dd HH:mm}";
 
             // Compute time-interval tick marks
             TimelineTicks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -114,6 +114,42 @@
                 </StackPanel>
             </Border>
 
+            <!-- Findings about the discovered backups rather than the selected chain: things that
+                 exist in the container but can never be offered as a restore point (#46).
+
+                 Deliberately OUTSIDE the restore-point card below. It used to be nested inside it,
+                 which hid it exactly when it mattered most - "no full backup found" is precisely
+                 the case where there are no restore points, so the user got an empty screen and no
+                 explanation. A XAML load test caught that. -->
+            <Border CornerRadius="4" Padding="12" Margin="0,0,0,16"
+                    Background="#332B1A" BorderBrush="#8A6D2F" BorderThickness="1"
+                    Visibility="{Binding HasInventoryIssues, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Text="About the backups found in this container"
+                               FontWeight="SemiBold"
+                               Foreground="{StaticResource PrimaryTextBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,8" />
+                    <ItemsControl ItemsSource="{Binding InventoryIssues}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,8">
+                                    <TextBlock TextWrapping="Wrap" FontWeight="SemiBold">
+                                        <Run Text="{Binding SeverityDisplay, Mode=OneWay}" />
+                                        <Run Text="  " />
+                                        <Run Text="{Binding Title, Mode=OneWay}" />
+                                    </TextBlock>
+                                    <TextBlock Text="{Binding Detail}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap"
+                                               Margin="0,2,0,0" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
             <!-- Step 2: Restore Point Selection -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
                     Visibility="{Binding HasRestorePoints, Converter={StaticResource BoolToVis}}">
@@ -259,7 +295,7 @@
                             <!-- Start/End date labels -->
                             <Grid Grid.Row="3" Margin="7,2,7,0">
                                 <TextBlock Style="{StaticResource SecondaryText}" HorizontalAlignment="Left"
-                                           Text="{Binding RestorePoints[0].Timestamp, StringFormat='{}{0:yyyy-MM-dd HH:mm}', FallbackValue=''}"
+                                           Text="{Binding TimelineStartText}"
                                            FontSize="10" />
                                 <TextBlock Style="{StaticResource SecondaryText}" HorizontalAlignment="Right"
                                            FontSize="10">
@@ -420,35 +456,6 @@
                          things that exist in the container but can never be offered as a restore
                          point. Shown whether or not a point is selected, because they explain why
                          the timeline has fewer entries than the browse list has files (#46). -->
-                    <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
-                            Background="#332B1A" BorderBrush="#8A6D2F" BorderThickness="1"
-                            Visibility="{Binding HasInventoryIssues, Converter={StaticResource BoolToVis}}">
-                        <StackPanel>
-                            <TextBlock Text="About the backups found in this container"
-                                       FontWeight="SemiBold"
-                                       Foreground="{StaticResource PrimaryTextBrush}"
-                                       TextWrapping="Wrap"
-                                       Margin="0,0,0,8" />
-                            <ItemsControl ItemsSource="{Binding InventoryIssues}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Margin="0,0,0,8">
-                                            <TextBlock TextWrapping="Wrap" FontWeight="SemiBold">
-                                                <Run Text="{Binding SeverityDisplay, Mode=OneWay}" />
-                                                <Run Text="  " />
-                                                <Run Text="{Binding Title, Mode=OneWay}" />
-                                            </TextBlock>
-                                            <TextBlock Text="{Binding Detail}"
-                                                       Style="{StaticResource SecondaryText}"
-                                                       TextWrapping="Wrap"
-                                                       Margin="0,2,0,0" />
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-
                     <!-- Restore Chain Detail (togglable) -->
                     <Border Background="{StaticResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="12" Margin="0,12,0,0"


### PR DESCRIPTION
Groundwork for reviewing #87 — and it found three real problems before it even got there.

## What it does

A `WpfFixture` hosts a real `Application` on a dedicated STA thread, loads every view against a real viewmodel, and forces a layout pass. That catches the two failure modes that otherwise need a human in front of the running app:

1. **A XAML parse error or missing `{StaticResource}`** — throws, so the test fails.
2. **A broken binding** — *doesn't* throw. WPF traces it and carries on with an empty value, which is why a wrong `RelativeSource` renders a perfectly normal-looking button that silently does nothing when clicked. `BindingErrorListener` hooks `PresentationTraceSources.DataBindingSource` to make those visible.

It does **not** check whether anything *looks* right. That still needs your eyes.

## Three things it found — two of them mine, from today

**`AboutView` couldn't resolve `BoolToVis`.** Every other view declares its own copy of the converter; About didn't. The **Open log folder** button I added in #40 uses it, so opening About would have thrown `XamlParseException` — a crash on a page you'd reach in about two clicks. Now declared once in `DarkTheme.xaml`.

**The inventory panel from #46 was nested inside the restore-point card**, which is collapsed when `HasRestorePoints` is false. So it was hidden exactly when it mattered most — `"No full backup found"` is *by definition* the case where there are no restore points, meaning you'd get an empty screen with no explanation. Moved to the top level. (Honest note: I found this reading the XAML while debugging a test failure, not from an assertion — but the test is what sent me looking.)

**`{Binding RestorePoints[0].Timestamp}`** wrote an index error into the binding trace on every layout while the collection was empty. Harmless, but it's noise that would mask real failures. Replaced with a plain `TimelineStartText` property.

## Plus the bug you spotted

The status bar had a hardcoded `v1.0.0` while About read `v1.1.0` from the assembly — #35 fixed the About box and missed the status bar, which is the one people actually glance at. Now bound to the assembly version, so it can't drift again.

## Coverage

Every view and both windows, plus targeted tests for the pieces I wrote blind:

- **the recovery panel** (#14) — asserts all four buttons resolved a `Command` *and* a `CommandParameter` through `RelativeSource AncestorType=ItemsControl`
- **the credential button** (#78) — asserts the `DataTrigger` actually swaps the label to "Refresh credential with stored SAS token"
- **the inventory panel** (#46) and **tag pills** (#67)

**509 tests pass.** Once this is on `dev` I'll merge it into #87 so it runs against .NET 10 too — which was the point.
