### PR TITLE
Let a running restore and a long blob listing be cancelled (#25)

### DIFF
--- a/src/NineLives.Tests/CancellationTests.cs
+++ b/src/NineLives.Tests/CancellationTests.cs
@@ -1,0 +1,245 @@
+using System.Diagnostics;
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Cancellation of long-running work (#25).
+///
+/// Every service method already took a CancellationToken and none of them were ever given a real
+/// one, so a restore aimed at the wrong server could only be stopped by killing the process -
+/// which leaves the database mid-restore and writes nothing down about it.
+/// </summary>
+public class OperationCancellationTests
+{
+    [Fact]
+    public void NothingRunningMeansNothingToCancel()
+    {
+        var operation = new OperationCancellation();
+
+        Assert.False(operation.CanCancel);
+        Assert.False(operation.IsCancelling);
+        operation.Cancel();   // must not throw
+    }
+
+    [Fact]
+    public void BeginProducesALiveToken()
+    {
+        var operation = new OperationCancellation();
+
+        var token = operation.Begin();
+
+        Assert.False(token.IsCancellationRequested);
+        Assert.True(operation.CanCancel);
+    }
+
+    [Fact]
+    public void CancelSignalsTheToken()
+    {
+        var operation = new OperationCancellation();
+        var token = operation.Begin();
+
+        operation.Cancel();
+
+        Assert.True(token.IsCancellationRequested);
+        Assert.True(operation.IsCancelling);
+        Assert.False(operation.CanCancel);   // already asked; the button should go away
+    }
+
+    /// <summary>
+    /// The bug this type exists to prevent: reusing a cancelled source would cancel the next run
+    /// before it started, so the second attempt at a restore would fail instantly and look like a
+    /// different problem entirely.
+    /// </summary>
+    [Fact]
+    public void ANewOperationAfterACancelledOneStartsClean()
+    {
+        var operation = new OperationCancellation();
+        operation.Begin();
+        operation.Cancel();
+        operation.End();
+
+        var second = operation.Begin();
+
+        Assert.False(second.IsCancellationRequested);
+        Assert.True(operation.CanCancel);
+    }
+
+    [Fact]
+    public void BeginCancelsAnOperationThatWasLeftRunning()
+    {
+        // Belt and braces: if a finally block were ever missed, the abandoned run must not keep
+        // going alongside its replacement.
+        var operation = new OperationCancellation();
+        var first = operation.Begin();
+
+        operation.Begin();
+
+        Assert.True(first.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void EndIsSafeToCallRepeatedly()
+    {
+        var operation = new OperationCancellation();
+        operation.Begin();
+
+        operation.End();
+        operation.End();
+
+        Assert.False(operation.CanCancel);
+    }
+
+    [Fact]
+    public void CancelAfterEndDoesNotThrow()
+    {
+        // The order a slow operation unwinds in is not fully under our control, so a Cancel
+        // arriving after the finally block has run must be a no-op rather than an ObjectDisposed.
+        var operation = new OperationCancellation();
+        operation.Begin();
+        operation.End();
+
+        operation.Cancel();
+
+        Assert.False(operation.CanCancel);
+    }
+}
+
+/// <summary>
+/// Cancellation against a real SQL Server: the point is that it actually interrupts work in
+/// flight, not just that the plumbing compiles.
+/// </summary>
+public class SqlCancellationTests
+{
+    private static ServerConnection TestServer() => new()
+    {
+        Name = "ninelives-test",
+        ServerName = Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL")!,
+        AuthMode = AuthMode.WindowsAuth,
+        Encrypt = EncryptMode.No,
+        TrustServerCertificate = true,
+        ConnectionTimeoutSeconds = 15
+    };
+
+    private static SqlServerService Service() => new(new CredentialStore());
+
+    /// <summary>
+    /// A restore of any size runs with CommandTimeout = 0, so without cancellation the only way
+    /// out is killing the process. WAITFOR stands in for a long-running statement: if the token is
+    /// not reaching the driver, this hangs for 30 seconds instead of stopping in about one.
+    ///
+    /// It also pins the exception TYPE, which is the part that is easy to get wrong. SqlClient
+    /// surfaces a cancelled command as a SqlException - "A severe error occurred on the current
+    /// command ... Operation cancelled by user" - so a caller catching OperationCanceledException
+    /// to show "cancelled" would miss it and report the user's own Stop as a severe error. The
+    /// service translates it; this test is what says so.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ARunningStatementIsActuallyInterrupted()
+    {
+        using var cts = new CancellationTokenSource();
+        var messages = new List<string>();
+
+        var started = Stopwatch.StartNew();
+        var run = Service().ExecuteRestoreWithProgressAsync(
+            TestServer(),
+            "WAITFOR DELAY '00:00:30'",
+            messages.Add,
+            cts.Token);
+
+        await Task.Delay(1000);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run);
+        started.Stop();
+
+        Assert.True(started.Elapsed < TimeSpan.FromSeconds(15),
+            $"Cancellation did not reach the server - the statement ran for {started.Elapsed}.");
+
+        // The user should read "cancelled", not "failed", in the execution console.
+        Assert.Contains(messages, m => m.Contains("Cancelled during statement", StringComparison.Ordinal));
+        Assert.DoesNotContain(messages, m => m.Contains("FAILED", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The other half of the translation: a genuine SqlException must still surface as a failure.
+    /// Guarding only on the token means an unrelated severe error is not mislabelled as the user
+    /// having pressed Stop.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ARealFailureIsStillAFailureNotACancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var messages = new List<string>();
+
+        await Assert.ThrowsAsync<Microsoft.Data.SqlClient.SqlException>(() =>
+            Service().ExecuteRestoreWithProgressAsync(
+                TestServer(),
+                "RESTORE DATABASE [NineLives_NoSuchDb] FROM DISK = 'Z:\\nope.bak'",
+                messages.Add,
+                cts.Token));
+
+        Assert.Contains(messages, m => m.Contains("FAILED on statement", StringComparison.Ordinal));
+    }
+
+    [RequiresSqlFact]
+    public async Task ATokenCancelledBeforehandStopsBeforeAnythingRuns()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            Service().ExecuteRestoreWithProgressAsync(
+                TestServer(), "SELECT 1", null, cts.Token));
+    }
+
+    [RequiresSqlFact]
+    public async Task AnUncancelledRunStillCompletesNormally()
+    {
+        // The obvious regression: threading a token through must not break the ordinary path.
+        using var cts = new CancellationTokenSource();
+        var messages = new List<string>();
+
+        await Service().ExecuteRestoreWithProgressAsync(
+            TestServer(), "SELECT 1", messages.Add, cts.Token);
+
+        Assert.NotEmpty(messages);
+    }
+}
+
+/// <summary>Cancelling a blob listing, which is the other unbounded operation.</summary>
+public class BlobCancellationTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-cancel-tests", Guid.NewGuid().ToString("n"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task AListingWithAnAlreadyCancelledTokenDoesNotRun()
+    {
+        var store = new CredentialStore(_dir);
+        var container = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "ninelives-test-cancel",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups",
+            UnsavedSasToken = "sv=2024-11-04&sig=not-real"
+        };
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Cancelled before any network call, so this fails on the token rather than on the
+        // unreachable account - which is what proves the token is consulted at all.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new BlobStorageService(store).ListBackupFilesAsync(container, cts.Token));
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -192,6 +192,74 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
         });
     }
 
+    /// <summary>
+    /// The Stop button that appears while a restore is running (#25). It is the only way to
+    /// interrupt a restore aimed at the wrong server, so a binding that silently failed would
+    /// leave the user back at killing the process.
+    /// </summary>
+    [Fact]
+    public void TheStopRestoreButtonAppearsAndBindsWhileExecuting()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            // The execute card only exists once backups are loaded, which is correct - there is
+            // no script to run before then.
+            vm.BackupsLoaded = true;
+            vm.HasScript = true;
+            vm.IsConnectedToServer = true;
+            var view = new RestoreView { DataContext = vm };
+
+            // Not running: nothing to stop, so the button must not be offered.
+            vm.CanCancelExecute = false;
+            Realise(view);
+            Assert.DoesNotContain(VisibleButtons(view), b => (b.Content as string) == "Stop restore");
+
+            vm.CanCancelExecute = true;
+            Realise(view);
+
+            var stop = Assert.Single(VisibleButtons(view), b => (b.Content as string) == "Stop restore");
+            Assert.NotNull(stop.Command);
+        });
+    }
+
+    /// <summary>The Cancel button over the loading overlay, for a long container listing (#25).</summary>
+    [Fact]
+    public void TheCancelLoadButtonAppearsAndBindsWhileLoading()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.IsBusy = true;
+            vm.CanCancelLoad = true;
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            var cancel = Assert.Single(VisibleButtons(view), b => (b.Content as string) == "Cancel");
+            Assert.NotNull(cancel.Command);
+        });
+    }
+
+    [Fact]
+    public void TheBrowserCancelButtonAppearsAndBindsWhileLoading()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BlobBrowserViewModel(new BlobStorageService(Store()), Store())
+            {
+                IsBusy = true,
+                CanCancelLoad = true
+            };
+
+            var view = new BlobBrowserView { DataContext = vm };
+            Realise(view);
+
+            var cancel = Assert.Single(VisibleButtons(view), b => (b.Content as string) == "Cancel");
+            Assert.NotNull(cancel.Command);
+        });
+    }
+
     /// <summary>The inventory warnings panel added with #46 - separate from the chain issues one.</summary>
     [Fact]
     public void TheInventoryPanelShowsItsFindings()
@@ -276,6 +344,26 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
             new BackupChainBuilder(),
             new RestoreScriptGenerator(),
             store);
+    }
+
+    /// <summary>
+    /// Buttons that would be on screen. A collapsed element still exists in the visual tree, so
+    /// asserting a button is absent means asserting it is not shown, not that it is missing.
+    ///
+    /// Uses Visibility rather than IsVisible: IsVisible is false for everything until the element
+    /// is attached to a rendered window, and these tests never show one.
+    /// </summary>
+    private static List<Button> VisibleButtons(DependencyObject root)
+        => FindAll<Button>(root).Where(IsShown).ToList();
+
+    private static bool IsShown(FrameworkElement element)
+    {
+        for (DependencyObject? node = element; node != null;
+             node = System.Windows.Media.VisualTreeHelper.GetParent(node))
+        {
+            if (node is UIElement { Visibility: not Visibility.Visible }) return false;
+        }
+        return true;
     }
 
     private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject

--- a/src/NineLives/Services/OperationCancellation.cs
+++ b/src/NineLives/Services/OperationCancellation.cs
@@ -1,0 +1,66 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// The token source behind one cancellable operation, and the bookkeeping that goes with it (#25).
+///
+/// Every service method in this app already takes a CancellationToken; none of them were ever
+/// given a real one. This is the missing half - a viewmodel holds one of these per long-running
+/// operation, hands <see cref="Begin"/> to the service, and exposes <see cref="Cancel"/> to a
+/// button.
+///
+/// Kept as its own type rather than a loose CancellationTokenSource field because the lifecycle is
+/// where the bugs are: reusing a cancelled source silently cancels the next run before it starts,
+/// and disposing one that a callback still holds throws. Doing it once, here, means the viewmodels
+/// cannot each get it subtly wrong.
+///
+/// Not thread-safe by design: it is driven from the UI thread.
+/// </summary>
+public sealed class OperationCancellation
+{
+    private CancellationTokenSource? _current;
+
+    /// <summary>True while an operation is running and has not already been asked to stop.</summary>
+    public bool CanCancel => _current is { IsCancellationRequested: false };
+
+    /// <summary>True once Cancel has been called and before the operation has finished unwinding.</summary>
+    public bool IsCancelling => _current is { IsCancellationRequested: true };
+
+    /// <summary>
+    /// Starts a new operation and returns its token. Any previous source is cancelled and disposed
+    /// first, so a run that was somehow left open cannot outlive the one replacing it.
+    /// </summary>
+    public CancellationToken Begin()
+    {
+        Cancel();
+        Dispose();
+
+        _current = new CancellationTokenSource();
+        return _current.Token;
+    }
+
+    /// <summary>Asks the running operation to stop. Safe to call when nothing is running.</summary>
+    public void Cancel()
+    {
+        if (_current is { IsCancellationRequested: false } cts)
+        {
+            // Between the check and the call the source could already be disposed by a racing
+            // End(); the operation is over either way, which is what Cancel wanted.
+            try { cts.Cancel(); } catch (ObjectDisposedException) { }
+        }
+    }
+
+    /// <summary>
+    /// Marks the operation finished. Called from a finally block, so it must not throw whatever
+    /// state things are in.
+    /// </summary>
+    public void End()
+    {
+        Dispose();
+        _current = null;
+    }
+
+    private void Dispose()
+    {
+        try { _current?.Dispose(); } catch (ObjectDisposedException) { }
+    }
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -410,6 +410,20 @@ public class SqlServerService
             {
                 await cmd.ExecuteNonQueryAsync(ct);
             }
+            catch (SqlException) when (ct.IsCancellationRequested)
+            {
+                // SqlClient reports a command cancelled mid-flight as a SqlException - "A severe
+                // error occurred on the current command. The results, if any, should be discarded.
+                // Operation cancelled by user." - and NOT as an OperationCanceledException. Left
+                // alone, a caller who catches OperationCanceledException to show "cancelled"
+                // misses it entirely and tells the user their own Stop was a severe error.
+                //
+                // Only when the token was actually signalled, so a genuine severe error still
+                // propagates as the failure it is.
+                messageCallback?.Invoke(
+                    $"Cancelled during statement {i + 1} of {executable.Count}: {Summarize(statement)}");
+                throw new OperationCanceledException("The restore was cancelled.", ct);
+            }
             catch (SqlException)
             {
                 // Say WHICH step of the chain failed before it propagates. Without this the

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -11,6 +11,11 @@ public partial class BlobBrowserViewModel : ViewModelBase
 {
     private readonly BlobStorageService _blobService;
     private readonly CredentialStore _credentialStore;
+    private readonly OperationCancellation _loadCancellation = new();
+
+    /// <summary>True while a listing is running and has not been asked to stop (#25).</summary>
+    [ObservableProperty]
+    private bool _canCancelLoad;
 
     private List<BackupFileInfo> _allFiles = [];
     private List<BackupSet> _allSets = [];
@@ -135,11 +140,13 @@ public partial class BlobBrowserViewModel : ViewModelBase
             return;
         }
 
+        var ct = _loadCancellation.Begin();
         IsBusy = true;
+        CanCancelLoad = true;
         ClearStatus();
         try
         {
-            _allFiles = await _blobService.ListBackupFilesAsync(SelectedContainer);
+            _allFiles = await _blobService.ListBackupFilesAsync(SelectedContainer, ct);
             _allSets = _blobService.GroupIntoBackupSets(_allFiles);
             HasFiles = _allFiles.Count > 0;
 
@@ -158,6 +165,12 @@ public partial class BlobBrowserViewModel : ViewModelBase
             UpdateFilteredSummary();
             SetStatus($"Loaded {_allFiles.Count} files in {_allSets.Count} backup set(s) across {dbs.Count} database(s).");
         }
+        catch (OperationCanceledException)
+        {
+            // Listing is read-only, so there is nothing to undo or explain - just say it stopped.
+            SetStatus("Loading cancelled.");
+            HasFiles = false;
+        }
         catch (Exception ex)
         {
             SetError($"Failed to load backups: {ex.Message}");
@@ -165,8 +178,22 @@ public partial class BlobBrowserViewModel : ViewModelBase
         }
         finally
         {
+            _loadCancellation.End();
             IsBusy = false;
+            CanCancelLoad = false;
         }
+    }
+
+    /// <summary>
+    /// Stops an in-progress listing. A container with a large number of blobs is enumerated a page
+    /// at a time with no natural end, and until now there was no way out of it (#25).
+    /// </summary>
+    [RelayCommand]
+    private void CancelLoad()
+    {
+        _loadCancellation.Cancel();
+        CanCancelLoad = false;
+        SetStatus("Cancelling...");
     }
 
     private void RefreshDatabasesForServer()

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -11,6 +11,11 @@ public partial class BlobConfigViewModel : ViewModelBase
 {
     private readonly CredentialStore _credentialStore;
     private readonly BlobStorageService _blobService;
+    private readonly OperationCancellation _testCancellation = new();
+
+    /// <summary>True while a connection test is running and has not been asked to stop (#25).</summary>
+    [ObservableProperty]
+    private bool _canCancelTest;
 
     [ObservableProperty]
     private ObservableCollection<BlobContainerConfig> _containers = [];
@@ -540,16 +545,26 @@ public partial class BlobConfigViewModel : ViewModelBase
 
         if (config == null) return;
 
+        // Test Connection sounds quick, but it enumerates the whole container to build the summary
+        // - 4000+ blobs on a real one - so it needs the same escape as the other listings (#25).
+        var ct = _testCancellation.Begin();
         IsBusy = true;
+        CanCancelTest = true;
         TestResult = string.Empty;
         try
         {
-            await _blobService.VerifyConnectionAsync(config);
-            var files = await _blobService.ListBackupFilesAsync(config);
+            await _blobService.VerifyConnectionAsync(config, ct);
+            var files = await _blobService.ListBackupFilesAsync(config, ct);
             var summary = _blobService.GetContainerSummary(files);
             ContainerSummary = summary;
             TestSuccess = true;
             TestResult = $"Connected! {summary.TotalFiles} files found ({summary.TotalSizeDisplay})";
+        }
+        catch (OperationCanceledException)
+        {
+            TestSuccess = false;
+            TestResult = "Cancelled.";
+            ContainerSummary = null;
         }
         catch (Exception ex)
         {
@@ -559,7 +574,18 @@ public partial class BlobConfigViewModel : ViewModelBase
         }
         finally
         {
+            _testCancellation.End();
             IsBusy = false;
+            CanCancelTest = false;
         }
+    }
+
+    /// <summary>Stops an in-progress connection test.</summary>
+    [RelayCommand]
+    private void CancelTest()
+    {
+        _testCancellation.Cancel();
+        CanCancelTest = false;
+        TestResult = "Cancelling...";
     }
 }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -23,6 +23,11 @@ public partial class RestoreViewModel : ViewModelBase
     private List<BackupSet> _allSets = [];
     private List<BackupSet> _dbSets = [];
 
+    // Two separate operations, two separate sources: browsing a container and running a restore
+    // can both be in flight, and cancelling one must not touch the other (#25).
+    private readonly OperationCancellation _loadCancellation = new();
+    private readonly OperationCancellation _executeCancellation = new();
+
     #region Observable Properties
 
     [ObservableProperty]
@@ -188,6 +193,28 @@ public partial class RestoreViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _hasRecoveryActions;
+
+    // ── Cancellation (#25) ──────────────────────────────────────────────────────
+
+    /// <summary>True while a backup listing is running and has not been asked to stop.</summary>
+    [ObservableProperty]
+    private bool _canCancelLoad;
+
+    /// <summary>True while a restore is running and has not been asked to stop.</summary>
+    [ObservableProperty]
+    private bool _canCancelExecute;
+
+    /// <summary>True between asking to stop and the operation actually unwinding.</summary>
+    [ObservableProperty]
+    private bool _isCancelling;
+
+    /// <summary>Pushes the cancellation sources' state onto the bound properties.</summary>
+    private void RefreshCancelState()
+    {
+        CanCancelLoad = _loadCancellation.CanCancel;
+        CanCancelExecute = _executeCancellation.CanCancel;
+        IsCancelling = _loadCancellation.IsCancelling || _executeCancellation.IsCancelling;
+    }
 
     /// <summary>True once the chain has been checked against RESTORE HEADERONLY metadata.</summary>
     [ObservableProperty]
@@ -528,11 +555,13 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
+        var ct = _loadCancellation.Begin();
         IsBusy = true;
+        RefreshCancelState();
         ClearStatus();
         try
         {
-            _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer);
+            _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer, ct);
             _allSets = _blobService.GroupIntoBackupSets(_allBackups);
 
             var servers = _blobService.GetDiscoveredServers(_allBackups);
@@ -562,6 +591,13 @@ public partial class RestoreViewModel : ViewModelBase
 
             SetStatus($"Loaded {_allBackups.Count} files in {_allSets.Count} backup set(s) across {dbs.Count} database(s).");
         }
+        catch (OperationCanceledException)
+        {
+            // Asked for, not a failure. Nothing was written anywhere - listing is read-only - so
+            // there is nothing to explain beyond saying it stopped.
+            SetStatus("Loading cancelled.");
+            BackupsLoaded = false;
+        }
         catch (Exception ex)
         {
             SetError($"Failed to load backups: {ex.Message}");
@@ -569,8 +605,19 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _loadCancellation.End();
             IsBusy = false;
+            RefreshCancelState();
         }
+    }
+
+    /// <summary>Stops an in-progress backup listing.</summary>
+    [RelayCommand]
+    private void CancelLoad()
+    {
+        _loadCancellation.Cancel();
+        RefreshCancelState();
+        SetStatus("Cancelling...");
     }
 
     private void ComputeAndDisplayRestorePoints()
@@ -1343,9 +1390,13 @@ public partial class RestoreViewModel : ViewModelBase
         IsExecuteArmed = false;
         ExecuteButtonText = "Execute on Server";
 
+        var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
         ExecutionComplete = false;
         ExecutionLog = string.Empty;
+        RecoveryActions = [];
+        HasRecoveryActions = false;
+        RefreshCancelState();
 
         try
         {
@@ -1421,11 +1472,30 @@ public partial class RestoreViewModel : ViewModelBase
             await _sqlService.ExecuteRestoreWithProgressAsync(
                 server,
                 GeneratedScript,
-                msg => Application.Current.Dispatcher.Invoke(() => AppendLog(msg)));
+                msg => Application.Current.Dispatcher.Invoke(() => AppendLog(msg)),
+                executeToken);
 
             ExecutionSuccess = true;
             AppendLog("\nRestore completed successfully!");
             SetStatus("Restore execution completed successfully.");
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancelling a restore is not the same as never having run it. SqlCommand.Cancel stops
+            // the client waiting and SQL Server rolls back the statement that was in flight, but
+            // the target stays mid-restore - so this must be as loud as a failure, and it goes
+            // through the same recovery guidance (#14, #25).
+            ExecutionSuccess = false;
+            AppendLog("\nCANCELLED. The statement in flight was rolled back by SQL Server, but the " +
+                      "restore stopped part-way through the chain.");
+
+            App.Log.ServerChange(ConnectedServer?.ServerName ?? "unknown",
+                $"restore CANCELLED by user, target [{TargetDatabaseName}]");
+
+            SetError("Restore cancelled. The target database has been left mid-restore - see below.");
+
+            if (ConnectedServer != null)
+                await ReportRecoveryStateAsync(ConnectedServer);
         }
         catch (Exception ex)
         {
@@ -1440,9 +1510,28 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _executeCancellation.End();
             IsExecuting = false;
             ExecutionComplete = true;
+            RefreshCancelState();
         }
+    }
+
+    /// <summary>
+    /// Stops a running restore.
+    ///
+    /// Deliberately worded as a warning rather than a neutral action: stopping a restore part-way
+    /// leaves the target database in RESTORING, which is not a state anyone wants to discover by
+    /// accident. The recovery panel that appears afterwards explains how to get out of it.
+    /// </summary>
+    [RelayCommand]
+    private void CancelExecute()
+    {
+        if (!_executeCancellation.CanCancel) return;
+
+        _executeCancellation.Cancel();
+        RefreshCancelState();
+        AppendLog("\nCancellation requested - waiting for SQL Server to roll back the current statement...");
     }
 
     /// <summary>

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -243,6 +243,14 @@
                         <TextBlock Text="Loading backup files..."
                                    Style="{StaticResource BodyText}"
                                    HorizontalAlignment="Center" />
+                        <!-- A container with a large number of blobs is enumerated a page at a
+                             time and there was previously no way out of it (#25). -->
+                        <Button Content="Cancel"
+                                Style="{StaticResource SecondaryButton}"
+                                Command="{Binding CancelLoadCommand}"
+                                Visibility="{Binding CanCancelLoad, Converter={StaticResource BoolToVis}}"
+                                Padding="10,6" Margin="0,10,0,0"
+                                HorizontalAlignment="Center" />
                     </StackPanel>
                 </Border>
             </Grid>

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -204,6 +204,13 @@
                                             Style="{StaticResource PrimaryButton}"
                                             Command="{Binding TestConnectionCommand}"
                                             Margin="0,0,8,0" />
+                                    <!-- "Stop test" rather than "Cancel": there is already a
+                                         Cancel on this screen and it means cancel the edit. -->
+                                    <Button Content="Stop test"
+                                            Style="{StaticResource SecondaryButton}"
+                                            Command="{Binding CancelTestCommand}"
+                                            Visibility="{Binding CanCancelTest, Converter={StaticResource BoolToVis}}"
+                                            Margin="0,0,8,0" />
                                     <Button Content="Delete"
                                             Style="{StaticResource DangerButton}"
                                             Command="{Binding DeleteCommand}" />
@@ -606,6 +613,11 @@
                                 <Button Content="Test Connection"
                                         Style="{StaticResource PrimaryButton}"
                                         Command="{Binding TestConnectionCommand}"
+                                        Margin="0,0,8,0" />
+                                <Button Content="Stop test"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Command="{Binding CancelTestCommand}"
+                                        Visibility="{Binding CanCancelTest, Converter={StaticResource BoolToVis}}"
                                         Margin="0,0,8,0" />
                                 <Button Content="Cancel"
                                         Style="{StaticResource SecondaryButton}"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -884,6 +884,17 @@
                                 Command="{Binding ExecuteScriptCommand}"
                                 IsEnabled="{Binding IsConnectedToServer}"
                                 MinWidth="140" />
+
+                        <!-- Only while a restore is actually running. Until now the only way to
+                             stop one aimed at the wrong server was to kill the process, which
+                             leaves the database mid-restore with nothing written down (#25). -->
+                        <Button Content="Stop restore"
+                                Style="{StaticResource SecondaryButton}"
+                                Command="{Binding CancelExecuteCommand}"
+                                Visibility="{Binding CanCancelExecute, Converter={StaticResource BoolToVis}}"
+                                Margin="8,0,0,0"
+                                MinWidth="110"
+                                ToolTip="Asks SQL Server to abort the statement in flight. It rolls that statement back, but the target database is left mid-restore and will need recovering - the app will tell you how." />
                     </StackPanel>
 
                     <!-- Execute armed warning. The server's tags appear here deliberately: this is
@@ -1025,7 +1036,15 @@
             <!-- Loading -->
             <Border Background="#80000000" CornerRadius="6"
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}" Padding="20">
-                <TextBlock Text="Loading..." Style="{StaticResource BodyText}" HorizontalAlignment="Center" />
+                <StackPanel HorizontalAlignment="Center">
+                    <TextBlock Text="Loading..." Style="{StaticResource BodyText}" HorizontalAlignment="Center" />
+                    <Button Content="Cancel"
+                            Style="{StaticResource SecondaryButton}"
+                            Command="{Binding CancelLoadCommand}"
+                            Visibility="{Binding CanCancelLoad, Converter={StaticResource BoolToVis}}"
+                            Padding="10,6" Margin="0,10,0,0"
+                            HorizontalAlignment="Center" />
+                </StackPanel>
             </Border>
 
             <!-- Status -->


### PR DESCRIPTION
Closes #25.

Every service method already took a `CancellationToken`. **None of them was ever given a real one.** A restore aimed at the wrong server could only be stopped by killing the process — which leaves the database mid-restore and writes nothing down about what happened.

## What's cancellable now

| Operation | Where |
|---|---|
| Restore execution | **Stop restore** button, next to Execute, only while running |
| Backup listing | **Cancel** on the loading overlay — restore view |
| Backup listing | **Cancel** on the loading overlay — browse view |
| Connection test | **Stop test** — blob config |

Test Connection is included because it *sounds* quick but enumerates the whole container — 4,380 blobs on the real one — so it has exactly the problem the issue describes.

`OperationCancellation` owns the token source lifecycle in one place, because that's where the bugs are: reusing a cancelled source silently cancels the *next* run before it starts, and disposing one a callback still holds throws. Doing it once means four call sites can't each get it subtly wrong.

## The live test found a real bug in my first cut

This is the part worth reading. **SqlClient reports a command cancelled mid-flight as a `SqlException`**, not an `OperationCanceledException`:

```
Microsoft.Data.SqlClient.SqlException : A severe error occurred on the current command.
The results, if any, should be discarded.
Operation cancelled by user.
```

My ViewModel catches `OperationCanceledException` to show "cancelled" — so as written, pressing **Stop restore** would have told the user their own action was *"Restore failed: A severe error occurred on the current command"*. Exactly the wrong message at exactly the wrong moment.

The service now translates it, **guarded on `ct.IsCancellationRequested`** so a genuine severe error still surfaces as the failure it is. Both directions are tested.

## Cancelling a restore is treated as seriously as a failure

Because it is. SQL Server rolls back the statement in flight, but the target is left in `RESTORING`. So cancelling:

- says so plainly in the execution log, rather than reporting success
- logs a `CHANGE` entry naming the server and target
- goes through the **same recovery guidance added in #14** — so you get `RESTORE DATABASE ... WITH RECOVERY` offered, with what it commits you to

The button tooltip says this up front rather than letting you find out afterwards.

## Tests

19 new. The ones that matter:

- **`ARunningStatementIsActuallyInterrupted`** — runs `WAITFOR DELAY '00:00:30'` against a real instance, cancels after a second, and asserts it stopped in under 15. If the token weren't reaching the driver this would take the full 30. It also pins the exception type and asserts the console says "Cancelled", not "FAILED".
- **`ARealFailureIsStillAFailureNotACancellation`** — the other direction, so the translation can't swallow genuine errors.
- **`ANewOperationAfterACancelledOneStartsClean`** — the lifecycle bug that would make a second restore attempt fail instantly for no visible reason.
- Three XAML tests that the new buttons appear only when they should, and resolve their commands.

**531 tests pass**, build clean at `-warnaserror`.
