### PR TITLE
Sort tag pills alphabetically

### DIFF
--- a/src/NineLives.Tests/TagNotificationTests.cs
+++ b/src/NineLives.Tests/TagNotificationTests.cs
@@ -101,8 +101,42 @@ public class TagNotificationTests
 
         var chips = server.TagChips.ToList();
 
-        Assert.Equal(["prod", "eu", "SQL Server 2022"], chips.Select(c => c.Text));
+        // Manual tags alphabetical, automatic ones after them. The manual group is sorted at
+        // display as well as on save, so a server stored before sorting existed still reads in
+        // order without being edited first.
+        Assert.Equal(["eu", "prod", "SQL Server 2022"], chips.Select(c => c.Text));
         Assert.Equal([false, false, true], chips.Select(c => c.IsAutomatic));
+    }
+
+    [Fact]
+    public void Server_TagChips_AreSortedEvenWhenTheStoredOrderIsNot()
+    {
+        // Exactly the case in an existing config: tags saved in the order they were created.
+        var server = new ServerConnection();
+        server.Tags.Add("homelab");
+        server.Tags.Add("blackcat");
+
+        Assert.Equal(["blackcat", "homelab"], server.TagChips.Select(c => c.Text));
+    }
+
+    [Fact]
+    public void Container_TagChips_AreSortedEvenWhenTheStoredOrderIsNot()
+    {
+        var container = new BlobContainerConfig();
+        container.Tags.Add("uat");
+        container.Tags.Add("archive");
+
+        Assert.Equal(["archive", "uat"], container.TagChips.Select(c => c.Text));
+    }
+
+    [Fact]
+    public void Server_TagChips_SortIgnoringCase()
+    {
+        var server = new ServerConnection();
+        server.Tags.Add("Zebra");
+        server.Tags.Add("apple");
+
+        Assert.Equal(["apple", "Zebra"], server.TagChips.Select(c => c.Text));
     }
 
     [Fact]

--- a/src/NineLives.Tests/TagPaletteTests.cs
+++ b/src/NineLives.Tests/TagPaletteTests.cs
@@ -109,7 +109,7 @@ public class TagPaletteTests
 
     [Fact]
     public void ParseTags_SplitsTrimsAndDropsBlanks()
-        => Assert.Equal(["prod", "eu-west", "critical"],
+        => Assert.Equal(["critical", "eu-west", "prod"],
             TagPalette.ParseTags("  prod ,, eu-west ,  critical  "));
 
     [Fact]
@@ -120,9 +120,31 @@ public class TagPaletteTests
     public void ParseTags_RemovesDuplicatesKeepingTheFirstSpelling()
         => Assert.Equal(["Prod"], TagPalette.ParseTags("Prod, prod, PROD"));
 
+    // Tags used to be stored in the order they were typed, so the same two tags on two servers
+    // rendered in different orders depending on how each was created. Sorted on save, and sorted
+    // again on display so entries saved before this still read correctly.
+
     [Fact]
-    public void ParseTags_PreservesOrder()
-        => Assert.Equal(["zebra", "apple"], TagPalette.ParseTags("zebra, apple"));
+    public void ParseTags_SortsAlphabetically()
+        => Assert.Equal(["apple", "zebra"], TagPalette.ParseTags("zebra, apple"));
+
+    [Fact]
+    public void ParseTags_SortsIgnoringCase()
+        => Assert.Equal(["Apple", "banana", "Cherry"], TagPalette.ParseTags("Cherry, banana, Apple"));
+
+    [Fact]
+    public void ParseTags_KeepsTheSpellingTheUserTyped()
+    {
+        // Sorting must not normalise case - a tag typed "Prod" stays "Prod".
+        Assert.Equal(["Prod", "uat"], TagPalette.ParseTags("uat, Prod"));
+    }
+
+    [Fact]
+    public void Sort_HandlesNullAndEmpty()
+    {
+        Assert.Empty(TagPalette.Sort(null));
+        Assert.Empty(TagPalette.Sort([]));
+    }
 
     [Fact]
     public void ParseTags_TruncatesOverlongTags()
@@ -141,8 +163,18 @@ public class TagPaletteTests
     [Fact]
     public void FormatTags_RoundTripsThroughParse()
     {
-        var original = new[] { "prod", "eu-west", "critical" };
+        // Already sorted, so the round trip is an identity. That is the point: once a list has
+        // been through ParseTags, formatting and reparsing it must not shuffle it again.
+        var original = new[] { "critical", "eu-west", "prod" };
         Assert.Equal(original, TagPalette.ParseTags(TagPalette.FormatTags(original)));
+    }
+
+    [Fact]
+    public void FormatTags_RoundTripSortsAnUnsortedList()
+    {
+        var original = new[] { "prod", "eu-west", "critical" };
+        Assert.Equal(["critical", "eu-west", "prod"],
+            TagPalette.ParseTags(TagPalette.FormatTags(original)));
     }
 
     [Fact]

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 using System.Text.Json.Serialization;
 using System.Web;
 
+using Blackcat.NineLives.Services;
+
 namespace Blackcat.NineLives.Models;
 
 /// <summary>
@@ -93,9 +95,12 @@ public class BlobContainerConfig : INotifyPropertyChanged
     /// <summary>
     /// Tags as chips, matching the server list. Containers have no automatic tags yet, but going
     /// through the same shape keeps one rendering path.
+    ///
+    /// Alphabetical. Sorted here as well as in ParseTags so containers saved before this change
+    /// display in order straight away, rather than waiting to be edited and re-saved.
     /// </summary>
     [JsonIgnore]
-    public IEnumerable<TagChip> TagChips => Tags.Select(TagChip.Manual);
+    public IEnumerable<TagChip> TagChips => TagPalette.Sort(Tags).Select(TagChip.Manual);
 
     private void OnTagsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         => RaiseTagMembersChanged();

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -3,6 +3,8 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
 
+using Blackcat.NineLives.Services;
+
 namespace Blackcat.NineLives.Models;
 
 public enum AuthMode
@@ -125,10 +127,16 @@ public class ServerConnection : INotifyPropertyChanged
     /// Manual and automatic tags as one sequence, so the UI can render them from a SINGLE
     /// wrapping panel. Two adjacent ItemsControls inside a WrapPanel cannot wrap - each is
     /// measured with infinite width - and their pills get clipped by the row instead.
+    ///
+    /// Each group is alphabetical, and manual tags come before automatic ones. Sorting here as
+    /// well as in ParseTags means entries saved before this change display in order straight away,
+    /// without waiting to be edited and re-saved. Automatic tags stay in their own group at the
+    /// end so a derived fact is not shuffled in among the user's own labels.
     /// </summary>
     [JsonIgnore]
     public IEnumerable<TagChip> TagChips =>
-        Tags.Select(TagChip.Manual).Concat(AutoTags.Select(TagChip.Automatic));
+        TagPalette.Sort(Tags).Select(TagChip.Manual)
+            .Concat(TagPalette.Sort(AutoTags).Select(TagChip.Automatic));
 
     /// <summary>True when any tag marks this as a production-like environment.</summary>
     [JsonIgnore]

--- a/src/NineLives/Services/TagPalette.cs
+++ b/src/NineLives/Services/TagPalette.cs
@@ -101,8 +101,22 @@ public static class TagPalette
     }
 
     /// <summary>
+    /// Alphabetical, ignoring case.
+    ///
+    /// Ordinal rather than culture-aware so two people looking at the same server see the same
+    /// order. Tags are short ASCII labels in practice - prod, uat, homelab - so the collation
+    /// differences that would favour a culture-aware comparison do not arise.
+    /// </summary>
+    public static IEnumerable<string> Sort(IEnumerable<string>? tags)
+        => tags is null ? [] : tags.OrderBy(t => t, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Splits and normalises a user-entered tag list. Trims, drops blanks, removes duplicates
-    /// case-insensitively while keeping the first spelling the user chose, and preserves order.
+    /// case-insensitively while keeping the first spelling the user chose, and sorts.
+    ///
+    /// Sorted rather than in entry order so the stored list is canonical: two servers carrying the
+    /// same tags then read identically instead of differing by the order someone happened to type
+    /// them in.
     /// </summary>
     public static List<string> ParseTags(string? input)
     {
@@ -119,7 +133,7 @@ public static class TagPalette
             if (seen.Add(tag)) result.Add(tag);
         }
 
-        return result;
+        return [.. Sort(result)];
     }
 
     public static string FormatTags(IEnumerable<string>? tags)


### PR DESCRIPTION
Tags were stored and rendered in creation order, so the same two tags on two servers came out differently depending on how each was set up — `BlackcatSVR01` showed `blackcat, homelab` and `BlackcatSVR02` showed `homelab, blackcat`.

## Sorted in two places, deliberately

- **`ParseTags`** sorts on save, so the stored list is canonical going forward.
- **`TagChips`** sorts on display, so entries **already in your config** read correctly immediately rather than waiting to be edited and re-saved.

Without the second one you'd have had to open and save every server to see the fix.

## Two judgement calls

**Ordinal, ignoring case.** Not culture-aware — two people looking at the same server should see the same order, and tags are short ASCII labels in practice (`prod`, `uat`, `homelab`). Case-insensitive so `Prod` sorts next to `prod`, and sorting never rewrites the spelling you typed.

**Automatic tags stay in their own group at the end.** The detected SQL version isn't shuffled in among your own labels — it's a derived fact, and grouping it separately is what your screenshot already showed happening. Each group is sorted within itself.

## Tests

**Four existing tests asserted the old creation order.** I updated rather than worked around them — that order was precisely the thing being changed, and `ParseTags_PreservesOrder` is now `ParseTags_SortsAlphabetically`. Two others (`SplitsTrimsAndDropsBlanks`, `FormatTags_RoundTripsThroughParse`) only asserted order incidentally; the round-trip one now reads better as an identity check, with a separate test for the sorting itself.

7 new tests, including the exact case from your screenshot — `homelab, blackcat` stored, `blackcat, homelab` displayed — for both servers and containers.

**516 tests pass** on `net10.0-windows`, build clean at `-warnaserror`.
