### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>


### PR DESCRIPTION
Version bump ahead of the v1.2.0 release PR.

Through a PR rather than pushed straight to `dev` - I bypassed branch protection for the v1.1.0 bump and said at the time I shouldn't make a habit of it.