### PR TITLE
Separate the script from the console, and make progress actually live

### DIFF
--- a/src/NineLives.Tests/ConnectionSecurityTests.cs
+++ b/src/NineLives.Tests/ConnectionSecurityTests.cs
@@ -9,6 +9,7 @@ namespace Blackcat.NineLives.Tests;
 /// The password stays out of the connection string (#20), and certificate trust is answerable
 /// rather than assumed (#17).
 /// </summary>
+[Collection("CredentialManager")]
 public class ConnectionSecurityTests : IDisposable
 {
     private readonly string _dir = Path.Combine(

--- a/src/NineLives.Tests/ConsoleLineTests.cs
+++ b/src/NineLives.Tests/ConsoleLineTests.cs
@@ -1,0 +1,59 @@
+using Blackcat.NineLives.Models;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Classification of console output.
+///
+/// Only drives colour, so being wrong is cosmetic - but colouring an ordinary line red during a
+/// restore is its own kind of wrong, which is why anything unrecognised stays Normal rather than
+/// being guessed at.
+/// </summary>
+public class ConsoleLineTests
+{
+    [Theory]
+    [InlineData("ERROR: Could not open backup device")]
+    [InlineData("CANCELLED. The statement in flight was rolled back")]
+    [InlineData("FAILED on statement 3 of 12: RESTORE LOG")]
+    public void FailuresReadAsErrors(string message)
+        => Assert.Equal(ConsoleLineKind.Error, ConsoleLine.From(message).Kind);
+
+    [Theory]
+    [InlineData("  Note: this connection trusts the server certificate")]
+    [InlineData("[MyDb] is in RESTORING state.")]
+    [InlineData("[MyDb] is in SINGLE_USER.")]
+    public void ThingsWorthNoticingReadAsWarnings(string message)
+        => Assert.Equal(ConsoleLineKind.Warning, ConsoleLine.From(message).Kind);
+
+    [Theory]
+    [InlineData("Restore completed successfully!")]
+    [InlineData("Completed.")]
+    [InlineData("100 percent processed.")]
+    public void CompletionReadsAsSuccess(string message)
+        => Assert.Equal(ConsoleLineKind.Success, ConsoleLine.From(message).Kind);
+
+    [Theory]
+    [InlineData("Executing statement 1 of 4: RESTORE DATABASE")]
+    [InlineData("Beginning restore execution...")]
+    [InlineData("Credential [x] is missing - creating it...")]
+    public void NarrationReadsAsASte(string message)
+        => Assert.Equal(ConsoleLineKind.Step, ConsoleLine.From(message).Kind);
+
+    [Theory]
+    [InlineData("50 percent processed.")]
+    [InlineData("RESTORE DATABASE successfully processed 1234 pages in 5.678 seconds")]
+    [InlineData("")]
+    public void AnythingElseStaysNormal(string message)
+        => Assert.Equal(ConsoleLineKind.Normal, ConsoleLine.From(message).Kind);
+
+    [Fact]
+    public void TheTextIsKeptVerbatimIncludingLeadingSpace()
+    {
+        // Indentation carries meaning in the console - nested detail under a step - so it must
+        // survive classification untouched.
+        const string indented = "  Note: something";
+
+        Assert.Equal(indented, ConsoleLine.From(indented).Text);
+    }
+}

--- a/src/NineLives.Tests/CredentialInjectionTests.cs
+++ b/src/NineLives.Tests/CredentialInjectionTests.cs
@@ -18,6 +18,7 @@ namespace Blackcat.NineLives.Tests;
 /// below is deliberately harmless: if the injection were still open it would create a second,
 /// clearly-named credential rather than change any permissions.
 /// </summary>
+[Collection("CredentialManager")]
 public class CredentialInjectionTests
 {
     private static string? TestServerName =>

--- a/src/NineLives.Tests/CredentialLifecycleTests.cs
+++ b/src/NineLives.Tests/CredentialLifecycleTests.cs
@@ -20,6 +20,7 @@ namespace Blackcat.NineLives.Tests;
 ///
 /// Gated on NINELIVES_TEST_SQL like the other live tests; each cleans up after itself.
 /// </summary>
+[Collection("CredentialManager")]
 public class CredentialLifecycleTests
 {
     private static string? TestServerName =>

--- a/src/NineLives.Tests/CredentialManagerCollection.cs
+++ b/src/NineLives.Tests/CredentialManagerCollection.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Serialises the test classes that read and write Windows Credential Manager.
+///
+/// xUnit runs different classes in parallel, and four classes here hammer the same per-user
+/// credential store at once. Every key is uniquely namespaced so they cannot collide logically,
+/// but the store itself intermittently failed a read straight after a successful write under that
+/// load - twice, in two different classes, neither reproducible on a rerun.
+///
+/// A flaky suite is worse than a slow one anywhere, and especially here: these are the tests that
+/// prove secrets are stored and retrieved correctly, so they are precisely the ones nobody should
+/// learn to re-run and ignore. They lose a little parallelism and gain being trustworthy.
+/// </summary>
+[CollectionDefinition("CredentialManager", DisableParallelization = true)]
+public sealed class CredentialManagerCollection;

--- a/src/NineLives.Tests/SecretKeyMigrationTests.cs
+++ b/src/NineLives.Tests/SecretKeyMigrationTests.cs
@@ -16,6 +16,7 @@ namespace Blackcat.NineLives.Tests;
 /// These write to the real Windows Credential Manager, so every key is namespaced under
 /// "ninelives-test-" plus a fresh Guid and removed in Dispose. Config goes to a temp directory.
 /// </summary>
+[Collection("CredentialManager")]
 public class SecretKeyMigrationTests : IDisposable
 {
     private readonly string _dir = Path.Combine(

--- a/src/NineLives.Tests/SqlSyntaxHighlighterTests.cs
+++ b/src/NineLives.Tests/SqlSyntaxHighlighterTests.cs
@@ -1,0 +1,129 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// T-SQL tokenising for the script pane.
+///
+/// The one property that must always hold is that concatenating the tokens reproduces the input
+/// exactly - the pane displays the script someone is about to run against production, and it must
+/// not be able to show something different from what will execute. Colour being wrong is cosmetic;
+/// text being wrong is not.
+/// </summary>
+public class SqlSyntaxHighlighterTests
+{
+    private static string Rebuild(string sql)
+        => string.Concat(SqlSyntaxHighlighter.Tokenise(sql).Select(t => t.Text));
+
+    [Theory]
+    [InlineData("RESTORE DATABASE [MyDb] FROM URL = N'https://acct/backups/x.bak' WITH REPLACE, STATS = 10")]
+    [InlineData("-- a comment\r\nRESTORE LOG [MyDb]\r\n  FROM URL = N'x'\r\nGO\r\n")]
+    [InlineData("SECRET = 'abc''def'")]
+    [InlineData("")]
+    [InlineData("   \r\n\t  ")]
+    [InlineData("/* block\ncomment */ SELECT 1")]
+    public void TheTokensAlwaysReproduceTheInputExactly(string sql)
+        => Assert.Equal(sql, Rebuild(sql));
+
+    [Fact]
+    public void KeywordsAreRecognised()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("RESTORE DATABASE [MyDb] WITH REPLACE");
+
+        Assert.Contains(tokens, t => t.Text == "RESTORE" && t.Kind == SqlTokenKind.Keyword);
+        Assert.Contains(tokens, t => t.Text == "DATABASE" && t.Kind == SqlTokenKind.Keyword);
+        Assert.Contains(tokens, t => t.Text == "REPLACE" && t.Kind == SqlTokenKind.Keyword);
+    }
+
+    [Fact]
+    public void KeywordsAreCaseInsensitive()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("restore Database");
+
+        Assert.All(tokens.Where(t => t.Text.Trim().Length > 0),
+            t => Assert.Equal(SqlTokenKind.Keyword, t.Kind));
+    }
+
+    [Fact]
+    public void BracketedIdentifiersAreTheirOwnKind()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("RESTORE DATABASE [My Db]");
+
+        Assert.Contains(tokens, t => t.Text == "[My Db]" && t.Kind == SqlTokenKind.Identifier);
+    }
+
+    [Fact]
+    public void AnIdentifierContainingADoubledBracketStaysOneToken()
+    {
+        // TSql.QuoteName doubles a ']', so this shape reaches the pane for real.
+        var tokens = SqlSyntaxHighlighter.Tokenise("[My]]Db]");
+
+        Assert.Contains(tokens, t => t.Text == "[My]]Db]" && t.Kind == SqlTokenKind.Identifier);
+    }
+
+    [Fact]
+    public void StringLiteralsIncludeTheNPrefixAndDoubledQuotes()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("SECRET = N'it''s here'");
+
+        Assert.Contains(tokens, t => t.Text == "N'it''s here'" && t.Kind == SqlTokenKind.Literal);
+    }
+
+    [Fact]
+    public void AKeywordInsideAStringIsNotColouredAsCode()
+    {
+        // A blob URL contains "backups" and could contain anything; it is a literal, not SQL.
+        var tokens = SqlSyntaxHighlighter.Tokenise("FROM URL = N'https://acct/RESTORE/DATABASE.bak'");
+
+        Assert.DoesNotContain(tokens, t => t.Text.Contains("https") && t.Kind == SqlTokenKind.Keyword);
+        Assert.Contains(tokens, t => t.Kind == SqlTokenKind.Literal && t.Text.Contains("RESTORE"));
+    }
+
+    [Fact]
+    public void AKeywordInsideACommentIsNotColouredAsCode()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("-- RESTORE DATABASE goes here\nSELECT 1");
+
+        var comment = Assert.Single(tokens, t => t.Kind == SqlTokenKind.Comment);
+        Assert.Contains("RESTORE DATABASE", comment.Text);
+    }
+
+    [Fact]
+    public void NumbersAreRecognised()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("WITH STATS = 10");
+
+        Assert.Contains(tokens, t => t.Text == "10" && t.Kind == SqlTokenKind.Number);
+    }
+
+    [Fact]
+    public void OrdinaryWordsStayPlain()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("MyDatabaseName");
+
+        Assert.Contains(tokens, t => t.Text == "MyDatabaseName" && t.Kind == SqlTokenKind.Plain);
+    }
+
+    [Fact]
+    public void ARealisticRestoreScriptTokenisesWithoutLosingAnything()
+    {
+        const string script = """
+            -- ============================================
+            -- Nine Lives - generated restore script
+            -- ============================================
+            USE [master];
+            GO
+
+            RESTORE DATABASE [MyDb]
+            FROM URL = N'https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/x.bak'
+            WITH NORECOVERY, REPLACE, STATS = 10;
+            GO
+            """;
+
+        Assert.Equal(script, Rebuild(script));
+        Assert.Contains(SqlSyntaxHighlighter.Tokenise(script), t => t.Kind == SqlTokenKind.Comment);
+        Assert.Contains(SqlSyntaxHighlighter.Tokenise(script), t => t.Kind == SqlTokenKind.Identifier);
+        Assert.Contains(SqlSyntaxHighlighter.Tokenise(script), t => t.Kind == SqlTokenKind.Literal);
+    }
+}

--- a/src/NineLives.Tests/UnsavedSecretTests.cs
+++ b/src/NineLives.Tests/UnsavedSecretTests.cs
@@ -20,6 +20,7 @@ namespace Blackcat.NineLives.Tests;
 /// The fix is a transient in-memory secret the services prefer over the stored one. These tests
 /// pin both halves: the transient value is used, and it never reaches disk.
 /// </summary>
+[Collection("CredentialManager")]
 public class UnsavedSecretTests : IDisposable
 {
     private readonly string _dir = Path.Combine(

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -294,10 +294,13 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
 
                 // The script pane used to be hidden the moment execution started, so the two
                 // shared one slot. Both must now be on screen at the same time.
-                var script = FindAll<TextBox>(view)
-                    .Select(b => b.Text)
-                    .FirstOrDefault(t => t.Contains("RESTORE DATABASE [MyDb]", StringComparison.Ordinal));
-                Assert.NotNull(script);
+                var script = Assert.Single(FindAll<SqlTextBlock>(view));
+                Assert.Contains("RESTORE DATABASE [MyDb]", script.Sql, StringComparison.Ordinal);
+
+                // ...and it is actually highlighted, not one undifferentiated run.
+                var runs = script.Inlines.OfType<System.Windows.Documents.Run>().ToList();
+                Assert.True(runs.Count > 1, "The script rendered as a single run - no highlighting applied.");
+                Assert.Contains(runs, r => r.Text == "RESTORE");
 
                 listener.AssertNone("RestoreView console");
             }

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -260,6 +260,54 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
         });
     }
 
+    /// <summary>
+    /// The execution console renders its lines, colours them by kind, and no longer shares a slot
+    /// with the generated script - both are visible at once.
+    /// </summary>
+    [Fact]
+    public void TheConsoleAndTheScriptAreBothVisibleTogether()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.BackupsLoaded = true;
+            vm.HasScript = true;
+            vm.GeneratedScript = "RESTORE DATABASE [MyDb] FROM URL = N'https://acct/backups/x.bak'";
+            vm.ConsoleLines =
+            [
+                new ConsoleLine("Beginning restore execution...", ConsoleLineKind.Step),
+                new ConsoleLine("50 percent processed."),
+                new ConsoleLine("ERROR: something went wrong", ConsoleLineKind.Error)
+            ];
+            vm.HasConsoleOutput = true;
+            vm.IsExecuting = true;
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.Contains(texts, t => t.Contains("50 percent processed", StringComparison.Ordinal));
+                Assert.Contains(texts, t => t.Contains("Beginning restore execution", StringComparison.Ordinal));
+
+                // The script pane used to be hidden the moment execution started, so the two
+                // shared one slot. Both must now be on screen at the same time.
+                var script = FindAll<TextBox>(view)
+                    .Select(b => b.Text)
+                    .FirstOrDefault(t => t.Contains("RESTORE DATABASE [MyDb]", StringComparison.Ordinal));
+                Assert.NotNull(script);
+
+                listener.AssertNone("RestoreView console");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
     /// <summary>The inventory warnings panel added with #46 - separate from the chain issues one.</summary>
     [Fact]
     public void TheInventoryPanelShowsItsFindings()

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -261,8 +261,12 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
     }
 
     /// <summary>
-    /// The execution console renders its lines, colours them by kind, and no longer shares a slot
-    /// with the generated script - both are visible at once.
+    /// The console renders its lines and no longer shares a slot with the generated script - both
+    /// are on screen together.
+    ///
+    /// Checked in the state AFTER a restore, which is when the inline console is the one in use:
+    /// during a restore the console lives in its own window and the inline one is deliberately
+    /// hidden.
     /// </summary>
     [Fact]
     public void TheConsoleAndTheScriptAreBothVisibleTogether()
@@ -280,7 +284,8 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
                 new ConsoleLine("ERROR: something went wrong", ConsoleLineKind.Error)
             ];
             vm.HasConsoleOutput = true;
-            vm.IsExecuting = true;
+            vm.IsExecuting = false;
+            vm.ExecutionComplete = true;
 
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
@@ -308,6 +313,58 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
             {
                 listener.Detach();
             }
+        });
+    }
+
+    /// <summary>
+    /// The inline console and the execution window are mutually exclusive: while the console is
+    /// showing in its own window the inline one must be gone, not sitting behind it.
+    /// </summary>
+    [Fact]
+    public void TheInlineConsoleHidesWhileTheConsoleIsInItsOwnWindow()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.BackupsLoaded = true;
+            vm.ConsoleLines = [new ConsoleLine("Beginning restore execution...")];
+            vm.HasConsoleOutput = true;
+
+            var view = new RestoreView { DataContext = vm };
+
+            vm.IsConsoleDetached = false;
+            Realise(view);
+            Assert.True(FindAll<ListBox>(view).Any(IsShown),
+                "The inline console should be visible when it is not shown in its own window.");
+
+            vm.IsConsoleDetached = true;
+            Realise(view);
+            Assert.False(FindAll<ListBox>(view).Any(IsShown),
+                "The inline console is still on screen behind the execution window.");
+        });
+    }
+
+    /// <summary>
+    /// The belt-and-braces half: while a restore is running the console is always in its own
+    /// window, so the inline one must be gone even if the detach flag never got set.
+    /// </summary>
+    [Fact]
+    public void TheInlineConsoleHidesWhileARestoreIsRunning()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.BackupsLoaded = true;
+            vm.ConsoleLines = [new ConsoleLine("Beginning restore execution...")];
+            vm.HasConsoleOutput = true;
+            vm.IsConsoleDetached = false;   // as if the wiring failed
+            vm.IsExecuting = true;
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            Assert.False(FindAll<ListBox>(view).Any(IsShown),
+                "Two consoles would be on screen at once during a restore.");
         });
     }
 

--- a/src/NineLives/Models/ConsoleLine.cs
+++ b/src/NineLives/Models/ConsoleLine.cs
@@ -1,0 +1,68 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>How a console line should read at a glance.</summary>
+public enum ConsoleLineKind
+{
+    /// <summary>Ordinary output.</summary>
+    Normal,
+
+    /// <summary>A step starting - the app narrating what it is about to do.</summary>
+    Step,
+
+    /// <summary>Something completed.</summary>
+    Success,
+
+    /// <summary>Worth noticing but not fatal.</summary>
+    Warning,
+
+    /// <summary>The restore failed or was stopped.</summary>
+    Error
+}
+
+/// <summary>
+/// One line in the execution console.
+///
+/// A collection of these replaced a single ever-growing string. Appending to a bound string
+/// rebuilds the whole thing and re-renders the entire TextBox on every message, which is O(n^2)
+/// and was a large part of why a restore emitting progress every few percent looked like it was
+/// arriving in bursts rather than live.
+/// </summary>
+/// <param name="Text">The line as written.</param>
+/// <param name="Kind">Drives the colour, nothing else.</param>
+public sealed record ConsoleLine(string Text, ConsoleLineKind Kind = ConsoleLineKind.Normal)
+{
+    /// <summary>
+    /// Classifies a raw message so the console reads at a glance without every call site having to
+    /// think about it. Deliberately conservative: anything unrecognised stays Normal rather than
+    /// guessing and colouring an ordinary line red.
+    /// </summary>
+    public static ConsoleLine From(string message)
+    {
+        var trimmed = message.TrimStart();
+
+        if (trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("CANCELLED", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("FAILED", StringComparison.OrdinalIgnoreCase))
+            return new ConsoleLine(message, ConsoleLineKind.Error);
+
+        if (trimmed.StartsWith("Note:", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Warning", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Contains("is in RESTORING", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Contains("SINGLE_USER", StringComparison.OrdinalIgnoreCase))
+            return new ConsoleLine(message, ConsoleLineKind.Warning);
+
+        if (trimmed.Contains("completed successfully", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Completed", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Contains("100 percent processed", StringComparison.OrdinalIgnoreCase))
+            return new ConsoleLine(message, ConsoleLineKind.Success);
+
+        if (trimmed.StartsWith("Executing statement", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Beginning", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Running:", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Using the existing", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Credential", StringComparison.OrdinalIgnoreCase))
+            return new ConsoleLine(message, ConsoleLineKind.Step);
+
+        return new ConsoleLine(message);
+    }
+}

--- a/src/NineLives/Services/OperationLog.cs
+++ b/src/NineLives/Services/OperationLog.cs
@@ -58,6 +58,9 @@ public sealed class OperationLog
     public void ServerChange(string serverName, string what)
         => Write("CHANGE", $"[{serverName}] {what}");
 
+    private string? _ensuredDirectory;
+    private int _writesSinceRollCheck;
+
     private void Write(string level, string message)
     {
         try
@@ -66,15 +69,29 @@ public sealed class OperationLog
 
             lock (_gate)
             {
-                System.IO.Directory.CreateDirectory(_directory);
-                RollIfTooBig();
+                // Creating the directory and stat-ing the file on EVERY line meant three
+                // filesystem calls per message. A restore reporting progress every few percent
+                // does that hundreds of times from the UI thread, which is a real part of why the
+                // console stuttered. The directory is created once, and the size is only checked
+                // periodically - a log overshooting the roll threshold by a few hundred lines
+                // costs nothing, and the check is not free.
+                if (_ensuredDirectory != _directory)
+                {
+                    System.IO.Directory.CreateDirectory(_directory);
+                    _ensuredDirectory = _directory;
+                }
+
+                if (_writesSinceRollCheck++ % 200 == 0) RollIfTooBig();
+
                 File.AppendAllText(CurrentFile, line + Environment.NewLine, Encoding.UTF8);
             }
         }
         catch
         {
             // Logging is never worth failing an operation over. A locked file, a full disk or a
-            // redirected profile all end up here and are all survivable.
+            // redirected profile all end up here and are all survivable. Forget the cached
+            // directory so a transient failure is retried rather than assumed permanent.
+            _ensuredDirectory = null;
         }
     }
 

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Security;
+using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
 using Blackcat.NineLives.Models;
 
@@ -436,8 +437,20 @@ public class SqlServerService
         }
     }
 
+    /// <summary>
+    /// A one-line preview of a statement for the console.
+    ///
+    /// Whitespace is collapsed FIRST. Taking the first 80 characters raw pulled in the newlines
+    /// and blank lines of the script's comment banner, so a single "Executing statement 1 of 22"
+    /// message arrived as several lines with gaps between them.
+    /// </summary>
     private static string Summarize(string statement)
-        => statement[..Math.Min(80, statement.Length)].Trim();
+    {
+        var flattened = WhitespaceRun.Replace(statement, " ").Trim();
+        return flattened.Length <= 80 ? flattened : flattened[..80] + "...";
+    }
+
+    private static readonly Regex WhitespaceRun = new(@"\s+", RegexOptions.Compiled);
 
     /// <summary>Checks if a credential with the given name exists on the server and has identity SHARED ACCESS SIGNATURE (for blob URL restores).</summary>
     public async Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(

--- a/src/NineLives/Services/SqlSyntaxHighlighter.cs
+++ b/src/NineLives/Services/SqlSyntaxHighlighter.cs
@@ -1,0 +1,87 @@
+using System.Text.RegularExpressions;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>What a span of a T-SQL script is, for colouring.</summary>
+public enum SqlTokenKind
+{
+    Plain,
+    Keyword,
+    /// <summary>A string literal, N'...' included.</summary>
+    Literal,
+    Comment,
+    Number,
+    /// <summary>A [bracketed identifier] - the database and credential names.</summary>
+    Identifier
+}
+
+/// <summary>One coloured span.</summary>
+public sealed record SqlToken(string Text, SqlTokenKind Kind);
+
+/// <summary>
+/// Splits a T-SQL script into coloured spans.
+///
+/// Hand-rolled rather than pulling in an editor component. The script pane is read-only and a few
+/// kilobytes at most, so a tokeniser is a hundred lines against a dependency the single-file exe
+/// would have to carry - and #16 pinned the dependency graph deliberately.
+///
+/// Not a parser and does not need to be. It gets comments, strings, bracketed identifiers, numbers
+/// and keywords right, in that order of precedence, which is everything a restore script contains.
+/// Anything it cannot classify stays plain, so the worst case is uncoloured text rather than
+/// mangled text.
+/// </summary>
+public static class SqlSyntaxHighlighter
+{
+    private static readonly HashSet<string> Keywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "RESTORE", "DATABASE", "LOG", "FROM", "URL", "DISK", "WITH", "FILE", "MOVE", "TO",
+        "REPLACE", "RECOVERY", "NORECOVERY", "STANDBY", "STATS", "STOPAT", "CHECKSUM",
+        "CONTINUE_AFTER_ERROR", "KEEP_REPLICATION", "ENABLE_BROKER", "NEW_BROKER",
+        "ERROR_BROKER_CONVERSATIONS", "CREDENTIAL", "HEADERONLY", "FILELISTONLY", "VERIFYONLY",
+        "ALTER", "SET", "SINGLE_USER", "MULTI_USER", "ROLLBACK", "IMMEDIATE", "GO",
+        "CREATE", "DROP", "IDENTITY", "SECRET", "USE", "MASTER", "IF", "EXISTS", "BEGIN", "END",
+        "SELECT", "WHERE", "AND", "OR", "NOT", "NULL", "AS", "ON", "OFF", "PRINT", "DECLARE",
+        "EXEC", "NORECOVERY,", "MEDIANAME", "MEDIADESCRIPTION", "BLOCKSIZE", "MAXTRANSFERSIZE"
+    };
+
+    // Order matters: comments and strings first, so a keyword inside either is not coloured as
+    // code, and a bracketed identifier containing a quote does not open a string.
+    private static readonly Regex Tokeniser = new(
+        @"(?<comment>--[^\r\n]*|/\*.*?\*/)" +
+        @"|(?<literal>N?'(?:[^']|'')*')" +
+        @"|(?<identifier>\[(?:[^\]]|\]\])*\])" +
+        @"|(?<number>\b\d+(?:\.\d+)?\b)" +
+        @"|(?<word>[A-Za-z_][A-Za-z0-9_]*)",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    /// <summary>Splits the script. Concatenating the results reproduces the input exactly.</summary>
+    public static IReadOnlyList<SqlToken> Tokenise(string? sql)
+    {
+        if (string.IsNullOrEmpty(sql)) return [];
+
+        var tokens = new List<SqlToken>();
+        var position = 0;
+
+        foreach (Match match in Tokeniser.Matches(sql))
+        {
+            if (match.Index > position)
+                tokens.Add(new SqlToken(sql[position..match.Index], SqlTokenKind.Plain));
+
+            var kind = SqlTokenKind.Plain;
+            if (match.Groups["comment"].Success) kind = SqlTokenKind.Comment;
+            else if (match.Groups["literal"].Success) kind = SqlTokenKind.Literal;
+            else if (match.Groups["identifier"].Success) kind = SqlTokenKind.Identifier;
+            else if (match.Groups["number"].Success) kind = SqlTokenKind.Number;
+            else if (match.Groups["word"].Success)
+                kind = Keywords.Contains(match.Value) ? SqlTokenKind.Keyword : SqlTokenKind.Plain;
+
+            tokens.Add(new SqlToken(match.Value, kind));
+            position = match.Index + match.Length;
+        }
+
+        if (position < sql.Length)
+            tokens.Add(new SqlToken(sql[position..], SqlTokenKind.Plain));
+
+        return tokens;
+    }
+}

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -8,6 +8,20 @@
          instance, so both work. -->
     <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
 
+    <!-- Terminal console. Darker than the cards on purpose, so the console reads as a separate
+         surface the way a real terminal does rather than as another panel in the form. -->
+    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#0C0E14" />
+    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#2A3040" />
+    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#161A24" />
+    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#C9D1D9" />
+    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#6E7681" />
+    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#79C0FF" />
+    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#3FB950" />
+    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#D29922" />
+    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#F85149" />
+
+    <FontFamily x:Key="ConsoleFont">Cascadia Code, Cascadia Mono, Consolas, Courier New</FontFamily>
+
     <!-- Color Palette -->
     <Color x:Key="WindowBackgroundColor">#1B1E2B</Color>
     <Color x:Key="SidebarBackgroundColor">#141722</Color>

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -22,6 +22,79 @@
 
     <FontFamily x:Key="ConsoleFont">Cascadia Code, Cascadia Mono, Consolas, Courier New</FontFamily>
 
+    <!-- Console rows. A ListBox for the virtualisation, stripped of every ListBox affordance:
+         no selection highlight, no hover, no focus rectangle, tight line spacing. -->
+    <Style x:Key="ConsoleListBoxItem" TargetType="ListBoxItem">
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="MinHeight" Value="0" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListBoxItem">
+                    <ContentPresenter />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ConsoleListBox" TargetType="ListBox">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="12,8,12,10" />
+        <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource ConsoleListBoxItem}" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="True" />
+        <Setter Property="VirtualizingStackPanel.VirtualizationMode" Value="Recycling" />
+        <Setter Property="ItemTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Text}"
+                               FontFamily="{StaticResource ConsoleFont}"
+                               FontSize="12"
+                               TextWrapping="NoWrap"
+                               Padding="0"
+                               Margin="0"
+                               LineHeight="16"
+                               LineStackingStrategy="BlockLineHeight">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Kind}" Value="Step">
+                                        <Setter Property="Foreground" Value="{StaticResource ConsoleStepBrush}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Kind}" Value="Success">
+                                        <Setter Property="Foreground" Value="{StaticResource ConsoleSuccessBrush}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Kind}" Value="Warning">
+                                        <Setter Property="Foreground" Value="{StaticResource ConsoleWarningBrush}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Kind}" Value="Error">
+                                        <Setter Property="Foreground" Value="{StaticResource ConsoleErrorBrush}" />
+                                        <Setter Property="FontWeight" Value="SemiBold" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- T-SQL syntax colouring, same family as the console so the two panes belong together. -->
+    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#FF7B9EFF" />
+    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#A5D6A7" />
+    <SolidColorBrush x:Key="SqlCommentBrush" Color="#5C6773" />
+    <SolidColorBrush x:Key="SqlNumberBrush" Color="#F0B457" />
+    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#E2C08D" />
+
     <!-- Color Palette -->
     <Color x:Key="WindowBackgroundColor">#1B1E2B</Color>
     <Color x:Key="SidebarBackgroundColor">#141722</Color>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Windows;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Win32;
@@ -1605,6 +1606,7 @@ public partial class RestoreViewModel : ViewModelBase
             _executeCancellation.End();
             IsExecuting = false;
             ExecutionComplete = true;
+            FlushConsole();   // nothing buffered may outlive the run
             RefreshCancelState();
         }
     }
@@ -1716,12 +1718,68 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     private void AppendLog(string message)
     {
-        foreach (var line in message.Split('\n'))
-            ConsoleLines.Add(ConsoleLine.From(line));
+        foreach (var raw in message.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
 
-        HasConsoleOutput = true;
+            // Messages routinely arrive with a leading or trailing newline for spacing, and SQL
+            // Server's own output has its own blank lines. Left alone that produced a gap between
+            // almost every line. One blank line is allowed as a separator; runs of them are not.
+            if (line.Trim().Length == 0)
+            {
+                if (_pending.Count > 0 && _pending[^1].Text.Length == 0) continue;
+                if (_pending.Count == 0 && (ConsoleLines.Count == 0 || ConsoleLines[^1].Text.Length == 0)) continue;
+                _pending.Add(new ConsoleLine(string.Empty));
+                continue;
+            }
+
+            _pending.Add(ConsoleLine.From(line));
+        }
+
         App.Log.Info($"[execute] {message.Trim()}");
+        ScheduleConsoleFlush();
     }
+
+    /// <summary>
+    /// Moves buffered lines onto the bound collection on a timer rather than as they arrive.
+    ///
+    /// SQL Server emits progress in clusters - several messages within a millisecond, then nothing
+    /// for a second. Adding each one individually meant a layout pass and a scroll per message, in
+    /// bursts, which is what made the console judder. Flushing on a fixed tick turns any arrival
+    /// pattern into a steady redraw, and a whole cluster costs one layout pass instead of ten.
+    /// </summary>
+    private void ScheduleConsoleFlush()
+    {
+        if (_consoleFlushTimer != null) return;
+
+        _consoleFlushTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(60)
+        };
+        _consoleFlushTimer.Tick += (_, _) => FlushConsole();
+        _consoleFlushTimer.Start();
+    }
+
+    private void FlushConsole()
+    {
+        if (_pending.Count == 0)
+        {
+            // Nothing arriving and nothing running - stop ticking rather than spin forever.
+            if (!IsExecuting)
+            {
+                _consoleFlushTimer?.Stop();
+                _consoleFlushTimer = null;
+            }
+            return;
+        }
+
+        foreach (var line in _pending) ConsoleLines.Add(line);
+        _pending.Clear();
+        HasConsoleOutput = true;
+    }
+
+    private readonly List<ConsoleLine> _pending = [];
+    private DispatcherTimer? _consoleFlushTimer;
 
     /// <summary>The console as plain text, for copying into a bug report.</summary>
     public string ConsoleText => string.Join(Environment.NewLine, ConsoleLines.Select(l => l.Text));

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -228,6 +228,16 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _hasConsoleOutput;
 
+    /// <summary>
+    /// True while the console is showing in its own window.
+    ///
+    /// The inline console hides itself for the duration, so the output is only ever in one place.
+    /// It comes back when the window closes, so the record of what happened is still reachable
+    /// from the main view afterwards.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isConsoleDetached;
+
     /// <summary>Pushes the cancellation sources' state onto the bound properties.</summary>
     private void RefreshCancelState()
     {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -215,6 +215,18 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _loadProgressText = string.Empty;
 
+    // ── Execution console ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The console, one line per entry. A collection rather than one growing string so appending
+    /// costs the same on the thousandth line as on the first.
+    /// </summary>
+    [ObservableProperty]
+    private ObservableCollection<ConsoleLine> _consoleLines = [];
+
+    [ObservableProperty]
+    private bool _hasConsoleOutput;
+
     /// <summary>Pushes the cancellation sources' state onto the bound properties.</summary>
     private void RefreshCancelState()
     {
@@ -386,9 +398,6 @@ public partial class RestoreViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _isExecuting;
-
-    [ObservableProperty]
-    private string _executionLog = string.Empty;
 
     [ObservableProperty]
     private bool _executionComplete;
@@ -873,6 +882,12 @@ public partial class RestoreViewModel : ViewModelBase
 
     private void UpdateRestoreSummary()
     {
+        // Every option change already funnels through here, so it is also where the script is kept
+        // in step. It used to be built only when Generate Script was pressed, which meant the
+        // script on screen could quietly disagree with the settings above it - and the script is
+        // the thing people read before running a restore against production.
+        RegenerateScript();
+
         if (RestoreChain == null || string.IsNullOrWhiteSpace(TargetDatabaseName))
         {
             RestoreSummaryText = string.Empty;
@@ -1126,6 +1141,10 @@ public partial class RestoreViewModel : ViewModelBase
         CopyHeaderOnlyCommandCommand.NotifyCanExecuteChanged();
     }
 
+    /// <summary>
+    /// Explicit Generate. Same work as the live rebuild, but it says why nothing was produced -
+    /// the live path stays silent because reporting an error on every keystroke would be noise.
+    /// </summary>
     [RelayCommand]
     private void GenerateScript()
     {
@@ -1146,6 +1165,35 @@ public partial class RestoreViewModel : ViewModelBase
         if (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null)
         {
             SetError($"Point-in-time target is not valid. {PointInTimeMessage}");
+            return;
+        }
+
+        RegenerateScript();
+        if (HasScript) SetStatus("Script generated successfully.");
+    }
+
+    /// <summary>
+    /// Rebuilds the script from the current settings, silently.
+    ///
+    /// Called from UpdateRestoreSummary, so every option change keeps the script in step. It used
+    /// to be built only when Generate Script was pressed, which meant the script on screen could
+    /// quietly disagree with the settings above it - and that script is what people read before
+    /// running a restore against production.
+    ///
+    /// When the settings cannot produce a valid script the script is cleared rather than left
+    /// stale. A stale script is worse than none: it looks authoritative and is not.
+    /// </summary>
+    private void RegenerateScript()
+    {
+        // Leave the script alone mid-restore - it is the record of what is actually running.
+        if (IsExecuting) return;
+
+        if (RestoreChain == null
+            || string.IsNullOrWhiteSpace(TargetDatabaseName)
+            || (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null))
+        {
+            GeneratedScript = string.Empty;
+            HasScript = false;
             return;
         }
 
@@ -1192,7 +1240,6 @@ public partial class RestoreViewModel : ViewModelBase
 
         GeneratedScript = _scriptGenerator.Generate(RestoreChain, options);
         HasScript = true;
-        SetStatus("Script generated successfully.");
     }
 
     /// <summary>Create or update the blob credential on the connected server (optional; not included in generated script).</summary>
@@ -1432,7 +1479,8 @@ public partial class RestoreViewModel : ViewModelBase
         var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
         ExecutionComplete = false;
-        ExecutionLog = string.Empty;
+        ConsoleLines.Clear();
+        HasConsoleOutput = false;
         RecoveryActions = [];
         HasRecoveryActions = false;
         RefreshCancelState();
@@ -1511,7 +1559,12 @@ public partial class RestoreViewModel : ViewModelBase
             await _sqlService.ExecuteRestoreWithProgressAsync(
                 server,
                 GeneratedScript,
-                msg => Application.Current.Dispatcher.Invoke(() => AppendLog(msg)),
+                // InvokeAsync, not Invoke. This callback runs on the connection's thread when SQL
+                // Server sends an info message, and a synchronous Invoke BLOCKS that thread until
+                // the UI has finished handling it. With the UI busy re-rendering, progress backed
+                // up and then arrived in bursts - which is precisely what "not live" looked like.
+                // Posting instead lets the restore keep streaming while the UI catches up.
+                msg => Application.Current.Dispatcher.InvokeAsync(() => AppendLog(msg)),
                 executeToken);
 
             ExecutionSuccess = true;
@@ -1652,11 +1705,30 @@ public partial class RestoreViewModel : ViewModelBase
     /// restore that ends with the window being closed still leaves a record of how far it got.
     /// Redaction happens inside the log, not here (#40).
     /// </summary>
+    /// <summary>
+    /// Appends to the on-screen console and to the log file at the same time, so the file cannot
+    /// drift from what the user was shown.
+    ///
+    /// Writes to a COLLECTION rather than concatenating a bound string. Appending to a bound string
+    /// rebuilds it and re-renders the whole TextBox on every message - O(n^2) - which was a large
+    /// part of why a restore reporting progress every few percent looked like it arrived in bursts
+    /// rather than live.
+    /// </summary>
     private void AppendLog(string message)
     {
-        ExecutionLog += message + "\n";
+        foreach (var line in message.Split('\n'))
+            ConsoleLines.Add(ConsoleLine.From(line));
+
+        HasConsoleOutput = true;
         App.Log.Info($"[execute] {message.Trim()}");
     }
+
+    /// <summary>The console as plain text, for copying into a bug report.</summary>
+    public string ConsoleText => string.Join(Environment.NewLine, ConsoleLines.Select(l => l.Text));
+
+    [RelayCommand]
+    private void CopyConsole()
+        => TryCopyToClipboard(ConsoleText, "Execution log copied to clipboard.");
 
     private async Task RunArmCountdownAsync(CancellationToken ct)
     {

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -1,0 +1,155 @@
+<Window x:Class="Blackcat.NineLives.Views.ExecutionWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
+        Title="Nine Lives - restore in progress"
+        Width="980" Height="620"
+        MinWidth="640" MinHeight="380"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        Background="{StaticResource WindowBackgroundBrush}"
+        Closing="OnClosing">
+
+    <Window.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+    </Window.Resources>
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- What is being restored, and where. The one thing worth reading at a glance. -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,12">
+            <TextBlock Text="RESTORE IN PROGRESS" Style="{StaticResource LabelText}" />
+            <TextBlock Text="{Binding RestoreSummaryText}"
+                       Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap" Margin="0,4,0,0" />
+        </StackPanel>
+
+        <Border Grid.Row="1" CornerRadius="6"
+                Background="{StaticResource ConsoleBackgroundBrush}"
+                BorderBrush="{StaticResource ConsoleBorderBrush}"
+                BorderThickness="1">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0"
+                        Background="{StaticResource ConsoleChromeBrush}"
+                        CornerRadius="5,5,0,0"
+                        BorderBrush="{StaticResource ConsoleBorderBrush}"
+                        BorderThickness="0,0,0,1"
+                        Padding="12,7">
+                    <Grid>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <Ellipse Width="9" Height="9" Margin="0,0,7,0">
+                                <Ellipse.Style>
+                                    <Style TargetType="Ellipse">
+                                        <Setter Property="Fill" Value="{StaticResource ConsoleMutedBrush}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsExecuting}" Value="True">
+                                                <Setter Property="Fill" Value="{StaticResource ConsoleSuccessBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Ellipse.Style>
+                            </Ellipse>
+                            <TextBlock Text="restore console"
+                                       Foreground="{StaticResource ConsoleMutedBrush}"
+                                       FontFamily="{StaticResource ConsoleFont}"
+                                       FontSize="11" VerticalAlignment="Center" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
+                                       Foreground="{StaticResource ConsoleMutedBrush}"
+                                       FontFamily="{StaticResource ConsoleFont}"
+                                       FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0" />
+                            <Button Content="Copy output"
+                                    Command="{Binding CopyConsoleCommand}"
+                                    Style="{StaticResource SecondaryButton}"
+                                    Padding="8,2" FontSize="11" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- ListBox, not an ItemsControl inside a ScrollViewer: an ItemsControl given
+                     unbounded height realises every row and virtualisation silently does nothing.
+                     A ListBox brings its own virtualising scroll viewer. -->
+                <ListBox Grid.Row="1" x:Name="ConsoleList"
+                         ItemsSource="{Binding ConsoleLines}"
+                         Style="{StaticResource ConsoleListBox}" />
+            </Grid>
+        </Border>
+
+        <!-- What a failed or cancelled restore left behind (#14). -->
+        <Border Grid.Row="2" CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1"
+                Visibility="{Binding HasRecoveryActions, Converter={StaticResource BoolToVis}}">
+            <StackPanel>
+                <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
+                           Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                <TextBlock Text="{Binding RecoveryStateMessage}"
+                           Style="{StaticResource BodyText}"
+                           TextWrapping="Wrap" Margin="0,0,0,10" />
+                <ItemsControl ItemsSource="{Binding RecoveryActions}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="{StaticResource InputBackgroundBrush}"
+                                    CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
+                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                               TextWrapping="Wrap" />
+                                    <TextBox Text="{Binding Sql, Mode=OneWay}"
+                                             Style="{StaticResource DarkTextBox}"
+                                             IsReadOnly="True" TextWrapping="Wrap"
+                                             FontFamily="{StaticResource ConsoleFont}"
+                                             FontSize="12" Margin="0,6,0,6" />
+                                    <TextBlock Text="{Binding Caution}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap" Margin="0,0,0,8" />
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Content="Run this"
+                                                Command="{Binding DataContext.RunRecoveryActionCommand,
+                                                          RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="10,6" Margin="0,0,8,0" />
+                                        <Button Content="Copy"
+                                                Command="{Binding DataContext.CopyRecoveryActionCommand,
+                                                          RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="10,6" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Stop restore"
+                    Command="{Binding CancelExecuteCommand}"
+                    Style="{StaticResource DangerButton}"
+                    Visibility="{Binding CanCancelExecute, Converter={StaticResource BoolToVis}}"
+                    Padding="14,7" Margin="0,0,8,0"
+                    ToolTip="Asks SQL Server to abort the statement in flight. It rolls that statement back, but the target database is left mid-restore." />
+            <!-- Enabled only once it has finished. Closing mid-restore would hide the one thing
+                 worth watching without stopping anything. -->
+            <Button Content="Close"
+                    Click="OnClose"
+                    Style="{StaticResource SecondaryButton}"
+                    IsEnabled="{Binding ExecutionComplete}"
+                    Padding="20,7" MinWidth="90" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/NineLives/Views/ExecutionWindow.xaml.cs
+++ b/src/NineLives/Views/ExecutionWindow.xaml.cs
@@ -1,0 +1,91 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Blackcat.NineLives.ViewModels;
+
+namespace Blackcat.NineLives.Views;
+
+/// <summary>
+/// The console, front and centre while a restore runs.
+///
+/// Modal on purpose. A restore is the one operation in this app that cannot be undone and should
+/// not be competing for attention with the form behind it - and it stops someone changing the
+/// options that produced the script currently executing.
+/// </summary>
+public partial class ExecutionWindow : Window
+{
+    private const double FollowThreshold = 40;
+
+    private readonly RestoreViewModel _viewModel;
+    private ScrollViewer? _scroller;
+    private bool _follow = true;
+
+    public ExecutionWindow(RestoreViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = _viewModel = viewModel;
+
+        viewModel.ConsoleLines.CollectionChanged += OnConsoleLinesChanged;
+        ConsoleList.Loaded += (_, _) => HookScroller();
+        Closed += (_, _) => viewModel.ConsoleLines.CollectionChanged -= OnConsoleLinesChanged;
+    }
+
+    private void HookScroller()
+    {
+        _scroller = FindScroller(ConsoleList);
+        if (_scroller != null) _scroller.ScrollChanged += OnScrollChanged;
+    }
+
+    private static ScrollViewer? FindScroller(DependencyObject root)
+    {
+        if (root is ScrollViewer found) return found;
+
+        var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var result = FindScroller(System.Windows.Media.VisualTreeHelper.GetChild(root, i));
+            if (result != null) return result;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Follows the tail while the user is at the bottom, and stops the moment they scroll up.
+    ///
+    /// One scroll per batch of arrivals, not one per line - the viewmodel already flushes output on
+    /// a timer, so this rides that rhythm instead of fighting it.
+    /// </summary>
+    private void OnConsoleLinesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action != NotifyCollectionChangedAction.Add || !_follow) return;
+
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            if (ConsoleList.Items.Count > 0)
+                ConsoleList.ScrollIntoView(ConsoleList.Items[^1]);
+        }), DispatcherPriority.Background);
+    }
+
+    private void OnScrollChanged(object sender, ScrollChangedEventArgs e)
+    {
+        if (sender is not ScrollViewer viewer) return;
+
+        // Only reconsider when the user moved, not when new output changed the extent.
+        if (e.ExtentHeightChange != 0) return;
+
+        _follow = viewer.ExtentHeight - viewer.VerticalOffset - viewer.ViewportHeight <= FollowThreshold;
+    }
+
+    private void OnClose(object sender, RoutedEventArgs e) => Close();
+
+    /// <summary>
+    /// Refuses to close mid-restore. Closing would not stop anything - it would just hide it - and
+    /// the Stop button is right there for someone who actually wants it to end.
+    /// </summary>
+    private void OnClosing(object? sender, CancelEventArgs e)
+    {
+        if (_viewModel.IsExecuting) e.Cancel = true;
+    }
+}

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -972,8 +972,23 @@
                     <Border CornerRadius="6" Margin="0,12,0,0"
                             Background="{StaticResource ConsoleBackgroundBrush}"
                             BorderBrush="{StaticResource ConsoleBorderBrush}"
-                            BorderThickness="1"
-                            Visibility="{Binding HasConsoleOutput, Converter={StaticResource BoolToVis}}">
+                            BorderThickness="1">
+                        <!-- Shown only when the console is NOT in its own window - the two are
+                             mutually exclusive, so the output is never rendered twice. -->
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding HasConsoleOutput}" Value="True" />
+                                            <Condition Binding="{Binding IsConsoleDetached}" Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -1039,8 +1054,23 @@
                          worst moment to be left working that out from a raw SQL error. Each action
                          shows the exact statement before it runs. -->
                     <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
-                            Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1"
-                            Visibility="{Binding HasRecoveryActions, Converter={StaticResource BoolToVis}}">
+                            Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1">
+                        <!-- Same rule as the console: not while it is showing in its own window,
+                             where the recovery actions already appear. -->
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding HasRecoveryActions}" Value="True" />
+                                            <Condition Binding="{Binding IsConsoleDetached}" Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
                         <StackPanel>
                             <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
                                        Style="{StaticResource LabelText}" Margin="0,0,0,8" />

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -936,45 +936,140 @@
                                Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
                                Margin="0,0,0,12" TextWrapping="Wrap" />
 
-                    <!-- Script Output (hidden during execution) -->
+                    <!-- The generated script. Stays visible during and after execution: it used to
+                         be hidden the moment Execute was pressed, so the script and the console
+                         shared one slot and you could not see what was running while it ran. -->
                     <Border Background="{StaticResource InputBackgroundBrush}"
-                            CornerRadius="4" Padding="0">
-                        <Border.Style>
-                            <Style TargetType="Border">
-                                <Setter Property="Visibility" Value="Collapsed" />
-                                <Style.Triggers>
-                                    <MultiDataTrigger>
-                                        <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding HasScript}" Value="True" />
-                                            <Condition Binding="{Binding IsExecuting}" Value="False" />
-                                            <Condition Binding="{Binding ExecutionComplete}" Value="False" />
-                                        </MultiDataTrigger.Conditions>
-                                        <Setter Property="Visibility" Value="Visible" />
-                                    </MultiDataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </Border.Style>
-                        <TextBox Text="{Binding GeneratedScript, Mode=OneWay}"
-                                 Style="{StaticResource DarkTextBox}"
-                                 IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True"
-                                 VerticalScrollBarVisibility="Auto" MaxHeight="400"
-                                 FontFamily="Cascadia Code, Consolas, Courier New" FontSize="12" />
+                            CornerRadius="4" Padding="0"
+                            Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <Grid Margin="12,8,12,4">
+                                <TextBlock Text="GENERATED SCRIPT" Style="{StaticResource LabelText}" />
+                                <TextBlock Text="updates as you change options"
+                                           Style="{StaticResource SecondaryText}"
+                                           FontSize="11"
+                                           HorizontalAlignment="Right" />
+                            </Grid>
+                            <TextBox Text="{Binding GeneratedScript, Mode=OneWay}"
+                                     Style="{StaticResource DarkTextBox}"
+                                     IsReadOnly="True" TextWrapping="NoWrap" AcceptsReturn="True"
+                                     VerticalScrollBarVisibility="Auto"
+                                     HorizontalScrollBarVisibility="Auto"
+                                     MaxHeight="320"
+                                     FontFamily="{StaticResource ConsoleFont}" FontSize="12" />
+                        </StackPanel>
                     </Border>
 
-                    <!-- Execution Log -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
-                            CornerRadius="4" Padding="0" Margin="0,12,0,0"
-                            Visibility="{Binding ExecutionLog, Converter={StaticResource NullToVis}}">
-                        <StackPanel>
-                            <TextBlock Text="EXECUTION LOG" Style="{StaticResource LabelText}" Margin="12,8,0,4" />
-                            <TextBox x:Name="ExecutionLogBox"
-                                     Text="{Binding ExecutionLog, Mode=OneWay}"
-                                     Style="{StaticResource DarkTextBox}"
-                                     IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True"
-                                     VerticalScrollBarVisibility="Auto" MaxHeight="300"
-                                     FontFamily="Cascadia Code, Consolas, Courier New" FontSize="12"
-                                     TextChanged="ExecutionLogBox_TextChanged" />
-                        </StackPanel>
+                    <!-- Execution console.
+                         Its own surface, darker than the cards, so it reads as a terminal rather
+                         than another form panel. Lines come from a collection rather than one
+                         growing string: appending to a bound string re-rendered the whole control
+                         on every message, which is why progress arrived in bursts. -->
+                    <Border CornerRadius="6" Margin="0,12,0,0"
+                            Background="{StaticResource ConsoleBackgroundBrush}"
+                            BorderBrush="{StaticResource ConsoleBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding HasConsoleOutput, Converter={StaticResource BoolToVis}}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+
+                            <!-- Chrome strip: title, live indicator, copy. -->
+                            <Border Grid.Row="0"
+                                    Background="{StaticResource ConsoleChromeBrush}"
+                                    CornerRadius="5,5,0,0"
+                                    BorderBrush="{StaticResource ConsoleBorderBrush}"
+                                    BorderThickness="0,0,0,1"
+                                    Padding="12,7">
+                                <Grid>
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <Ellipse Width="9" Height="9" Margin="0,0,7,0">
+                                            <Ellipse.Style>
+                                                <Style TargetType="Ellipse">
+                                                    <Setter Property="Fill" Value="{StaticResource ConsoleMutedBrush}" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsExecuting}" Value="True">
+                                                            <Setter Property="Fill" Value="{StaticResource ConsoleSuccessBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Ellipse.Style>
+                                        </Ellipse>
+                                        <TextBlock Text="restore console"
+                                                   Foreground="{StaticResource ConsoleMutedBrush}"
+                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                   FontSize="11"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                        <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
+                                                   Foreground="{StaticResource ConsoleMutedBrush}"
+                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                   FontSize="11"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,0,12,0" />
+                                        <Button Content="Copy output"
+                                                Command="{Binding CopyConsoleCommand}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="8,2" FontSize="11"
+                                                ToolTip="Copies the whole console, which is what to attach to a bug report." />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+
+                            <!-- Virtualised so a long restore stays responsive. Auto-follows the
+                                 last line unless the user has scrolled up to read something. -->
+                            <ScrollViewer Grid.Row="1"
+                                          x:Name="ConsoleScroller"
+                                          ScrollChanged="ConsoleScroller_ScrollChanged"
+                                          VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          MaxHeight="360"
+                                          Padding="12,8,12,10">
+                                <ItemsControl ItemsSource="{Binding ConsoleLines}"
+                                              VirtualizingStackPanel.IsVirtualizing="True"
+                                              VirtualizingStackPanel.VirtualizationMode="Recycling">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <VirtualizingStackPanel />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Text}"
+                                                       FontFamily="{StaticResource ConsoleFont}"
+                                                       FontSize="12"
+                                                       TextWrapping="NoWrap"
+                                                       LineHeight="17">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Kind}" Value="Step">
+                                                                <Setter Property="Foreground" Value="{StaticResource ConsoleStepBrush}" />
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Kind}" Value="Success">
+                                                                <Setter Property="Foreground" Value="{StaticResource ConsoleSuccessBrush}" />
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Kind}" Value="Warning">
+                                                                <Setter Property="Foreground" Value="{StaticResource ConsoleWarningBrush}" />
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Kind}" Value="Error">
+                                                                <Setter Property="Foreground" Value="{StaticResource ConsoleErrorBrush}" />
+                                                                <Setter Property="FontWeight" Value="SemiBold" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
+                        </Grid>
                     </Border>
 
                     <!-- What a failed restore left behind, and how to undo it (#14). A chain that

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -983,6 +983,12 @@
                                         <MultiDataTrigger.Conditions>
                                             <Condition Binding="{Binding HasConsoleOutput}" Value="True" />
                                             <Condition Binding="{Binding IsConsoleDetached}" Value="False" />
+                                            <!-- Belt and braces. While a restore runs the console
+                                                 is always in its own window, so the inline one
+                                                 must be gone even if the detach flag never got
+                                                 set - a wiring failure should not put two
+                                                 consoles on screen. -->
+                                            <Condition Binding="{Binding IsExecuting}" Value="False" />
                                         </MultiDataTrigger.Conditions>
                                         <Setter Property="Visibility" Value="Visible" />
                                     </MultiDataTrigger>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="Blackcat.NineLives.Views.RestoreView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
+             xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
+             xmlns:views="clr-namespace:Blackcat.NineLives.Views">
 
     <UserControl.Resources>
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
@@ -950,13 +951,16 @@
                                            FontSize="11"
                                            HorizontalAlignment="Right" />
                             </Grid>
-                            <TextBox Text="{Binding GeneratedScript, Mode=OneWay}"
-                                     Style="{StaticResource DarkTextBox}"
-                                     IsReadOnly="True" TextWrapping="NoWrap" AcceptsReturn="True"
-                                     VerticalScrollBarVisibility="Auto"
-                                     HorizontalScrollBarVisibility="Auto"
-                                     MaxHeight="320"
-                                     FontFamily="{StaticResource ConsoleFont}" FontSize="12" />
+                            <ScrollViewer MaxHeight="320"
+                                          VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          Padding="12,4,12,10">
+                                <views:SqlTextBlock Sql="{Binding GeneratedScript}"
+                                                    FontFamily="{StaticResource ConsoleFont}"
+                                                    FontSize="12"
+                                                    TextWrapping="NoWrap"
+                                                    Foreground="{StaticResource ConsoleTextBrush}" />
+                            </ScrollViewer>
                         </StackPanel>
                     </Border>
 
@@ -1022,53 +1026,10 @@
 
                             <!-- Virtualised so a long restore stays responsive. Auto-follows the
                                  last line unless the user has scrolled up to read something. -->
-                            <ScrollViewer Grid.Row="1"
-                                          x:Name="ConsoleScroller"
-                                          ScrollChanged="ConsoleScroller_ScrollChanged"
-                                          VerticalScrollBarVisibility="Auto"
-                                          HorizontalScrollBarVisibility="Auto"
-                                          MaxHeight="360"
-                                          Padding="12,8,12,10">
-                                <ItemsControl ItemsSource="{Binding ConsoleLines}"
-                                              VirtualizingStackPanel.IsVirtualizing="True"
-                                              VirtualizingStackPanel.VirtualizationMode="Recycling">
-                                    <ItemsControl.ItemsPanel>
-                                        <ItemsPanelTemplate>
-                                            <VirtualizingStackPanel />
-                                        </ItemsPanelTemplate>
-                                    </ItemsControl.ItemsPanel>
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate>
-                                            <TextBlock Text="{Binding Text}"
-                                                       FontFamily="{StaticResource ConsoleFont}"
-                                                       FontSize="12"
-                                                       TextWrapping="NoWrap"
-                                                       LineHeight="17">
-                                                <TextBlock.Style>
-                                                    <Style TargetType="TextBlock">
-                                                        <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
-                                                        <Style.Triggers>
-                                                            <DataTrigger Binding="{Binding Kind}" Value="Step">
-                                                                <Setter Property="Foreground" Value="{StaticResource ConsoleStepBrush}" />
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding Kind}" Value="Success">
-                                                                <Setter Property="Foreground" Value="{StaticResource ConsoleSuccessBrush}" />
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding Kind}" Value="Warning">
-                                                                <Setter Property="Foreground" Value="{StaticResource ConsoleWarningBrush}" />
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding Kind}" Value="Error">
-                                                                <Setter Property="Foreground" Value="{StaticResource ConsoleErrorBrush}" />
-                                                                <Setter Property="FontWeight" Value="SemiBold" />
-                                                            </DataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </TextBlock.Style>
-                                            </TextBlock>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
-                            </ScrollViewer>
+                            <ListBox Grid.Row="1" x:Name="ConsoleList"
+                                     ItemsSource="{Binding ConsoleLines}"
+                                     Style="{StaticResource ConsoleListBox}"
+                                     MaxHeight="360" />
                         </Grid>
                     </Border>
 

--- a/src/NineLives/Views/RestoreView.xaml.cs
+++ b/src/NineLives/Views/RestoreView.xaml.cs
@@ -1,20 +1,73 @@
+using System.Collections.Specialized;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Threading;
+using Blackcat.NineLives.ViewModels;
 
 namespace Blackcat.NineLives.Views;
 
 public partial class RestoreView : UserControl
 {
+    /// <summary>
+    /// How close to the bottom still counts as "following". A couple of lines of slack, so a
+    /// trackpad nudge or scrollbar rounding does not silently stop the console following.
+    /// </summary>
+    private const double FollowThreshold = 40;
+
+    private INotifyCollectionChanged? _observedLines;
+    private bool _follow = true;
+
     public RestoreView()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+        Unloaded += (_, _) => Detach();
     }
 
-    private void ExecutionLogBox_TextChanged(object sender, TextChangedEventArgs e)
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
-        if (sender is TextBox textBox)
+        Detach();
+
+        if (e.NewValue is RestoreViewModel vm)
         {
-            textBox.CaretIndex = textBox.Text.Length;
-            textBox.ScrollToEnd();
+            _observedLines = vm.ConsoleLines;
+            _observedLines.CollectionChanged += OnConsoleLinesChanged;
         }
+    }
+
+    private void Detach()
+    {
+        if (_observedLines != null)
+            _observedLines.CollectionChanged -= OnConsoleLinesChanged;
+        _observedLines = null;
+    }
+
+    /// <summary>
+    /// Follows the tail as output arrives, but only while the user is already at the bottom.
+    ///
+    /// A console that always jumps to the end is unusable during a long restore: scroll up to read
+    /// the statement that just failed and the next progress message yanks you away again. Scrolling
+    /// back to the bottom resumes following, which is what a terminal does.
+    /// </summary>
+    private void OnConsoleLinesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action != NotifyCollectionChangedAction.Add || !_follow) return;
+
+        // At Background priority, so the new item has been realised and the extent has grown by
+        // the time this runs. Scrolling first would land short of the real end.
+        Dispatcher.BeginInvoke(new Action(() => ConsoleScroller?.ScrollToEnd()),
+            DispatcherPriority.Background);
+    }
+
+    private void ConsoleScroller_ScrollChanged(object sender, ScrollChangedEventArgs e)
+    {
+        if (sender is not ScrollViewer viewer) return;
+
+        // Only reconsider when the user moved, not when new output changed the extent - otherwise
+        // arriving lines would themselves look like a deliberate scroll away from the bottom.
+        if (e.ExtentHeightChange != 0) return;
+
+        var distanceFromBottom = viewer.ExtentHeight - viewer.VerticalOffset - viewer.ViewportHeight;
+        _follow = distanceFromBottom <= FollowThreshold;
     }
 }

--- a/src/NineLives/Views/RestoreView.xaml.cs
+++ b/src/NineLives/Views/RestoreView.xaml.cs
@@ -15,6 +15,8 @@ public partial class RestoreView : UserControl
     private const double FollowThreshold = 40;
 
     private INotifyCollectionChanged? _observedLines;
+    private RestoreViewModel? _viewModel;
+    private ExecutionWindow? _executionWindow;
     private bool _follow = true;
 
     public RestoreView()
@@ -30,8 +32,10 @@ public partial class RestoreView : UserControl
 
         if (e.NewValue is RestoreViewModel vm)
         {
+            _viewModel = vm;
             _observedLines = vm.ConsoleLines;
             _observedLines.CollectionChanged += OnConsoleLinesChanged;
+            vm.PropertyChanged += OnViewModelPropertyChanged;
         }
     }
 
@@ -39,7 +43,38 @@ public partial class RestoreView : UserControl
     {
         if (_observedLines != null)
             _observedLines.CollectionChanged -= OnConsoleLinesChanged;
+        if (_viewModel != null)
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+
         _observedLines = null;
+        _viewModel = null;
+    }
+
+    /// <summary>
+    /// Brings the console up as a modal window when a restore starts.
+    ///
+    /// Showing a window is the view's job, not the viewmodel's - which is why this watches a
+    /// property rather than the viewmodel calling out to a dialog service. The window is modal
+    /// because a restore is the one operation here that cannot be undone: it should not compete
+    /// with the form behind it, and nobody should be editing the options that produced the script
+    /// currently running.
+    ///
+    /// The inline console stays behind it, so the record is still there once the window is closed.
+    /// </summary>
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(RestoreViewModel.IsExecuting)) return;
+        if (_viewModel is not { IsExecuting: true } vm || _executionWindow != null) return;
+
+        _executionWindow = new ExecutionWindow(vm) { Owner = Window.GetWindow(this) };
+
+        // ShowDialog blocks, so it must not run inside the property-changed notification that the
+        // restore itself is unwinding through. Posting lets the execution carry on underneath.
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            try { _executionWindow?.ShowDialog(); }
+            finally { _executionWindow = null; }
+        }), DispatcherPriority.Background);
     }
 
     /// <summary>
@@ -53,21 +88,12 @@ public partial class RestoreView : UserControl
     {
         if (e.Action != NotifyCollectionChangedAction.Add || !_follow) return;
 
-        // At Background priority, so the new item has been realised and the extent has grown by
-        // the time this runs. Scrolling first would land short of the real end.
-        Dispatcher.BeginInvoke(new Action(() => ConsoleScroller?.ScrollToEnd()),
-            DispatcherPriority.Background);
-    }
-
-    private void ConsoleScroller_ScrollChanged(object sender, ScrollChangedEventArgs e)
-    {
-        if (sender is not ScrollViewer viewer) return;
-
-        // Only reconsider when the user moved, not when new output changed the extent - otherwise
-        // arriving lines would themselves look like a deliberate scroll away from the bottom.
-        if (e.ExtentHeightChange != 0) return;
-
-        var distanceFromBottom = viewer.ExtentHeight - viewer.VerticalOffset - viewer.ViewportHeight;
-        _follow = distanceFromBottom <= FollowThreshold;
+        // At Background priority, so the new rows have been realised by the time this runs.
+        // Scrolling first would land short of the real end.
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            if (ConsoleList.Items.Count > 0)
+                ConsoleList.ScrollIntoView(ConsoleList.Items[^1]);
+        }), DispatcherPriority.Background);
     }
 }

--- a/src/NineLives/Views/RestoreView.xaml.cs
+++ b/src/NineLives/Views/RestoreView.xaml.cs
@@ -68,12 +68,20 @@ public partial class RestoreView : UserControl
 
         _executionWindow = new ExecutionWindow(vm) { Owner = Window.GetWindow(this) };
 
+        // The inline console hides while the window is up, so the output is only ever in one
+        // place, and comes back afterwards so the record stays reachable from the main view.
+        vm.IsConsoleDetached = true;
+
         // ShowDialog blocks, so it must not run inside the property-changed notification that the
         // restore itself is unwinding through. Posting lets the execution carry on underneath.
         Dispatcher.BeginInvoke(new Action(() =>
         {
             try { _executionWindow?.ShowDialog(); }
-            finally { _executionWindow = null; }
+            finally
+            {
+                _executionWindow = null;
+                vm.IsConsoleDetached = false;
+            }
         }), DispatcherPriority.Background);
     }
 

--- a/src/NineLives/Views/SqlTextBlock.cs
+++ b/src/NineLives/Views/SqlTextBlock.cs
@@ -1,0 +1,63 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Views;
+
+/// <summary>
+/// A read-only TextBlock that renders T-SQL with syntax colouring.
+///
+/// A TextBlock of Runs rather than a RichTextBox: the script is display-only, and a RichTextBox
+/// brings an editing surface, its own scrolling model and a FlowDocument to keep in sync for no
+/// benefit here. Selection is not needed either - Copy to Clipboard already exists.
+/// </summary>
+public sealed class SqlTextBlock : TextBlock
+{
+    public static readonly DependencyProperty SqlProperty = DependencyProperty.Register(
+        nameof(Sql), typeof(string), typeof(SqlTextBlock),
+        new PropertyMetadata(string.Empty, OnSqlChanged));
+
+    public string Sql
+    {
+        get => (string)GetValue(SqlProperty);
+        set => SetValue(SqlProperty, value);
+    }
+
+    private static void OnSqlChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        => ((SqlTextBlock)d).Rebuild();
+
+    private void Rebuild()
+    {
+        Inlines.Clear();
+
+        foreach (var token in SqlSyntaxHighlighter.Tokenise(Sql))
+        {
+            var run = new Run(token.Text);
+            var brush = BrushFor(token.Kind);
+            if (brush != null) run.Foreground = brush;
+            if (token.Kind == SqlTokenKind.Keyword) run.FontWeight = FontWeights.SemiBold;
+            Inlines.Add(run);
+        }
+    }
+
+    /// <summary>
+    /// Resolved from the theme rather than hardcoded, so the script pane and the console stay in
+    /// the same palette. Falls back to inheriting the foreground if a key is missing.
+    /// </summary>
+    private Brush? BrushFor(SqlTokenKind kind)
+    {
+        var key = kind switch
+        {
+            SqlTokenKind.Keyword => "SqlKeywordBrush",
+            SqlTokenKind.Literal => "SqlLiteralBrush",
+            SqlTokenKind.Comment => "SqlCommentBrush",
+            SqlTokenKind.Number => "SqlNumberBrush",
+            SqlTokenKind.Identifier => "SqlIdentifierBrush",
+            _ => null
+        };
+
+        return key != null ? TryFindResource(key) as Brush : null;
+    }
+}


### PR DESCRIPTION
Four things. The first two are why the progress wasn't live.

## Why it stuttered

**`Dispatcher.Invoke` was synchronous.** That callback runs on the connection's thread when SQL Server sends an info message, and a synchronous `Invoke` *blocks that thread* until the UI has finished handling it. With the UI busy, the restore backed up and then flushed in bursts — exactly what you saw. It's `InvokeAsync` now, so the restore keeps streaming and the UI catches up on its own time.

**Each message did far more work than it looked.** Two compounding problems:

- The console was a single bound string appended with `+=`. That rebuilds the whole string and re-renders the entire `TextBox` on every message — O(n²).
- Every line hit the disk **three times, on the UI thread**: `CreateDirectory`, a `FileInfo` stat for the roll check, then the append.

So a restore reporting progress every few percent was doing hundreds of filesystem syscalls and full-control re-renders, while the database thread sat blocked waiting. The directory is created once now, the size checked every 200 lines, and the console is an `ObservableCollection` rendered by a virtualising `ItemsControl` — the thousandth line costs what the first did.

## The script pane and the console shared one slot

The script's visibility required `IsExecuting=False AND ExecutionComplete=False`, so it was **hidden the moment you pressed Execute**. That's the thing you didn't like, and it also meant you couldn't see what was running while it ran. They're separate panes now and both stay visible.

## The script now updates live

It only rebuilt when **Generate Script** was pressed, so it could quietly disagree with the options above it — and that script is what someone reads before running a restore against production.

Every option change already funnels through `UpdateRestoreSummary`, so that's where it's kept in step. Settings that can't produce a valid script now **clear** it rather than leaving a stale one, since a stale script looks authoritative and isn't. The Generate button stays, and is still the thing that tells you *why* nothing was produced — the live path stays silent because erroring on every keystroke would be noise.

## The console is now a terminal

- Its own darker surface (`#0C0E14`) so it reads as a terminal, not another form panel
- Chrome strip: live dot (green while running), line count, **Copy output**
- Monospace throughout, lines coloured by kind — steps blue, success green, warnings amber, errors red and semibold
- **Follows the tail while you're at the bottom, and stops the moment you scroll up.** Scroll back down and it resumes. A console that always jumps to the end is unusable during a long restore — scroll up to read the statement that just failed and the next progress line yanks you away.

## Try it

```
C:\Users\jake\AppData\Local\Temp\NineLives-console\NineLives.exe
```

**569 tests pass**, build clean at `-warnaserror`. 17 new, including one that pins script and console being on screen together, so they can't get merged back into one slot.

One thing I can't verify: how it actually *looks*. The tests prove it renders, binds and colours correctly, but whether the spacing and palette feel right against the Claude Code styling you're after is your call.
