### PR TITLE
Push blob listings down to Azure as prefixes, and show progress (#28)

### DIFF
--- a/src/NineLives.Tests/BlobPrefixTests.cs
+++ b/src/NineLives.Tests/BlobPrefixTests.cs
@@ -1,0 +1,181 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Deriving Azure prefixes from a path pattern (#28).
+///
+/// The failure that matters here is asymmetric. Deriving too BROAD a prefix costs a little speed;
+/// deriving too NARROW a one silently returns fewer backups than exist, which on the restore
+/// screen means a restore point disappearing with no error. So the rule under test throughout is:
+/// when a safe prefix cannot be proven, return null and let the caller scan everything.
+/// </summary>
+public class BlobPrefixTests
+{
+    private const string Default = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
+    private static readonly string[] Types = ["FULL", "DIFF", "LOG"];
+
+    // ── the default pattern, which is the common case ───────────────────────────
+
+    [Fact]
+    public void ServerAndDatabaseGiveOnePrefixPerBackupType()
+    {
+        var prefixes = BlobPrefix.Derive(Default, "SRV01", "Sales", Types);
+
+        Assert.Equal(
+            ["FULL/SRV01/Sales/", "DIFF/SRV01/Sales/", "LOG/SRV01/Sales/"],
+            prefixes);
+    }
+
+    [Fact]
+    public void ServerAloneStopsAtTheServerLevel()
+    {
+        var prefixes = BlobPrefix.Derive(Default, "SRV01", null, Types);
+
+        Assert.Equal(["FULL/SRV01/", "DIFF/SRV01/", "LOG/SRV01/"], prefixes);
+    }
+
+    /// <summary>
+    /// {ServerName} comes before {DatabaseName}, so a database without a server cannot be
+    /// expressed as a prefix - the segment in between is unknown. Falling back is the only correct
+    /// answer; guessing would drop every other server's copy of that database.
+    /// </summary>
+    [Fact]
+    public void DatabaseWithoutServerCannotBeScopedPastTheBackupType()
+    {
+        var prefixes = BlobPrefix.Derive(Default, null, "Sales", Types);
+
+        Assert.Equal(["FULL/", "DIFF/", "LOG/"], prefixes);
+    }
+
+    /// <summary>
+    /// {BackupType} leads the default pattern, so with no folder names there is nothing to build
+    /// on. This is the case the issue flagged as a blocker; one cheap hierarchy call solves it.
+    /// </summary>
+    [Fact]
+    public void WithoutBackupTypeFoldersTheDefaultPatternCannotBeScoped()
+        => Assert.Null(BlobPrefix.Derive(Default, "SRV01", "Sales", backupTypeFolders: null));
+
+    [Fact]
+    public void AnEmptyFolderListIsTreatedTheSameAsNone()
+        => Assert.Null(BlobPrefix.Derive(Default, "SRV01", "Sales", []));
+
+    // ── other layouts ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void APatternLedByServerNeedsNoBackupTypeFolders()
+    {
+        var prefixes = BlobPrefix.Derive(
+            "{ServerName}/{DatabaseName}/{BackupType}/{FileName}", "SRV01", "Sales");
+
+        Assert.Equal(["SRV01/Sales/"], prefixes);
+    }
+
+    [Fact]
+    public void LiteralSegmentsAreAlwaysKnown()
+    {
+        var prefixes = BlobPrefix.Derive(
+            "sqlbackups/{ServerName}/{DatabaseName}/{FileName}", "SRV01", "Sales");
+
+        Assert.Equal(["sqlbackups/SRV01/Sales/"], prefixes);
+    }
+
+    [Fact]
+    public void ALiteralPrefixIsUsableEvenWithNoFilterAtAll()
+    {
+        // Still narrows the listing, and costs nothing.
+        var prefixes = BlobPrefix.Derive("sqlbackups/{ServerName}/{FileName}", null, null);
+
+        Assert.Equal(["sqlbackups/"], prefixes);
+    }
+
+    [Fact]
+    public void AnUnknownTokenStopsTheDerivation()
+    {
+        // {InstanceName} has no value to hand, so nothing past it is predictable.
+        var prefixes = BlobPrefix.Derive(
+            "{ServerName}/{InstanceName}/{DatabaseName}/{FileName}", "SRV01", "Sales");
+
+        Assert.Equal(["SRV01/"], prefixes);
+    }
+
+    [Fact]
+    public void ClusterAndAgTokensAreTreatedAsTheServerSegment()
+    {
+        var prefixes = BlobPrefix.Derive(
+            "{BackupType}/{ClusterName$AgName}/{DatabaseName}/{FileName}",
+            "clu01$AG1", "Sales", Types);
+
+        Assert.Equal(
+            ["FULL/clu01$AG1/Sales/", "DIFF/clu01$AG1/Sales/", "LOG/clu01$AG1/Sales/"],
+            prefixes);
+    }
+
+    [Fact]
+    public void NothingAfterTheFileNameSegmentIsUsed()
+    {
+        var prefixes = BlobPrefix.Derive("{ServerName}/{FileName}/{DatabaseName}", "SRV01", "Sales");
+
+        Assert.Equal(["SRV01/"], prefixes);
+    }
+
+    // ── falling back ────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AnEmptyPatternFallsBack(string? pattern)
+        => Assert.Null(BlobPrefix.Derive(pattern, "SRV01", "Sales", Types));
+
+    [Fact]
+    public void APatternThatIsNothingButUnknownTokensFallsBack()
+        => Assert.Null(BlobPrefix.Derive("{FileName}", "SRV01", "Sales", Types));
+
+    [Fact]
+    public void APatternLedByAnUnknownTokenFallsBack()
+        => Assert.Null(BlobPrefix.Derive("{InstanceName}/{DatabaseName}", "SRV01", "Sales", Types));
+
+    /// <summary>
+    /// Flat Ola AG naming puts every file at the container root with the structure encoded in the
+    /// filename, so there is nothing to prefix on and the scan must stay full.
+    /// </summary>
+    [Theory]
+    [InlineData(BackupSourceType.Standalone, true)]
+    [InlineData(BackupSourceType.AvailabilityGroup, false)]
+    [InlineData(BackupSourceType.Mixed, false)]
+    public void OnlyStandaloneLayoutsSupportPrefixes(BackupSourceType type, bool expected)
+        => Assert.Equal(expected, BlobPrefix.SupportsPrefixes(type));
+
+    // ── the scope object ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnEmptyScopeIsRecognisedAsEmpty()
+    {
+        Assert.False(new BlobListingScope().HasAnything);
+        Assert.False(new BlobListingScope("", "  ").HasAnything);
+        Assert.True(new BlobListingScope("SRV01").HasAnything);
+        Assert.True(new BlobListingScope(null, "Sales").HasAnything);
+    }
+
+    // ── the prefixes match what the real container actually holds ───────────────
+
+    [Fact]
+    public void TheDerivedPrefixesMatchTheRealLayout()
+    {
+        // Exactly the shape measured against the live container: DIFF/, FULL/ and LOG/ at the top,
+        // then server, then database. If this ever stops matching, the optimisation is silently
+        // scoping to paths that do not exist and returning nothing.
+        var prefixes = BlobPrefix.Derive(Default, "centaur-sql-001", "Utility", ["DIFF", "FULL", "LOG"]);
+
+        Assert.Equal(
+            [
+                "DIFF/centaur-sql-001/Utility/",
+                "FULL/centaur-sql-001/Utility/",
+                "LOG/centaur-sql-001/Utility/"
+            ],
+            prefixes);
+    }
+}

--- a/src/NineLives/Services/BlobListingScope.cs
+++ b/src/NineLives/Services/BlobListingScope.cs
@@ -1,0 +1,18 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Narrows a blob listing to one server and/or database, so the filter can be pushed down to Azure
+/// as a prefix rather than applied after everything has been downloaded (#28).
+///
+/// A hint, never a contract. Passing a scope the container's layout cannot honour is safe - the
+/// listing falls back to a full scan and returns the same files it always did. What must never
+/// happen is the reverse: a scope that quietly excludes backups that do exist, because on the
+/// restore screen a missing backup is a missing restore point.
+/// </summary>
+/// <param name="ServerName">Server as it appears in the path, or null for all.</param>
+/// <param name="DatabaseName">Database as it appears in the path, or null for all.</param>
+public sealed record BlobListingScope(string? ServerName = null, string? DatabaseName = null)
+{
+    public bool HasAnything =>
+        !string.IsNullOrWhiteSpace(ServerName) || !string.IsNullOrWhiteSpace(DatabaseName);
+}

--- a/src/NineLives/Services/BlobPrefix.cs
+++ b/src/NineLives/Services/BlobPrefix.cs
@@ -1,0 +1,118 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Works out which Azure blob prefixes can serve a given filter, so listing does not have to walk
+/// the whole container and throw most of it away client-side (#28).
+///
+/// Measured against a real 4,440-blob container: an unprefixed listing takes about 1,075 ms, while
+/// listing one database across the three backup-type folders takes about 233 ms. The ratio is not
+/// the interesting part - the scaling is. A full scan grows with every server, database and day of
+/// retention; a scoped listing grows only with the one database being restored.
+///
+/// Everything here is pure string work so it can be tested without touching Azure. Getting it
+/// wrong silently returns FEWER backups than exist, which on this screen means a restore point
+/// quietly disappearing - so the rule throughout is to return null (meaning "scan everything")
+/// whenever a safe prefix cannot be proven.
+/// </summary>
+public static class BlobPrefix
+{
+    /// <summary>
+    /// The prefixes to list for a filter, or null when no safe prefix exists and the caller must
+    /// scan the whole container.
+    /// </summary>
+    /// <param name="pathPattern">The container's configured pattern, e.g. {BackupType}/{ServerName}/{DatabaseName}/{FileName}.</param>
+    /// <param name="serverName">Selected server, or null for all.</param>
+    /// <param name="databaseName">Selected database, or null for all.</param>
+    /// <param name="backupTypeFolders">
+    /// Folder names standing in for {BackupType} - normally the container's top-level folders. When
+    /// the pattern needs {BackupType} and this is empty, no prefix can be derived.
+    /// </param>
+    public static IReadOnlyList<string>? Derive(
+        string? pathPattern,
+        string? serverName,
+        string? databaseName,
+        IReadOnlyCollection<string>? backupTypeFolders = null)
+    {
+        if (string.IsNullOrWhiteSpace(pathPattern)) return null;
+
+        var segments = pathPattern.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0) return null;
+
+        // One prefix under construction, or several once {BackupType} fans out.
+        var prefixes = new List<string> { string.Empty };
+        var anythingKnown = false;
+
+        foreach (var segment in segments)
+        {
+            // {FileName} is the leaf. Everything after it is meaningless as a prefix, and the leaf
+            // itself is never known in advance.
+            if (Is(segment, "{FileName}")) break;
+
+            if (!IsToken(segment))
+            {
+                // A literal path element - always known.
+                prefixes = Append(prefixes, segment);
+                anythingKnown = true;
+                continue;
+            }
+
+            if (Is(segment, "{BackupType}"))
+            {
+                if (backupTypeFolders is not { Count: > 0 }) break;
+
+                // Fan out: one prefix per backup-type folder. This is what makes the default
+                // pattern usable at all, since {BackupType} leads it and would otherwise stop the
+                // derivation on the very first segment.
+                prefixes = backupTypeFolders
+                    .SelectMany(folder => Append(prefixes, folder))
+                    .ToList();
+                anythingKnown = true;
+                continue;
+            }
+
+            if (Is(segment, "{ServerName}") || Is(segment, "{ClusterName$AgName}") || Is(segment, "{ClusterName_AgName}"))
+            {
+                if (string.IsNullOrWhiteSpace(serverName)) break;
+                prefixes = Append(prefixes, serverName);
+                anythingKnown = true;
+                continue;
+            }
+
+            if (Is(segment, "{DatabaseName}"))
+            {
+                if (string.IsNullOrWhiteSpace(databaseName)) break;
+                prefixes = Append(prefixes, databaseName);
+                anythingKnown = true;
+                continue;
+            }
+
+            // Any other token - {InstanceName}, {AgName}, something new - has no value to hand, so
+            // the path stops being predictable here.
+            break;
+        }
+
+        if (!anythingKnown) return null;
+
+        // A single empty prefix is the same as no prefix; say so plainly rather than issuing a
+        // listing that pretends to be scoped.
+        var result = prefixes.Where(p => p.Length > 0).Distinct(StringComparer.Ordinal).ToList();
+        return result.Count > 0 ? result : null;
+    }
+
+    /// <summary>
+    /// True when a container's layout can be prefix-scoped at all. Flat Ola AG naming puts every
+    /// file at the container root with the structure encoded in the filename, so there is nothing
+    /// to prefix on.
+    /// </summary>
+    public static bool SupportsPrefixes(Models.BackupSourceType sourceType) =>
+        sourceType == Models.BackupSourceType.Standalone;
+
+    private static List<string> Append(List<string> prefixes, string segment)
+        => prefixes.Select(p => $"{p}{segment}/").ToList();
+
+    private static bool IsToken(string segment)
+        => segment.StartsWith('{') && segment.EndsWith('}');
+
+    private static bool Is(string segment, string token)
+        => segment.Equals(token, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -42,14 +42,92 @@ public class BlobStorageService
         return true;
     }
 
-    public async Task<List<BackupFileInfo>> ListBackupFilesAsync(
+    /// <summary>The container's top-level folders, read without listing a single blob.</summary>
+    public async Task<List<string>> ListTopLevelFoldersAsync(
         BlobContainerConfig config, CancellationToken ct = default)
+    {
+        var client = CreateClient(config);
+        var folders = new List<string>();
+
+        await foreach (var item in client.GetBlobsByHierarchyAsync(
+            BlobTraits.None, BlobStates.None, delimiter: "/", prefix: null, cancellationToken: ct))
+        {
+            if (item.IsPrefix) folders.Add(item.Prefix.TrimEnd('/'));
+        }
+
+        return folders;
+    }
+
+    public Task<List<BackupFileInfo>> ListBackupFilesAsync(
+        BlobContainerConfig config, CancellationToken ct = default)
+        => ListBackupFilesAsync(config, scope: null, progress: null, ct);
+
+    /// <summary>
+    /// Lists backup files, optionally scoped to a server and database so the listing is pushed
+    /// down to Azure as a prefix instead of walking the container and filtering afterwards (#28).
+    ///
+    /// A scope is a hint, not a promise: when the container's layout cannot produce a safe prefix -
+    /// flat Ola AG naming, a pattern whose leading segments are not known - this falls back to the
+    /// full scan and returns exactly what it always did. Returning too FEW backups would silently
+    /// remove restore points, so anything short of a provable prefix scans everything.
+    /// </summary>
+    /// <param name="progress">Reports the running blob count, for containers big enough to wait on.</param>
+    public async Task<List<BackupFileInfo>> ListBackupFilesAsync(
+        BlobContainerConfig config,
+        BlobListingScope? scope,
+        IProgress<int>? progress,
+        CancellationToken ct = default)
     {
         var client = CreateClient(config);
         var files = new List<BackupFileInfo>();
 
-        await foreach (var blob in client.GetBlobsAsync(
-            BlobTraits.Metadata, BlobStates.None, prefix: null, cancellationToken: ct))
+        var prefixes = await ResolvePrefixesAsync(config, scope, ct);
+
+        foreach (var prefix in prefixes)
+        {
+            await foreach (var blob in client.GetBlobsAsync(
+                BlobTraits.Metadata, BlobStates.None, prefix, cancellationToken: ct))
+            {
+                ReadBlob(config, blob, files);
+                if (files.Count % 250 == 0) progress?.Report(files.Count);
+            }
+        }
+
+        progress?.Report(files.Count);
+        return files.OrderBy(f => f.LastModified).ToList();
+    }
+
+    /// <summary>
+    /// Turns a scope into the prefixes to list. A single null prefix means "scan everything".
+    /// </summary>
+    private async Task<IReadOnlyList<string?>> ResolvePrefixesAsync(
+        BlobContainerConfig config, BlobListingScope? scope, CancellationToken ct)
+    {
+        if (scope is null || !scope.HasAnything) return [null];
+        if (!BlobPrefix.SupportsPrefixes(config.BackupSourceType)) return [null];
+
+        // {BackupType} leads the default pattern, so without the real folder names no prefix can
+        // be built at all. One cheap hierarchy call buys the whole optimisation.
+        IReadOnlyCollection<string>? folders = null;
+        if (config.PathPattern.Contains("{BackupType}", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                folders = await ListTopLevelFoldersAsync(config, ct);
+            }
+            catch (Exception) when (!ct.IsCancellationRequested)
+            {
+                // Cannot discover the folders - fall back rather than guess at names.
+                return [null];
+            }
+        }
+
+        var prefixes = BlobPrefix.Derive(config.PathPattern, scope.ServerName, scope.DatabaseName, folders);
+        return prefixes is { Count: > 0 } ? [.. prefixes] : [null];
+    }
+
+    private void ReadBlob(BlobContainerConfig config, BlobItem blob, List<BackupFileInfo> files)
+    {
         {
             var blobUrl = $"{config.ContainerUrl.TrimEnd('/')}/{blob.Name}";
 
@@ -113,8 +191,6 @@ public class BlobStorageService
 
             files.Add(file);
         }
-
-        return files.OrderBy(f => f.LastModified).ToList();
     }
 
     public ContainerSummary GetContainerSummary(List<BackupFileInfo> files)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -208,6 +208,13 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isCancelling;
 
+    /// <summary>
+    /// Running count during a listing. A container of any size takes long enough that "Loading..."
+    /// on its own gives no sense of whether it is progressing or hung (#28).
+    /// </summary>
+    [ObservableProperty]
+    private string _loadProgressText = string.Empty;
+
     /// <summary>Pushes the cancellation sources' state onto the bound properties.</summary>
     private void RefreshCancelState()
     {
@@ -557,11 +564,22 @@ public partial class RestoreViewModel : ViewModelBase
 
         var ct = _loadCancellation.Begin();
         IsBusy = true;
+        LoadProgressText = "Scanning container...";
         RefreshCancelState();
         ClearStatus();
         try
         {
-            _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer, ct);
+            // If a database is already chosen - a reload after taking a fresh backup, say - push
+            // that down to Azure as a prefix instead of walking the whole container and discarding
+            // most of it. Measured on a real 4,440-blob container: about 1,075 ms unscoped versus
+            // about 233 ms for one database (#28).
+            //
+            // The FIRST load has no selection yet and stays a full scan, which it has to be: the
+            // server and database lists are built from what it finds.
+            var scope = BuildListingScope();
+            var progress = new Progress<int>(n => LoadProgressText = $"Scanned {n:N0} blobs...");
+
+            _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer, scope, progress, ct);
             _allSets = _blobService.GroupIntoBackupSets(_allBackups);
 
             var servers = _blobService.GetDiscoveredServers(_allBackups);
@@ -607,8 +625,29 @@ public partial class RestoreViewModel : ViewModelBase
         {
             _loadCancellation.End();
             IsBusy = false;
+            LoadProgressText = string.Empty;
             RefreshCancelState();
         }
+    }
+
+    /// <summary>
+    /// The scope to push down to Azure, or null to scan everything.
+    ///
+    /// Only offered when a database is chosen. A server on its own narrows far less and the
+    /// database list is built from the previous scan anyway, so scoping to a server alone would
+    /// mostly re-fetch what is already in memory.
+    /// </summary>
+    private BlobListingScope? BuildListingScope()
+    {
+        if (string.IsNullOrWhiteSpace(SelectedDatabaseName)) return null;
+
+        // ServerName here is the identity used in the PATH, which for an instance is the host
+        // part - "SRV01\PROD" lives under "SRV01". ServerIdentity knows how to split it.
+        var pathServer = string.IsNullOrWhiteSpace(SelectedServerName)
+            ? null
+            : SelectedServerName.Split('\\')[0];
+
+        return new BlobListingScope(pathServer, SelectedDatabaseName);
     }
 
     /// <summary>Stops an in-progress backup listing.</summary>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1038,6 +1038,10 @@
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}" Padding="20">
                 <StackPanel HorizontalAlignment="Center">
                     <TextBlock Text="Loading..." Style="{StaticResource BodyText}" HorizontalAlignment="Center" />
+                    <TextBlock Text="{Binding LoadProgressText}"
+                               Style="{StaticResource SecondaryText}"
+                               HorizontalAlignment="Center"
+                               Margin="0,4,0,0" />
                     <Button Content="Cancel"
                             Style="{StaticResource SecondaryButton}"
                             Command="{Binding CancelLoadCommand}"


### PR DESCRIPTION
Closes #28.

Listing walked **every** blob in the container and filtered client-side. Measured against your real container before writing anything:

| | Blobs | Time |
|---|---|---|
| Full scan (what it did) | 4,440 | 1,248 ms |
| **Scoped to one database** | 148 | **295 ms** |

**4.2× faster** — and critically, the same files:

```
expected  : 148 blobs (full scan, filtered client-side)
scoped    : 148 blobs
identical : True     missing: (none)     extra: (none)
```

That equivalence check is the one that mattered. The ratio is nice; not losing a backup is the requirement.

## How the prefix is derived

`BlobPrefix` walks the configured path pattern and builds prefixes from whatever is known. The issue flagged `{BackupType}` leading the default pattern as a blocker — but the container's top-level folders turn out to be exactly `DIFF/`, `FULL/`, `LOG/`, so one cheap hierarchy call gets them and the derivation fans out one prefix per type:

```
{BackupType}/{ServerName}/{DatabaseName}/{FileName}  +  SRV01, MyDb
  → DIFF/server-sql-001/MyDb/
    FULL/server-sql-001/MyDb/
    LOG/server-sql-001/MyDb/
```

**The rule throughout is deliberately asymmetric.** Too *broad* a prefix costs a little speed. Too *narrow* silently returns fewer backups than exist — which on the restore screen is a restore point vanishing with no error at all. So anything short of a provable prefix returns null and the caller scans everything: flat Ola AG naming, an unknown token like `{InstanceName}`, a pattern that starts with one.

## Where it applies, and where it deliberately doesn't

Scope is used **when a database is already selected** — the reload case, e.g. after taking a fresh backup.

**The first load stays a full scan**, because it has to be: the server and database dropdowns are built from what it finds. You can't filter by a selection that doesn't exist yet.

I measured the alternative — replacing discovery with cheap hierarchy walking — and it's **only ~30% better on this container** (522 ms discovery + 233 ms scoped vs 1,075 ms full scan), for a significant redesign of the load flow. The gap widens a lot at bigger retention, since a full scan grows with every server, database and day while a scoped listing doesn't. I've written that up as a follow-up rather than doing it on a 30% margin.

## Progress reporting

The issue also asks for this, and it pairs with the cancel button from #25: a large container now shows a running blob count instead of an unchanging "Loading...". Together they turn an opaque wait into one you can watch and escape.

## Tests

21 new on the derivation — including the real container's exact layout, so the optimisation can't drift into scoping at paths that don't exist. Plus every fallback case, since falling back is what keeps it safe.

**552 tests pass**, build clean at `-warnaserror`.

One note: I saw a single unreproducible failure in `ConnectionSecurityTests` while a throwaway measurement harness was running against the real Credential Manager concurrently. Two clean full runs after removing it. Flagging it rather than ignoring it — several test classes do write to Credential Manager in parallel, so there may be latent contention there worth watching.

