### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,11 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    labels: [dependencies]
     groups:
-      # One PR per week for routine bumps instead of five.
+      # One PR per week for routine bumps instead of five. Major bumps are deliberately
+      # left out of the group, so each one arrives as its own PR and gets looked at on its
+      # own merits - SqlClient 5.x to 7.x went through here unnoticed once already (#16).
       nuget-minor-patch:
         update-types: [minor, patch]
 
@@ -15,3 +18,4 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    labels: [dependencies]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,14 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      # Actions are pinned by commit SHA rather than tag. A tag is mutable: whoever controls the
+      # action's repository can repoint v7 at different code, and that code then runs inside our
+      # workflows - the release one holds contents: write and a signing identity. The trailing
+      # comment is the human-readable version, and Dependabot updates both together.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 8.0.x
 
@@ -84,7 +88,7 @@ jobs:
       # smoke publish above already proved the shape, and fork PRs shouldn't mint artifacts.
       - name: Upload build artifact
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: NineLives-main-${{ github.sha }}
           path: publish/NineLives.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,12 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      # --locked-mode restores exactly the graph in packages.lock.json and fails (NU1004) on
+      # any drift. Two builds of the same commit therefore produce the same binaries, and a
+      # dependency cannot change under us without a commit that says so. Updating a package
+      # means running "dotnet restore --force-evaluate" and committing the new lock file.
       - name: Restore dependencies
-        run: dotnet restore NineLives.sln
+        run: dotnet restore NineLives.sln --locked-mode
 
       # -warnaserror locks in the current zero-warning state: a PR that introduces the
       # first compiler warning fails here instead of starting an accumulation nobody

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       # --locked-mode restores exactly the graph in packages.lock.json and fails (NU1004) on
       # any drift. Two builds of the same commit therefore produce the same binaries, and a

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,10 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      # Locked, same as build.yml — the shipped exe is built from the exact dependency graph
+      # that was reviewed and tested, not from whatever was newest on nuget.org that morning.
       - name: Restore dependencies
-        run: dotnet restore NineLives.sln
+        run: dotnet restore NineLives.sln --locked-mode
 
       - name: Build
         run: dotnet build NineLives.sln -c Release --no-restore -warnaserror

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
 
 permissions:
   contents: write
+  # Build provenance attestation: id-token mints the short-lived Sigstore identity that
+  # proves the signature came from this workflow, attestations stores the result.
+  id-token: write
+  attestations: write
 
 # Release runs are never cancelled and never share a concurrency group — each one must
 # finish and attach its assets to the release that triggered it.
@@ -67,6 +71,22 @@ jobs:
           $checksums | Out-File -FilePath releases/SHA256SUMS.txt -Encoding utf8
           Write-Host "Checksums:"
           $checksums | ForEach-Object { Write-Host $_ }
+
+      # Signed, tamper-evident proof of where this exe came from: which repo, which commit,
+      # which workflow run. Anyone can check it with
+      #     gh attestation verify NineLives.exe --repo jakemorgangit/NineLives
+      # and get a hard answer, rather than trusting that the file on the Releases page is
+      # the one this workflow built. A checksum only proves the file matches a number
+      # published next to it; provenance ties it back to source.
+      #
+      # This is NOT code signing and does nothing for SmartScreen - see #33 and
+      # docs/code-signing.md. It is the part that can be done without a certificate.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            releases/NineLives.exe
+            releases/NineLives-${{ steps.version.outputs.VERSION }}-win-x64.zip
 
       - name: Upload release assets
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       # Locked, same as build.yml — the shipped exe is built from the exact dependency graph
       # that was reviewed and tested, not from whatever was newest on nuget.org that morning.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 8.0.x
 
@@ -82,7 +82,7 @@ jobs:
       # This is NOT code signing and does nothing for SmartScreen - see #33 and
       # docs/code-signing.md. It is the part that can be done without a certificate.
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             releases/NineLives.exe

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ dotnet build
 dotnet test
 ```
 
-Requires the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) and Windows (it is a
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) and Windows (it is a
 WPF app).
 
 ### Live SQL Server tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,39 @@ dotnet test
 They create and drop only their own objects and clean up after themselves. CI starts LocalDB on
 a best-effort basis, so they run there too.
 
+## Dependencies
+
+Package versions are pinned exactly, and `packages.lock.json` in each project records the whole
+resolved graph — direct and transitive — with content hashes. CI restores with `--locked-mode`,
+so a dependency cannot change without a commit that says so.
+
+**Changing a package version means committing the new lock file:**
+
+```bash
+# edit the <PackageReference Version="..."> in the csproj, then
+dotnet restore --force-evaluate
+git add src/*/packages.lock.json
+```
+
+Skip that and CI fails with `NU1004`, telling you exactly which reference drifted.
+
+Dependabot raises minor and patch bumps as one grouped weekly PR. **Major bumps come as their own
+PR** and want a real look — `Microsoft.Data.SqlClient` once went from 5.x to 7.x on a wildcard
+with green CI, because no test in the suite opened a `SqlConnection`. Dependabot does not always
+refresh the lock file, so a red `NU1004` on its PR usually just means running the command above.
+
+Restore also audits the full graph against the GitHub Advisory Database and warns on anything
+known-vulnerable. That is the trade for pinning: patches no longer arrive on their own, so the
+warning is what tells you one is needed.
+
 ## What CI checks
 
 Every PR runs on `windows-latest`:
 
-1. `dotnet build -warnaserror` — **the build is warning-free and must stay that way**
-2. the full test suite
-3. a self-contained single-file publish, proving the shipping artifact still builds
+1. `dotnet restore --locked-mode` — **dependencies match the committed lock file exactly**
+2. `dotnet build -warnaserror` — **the build is warning-free and must stay that way**
+3. the full test suite
+4. a self-contained single-file publish, proving the shipping artifact still builds
 
 ## Expectations for a change
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,36 @@
+<Project>
+
+  <PropertyGroup>
+    <!-- Every project writes a packages.lock.json recording the whole resolved graph,
+         direct and transitive. CI restores in locked mode, so a package that changes
+         underneath us fails the build instead of quietly shipping. New projects
+         inherit this automatically.
+
+         The exception is a single-file publish. That restore additionally pulls
+         Microsoft.NET.ILLink.Tasks, an SDK-internal tool pack whose version tracks the
+         installed SDK rather than anything we chose. Recording it would mean the lock
+         file only validates on whichever SDK patch generated it - CI and every
+         contributor would break apart the moment their SDKs diverged. So the publish
+         restore neither reads nor rewrites the lock file. What it does still get is the
+         exact pinned versions from the csproj files, and the win-x64 runtime assets for
+         those packages are recorded in the lock file via RuntimeIdentifiers. The
+         unlocked part is SDK tooling, not our dependencies.
+
+         Clearing RestorePackagesWithLockFile is not enough on its own - NuGet keeps an
+         existing lock file up to date whether or not the property is set - so the publish
+         restore is also pointed at a throwaway file under obj/. Without that, every
+         publish leaves the committed lock file dirty. -->
+    <RestorePackagesWithLockFile Condition="'$(PublishSingleFile)' != 'true'">true</RestorePackagesWithLockFile>
+    <NuGetLockFilePath Condition="'$(PublishSingleFile)' == 'true'">$(MSBuildProjectDirectory)\obj\publish-packages.lock.json</NuGetLockFilePath>
+
+    <!-- Pinned versions no longer pick up security patches on their own, so restore has to
+         say when a pinned package develops a known vulnerability. "all" covers the
+         transitive graph too, which is where most of them actually live. These stay
+         warnings rather than errors: a freshly disclosed CVE should be loud, but it
+         should not brick a release build at 2am. -->
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+  </PropertyGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -112,6 +112,37 @@ Download the latest release from the [Releases page](https://github.com/jakemorg
 - Windows 10/11 (x64)
 - No .NET runtime installation required (self-contained)
 
+### "Windows protected your PC"
+
+The executable is not yet code-signed, so SmartScreen will stop it the first time you run it.
+Click **More info** → **Run anyway**.
+
+That warning means Windows has not seen this file before — not that anything is wrong with it. But
+you shouldn't have to take that on faith for a tool you're about to point at production with
+sysadmin rights, so there are two ways to check.
+
+**Checksum** — confirms the file matches what the release page publishes:
+
+```powershell
+Get-FileHash NineLives.exe -Algorithm SHA256
+```
+
+Compare against `SHA256SUMS.txt` on the release.
+
+**Build provenance** — confirms the file was built by this repository's release workflow, from a
+specific commit, and has not been altered since. Needs the [GitHub CLI](https://cli.github.com):
+
+```powershell
+gh attestation verify NineLives.exe --repo jakemorgangit/NineLives
+```
+
+A pass prints the commit and workflow that produced it. This is a stronger guarantee than the
+checksum, which only proves the file matches a number published beside it.
+
+Getting the exe signed properly is tracked in
+[#33](https://github.com/jakemorgangit/NineLives/issues/33); the options are written up in
+[docs/code-signing.md](docs/code-signing.md).
+
 ### Build from Source
 
 #### Prerequisites

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Every database deserves nine lives.**
 
-Nine Lives is a modern desktop application for restoring SQL Server databases from Azure Blob Storage backups — point-in-time recovery with a visual timeline, intelligent backup chain detection, striped backup support, and secure credential management. Built with WPF on .NET 8, featuring a dark-mode UI.
+Nine Lives is a modern desktop application for restoring SQL Server databases from Azure Blob Storage backups — point-in-time recovery with a visual timeline, intelligent backup chain detection, striped backup support, and secure credential management. Built with WPF on .NET 10, featuring a dark-mode UI.
 
 *A free tool from [Blackcat Data Solutions](https://blackcat.wales).*
 
@@ -146,7 +146,7 @@ Getting the exe signed properly is tracked in
 ### Build from Source
 
 #### Prerequisites
-- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later
 - Windows 10/11 (WPF application)
 
 #### Clone and Build
@@ -331,7 +331,7 @@ When you select a transaction log restore point, the chain includes:
 ## Architecture
 
 Built with:
-- **.NET 8** (LTS) - Windows Presentation Foundation (WPF)
+- **.NET 10** (LTS) - Windows Presentation Foundation (WPF)
 - **CommunityToolkit.Mvvm** - MVVM pattern implementation
 - **Azure.Storage.Blobs** - Azure Blob Storage SDK
 - **Microsoft.Data.SqlClient** - SQL Server connectivity

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,81 @@
+# Security policy
+
+Nine Lives holds Azure SAS tokens and SQL Server passwords, and it generates and runs T-SQL against
+instances you point it at — usually with rights to drop and replace databases. Security reports are
+taken seriously here.
+
+## Reporting a vulnerability
+
+**Please don't open a public issue.** Use either:
+
+- **[Private vulnerability reporting](https://github.com/jakemorgangit/NineLives/security/advisories/new)**
+  — the Report a vulnerability button under the Security tab. Preferred, because the discussion and
+  the fix stay in one place until there's something to release.
+- **jake@blackcat.wales** if you'd rather use email.
+
+Useful things to include: the version (Help → About), what an attacker would gain, and the smallest
+set of steps that shows it. A proof of concept helps but is not required — a clear description of
+the flaw is enough.
+
+### What to expect
+
+This is maintained by one person alongside client work, so:
+
+- **Acknowledgement within 3 working days.** If you haven't heard back by then, please chase — it
+  means the message went astray.
+- An assessment, and either a fix or an explanation of why it isn't one, within 30 days.
+- Credit in the release notes if you'd like it, or none if you'd rather not.
+
+Please give a fix a reasonable chance to ship before disclosing publicly. If something is being
+actively exploited, say so and it'll jump the queue.
+
+## Supported versions
+
+Only the **latest release** is supported. There are no maintenance branches — fixes go into the
+next release. If you're running something older, upgrading is the fix.
+
+## What the tool assumes
+
+Worth stating plainly, because it determines whether a given finding is a bug or the design:
+
+- **It runs locally as you.** It has whatever access your Windows account has, and no privilege
+  boundary of its own.
+- **Secrets live in Windows Credential Manager**, per-user, under `NineLives:Blob:*` and
+  `NineLives:SQL:*`. They are never written to `config.json`, never included in generated scripts,
+  and never sent anywhere except the SQL Server you connect to.
+- **`config.json` is trusted input.** It sits in `%LOCALAPPDATA%\NineLives`, is plain text, and has
+  no integrity checking. Anything able to write it is already running as you. That said, values
+  read from it still get escaped properly before reaching T-SQL — someone who can write that file
+  should not thereby get a cleaner path to running arbitrary SQL as sysadmin.
+- **You choose the server.** The tool connects where you tell it to and runs the script you can
+  read before you run it.
+
+So: anything an attacker who is *already you, on your machine* can do is generally not a
+vulnerability. Anything that leaks a secret somewhere it shouldn't go, sends it somewhere
+unexpected, or turns untrusted data into executed T-SQL, is.
+
+### Particularly interested in
+
+- SAS tokens or SQL passwords ending up anywhere other than Credential Manager — logs, the
+  generated script, `config.json`, the clipboard, an error message, a crash dump.
+- Anything that reaches T-SQL without going through `Services/TSql.cs`, or a way past its quoting.
+- A restore being aimed at a server or database other than the one shown in the confirmation.
+- Credentials being sent over a connection that isn't validated the way the settings claim.
+
+### Known and already tracked
+
+Not vulnerabilities to report — they're on the list:
+
+- The released binary is **unsigned**, so SmartScreen warns on download
+  ([#33](https://github.com/jakemorgangit/NineLives/issues/33)). Releases carry a
+  [build provenance attestation](https://github.com/jakemorgangit/NineLives#windows-protected-your-pc)
+  you can verify in the meantime.
+- `TrustServerCertificate` defaults to true
+  ([#17](https://github.com/jakemorgangit/NineLives/issues/17)).
+- Entra ID / Managed Identity is not supported yet; SAS tokens only
+  ([#29](https://github.com/jakemorgangit/NineLives/issues/29)).
+
+## Thank you
+
+Genuinely — a private report is a favour, and it's the difference between fixing something quietly
+and finding out about it the hard way.

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -25,57 +25,72 @@ consult Sigstore; it looks for an Authenticode signature. Provenance answers "di
 the source I think it did", which is the question a careful reviewer asks. SmartScreen asks "does
 Windows recognise the publisher", and only a certificate answers that.
 
-## Options for the certificate
+## The constraint that decides this
 
-### SignPath — free for open source
+**Nine Lives is a free tool with no revenue behind it. There is no budget for a recurring
+subscription.** That rules out the managed signing services regardless of how convenient they are,
+and it is not a detail to be traded away because a monthly figure looks small — small recurring
+costs on an unfunded project are exactly the ones that accumulate.
 
-The route the issue proposed, and what several OSS .NET projects use. SignPath issues the
-certificate; there is nothing to buy or store.
+So the order below is by cost, and anything with a monthly fee is out.
 
-- **Cost:** free, subject to their OSS eligibility review.
-- **Effort:** register the project, define a signing policy and an artifact configuration, add
-  `signpath/github-action-submit-signing-request@v2` to the release job, store the API token as a
-  repository secret.
-- **Catch:** signing is a submit-and-poll round trip through their service, so the release job gets
-  slower. Worth confirming their upload size limit up front — `NineLives.exe` is ~166 MB, which is
-  large for a signing submission.
+## SignPath Foundation — free, and the route to take
 
-### Azure Trusted Signing — ~$10/month
+SignPath's Foundation programme issues free code signing certificates to open source projects, and
+runs the signing service too, so there is no private key to buy, store or protect. It is what a
+number of OSS .NET projects use.
 
-Microsoft's managed signing service. Short-lived certificates, no private key to look after, and
-because it is Microsoft's own CA it carries SmartScreen reputation well.
+- **Cost:** free, subject to their review that the project qualifies as open source.
+- **Effort:** apply to the Foundation programme, then define a signing policy and an artifact
+  configuration, add `signpath/github-action-submit-signing-request@v2` to the release job, and
+  store the API token as a repository secret.
+- **Worth checking up front:**
+  - **Artifact size.** `NineLives.exe` is ~146 MB, which is large for a signing submission. Confirm
+    their limit before building the workflow around it. If it is a problem, signing the contents of
+    the zip rather than the single-file exe is the usual way out.
+  - **Certificate type.** A standard OV certificate removes the "unrecognised publisher" wording and
+    shows a real name, but SmartScreen reputation still builds with download volume — so warnings
+    may not vanish on day one. Ask them what they issue and set expectations from the answer rather
+    than from this document.
+  - **Turnaround.** Signing is a submit-and-poll round trip through their service, so the release
+    job gets slower.
 
-- **Cost:** Basic tier, around $9.99/month.
-- **Effort:** likely the least of the three — there is already an Azure tenant here, and
-  `azure/trusted-signing-action` is a single step.
-- **Catch:** identity validation, and eligibility rules that have included a minimum trading
-  history for organisations. **Check whether Blackcat Data Solutions Ltd qualifies before
-  committing to this route** — that is the deciding factor, not the price.
+## If SignPath declines
 
-### A traditional OV certificate — £200–400/year
+**Certum Open Source Code Signing** is the cheap paid fallback — priced specifically for open
+source, in the region of €25–30 per year rather than per month, on a hardware token. Verify current
+pricing and terms directly; the figure moves. It is a real annual cost, so only worth considering if
+the free route is closed.
 
-Buy from a CA, keep it on a hardware token or in a KMS. Full control, most work, and an OV
-certificate builds SmartScreen reputation slowly by download volume. Hard to recommend over the
-other two.
+## Ruled out
 
-## Recommendation
+- **Azure Trusted Signing** — around $10/month. Convenient, and Microsoft's own CA, but a
+  subscription this project cannot justify. Not an option unless that changes.
+- **A traditional OV/EV certificate from a CA** — £200–400/year. Same objection, more work.
 
-Try **Azure Trusted Signing** first — the tenant already exists, the wiring is one action, and it
-gives the best SmartScreen outcome. Fall back to **SignPath** if the eligibility check fails.
+## Free things that help without a certificate
+
+- **Build provenance attestation** — already shipping, see above.
+- **Submitting the binary to Microsoft for analysis.** Developers can submit software through
+  Microsoft's file submission portal to have a false positive reviewed. It does not put a publisher
+  name on the exe, but it is free and can reduce warnings. Worth doing per release if SmartScreen
+  proves stubborn.
 
 ## What still needs a human
 
-Both routes need an account created and an identity verified by the project owner. That part
-cannot be automated or delegated. Once the account exists, wiring it up is a small PR:
+Applying to the Foundation programme and verifying identity has to be done by the project owner.
+That part cannot be automated or delegated. Once the account exists, wiring it up is a small PR:
 
 ```yaml
 # after "Package release assets", before "Attest build provenance"
 - name: Sign
-  uses: azure/trusted-signing-action@v0   # or signpath/github-action-submit-signing-request@v2
+  uses: signpath/github-action-submit-signing-request@v2
   with:
-    files-folder: releases
-    files-folder-filter: exe
-    # ...plus the account/profile inputs from the service
+    api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+    organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+    project-slug: nine-lives
+    signing-policy-slug: release-signing
+    # ...plus the artifact configuration and github-artifact-id inputs
 ```
 
 Attestation should stay, and should run **after** signing so it covers the signed bytes. Repackage

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -1,0 +1,86 @@
+# Code signing
+
+Tracking issue: [#33](https://github.com/jakemorgangit/NineLives/issues/33).
+
+`NineLives.exe` is unsigned. Every person who downloads it meets **"Windows protected your PC —
+Microsoft Defender SmartScreen prevented an unrecognised app from starting"** and has to click
+through *More info → Run anyway*.
+
+For most tools that is a papercut. For this one it is the first impression made by software that
+asks to be pointed at a production SQL Server with rights to drop and replace databases. A fair
+number of DBAs will stop there, and plenty of corporate policies will stop for them.
+
+## What is already in place
+
+Releases carry a **Sigstore build provenance attestation**, added in
+`.github/workflows/release.yml`. It is cryptographic proof that the exe on the release page was
+built by this repo's release workflow from a named commit:
+
+```powershell
+gh attestation verify NineLives.exe --repo jakemorgangit/NineLives
+```
+
+That is a real guarantee and it costs nothing. **It does not touch SmartScreen.** Windows does not
+consult Sigstore; it looks for an Authenticode signature. Provenance answers "did this come from
+the source I think it did", which is the question a careful reviewer asks. SmartScreen asks "does
+Windows recognise the publisher", and only a certificate answers that.
+
+## Options for the certificate
+
+### SignPath — free for open source
+
+The route the issue proposed, and what several OSS .NET projects use. SignPath issues the
+certificate; there is nothing to buy or store.
+
+- **Cost:** free, subject to their OSS eligibility review.
+- **Effort:** register the project, define a signing policy and an artifact configuration, add
+  `signpath/github-action-submit-signing-request@v2` to the release job, store the API token as a
+  repository secret.
+- **Catch:** signing is a submit-and-poll round trip through their service, so the release job gets
+  slower. Worth confirming their upload size limit up front — `NineLives.exe` is ~166 MB, which is
+  large for a signing submission.
+
+### Azure Trusted Signing — ~$10/month
+
+Microsoft's managed signing service. Short-lived certificates, no private key to look after, and
+because it is Microsoft's own CA it carries SmartScreen reputation well.
+
+- **Cost:** Basic tier, around $9.99/month.
+- **Effort:** likely the least of the three — there is already an Azure tenant here, and
+  `azure/trusted-signing-action` is a single step.
+- **Catch:** identity validation, and eligibility rules that have included a minimum trading
+  history for organisations. **Check whether Blackcat Data Solutions Ltd qualifies before
+  committing to this route** — that is the deciding factor, not the price.
+
+### A traditional OV certificate — £200–400/year
+
+Buy from a CA, keep it on a hardware token or in a KMS. Full control, most work, and an OV
+certificate builds SmartScreen reputation slowly by download volume. Hard to recommend over the
+other two.
+
+## Recommendation
+
+Try **Azure Trusted Signing** first — the tenant already exists, the wiring is one action, and it
+gives the best SmartScreen outcome. Fall back to **SignPath** if the eligibility check fails.
+
+## What still needs a human
+
+Both routes need an account created and an identity verified by the project owner. That part
+cannot be automated or delegated. Once the account exists, wiring it up is a small PR:
+
+```yaml
+# after "Package release assets", before "Attest build provenance"
+- name: Sign
+  uses: azure/trusted-signing-action@v0   # or signpath/github-action-submit-signing-request@v2
+  with:
+    files-folder: releases
+    files-folder-filter: exe
+    # ...plus the account/profile inputs from the service
+```
+
+Attestation should stay, and should run **after** signing so it covers the signed bytes. Repackage
+the zip and regenerate `SHA256SUMS.txt` after signing too, or the published checksums will describe
+the unsigned file.
+
+Until then the README tells people plainly why the warning appears and how to verify the download
+themselves.

--- a/src/NineLives.Tests/BackupTypeInferenceTests.cs
+++ b/src/NineLives.Tests/BackupTypeInferenceTests.cs
@@ -1,0 +1,134 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Filename-based backup type inference (#45, #44).
+///
+/// This is the last resort, used when the path structure did not say what a file is. Getting it
+/// wrong is not a cosmetic mislabel:
+///
+///   - a full read as a differential never enters the fulls collection in BackupChainBuilder, so
+///     if it is the only full in the container that database gets no restore points at all (#45)
+///   - a log read as a full becomes a chain root, so the timeline offers a log file as a
+///     restorable Full point and drops every earlier log from the chain (#44)
+/// </summary>
+public class BackupTypeInferenceTests
+{
+    // ── #45: the substring match, live on the default path ──────────────────────
+
+    [Theory]
+    [InlineData("DiffusionDb_FULL_20260804_220000.bak")]
+    [InlineData("TrafficDiffusion_20260804_220000.bak")]
+    [InlineData("DiffEngineDb_20260804_220000.bak")]
+    [InlineData("diffusion_20260804.bak")]
+    public void ADatabaseWhoseNameContainsDiffIsStillAFullBackup(string fileName)
+    {
+        Assert.Equal(BackupType.Full, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    [Theory]
+    [InlineData("MyDb_DIFF_20260804_220000.bak")]
+    [InlineData("MyDb-diff-20260804.bak")]
+    [InlineData("MyDb.DIFF.20260804.bak")]
+    [InlineData("MyDb_DIFFERENTIAL_20260804.bak")]
+    [InlineData("MyDb_20260804.diff")]
+    public void ARealDifferentialMarkerIsStillDetected(string fileName)
+    {
+        Assert.Equal(BackupType.Differential, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    // ── #44: a log written as .bak ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("MyDb_LOG_20260804_120000.bak")]
+    [InlineData("MyDb-log-20260804.bak")]
+    [InlineData("MyDb_TLOG_20260804.bak")]
+    [InlineData("MyDb_TRN_20260804.bak")]
+    [InlineData("MyDb_TRANSACTIONLOG_20260804.bak")]
+    public void ALogWrittenAsBakIsNotAFullBackup(string fileName)
+    {
+        Assert.Equal(BackupType.TransactionLog, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    /// <summary>
+    /// The trap the issue calls out. A bare "log" substring would retype all of these, which is
+    /// exactly the mistake ContainsDiffIndicator was making with "diff".
+    /// </summary>
+    [Theory]
+    [InlineData("CatalogDb_FULL_20260804_220000.bak")]
+    [InlineData("BlogDb_20260804.bak")]
+    [InlineData("DialogDb_FULL_20260804.bak")]
+    [InlineData("AnalogData_20260804.bak")]
+    [InlineData("Catalog_20260804.bak")]
+    public void ADatabaseWhoseNameContainsLogIsStillAFullBackup(string fileName)
+    {
+        Assert.Equal(BackupType.Full, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    // ── extensions still win where they are unambiguous ─────────────────────────
+
+    [Theory]
+    [InlineData("MyDb_20260804.trn", BackupType.TransactionLog)]
+    [InlineData("MyDb_20260804.log", BackupType.TransactionLog)]
+    [InlineData("CatalogDb_20260804.trn", BackupType.TransactionLog)]
+    [InlineData("MyDb_20260804.bak", BackupType.Full)]
+    [InlineData("MyDb_20260804.bkp", BackupType.Full)]
+    [InlineData("MyDb_20260804.txt", BackupType.Unknown)]
+    [InlineData("MyDb_20260804", BackupType.Unknown)]
+    public void ExtensionDrivesTheAnswerWhenItIsUnambiguous(string fileName, BackupType expected)
+    {
+        Assert.Equal(expected, BlobStorageService.InferBackupTypeFromExtension(fileName));
+    }
+
+    [Fact]
+    public void ADifferentialMarkerBeatsALogMarker()
+    {
+        // Ola-style names can carry both words; DIFF is the more specific claim.
+        Assert.Equal(
+            BackupType.Differential,
+            BlobStorageService.InferBackupTypeFromExtension("MyDb_DIFF_LOG_20260804.bak"));
+    }
+
+    // ── folders must not retype files ───────────────────────────────────────────
+
+    [Theory]
+    [InlineData("logs/MyDb_FULL_20260804.bak")]
+    [InlineData("log/MyDb_FULL_20260804.bak")]
+    [InlineData("diff/MyDb_FULL_20260804.bak")]
+    [InlineData("backups/LOG/CatalogDb_20260804.bak")]
+    public void IndicatorsAreReadFromTheFilenameNotTheFoldersAboveIt(string blobName)
+    {
+        // Folder-based typing is the primary path's job and runs before this. If this method also
+        // looked at the path, a container organised under a "logs/" prefix would have every file
+        // in it retyped regardless of what the file actually is.
+        Assert.Equal(BackupType.Full, BlobStorageService.InferBackupTypeFromExtension(blobName));
+    }
+
+    [Fact]
+    public void CaseDoesNotMatter()
+    {
+        Assert.Equal(BackupType.TransactionLog, BlobStorageService.InferBackupTypeFromExtension("MyDb_log_20260804.BAK"));
+        Assert.Equal(BackupType.Differential, BlobStorageService.InferBackupTypeFromExtension("MyDb_Diff_20260804.BAK"));
+    }
+
+    // ── the indicator helpers directly ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData("MyDb_DIFF_1.bak", true)]
+    [InlineData("DiffusionDb_FULL.bak", false)]
+    [InlineData("TariffData_FULL.bak", false)]
+    [InlineData("diff_20260804.bak", true)]
+    public void DiffIndicatorIsDelimited(string fileName, bool expected)
+        => Assert.Equal(expected, BlobStorageService.ContainsDiffIndicator(fileName));
+
+    [Theory]
+    [InlineData("MyDb_LOG_1.trn", true)]
+    [InlineData("CatalogDb_FULL.bak", false)]
+    [InlineData("BlogDb.bak", false)]
+    [InlineData("MyDb.log.bak", true)]
+    public void LogIndicatorIsDelimited(string fileName, bool expected)
+        => Assert.Equal(expected, BlobStorageService.ContainsLogIndicator(fileName));
+}

--- a/src/NineLives.Tests/BlobPrefixTests.cs
+++ b/src/NineLives.Tests/BlobPrefixTests.cs
@@ -1,0 +1,180 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Deriving Azure prefixes from a path pattern (#28).
+///
+/// The failure that matters here is asymmetric. Deriving too BROAD a prefix costs a little speed;
+/// deriving too NARROW a one silently returns fewer backups than exist, which on the restore
+/// screen means a restore point disappearing with no error. So the rule under test throughout is:
+/// when a safe prefix cannot be proven, return null and let the caller scan everything.
+/// </summary>
+public class BlobPrefixTests
+{
+    private const string Default = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
+    private static readonly string[] Types = ["FULL", "DIFF", "LOG"];
+
+    // ── the default pattern, which is the common case ───────────────────────────
+
+    [Fact]
+    public void ServerAndDatabaseGiveOnePrefixPerBackupType()
+    {
+        var prefixes = BlobPrefix.Derive(Default, "SRV01", "Sales", Types);
+
+        Assert.Equal(
+            ["FULL/SRV01/Sales/", "DIFF/SRV01/Sales/", "LOG/SRV01/Sales/"],
+            prefixes);
+    }
+
+    [Fact]
+    public void ServerAloneStopsAtTheServerLevel()
+    {
+        var prefixes = BlobPrefix.Derive(Default, "SRV01", null, Types);
+
+        Assert.Equal(["FULL/SRV01/", "DIFF/SRV01/", "LOG/SRV01/"], prefixes);
+    }
+
+    /// <summary>
+    /// {ServerName} comes before {DatabaseName}, so a database without a server cannot be
+    /// expressed as a prefix - the segment in between is unknown. Falling back is the only correct
+    /// answer; guessing would drop every other server's copy of that database.
+    /// </summary>
+    [Fact]
+    public void DatabaseWithoutServerCannotBeScopedPastTheBackupType()
+    {
+        var prefixes = BlobPrefix.Derive(Default, null, "Sales", Types);
+
+        Assert.Equal(["FULL/", "DIFF/", "LOG/"], prefixes);
+    }
+
+    /// <summary>
+    /// {BackupType} leads the default pattern, so with no folder names there is nothing to build
+    /// on. This is the case the issue flagged as a blocker; one cheap hierarchy call solves it.
+    /// </summary>
+    [Fact]
+    public void WithoutBackupTypeFoldersTheDefaultPatternCannotBeScoped()
+        => Assert.Null(BlobPrefix.Derive(Default, "SRV01", "Sales", backupTypeFolders: null));
+
+    [Fact]
+    public void AnEmptyFolderListIsTreatedTheSameAsNone()
+        => Assert.Null(BlobPrefix.Derive(Default, "SRV01", "Sales", []));
+
+    // ── other layouts ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void APatternLedByServerNeedsNoBackupTypeFolders()
+    {
+        var prefixes = BlobPrefix.Derive(
+            "{ServerName}/{DatabaseName}/{BackupType}/{FileName}", "SRV01", "Sales");
+
+        Assert.Equal(["SRV01/Sales/"], prefixes);
+    }
+
+    [Fact]
+    public void LiteralSegmentsAreAlwaysKnown()
+    {
+        var prefixes = BlobPrefix.Derive(
+            "sqlbackups/{ServerName}/{DatabaseName}/{FileName}", "SRV01", "Sales");
+
+        Assert.Equal(["sqlbackups/SRV01/Sales/"], prefixes);
+    }
+
+    [Fact]
+    public void ALiteralPrefixIsUsableEvenWithNoFilterAtAll()
+    {
+        // Still narrows the listing, and costs nothing.
+        var prefixes = BlobPrefix.Derive("sqlbackups/{ServerName}/{FileName}", null, null);
+
+        Assert.Equal(["sqlbackups/"], prefixes);
+    }
+
+    [Fact]
+    public void AnUnknownTokenStopsTheDerivation()
+    {
+        // {InstanceName} has no value to hand, so nothing past it is predictable.
+        var prefixes = BlobPrefix.Derive(
+            "{ServerName}/{InstanceName}/{DatabaseName}/{FileName}", "SRV01", "Sales");
+
+        Assert.Equal(["SRV01/"], prefixes);
+    }
+
+    [Fact]
+    public void ClusterAndAgTokensAreTreatedAsTheServerSegment()
+    {
+        var prefixes = BlobPrefix.Derive(
+            "{BackupType}/{ClusterName$AgName}/{DatabaseName}/{FileName}",
+            "clu01$AG1", "Sales", Types);
+
+        Assert.Equal(
+            ["FULL/clu01$AG1/Sales/", "DIFF/clu01$AG1/Sales/", "LOG/clu01$AG1/Sales/"],
+            prefixes);
+    }
+
+    [Fact]
+    public void NothingAfterTheFileNameSegmentIsUsed()
+    {
+        var prefixes = BlobPrefix.Derive("{ServerName}/{FileName}/{DatabaseName}", "SRV01", "Sales");
+
+        Assert.Equal(["SRV01/"], prefixes);
+    }
+
+    // ── falling back ────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AnEmptyPatternFallsBack(string? pattern)
+        => Assert.Null(BlobPrefix.Derive(pattern, "SRV01", "Sales", Types));
+
+    [Fact]
+    public void APatternThatIsNothingButUnknownTokensFallsBack()
+        => Assert.Null(BlobPrefix.Derive("{FileName}", "SRV01", "Sales", Types));
+
+    [Fact]
+    public void APatternLedByAnUnknownTokenFallsBack()
+        => Assert.Null(BlobPrefix.Derive("{InstanceName}/{DatabaseName}", "SRV01", "Sales", Types));
+
+    /// <summary>
+    /// Flat Ola AG naming puts every file at the container root with the structure encoded in the
+    /// filename, so there is nothing to prefix on and the scan must stay full.
+    /// </summary>
+    [Theory]
+    [InlineData(BackupSourceType.Standalone, true)]
+    [InlineData(BackupSourceType.AvailabilityGroup, false)]
+    [InlineData(BackupSourceType.Mixed, false)]
+    public void OnlyStandaloneLayoutsSupportPrefixes(BackupSourceType type, bool expected)
+        => Assert.Equal(expected, BlobPrefix.SupportsPrefixes(type));
+
+    // ── the scope object ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnEmptyScopeIsRecognisedAsEmpty()
+    {
+        Assert.False(new BlobListingScope().HasAnything);
+        Assert.False(new BlobListingScope("", "  ").HasAnything);
+        Assert.True(new BlobListingScope("SRV01").HasAnything);
+        Assert.True(new BlobListingScope(null, "Sales").HasAnything);
+    }
+
+    // ── the prefixes match what the real container actually holds ───────────────
+
+    [Fact]
+    public void TheDerivedPrefixesMatchAnOlaStyleLayout()
+    {
+        // The shape verified against a live container: backup-type folders at the top, then
+        // server, then database. If this ever stops matching, the optimisation is silently scoping
+        // to paths that do not exist and returning nothing.
+        //
+        // Hostnames here are deliberately fictitious - see CONTRIBUTING. Real server and database
+        // names do not belong in a public repository.
+        var prefixes = BlobPrefix.Derive(Default, "SRV01", "MyDb", ["DIFF", "FULL", "LOG"]);
+
+        Assert.Equal(
+            ["DIFF/SRV01/MyDb/", "FULL/SRV01/MyDb/", "LOG/SRV01/MyDb/"],
+            prefixes);
+    }
+}

--- a/src/NineLives.Tests/ByteSizeTests.cs
+++ b/src/NineLives.Tests/ByteSizeTests.cs
@@ -1,0 +1,45 @@
+using Blackcat.NineLives.Models;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The single byte formatter (#42). The same loop had been copied into four SizeDisplay
+/// properties across three files - nothing had gone wrong with it yet, but four copies is four
+/// chances to drift and start disagreeing about the size of the same backup on different screens.
+/// </summary>
+public class ByteSizeTests
+{
+    [Theory]
+    [InlineData(0, "0.0 B")]
+    [InlineData(512, "512.0 B")]
+    [InlineData(1024, "1.0 KB")]
+    [InlineData(1536, "1.5 KB")]
+    [InlineData(1024L * 1024, "1.0 MB")]
+    [InlineData(1024L * 1024 * 1024, "1.0 GB")]
+    [InlineData(1024L * 1024 * 1024 * 1024, "1.0 TB")]
+    public void SizesFormatInBinaryUnits(long bytes, string expected)
+        => Assert.Equal(expected, ByteSize.Format(bytes));
+
+    [Fact]
+    public void VeryLargeSizesStopAtTerabytes()
+    {
+        // The loop is bounded by the unit list, so a petabyte-scale container reads as thousands
+        // of TB rather than running off the end of the array.
+        Assert.Equal("2048.0 TB", ByteSize.Format(2048L * 1024 * 1024 * 1024 * 1024));
+    }
+
+    [Fact]
+    public void ANegativeSizeIsShownAsIsRatherThanLoopingOrPrintingNonsense()
+    {
+        // Not physically meaningful, but a subtraction bug upstream should look odd rather than
+        // print "-0.0 B".
+        Assert.Equal("-5 B", ByteSize.Format(-5));
+    }
+
+    [Fact]
+    public void TheBoundaryBelowAUnitDoesNotRoundUpIntoIt()
+    {
+        Assert.Equal("1023.0 B", ByteSize.Format(1023));
+    }
+}

--- a/src/NineLives.Tests/CancellationTests.cs
+++ b/src/NineLives.Tests/CancellationTests.cs
@@ -1,0 +1,245 @@
+using System.Diagnostics;
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Cancellation of long-running work (#25).
+///
+/// Every service method already took a CancellationToken and none of them were ever given a real
+/// one, so a restore aimed at the wrong server could only be stopped by killing the process -
+/// which leaves the database mid-restore and writes nothing down about it.
+/// </summary>
+public class OperationCancellationTests
+{
+    [Fact]
+    public void NothingRunningMeansNothingToCancel()
+    {
+        var operation = new OperationCancellation();
+
+        Assert.False(operation.CanCancel);
+        Assert.False(operation.IsCancelling);
+        operation.Cancel();   // must not throw
+    }
+
+    [Fact]
+    public void BeginProducesALiveToken()
+    {
+        var operation = new OperationCancellation();
+
+        var token = operation.Begin();
+
+        Assert.False(token.IsCancellationRequested);
+        Assert.True(operation.CanCancel);
+    }
+
+    [Fact]
+    public void CancelSignalsTheToken()
+    {
+        var operation = new OperationCancellation();
+        var token = operation.Begin();
+
+        operation.Cancel();
+
+        Assert.True(token.IsCancellationRequested);
+        Assert.True(operation.IsCancelling);
+        Assert.False(operation.CanCancel);   // already asked; the button should go away
+    }
+
+    /// <summary>
+    /// The bug this type exists to prevent: reusing a cancelled source would cancel the next run
+    /// before it started, so the second attempt at a restore would fail instantly and look like a
+    /// different problem entirely.
+    /// </summary>
+    [Fact]
+    public void ANewOperationAfterACancelledOneStartsClean()
+    {
+        var operation = new OperationCancellation();
+        operation.Begin();
+        operation.Cancel();
+        operation.End();
+
+        var second = operation.Begin();
+
+        Assert.False(second.IsCancellationRequested);
+        Assert.True(operation.CanCancel);
+    }
+
+    [Fact]
+    public void BeginCancelsAnOperationThatWasLeftRunning()
+    {
+        // Belt and braces: if a finally block were ever missed, the abandoned run must not keep
+        // going alongside its replacement.
+        var operation = new OperationCancellation();
+        var first = operation.Begin();
+
+        operation.Begin();
+
+        Assert.True(first.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void EndIsSafeToCallRepeatedly()
+    {
+        var operation = new OperationCancellation();
+        operation.Begin();
+
+        operation.End();
+        operation.End();
+
+        Assert.False(operation.CanCancel);
+    }
+
+    [Fact]
+    public void CancelAfterEndDoesNotThrow()
+    {
+        // The order a slow operation unwinds in is not fully under our control, so a Cancel
+        // arriving after the finally block has run must be a no-op rather than an ObjectDisposed.
+        var operation = new OperationCancellation();
+        operation.Begin();
+        operation.End();
+
+        operation.Cancel();
+
+        Assert.False(operation.CanCancel);
+    }
+}
+
+/// <summary>
+/// Cancellation against a real SQL Server: the point is that it actually interrupts work in
+/// flight, not just that the plumbing compiles.
+/// </summary>
+public class SqlCancellationTests
+{
+    private static ServerConnection TestServer() => new()
+    {
+        Name = "ninelives-test",
+        ServerName = Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL")!,
+        AuthMode = AuthMode.WindowsAuth,
+        Encrypt = EncryptMode.No,
+        TrustServerCertificate = true,
+        ConnectionTimeoutSeconds = 15
+    };
+
+    private static SqlServerService Service() => new(new CredentialStore());
+
+    /// <summary>
+    /// A restore of any size runs with CommandTimeout = 0, so without cancellation the only way
+    /// out is killing the process. WAITFOR stands in for a long-running statement: if the token is
+    /// not reaching the driver, this hangs for 30 seconds instead of stopping in about one.
+    ///
+    /// It also pins the exception TYPE, which is the part that is easy to get wrong. SqlClient
+    /// surfaces a cancelled command as a SqlException - "A severe error occurred on the current
+    /// command ... Operation cancelled by user" - so a caller catching OperationCanceledException
+    /// to show "cancelled" would miss it and report the user's own Stop as a severe error. The
+    /// service translates it; this test is what says so.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ARunningStatementIsActuallyInterrupted()
+    {
+        using var cts = new CancellationTokenSource();
+        var messages = new List<string>();
+
+        var started = Stopwatch.StartNew();
+        var run = Service().ExecuteRestoreWithProgressAsync(
+            TestServer(),
+            "WAITFOR DELAY '00:00:30'",
+            messages.Add,
+            cts.Token);
+
+        await Task.Delay(1000);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run);
+        started.Stop();
+
+        Assert.True(started.Elapsed < TimeSpan.FromSeconds(15),
+            $"Cancellation did not reach the server - the statement ran for {started.Elapsed}.");
+
+        // The user should read "cancelled", not "failed", in the execution console.
+        Assert.Contains(messages, m => m.Contains("Cancelled during statement", StringComparison.Ordinal));
+        Assert.DoesNotContain(messages, m => m.Contains("FAILED", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The other half of the translation: a genuine SqlException must still surface as a failure.
+    /// Guarding only on the token means an unrelated severe error is not mislabelled as the user
+    /// having pressed Stop.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ARealFailureIsStillAFailureNotACancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var messages = new List<string>();
+
+        await Assert.ThrowsAsync<Microsoft.Data.SqlClient.SqlException>(() =>
+            Service().ExecuteRestoreWithProgressAsync(
+                TestServer(),
+                "RESTORE DATABASE [NineLives_NoSuchDb] FROM DISK = 'Z:\\nope.bak'",
+                messages.Add,
+                cts.Token));
+
+        Assert.Contains(messages, m => m.Contains("FAILED on statement", StringComparison.Ordinal));
+    }
+
+    [RequiresSqlFact]
+    public async Task ATokenCancelledBeforehandStopsBeforeAnythingRuns()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            Service().ExecuteRestoreWithProgressAsync(
+                TestServer(), "SELECT 1", null, cts.Token));
+    }
+
+    [RequiresSqlFact]
+    public async Task AnUncancelledRunStillCompletesNormally()
+    {
+        // The obvious regression: threading a token through must not break the ordinary path.
+        using var cts = new CancellationTokenSource();
+        var messages = new List<string>();
+
+        await Service().ExecuteRestoreWithProgressAsync(
+            TestServer(), "SELECT 1", messages.Add, cts.Token);
+
+        Assert.NotEmpty(messages);
+    }
+}
+
+/// <summary>Cancelling a blob listing, which is the other unbounded operation.</summary>
+public class BlobCancellationTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-cancel-tests", Guid.NewGuid().ToString("n"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task AListingWithAnAlreadyCancelledTokenDoesNotRun()
+    {
+        var store = new CredentialStore(_dir);
+        var container = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "ninelives-test-cancel",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups",
+            UnsavedSasToken = "sv=2024-11-04&sig=not-real"
+        };
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Cancelled before any network call, so this fails on the token rather than on the
+        // unreachable account - which is what proves the token is consulted at all.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new BlobStorageService(store).ListBackupFilesAsync(container, cts.Token));
+    }
+}

--- a/src/NineLives.Tests/ChainReachabilityTests.cs
+++ b/src/NineLives.Tests/ChainReachabilityTests.cs
@@ -1,0 +1,157 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Backups that exist but reach no restore point (#46).
+///
+/// The chain builder bounds each full's log range with strict inequalities at both ends, so a log
+/// whose timestamp exactly equals a full's belongs to neither the earlier full's range nor the
+/// colliding full's own. It vanishes from the timeline while still being counted in the header.
+///
+/// The collision is not exotic: timestamps come from filenames and the seconds group is optional,
+/// so under HHMM naming any full and log starting in the same minute collide - a nightly full plus
+/// quarter-hourly logs does it every day.
+///
+/// These tests pin the reporting, not a repair. Widening the bound would force the log to restore
+/// after the full always, which is wrong whenever the log job fired first and finished before the
+/// full's checkpoint. Only the LSNs can tell those apart.
+/// </summary>
+public class ChainReachabilityTests
+{
+    private static readonly DateTime Day = new(2026, 8, 4, 0, 0, 0, DateTimeKind.Unspecified);
+
+    private static BackupSet Set(BackupType type, DateTime timestamp, string name) => new()
+    {
+        Type = type,
+        Timestamp = timestamp,
+        SetId = name,
+        DatabaseName = "MyDb",
+        Files = [new BackupFileInfo { BlobName = name, SizeBytes = 1024, Type = type }]
+    };
+
+    private static (List<BackupSet> Sets, List<RestorePoint> Points) Build(params BackupSet[] sets)
+    {
+        var list = sets.ToList();
+        return (list, new BackupChainBuilder().ComputeRestorePoints(list));
+    }
+
+    // ── the defect ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ALogAtAFullsExactTimestampReachesNoRestorePoint()
+    {
+        // Establishes the behaviour the warning exists for. If this ever starts failing because
+        // the builder learned to place the log, the warning below should go with it.
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL_20260804_2200.bak");
+        var collide = Set(BackupType.TransactionLog, Day.AddHours(22), "MyDb_LOG_20260804_2200.trn");
+        var later = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_20260804_2230.trn");
+
+        var (_, points) = Build(full, collide, later);
+
+        var reached = points.Any(p => ReferenceEquals(p.PrimarySet, collide))
+                   || points.Any(p => p.RequiredLogSets.Contains(collide));
+        Assert.False(reached);
+
+        // ...while the log that does not collide is fine, so this is about the collision and not
+        // about logs generally.
+        Assert.Contains(points, p => ReferenceEquals(p.PrimarySet, later));
+    }
+
+    [Fact]
+    public void TheUnreachableLogIsReported()
+    {
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL_20260804_2200.bak");
+        var collide = Set(BackupType.TransactionLog, Day.AddHours(22), "MyDb_LOG_20260804_2200.trn");
+        var later = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_20260804_2230.trn");
+
+        var (sets, points) = Build(full, collide, later);
+        var issues = new BackupChainValidator().ValidateReachability(sets, points);
+
+        var issue = Assert.Single(issues);
+        Assert.Equal(ChainIssueSeverity.Warning, issue.Severity);
+        Assert.Contains("1 log backup(s) are not reachable", issue.Title);
+        Assert.Contains("share an exact timestamp with a full backup", issue.Detail);
+    }
+
+    [Fact]
+    public void TheReportNamesTheEarliestAffectedTime()
+    {
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL_20260804_2200.bak");
+        var collide = Set(BackupType.TransactionLog, Day.AddHours(22), "MyDb_LOG_20260804_2200.trn");
+        var later = Set(BackupType.TransactionLog, Day.AddHours(23), "MyDb_LOG_20260804_2300.trn");
+
+        var (sets, points) = Build(full, collide, later);
+        var issue = Assert.Single(new BackupChainValidator().ValidateReachability(sets, points));
+
+        Assert.Contains("2026-08-04 22:00:00", issue.Detail);
+    }
+
+    [Fact]
+    public void CollisionsAtASecondFullAreAlsoCaught()
+    {
+        // The issue's boundary sweep found the same behaviour at the later full, not just the first.
+        var first = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL_20260804_2200.bak");
+        var between = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_20260804_2230.trn");
+        var second = Set(BackupType.Full, Day.AddHours(23), "MyDb_FULL_20260804_2300.bak");
+        var collide = Set(BackupType.TransactionLog, Day.AddHours(23), "MyDb_LOG_20260804_2300.trn");
+
+        var (sets, points) = Build(first, between, second, collide);
+        var issue = Assert.Single(new BackupChainValidator().ValidateReachability(sets, points));
+
+        Assert.Contains("1 log backup(s) are not reachable", issue.Title);
+    }
+
+    // ── no false positives ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnOrdinaryChainReportsNothing()
+    {
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL.bak");
+        var log1 = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(15), "MyDb_LOG_2215.trn");
+        var log2 = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_2230.trn");
+
+        var (sets, points) = Build(full, log1, log2);
+
+        Assert.Empty(new BackupChainValidator().ValidateReachability(sets, points));
+    }
+
+    [Fact]
+    public void LogsBeforeTheFirstFullAreLeftToTheInventoryCheck()
+    {
+        // ValidateInventory already explains these. Reporting them twice in different words makes
+        // both messages easier to ignore.
+        var early = Set(BackupType.TransactionLog, Day.AddHours(20), "MyDb_LOG_2000.trn");
+        var full = Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL.bak");
+        var after = Set(BackupType.TransactionLog, Day.AddHours(22).AddMinutes(30), "MyDb_LOG_2230.trn");
+
+        var (sets, points) = Build(early, full, after);
+
+        Assert.Empty(new BackupChainValidator().ValidateReachability(sets, points));
+        Assert.Contains(
+            new BackupChainValidator().ValidateInventory(sets),
+            i => i.Title.Contains("predate the earliest full"));
+    }
+
+    [Fact]
+    public void NothingIsReportedWhenThereAreNoLogs()
+    {
+        var (sets, points) = Build(Set(BackupType.Full, Day.AddHours(22), "MyDb_FULL.bak"));
+
+        Assert.Empty(new BackupChainValidator().ValidateReachability(sets, points));
+    }
+
+    [Fact]
+    public void NothingIsReportedWhenThereAreNoRestorePointsAtAll()
+    {
+        // A container with only logs produces no points; ValidateInventory reports the missing
+        // full, and this check must not pile on with a second warning about all of them.
+        var (sets, points) = Build(
+            Set(BackupType.TransactionLog, Day.AddHours(22), "MyDb_LOG_2200.trn"));
+
+        Assert.Empty(points);
+        Assert.Empty(new BackupChainValidator().ValidateReachability(sets, points));
+    }
+}

--- a/src/NineLives.Tests/ConfigPersistenceTests.cs
+++ b/src/NineLives.Tests/ConfigPersistenceTests.cs
@@ -1,0 +1,177 @@
+using System.IO;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Config load/save behaviour (#7).
+///
+/// LoadConfig used to catch everything and return empty defaults, and SaveConfig used to catch
+/// everything and return silently while the UI reported success. Together those turned a
+/// momentary file lock - antivirus, a backup agent, a sync client mid-upload - into permanent
+/// data loss: the app came up showing nothing, the user re-added one container, and the save
+/// wrote that single entry over every server and container they had.
+///
+/// These use a temp directory through the internal constructor, so they never touch the real
+/// %LOCALAPPDATA%\NineLives\config.json.
+/// </summary>
+public class ConfigPersistenceTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-config-tests", Guid.NewGuid().ToString("n"));
+
+    private string ConfigPath => Path.Combine(_dir, "config.json");
+    private CredentialStore Store() => new(_dir);
+
+    public ConfigPersistenceTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* temp dir */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private static AppConfig ConfigWith(params string[] containerNames)
+    {
+        var config = new AppConfig();
+        foreach (var name in containerNames)
+        {
+            config.BlobContainers.Add(new BlobContainerConfig
+            {
+                Name = name,
+                ContainerUrl = $"https://acct.blob.core.windows.net/{name}"
+            });
+        }
+        return config;
+    }
+
+    // ── the distinction that matters ────────────────────────────────────────────
+
+    [Fact]
+    public void MissingFile_IsAFreshInstall_NotAnError()
+    {
+        var config = Store().LoadConfig();
+
+        Assert.Null(config.LoadError);
+        Assert.Empty(config.BlobContainers);
+    }
+
+    [Fact]
+    public void UnreadableFile_ReportsLoadError()
+    {
+        Store().SaveConfig(ConfigWith("prod", "uat", "dev"));
+
+        // Hold the file open exclusively, the way a scanner or sync client briefly does.
+        using var _ = new FileStream(ConfigPath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var config = Store().LoadConfig();
+
+        Assert.NotNull(config.LoadError);
+        Assert.Empty(config.BlobContainers);
+    }
+
+    [Fact]
+    public void CorruptFile_ReportsLoadError()
+    {
+        File.WriteAllText(ConfigPath, "{ this is not json");
+
+        var config = Store().LoadConfig();
+
+        Assert.NotNull(config.LoadError);
+    }
+
+    // ── the data-loss regression ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The whole of #7 in one test: the file is briefly locked, the app comes up empty, the user
+    /// re-adds a container and saves. Before the fix that wrote one container over three. The
+    /// save must now refuse, and the file on disk must be untouched.
+    /// </summary>
+    [Fact]
+    public void SavingAConfigThatFailedToLoad_IsRefused_AndLeavesTheFileIntact()
+    {
+        Store().SaveConfig(ConfigWith("prod", "uat", "dev"));
+
+        AppConfig loaded;
+        using (var _ = new FileStream(ConfigPath, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            loaded = Store().LoadConfig();
+            Assert.NotNull(loaded.LoadError);
+        }
+
+        // The user, seeing an empty list, adds a container back.
+        loaded.BlobContainers.Add(new BlobContainerConfig { Name = "prod", ContainerUrl = "https://acct/prod" });
+
+        Assert.Throws<ConfigSaveRefusedException>(() => Store().SaveConfig(loaded));
+
+        var onDisk = Store().LoadConfig();
+        Assert.Null(onDisk.LoadError);
+        Assert.Equal(new[] { "prod", "uat", "dev" }, onDisk.BlobContainers.Select(c => c.Name));
+    }
+
+    [Fact]
+    public void SaveFailure_Propagates_RatherThanReportingSuccess()
+    {
+        Store().SaveConfig(ConfigWith("prod"));
+        var config = Store().LoadConfig();
+
+        // Something else holds the target open for writing; the swap cannot happen.
+        using var _ = new FileStream(ConfigPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        Assert.ThrowsAny<IOException>(() => Store().SaveConfig(config));
+    }
+
+    // ── ordinary behaviour that must keep working ───────────────────────────────
+
+    [Fact]
+    public void SaveThenLoad_RoundTrips()
+    {
+        Store().SaveConfig(ConfigWith("prod", "uat"));
+
+        var config = Store().LoadConfig();
+
+        Assert.Null(config.LoadError);
+        Assert.Equal(new[] { "prod", "uat" }, config.BlobContainers.Select(c => c.Name));
+    }
+
+    [Fact]
+    public void LoadError_IsNotWrittenToTheFile()
+    {
+        // It describes one load attempt, not the configuration. Persisting it would make a
+        // transient failure permanent, and every later save would be refused.
+        Store().SaveConfig(ConfigWith("prod"));
+
+        Assert.DoesNotContain("LoadError", File.ReadAllText(ConfigPath));
+    }
+
+    [Fact]
+    public void OverwritingAnExistingConfig_KeepsThePreviousContentsAsBak()
+    {
+        Store().SaveConfig(ConfigWith("prod", "uat"));
+        Store().SaveConfig(ConfigWith("prod"));
+
+        var backup = JsonSerializer.Deserialize<AppConfig>(File.ReadAllText(ConfigPath + ".bak"))!;
+        Assert.Equal(new[] { "prod", "uat" }, backup.BlobContainers.Select(c => c.Name));
+    }
+
+    [Fact]
+    public void SaveLeavesNoTempFileBehind()
+    {
+        Store().SaveConfig(ConfigWith("prod"));
+
+        Assert.False(File.Exists(ConfigPath + ".tmp"));
+    }
+
+    [Fact]
+    public void SaveCreatesTheDirectoryWhenItIsMissing()
+    {
+        Directory.Delete(_dir, recursive: true);
+
+        Store().SaveConfig(ConfigWith("prod"));
+
+        Assert.Single(Store().LoadConfig().BlobContainers);
+    }
+}

--- a/src/NineLives.Tests/ConnectionSecurityTests.cs
+++ b/src/NineLives.Tests/ConnectionSecurityTests.cs
@@ -9,6 +9,7 @@ namespace Blackcat.NineLives.Tests;
 /// The password stays out of the connection string (#20), and certificate trust is answerable
 /// rather than assumed (#17).
 /// </summary>
+[Collection("CredentialManager")]
 public class ConnectionSecurityTests : IDisposable
 {
     private readonly string _dir = Path.Combine(

--- a/src/NineLives.Tests/ConnectionSecurityTests.cs
+++ b/src/NineLives.Tests/ConnectionSecurityTests.cs
@@ -1,0 +1,186 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The password stays out of the connection string (#20), and certificate trust is answerable
+/// rather than assumed (#17).
+/// </summary>
+public class ConnectionSecurityTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-connsec-tests", Guid.NewGuid().ToString("n"));
+
+    private readonly List<string> _writtenKeys = [];
+
+    private CredentialStore Store() => new(_dir);
+    private SqlServerService Service() => new(Store());
+
+    public ConnectionSecurityTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        var store = Store();
+        foreach (var key in _writtenKeys) { try { store.DeleteSecret(key); } catch { } }
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private ServerConnection SqlAuthServer(string password)
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8],
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+        Store().SaveSqlPassword(server, password);
+        _writtenKeys.Add(server.CredentialKey);
+        return server;
+    }
+
+    // ── #20 ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The regression. The password used to be assigned into the connection string, which is a
+    /// long-lived managed string that cannot be zeroed and turns up in crash dumps - and which
+    /// anything logging a connection string would spill.
+    /// </summary>
+    [Fact]
+    public void ThePasswordNeverAppearsInTheConnectionString()
+    {
+        const string password = "unmistakeable-password-value";
+        var server = SqlAuthServer(password);
+
+        var connectionString = Service().BuildConnectionString(server);
+
+        Assert.DoesNotContain(password, connectionString);
+        Assert.DoesNotContain("Password", connectionString, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AnUnsavedPasswordDoesNotAppearInTheConnectionStringEither()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-unsaved-conn",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa",
+            UnsavedPassword = "candidate-password-value"
+        };
+
+        var connectionString = Service().BuildConnectionString(server);
+
+        Assert.DoesNotContain("candidate-password-value", connectionString);
+    }
+
+    [Fact]
+    public void SqlAuthConnectionsCarryACredential()
+    {
+        var server = SqlAuthServer("stored");
+
+        using var conn = Service().CreateConnection(server);
+
+        Assert.NotNull(conn.Credential);
+        Assert.Equal("sa", conn.Credential!.UserId);
+    }
+
+    [Fact]
+    public void SqlAuthConnectionStringDoesNotUseIntegratedSecurity()
+    {
+        // SqlCredential refuses to attach when the connection string asks for integrated security,
+        // so this is load-bearing rather than cosmetic.
+        var connectionString = Service().BuildConnectionString(SqlAuthServer("stored"));
+
+        Assert.Contains("Integrated Security=False", connectionString);
+    }
+
+    [Fact]
+    public void WindowsAuthStillUsesIntegratedSecurityAndNoCredential()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test-winauth-conn",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.WindowsAuth
+        };
+
+        var connectionString = Service().BuildConnectionString(server);
+        using var conn = Service().CreateConnection(server);
+
+        Assert.Contains("Integrated Security=True", connectionString);
+        Assert.Null(conn.Credential);
+    }
+
+    [Fact]
+    public void SqlAuthWithNoStoredPasswordGetsNoCredentialRatherThanAnEmptyOne()
+    {
+        // SqlCredential with an empty password would send a blank password rather than failing
+        // clearly, so a missing one is left off entirely.
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-nopassword",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+
+        using var conn = Service().CreateConnection(server);
+
+        Assert.Null(conn.Credential);
+    }
+
+    // ── #17 ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TrustServerCertificateIsReflectedInTheConnectionString()
+    {
+        var trusting = new ServerConnection { ServerName = "SRV01", TrustServerCertificate = true };
+        var validating = new ServerConnection { ServerName = "SRV01", TrustServerCertificate = false };
+
+        Assert.Contains("Trust Server Certificate=True", Service().BuildConnectionString(trusting));
+        Assert.Contains("Trust Server Certificate=False", Service().BuildConnectionString(validating));
+    }
+
+    [Fact]
+    public async Task AServerThatAlreadyValidatesNeedsNoProbe()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test-validating",
+            ServerName = "SRV01",
+            TrustServerCertificate = false
+        };
+
+        Assert.True(await Service().WouldConnectWithCertificateValidationAsync(server));
+    }
+
+    [RequiresSqlFact]
+    public async Task AgainstARealInstanceTheProbeGivesADefiniteAnswer()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test-probe",
+            ServerName = Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL")!,
+            AuthMode = AuthMode.WindowsAuth,
+            Encrypt = EncryptMode.Yes,
+            TrustServerCertificate = true,
+            ConnectionTimeoutSeconds = 15
+        };
+
+        // Either answer is fine - a local instance may or may not have a trusted certificate. What
+        // matters is that the probe reaches a conclusion rather than returning null, which is what
+        // the UI treats as "say nothing".
+        var result = await Service().WouldConnectWithCertificateValidationAsync(server);
+
+        Assert.NotNull(result);
+    }
+}

--- a/src/NineLives.Tests/ConsoleLineTests.cs
+++ b/src/NineLives.Tests/ConsoleLineTests.cs
@@ -1,0 +1,59 @@
+using Blackcat.NineLives.Models;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Classification of console output.
+///
+/// Only drives colour, so being wrong is cosmetic - but colouring an ordinary line red during a
+/// restore is its own kind of wrong, which is why anything unrecognised stays Normal rather than
+/// being guessed at.
+/// </summary>
+public class ConsoleLineTests
+{
+    [Theory]
+    [InlineData("ERROR: Could not open backup device")]
+    [InlineData("CANCELLED. The statement in flight was rolled back")]
+    [InlineData("FAILED on statement 3 of 12: RESTORE LOG")]
+    public void FailuresReadAsErrors(string message)
+        => Assert.Equal(ConsoleLineKind.Error, ConsoleLine.From(message).Kind);
+
+    [Theory]
+    [InlineData("  Note: this connection trusts the server certificate")]
+    [InlineData("[MyDb] is in RESTORING state.")]
+    [InlineData("[MyDb] is in SINGLE_USER.")]
+    public void ThingsWorthNoticingReadAsWarnings(string message)
+        => Assert.Equal(ConsoleLineKind.Warning, ConsoleLine.From(message).Kind);
+
+    [Theory]
+    [InlineData("Restore completed successfully!")]
+    [InlineData("Completed.")]
+    [InlineData("100 percent processed.")]
+    public void CompletionReadsAsSuccess(string message)
+        => Assert.Equal(ConsoleLineKind.Success, ConsoleLine.From(message).Kind);
+
+    [Theory]
+    [InlineData("Executing statement 1 of 4: RESTORE DATABASE")]
+    [InlineData("Beginning restore execution...")]
+    [InlineData("Credential [x] is missing - creating it...")]
+    public void NarrationReadsAsASte(string message)
+        => Assert.Equal(ConsoleLineKind.Step, ConsoleLine.From(message).Kind);
+
+    [Theory]
+    [InlineData("50 percent processed.")]
+    [InlineData("RESTORE DATABASE successfully processed 1234 pages in 5.678 seconds")]
+    [InlineData("")]
+    public void AnythingElseStaysNormal(string message)
+        => Assert.Equal(ConsoleLineKind.Normal, ConsoleLine.From(message).Kind);
+
+    [Fact]
+    public void TheTextIsKeptVerbatimIncludingLeadingSpace()
+    {
+        // Indentation carries meaning in the console - nested detail under a step - so it must
+        // survive classification untouched.
+        const string indented = "  Note: something";
+
+        Assert.Equal(indented, ConsoleLine.From(indented).Text);
+    }
+}

--- a/src/NineLives.Tests/CredentialInjectionTests.cs
+++ b/src/NineLives.Tests/CredentialInjectionTests.cs
@@ -18,6 +18,7 @@ namespace Blackcat.NineLives.Tests;
 /// below is deliberately harmless: if the injection were still open it would create a second,
 /// clearly-named credential rather than change any permissions.
 /// </summary>
+[Collection("CredentialManager")]
 public class CredentialInjectionTests
 {
     private static string? TestServerName =>

--- a/src/NineLives.Tests/CredentialInjectionTests.cs
+++ b/src/NineLives.Tests/CredentialInjectionTests.cs
@@ -98,7 +98,7 @@ public class CredentialInjectionTests
     [RequiresSqlFact]
     public async Task EnsureCredentialExists_IsIdempotentForAwkwardNames()
     {
-        // Second call takes the DROP-then-CREATE path, which is the other interpolation site.
+        // Second call takes the ALTER path, which is the other interpolation site.
         const string name = "ninelives-test]awkward]name";
         try
         {

--- a/src/NineLives.Tests/CredentialLifecycleTests.cs
+++ b/src/NineLives.Tests/CredentialLifecycleTests.cs
@@ -1,0 +1,185 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Live proof of how <see cref="SqlServerService.EnsureCredentialExistsAsync"/> touches server
+/// state (#10).
+///
+/// It used to unconditionally DROP and re-CREATE the credential. A credential is server-scoped,
+/// so that momentarily removed something other sessions may have been mid-way through using - a
+/// backup job writing to the same container being the obvious one - and it happened on every
+/// single Execute, whether or not anything needed changing.
+///
+/// The tell is <c>sys.credentials.create_date</c>: ALTER leaves it alone, DROP-then-CREATE resets
+/// it. Asserting on it is what makes these tests fail against the old implementation rather than
+/// just describing the new one.
+///
+/// Gated on NINELIVES_TEST_SQL like the other live tests; each cleans up after itself.
+/// </summary>
+public class CredentialLifecycleTests
+{
+    private static string? TestServerName =>
+        Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL");
+
+    private static ServerConnection TestServer() => new()
+    {
+        Name = "ninelives-test",
+        ServerName = TestServerName!,
+        AuthMode = AuthMode.WindowsAuth,
+        Encrypt = EncryptMode.No,
+        TrustServerCertificate = true,
+        ConnectionTimeoutSeconds = 15
+    };
+
+    private static SqlServerService Service() => new(new CredentialStore());
+
+    private const string Url = "https://acct.blob.core.windows.net/backups";
+    private const string FirstSas = "sv=2026-01-01&sig=first-token";
+    private const string SecondSas = "sv=2026-01-01&sig=second-token";
+
+    [RequiresSqlFact]
+    public async Task FirstCall_CreatesTheCredential_AndSaysSo()
+    {
+        const string name = "ninelives-test-lifecycle-create";
+        try
+        {
+            await DropCredentialIfExists(name);
+
+            var change = await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, FirstSas);
+
+            Assert.Equal(CredentialChange.Created, change);
+            Assert.True(await CredentialExists(name));
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    /// <summary>
+    /// The regression test for #10. Under the old DROP-then-CREATE the credential came back as a
+    /// brand new object with a fresh create_date, and for the moment between the two statements
+    /// it did not exist at all.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task SecondCall_AltersInPlace_AndDoesNotRecreateTheCredential()
+    {
+        const string name = "ninelives-test-lifecycle-alter";
+        try
+        {
+            await DropCredentialIfExists(name);
+            await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, FirstSas);
+            var createdAt = await CreateDate(name);
+
+            // A second later, so a recreate would land on a visibly different timestamp.
+            await Task.Delay(1100);
+            var change = await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, SecondSas);
+
+            Assert.Equal(CredentialChange.Updated, change);
+            Assert.Equal(createdAt, await CreateDate(name));
+            Assert.True(await ModifyDate(name) > createdAt, "The secret should actually have been rewritten.");
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    /// <summary>
+    /// A credential sitting there under some other identity cannot serve a RESTORE FROM URL, so
+    /// ALTER resets IDENTITY too rather than leaving a broken credential to fail the restore.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task NonSasCredential_IsConvertedToSharedAccessSignature()
+    {
+        const string name = "ninelives-test-lifecycle-identity";
+        try
+        {
+            await DropCredentialIfExists(name);
+            await CreateNonSasCredential(name);
+
+            Assert.False((await Service().CredentialExistsAsync(TestServer(), name)).IsSharedAccessSignature);
+
+            var change = await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, FirstSas);
+
+            Assert.Equal(CredentialChange.Updated, change);
+            var (exists, isSas) = await Service().CredentialExistsAsync(TestServer(), name);
+            Assert.True(exists);
+            Assert.True(isSas);
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    [RequiresSqlFact]
+    public async Task CredentialExists_ReportsAbsenceWithoutCreatingAnything()
+    {
+        // Execute now asks this question before deciding whether to write. If the check itself
+        // had a side effect, the "don't touch the server" path would not be true.
+        const string name = "ninelives-test-lifecycle-absent";
+        await DropCredentialIfExists(name);
+
+        var (exists, isSas) = await Service().CredentialExistsAsync(TestServer(), name);
+
+        Assert.False(exists);
+        Assert.False(isSas);
+        Assert.False(await CredentialExists(name));
+    }
+
+    // ── helpers (parameterised) ──────────────────────────────────────────────────
+
+    private static async Task<SqlConnection> OpenAsync()
+    {
+        var conn = new SqlConnection(Service().BuildConnectionString(TestServer()));
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private static async Task<bool> CredentialExists(string name)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM sys.credentials WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", name);
+        return (int)(await cmd.ExecuteScalarAsync())! > 0;
+    }
+
+    private static Task<DateTime> CreateDate(string name) => DateColumn(name, "create_date");
+    private static Task<DateTime> ModifyDate(string name) => DateColumn(name, "modify_date");
+
+    private static async Task<DateTime> DateColumn(string name, string column)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        // The column name is a compile-time constant from the two callers above, never user input.
+        cmd.CommandText = $"SELECT {column} FROM sys.credentials WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", name);
+        var value = await cmd.ExecuteScalarAsync();
+        Assert.NotNull(value);
+        return (DateTime)value!;
+    }
+
+    private static async Task CreateNonSasCredential(string name)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"CREATE CREDENTIAL {TSql.QuoteName(name)} WITH IDENTITY = 'ninelives-test-identity', SECRET = 'not-a-sas'";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task DropCredentialIfExists(string name)
+    {
+        if (!await CredentialExists(name)) return;
+
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DROP CREDENTIAL {TSql.QuoteName(name)}";
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/NineLives.Tests/CredentialLifecycleTests.cs
+++ b/src/NineLives.Tests/CredentialLifecycleTests.cs
@@ -20,6 +20,7 @@ namespace Blackcat.NineLives.Tests;
 ///
 /// Gated on NINELIVES_TEST_SQL like the other live tests; each cleans up after itself.
 /// </summary>
+[Collection("CredentialManager")]
 public class CredentialLifecycleTests
 {
     private static string? TestServerName =>

--- a/src/NineLives.Tests/CredentialManagerCollection.cs
+++ b/src/NineLives.Tests/CredentialManagerCollection.cs
@@ -1,0 +1,18 @@
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Serialises the test classes that read and write Windows Credential Manager.
+///
+/// xUnit runs different classes in parallel, and four classes here hammer the same per-user
+/// credential store at once. Every key is uniquely namespaced so they cannot collide logically,
+/// but the store itself intermittently failed a read straight after a successful write under that
+/// load - twice, in two different classes, neither reproducible on a rerun.
+///
+/// A flaky suite is worse than a slow one anywhere, and especially here: these are the tests that
+/// prove secrets are stored and retrieved correctly, so they are precisely the ones nobody should
+/// learn to re-run and ignore. They lose a little parallelism and gain being trustworthy.
+/// </summary>
+[CollectionDefinition("CredentialManager", DisableParallelization = true)]
+public sealed class CredentialManagerCollection;

--- a/src/NineLives.Tests/DatabaseRecoveryStateTests.cs
+++ b/src/NineLives.Tests/DatabaseRecoveryStateTests.cs
@@ -1,0 +1,225 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// What a failed restore left behind, and the statements that undo it (#14).
+///
+/// A chain that stops part-way leaves the target in RESTORING, and in SINGLE_USER too when
+/// Disconnect sessions was on, because the closing SET MULTI_USER never runs. Both block other
+/// connections, at the worst possible moment.
+/// </summary>
+public class DatabaseRecoveryStateTests
+{
+    private static DatabaseRecoveryState State(string? state, string? access = "MULTI_USER")
+        => new(true, state, access);
+
+    // ── reading the state ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnOnlineMultiUserDatabaseNeedsNothing()
+    {
+        Assert.False(State("ONLINE").NeedsAttention);
+        Assert.Empty(State("ONLINE").SuggestedActions("MyDb"));
+    }
+
+    [Fact]
+    public void AMissingDatabaseNeedsNothingAndSaysSo()
+    {
+        var missing = DatabaseRecoveryState.Missing;
+
+        Assert.False(missing.NeedsAttention);
+        Assert.Empty(missing.SuggestedActions("MyDb"));
+        Assert.Contains("not on the server", missing.Explain("MyDb"));
+    }
+
+    [Theory]
+    [InlineData("RESTORING")]
+    [InlineData("restoring")]
+    [InlineData("RECOVERY_PENDING")]
+    public void AnInterruptedRestoreNeedsAttention(string stateDesc)
+        => Assert.True(State(stateDesc).NeedsAttention);
+
+    [Fact]
+    public void SingleUserAloneNeedsAttention()
+    {
+        // The database came online but Disconnect sessions left it locked to one connection.
+        var state = State("ONLINE", "SINGLE_USER");
+
+        Assert.True(state.NeedsAttention);
+        Assert.True(state.IsSingleUser);
+    }
+
+    // ── the statements offered ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ARestoringDatabaseIsOfferedWithRecovery()
+    {
+        var action = Assert.Single(State("RESTORING").SuggestedActions("MyDb"));
+
+        Assert.Equal("RESTORE DATABASE [MyDb] WITH RECOVERY", action.Sql);
+        Assert.Contains("cannot be applied after this", action.Caution);
+    }
+
+    [Fact]
+    public void ASingleUserDatabaseIsOfferedMultiUser()
+    {
+        var action = Assert.Single(State("ONLINE", "SINGLE_USER").SuggestedActions("MyDb"));
+
+        Assert.Equal("ALTER DATABASE [MyDb] SET MULTI_USER", action.Sql);
+    }
+
+    [Fact]
+    public void BothProblemsAtOnceAreOfferedInOrder()
+    {
+        // The usual shape of a failed restore with Disconnect sessions on. Recovery first: there
+        // is no point restoring access to a database that is still mid-restore.
+        var actions = State("RESTORING", "SINGLE_USER").SuggestedActions("MyDb");
+
+        Assert.Equal(2, actions.Count);
+        Assert.Contains("WITH RECOVERY", actions[0].Sql);
+        Assert.Contains("SET MULTI_USER", actions[1].Sql);
+    }
+
+    [Fact]
+    public void TheDatabaseNameIsQuoted()
+    {
+        // Free text from the target-name box, so it goes through TSql like everything else.
+        var actions = State("RESTORING", "SINGLE_USER").SuggestedActions("My Db]with-bracket");
+
+        Assert.All(actions, a => Assert.Contains("[My Db]]with-bracket]", a.Sql));
+    }
+
+    // ── the explanation ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheExplanationNamesTheDatabaseAndTheCause()
+    {
+        var text = State("RESTORING", "SINGLE_USER").Explain("MyDb");
+
+        Assert.Contains("[MyDb] is in RESTORING state", text);
+        Assert.Contains("SINGLE_USER", text);
+        Assert.Contains("Disconnect sessions", text);
+    }
+
+    [Fact]
+    public void AnUnrecognisedStateStillGetsDescribed()
+    {
+        // Better a plain readout than an empty panel if SQL Server reports something unexpected.
+        var text = State("SUSPECT", "RESTRICTED_USER").Explain("MyDb");
+
+        Assert.Contains("SUSPECT", text);
+        Assert.Contains("RESTRICTED_USER", text);
+    }
+
+    // ── against a real server ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// The end-to-end version: put a database into the exact state a failed chain leaves, confirm
+    /// it is detected, run the suggested statement, and confirm it is fixed. A NORECOVERY restore
+    /// is what a mid-chain stop actually looks like, so this reproduces the situation rather than
+    /// simulating it.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ARealRestoringDatabaseIsDetectedAndRecovered()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test",
+            ServerName = Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL")!,
+            AuthMode = AuthMode.WindowsAuth,
+            Encrypt = EncryptMode.No,
+            TrustServerCertificate = true,
+            ConnectionTimeoutSeconds = 15
+        };
+
+        var service = new SqlServerService(new CredentialStore());
+        var dbName = "NineLives_RecoveryTest_" + Guid.NewGuid().ToString("n")[..8];
+
+        // The server's own data directory, not ours. SQL Server writes the backup as its service
+        // account, which has no business being able to reach a user's temp folder - and on this
+        // machine it cannot.
+        var (dataPath, _) = await service.GetDefaultPathsAsync(server);
+        var backupPath = Path.Combine(dataPath, dbName + ".bak");
+
+        try
+        {
+            await Exec(service, server, $"CREATE DATABASE {TSql.QuoteName(dbName)}");
+            await Exec(service, server,
+                $"BACKUP DATABASE {TSql.QuoteName(dbName)} TO DISK = '{TSql.EscapeLiteral(backupPath)}'");
+
+            // Leave it mid-restore, exactly as a chain that stopped part-way would.
+            await Exec(service, server,
+                $"RESTORE DATABASE {TSql.QuoteName(dbName)} FROM DISK = '{TSql.EscapeLiteral(backupPath)}' " +
+                "WITH NORECOVERY, REPLACE");
+
+            var state = await service.GetDatabaseRecoveryStateAsync(server, dbName);
+            Assert.True(state.Exists);
+            Assert.True(state.IsRestoring);
+            Assert.True(state.NeedsAttention);
+
+            var action = Assert.Single(state.SuggestedActions(dbName));
+            await service.ExecuteRecoveryActionAsync(server, action.Sql);
+
+            var after = await service.GetDatabaseRecoveryStateAsync(server, dbName);
+            Assert.Equal("ONLINE", after.StateDescription);
+            Assert.False(after.NeedsAttention);
+        }
+        finally
+        {
+            try
+            {
+                await Exec(service, server,
+                    $"IF DB_ID('{TSql.EscapeLiteral(dbName)}') IS NOT NULL BEGIN " +
+                    $"ALTER DATABASE {TSql.QuoteName(dbName)} SET SINGLE_USER WITH ROLLBACK IMMEDIATE; " +
+                    $"DROP DATABASE {TSql.QuoteName(dbName)}; END");
+            }
+            catch { /* cleanup */ }
+
+            // The backup lives on the server's filesystem, so remove it through the server rather
+            // than assuming this process can reach the path.
+            try
+            {
+                await Exec(service, server,
+                    $"EXEC master.dbo.xp_delete_files N'{TSql.EscapeLiteral(backupPath)}'");
+            }
+            catch
+            {
+                try { File.Delete(backupPath); } catch { /* cleanup */ }
+            }
+        }
+    }
+
+    [RequiresSqlFact]
+    public async Task ADatabaseThatDoesNotExistReportsMissing()
+    {
+        var server = new ServerConnection
+        {
+            Name = "ninelives-test",
+            ServerName = Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL")!,
+            AuthMode = AuthMode.WindowsAuth,
+            Encrypt = EncryptMode.No,
+            TrustServerCertificate = true,
+            ConnectionTimeoutSeconds = 15
+        };
+
+        var state = await new SqlServerService(new CredentialStore())
+            .GetDatabaseRecoveryStateAsync(server, "NineLives_NoSuchDatabase_" + Guid.NewGuid().ToString("n"));
+
+        Assert.False(state.Exists);
+        Assert.False(state.NeedsAttention);
+    }
+
+    private static async Task Exec(SqlServerService service, ServerConnection server, string sql)
+    {
+        await using var conn = service.CreateConnection(server);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandTimeout = 0;
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/src/NineLives.Tests/NineLives.Tests.csproj
+++ b/src/NineLives.Tests/NineLives.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/NineLives.Tests/NineLives.Tests.csproj
+++ b/src/NineLives.Tests/NineLives.Tests.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
-    <PackageReference Include="xunit" Version="2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.*">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/NineLives.Tests/OperationLogTests.cs
+++ b/src/NineLives.Tests/OperationLogTests.cs
@@ -1,0 +1,233 @@
+using System.IO;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The log must never contain a secret (#40).
+///
+/// Redaction happens at the logging boundary rather than at the call sites, so these tests are the
+/// guarantee for every current and future caller. A log line that is over-redacted is a mild
+/// annoyance; a log line with a working SAS token in it is a credential leak with a filename
+/// attached, sitting in the folder people are told to attach to bug reports.
+/// </summary>
+public class LogRedactorTests
+{
+    private const string RealisticSas =
+        "sv=2024-11-04&ss=b&srt=sco&sp=rl&se=2026-09-01T18:00:00Z&st=2026-08-01T10:00:00Z&spr=https&sig=aBcD1234%2FefGh%2BijKl%3D";
+
+    [Fact]
+    public void ASasSignatureIsRemoved()
+    {
+        var redacted = LogRedactor.Redact($"listing https://acct.blob.core.windows.net/backups?{RealisticSas}");
+
+        Assert.DoesNotContain("aBcD1234", redacted);
+        Assert.Contains("sig=[redacted]", redacted);
+    }
+
+    [Fact]
+    public void EverySasParameterIsRemoved()
+    {
+        // Not just sig. The whole token is the credential - se and sp alone tell an attacker what
+        // a leaked signature would be good for, and there is no diagnostic value in any of it.
+        var redacted = LogRedactor.Redact(RealisticSas);
+
+        foreach (var fragment in new[] { "2024-11-04", "sco", "2026-09-01T18:00:00Z", "https", "aBcD1234" })
+            Assert.DoesNotContain(fragment, redacted);
+    }
+
+    [Fact]
+    public void TheUrlItselfSurvivesSoTheLineStaysUseful()
+    {
+        var redacted = LogRedactor.Redact($"GET https://acct.blob.core.windows.net/backups/FULL/MyDb.bak?{RealisticSas}");
+
+        Assert.Contains("https://acct.blob.core.windows.net/backups/FULL/MyDb.bak", redacted);
+    }
+
+    [Fact]
+    public void ATsqlCredentialSecretIsRemoved()
+    {
+        const string sql =
+            "CREATE CREDENTIAL [https://acct/backups] WITH IDENTITY = 'SHARED ACCESS SIGNATURE', SECRET = 'sv=2024&sig=verysecret'";
+
+        var redacted = LogRedactor.Redact(sql);
+
+        Assert.DoesNotContain("verysecret", redacted);
+        Assert.Contains("SECRET = '[redacted]'", redacted);
+        // The rest of the statement is what makes the line worth logging.
+        Assert.Contains("CREATE CREDENTIAL", redacted);
+        Assert.Contains("SHARED ACCESS SIGNATURE", redacted);
+    }
+
+    [Fact]
+    public void AnAlterCredentialSecretIsRemovedToo()
+    {
+        var redacted = LogRedactor.Redact("ALTER CREDENTIAL [x] WITH IDENTITY = 'SHARED ACCESS SIGNATURE', SECRET = N'token'");
+
+        Assert.DoesNotContain("token", redacted);
+    }
+
+    [Fact]
+    public void ASecretContainingDoubledQuotesIsStillFullyRemoved()
+    {
+        // TSql.EscapeLiteral doubles single quotes, so a naive "up to the next quote" match would
+        // stop early and leave the tail of the secret in the log.
+        var redacted = LogRedactor.Redact("SECRET = 'abc''def''ghi' AND something_else = 1");
+
+        Assert.DoesNotContain("abc", redacted);
+        Assert.DoesNotContain("ghi", redacted);
+        Assert.Contains("something_else", redacted);
+    }
+
+    [Theory]
+    [InlineData("Server=x;User ID=sa;Password=hunter2;Encrypt=True")]
+    [InlineData("Server=x;pwd=hunter2;Encrypt=True")]
+    [InlineData("Password = hunter2")]
+    public void AConnectionStringPasswordIsRemoved(string text)
+    {
+        var redacted = LogRedactor.Redact(text);
+
+        Assert.DoesNotContain("hunter2", redacted);
+    }
+
+    [Fact]
+    public void OrdinaryTextIsLeftAlone()
+    {
+        const string line = "Executing statement 3 of 12: RESTORE LOG [MyDb] FROM URL = N'https://acct/backups/x.trn'";
+
+        Assert.Equal(line, LogRedactor.Redact(line));
+    }
+
+    [Fact]
+    public void NullAndEmptyAreSafe()
+    {
+        Assert.Equal(string.Empty, LogRedactor.Redact(null));
+        Assert.Equal(string.Empty, LogRedactor.Redact(""));
+    }
+}
+
+/// <summary>The writer itself: it must record what it is given and must never throw.</summary>
+public class OperationLogTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-log-tests", Guid.NewGuid().ToString("n"));
+
+    private OperationLog Log() => new(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private string ReadLog() => File.ReadAllText(Log().CurrentFile);
+
+    [Fact]
+    public void WritingCreatesTheDirectoryAndTheFile()
+    {
+        var log = Log();
+        log.Info("hello");
+
+        Assert.True(File.Exists(log.CurrentFile));
+        Assert.Contains("hello", ReadLog());
+    }
+
+    [Fact]
+    public void EachLineCarriesATimestampAndLevel()
+    {
+        Log().Warn("something odd");
+
+        var line = File.ReadAllLines(Log().CurrentFile).Last();
+        Assert.Matches(@"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} WARN  something odd$", line);
+    }
+
+    [Fact]
+    public void EntriesAccumulateRatherThanOverwrite()
+    {
+        var log = Log();
+        log.Info("first");
+        log.Info("second");
+
+        var text = ReadLog();
+        Assert.Contains("first", text);
+        Assert.Contains("second", text);
+    }
+
+    /// <summary>The reason redaction lives in the writer: a caller cannot opt out of it.</summary>
+    [Fact]
+    public void SecretsAreRedactedOnTheWayToDisk()
+    {
+        Log().Info("CREATE CREDENTIAL [x] WITH IDENTITY = 'SHARED ACCESS SIGNATURE', SECRET = 'sig=leaked'");
+
+        var text = ReadLog();
+        Assert.DoesNotContain("leaked", text);
+        Assert.Contains("[redacted]", text);
+    }
+
+    [Fact]
+    public void ServerChangesAreMarkedSoTheyCanBeFound()
+    {
+        Log().ServerChange("SRV01", "credential [https://acct/backups] updated");
+
+        var text = ReadLog();
+        Assert.Contains("CHANGE", text);
+        Assert.Contains("[SRV01]", text);
+    }
+
+    [Fact]
+    public void AnExceptionIsRecordedWithItsTypeAndMessage()
+    {
+        Log().Error("while restoring", new InvalidOperationException("chain broken"));
+
+        var text = ReadLog();
+        Assert.Contains("InvalidOperationException", text);
+        Assert.Contains("chain broken", text);
+    }
+
+    /// <summary>
+    /// A logging failure must never break the operation being logged. An unusable directory is the
+    /// easiest way to prove the swallow works.
+    /// </summary>
+    [Fact]
+    public void AnUnwritableLocationDoesNotThrow()
+    {
+        var log = new OperationLog("\0:\\definitely\\not\\a\\path");
+
+        log.Info("this should vanish quietly");
+        log.Error("so should this", new Exception("boom"));
+        log.Prune();
+    }
+
+    [Fact]
+    public void PruningAnAbsentDirectoryDoesNotThrow() => new OperationLog(_dir).Prune();
+
+    [Fact]
+    public void PruningRemovesOldFilesAndKeepsRecentOnes()
+    {
+        var log = Log();
+        log.Info("today");
+
+        Directory.CreateDirectory(_dir);
+        var old = Path.Combine(_dir, "ninelives-20200101.log");
+        File.WriteAllText(old, "ancient");
+        File.SetLastWriteTime(old, DateTime.Now.AddDays(-60));
+
+        log.Prune();
+
+        Assert.False(File.Exists(old));
+        Assert.True(File.Exists(log.CurrentFile));
+    }
+
+    [Fact]
+    public void ConcurrentWritesDoNotLoseLines()
+    {
+        // The execution log appends from a progress callback while the UI thread is also writing.
+        var log = Log();
+
+        Parallel.For(0, 200, i => log.Info($"line-{i}"));
+
+        var lines = File.ReadAllLines(log.CurrentFile);
+        Assert.Equal(200, lines.Length);
+    }
+}

--- a/src/NineLives.Tests/SasExpiryTests.cs
+++ b/src/NineLives.Tests/SasExpiryTests.cs
@@ -1,0 +1,168 @@
+using System.Globalization;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// SAS expiry parsing (#21), and keeping the token off the clipboard (#18).
+///
+/// The expiry was parsed with DateTime.TryParse and no culture, and any failure returned null -
+/// which every caller reads as "not expired". So on a non-invariant locale an expired token could
+/// be presented as perfectly valid, and the user found out when the restore failed.
+/// </summary>
+public class SasExpiryTests
+{
+    private static BlobContainerConfig Container() => new()
+    {
+        Name = "prod",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups"
+    };
+
+    private static string TokenExpiring(string se) => $"sv=2024-11-04&se={se}&sr=c&sp=rl&sig=abc";
+
+    // ── culture ─────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("en-GB")]
+    [InlineData("en-US")]
+    [InlineData("de-DE")]
+    [InlineData("fr-FR")]
+    [InlineData("ar-SA")]   // non-Gregorian default calendar
+    [InlineData("th-TH")]   // Buddhist calendar: years land ~543 out under the ambient culture
+    public void ExpiryIsReadIdenticallyInEveryCulture(string culture)
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+
+            var expiry = Container().ReadSasExpiry(TokenExpiring("2026-03-09T17:45:00Z"));
+
+            Assert.Equal(new DateTime(2026, 3, 9, 17, 45, 0, DateTimeKind.Utc), expiry.ExpiresAt);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void AnExpiryWithNoZoneIsTreatedAsUtc()
+    {
+        // Azure writes UTC here. Reading it as local time would shift the answer by the machine's
+        // offset, so a token could look valid for another hour on one desk and not on the next.
+        var expiry = Container().ReadSasExpiry(TokenExpiring("2026-03-09T17:45:00"));
+
+        Assert.Equal(new DateTime(2026, 3, 9, 17, 45, 0, DateTimeKind.Utc), expiry.ExpiresAt);
+    }
+
+    // ── the three states ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AReadableFutureExpiryIsNotExpired()
+    {
+        var se = DateTime.UtcNow.AddHours(4).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        var expiry = Container().ReadSasExpiry(TokenExpiring(se));
+
+        Assert.False(expiry.IsExpired);
+        Assert.False(expiry.CouldNotParse);
+    }
+
+    [Fact]
+    public void AReadablePastExpiryIsExpired()
+    {
+        var se = DateTime.UtcNow.AddHours(-4).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        Assert.True(Container().ReadSasExpiry(TokenExpiring(se)).IsExpired);
+    }
+
+    /// <summary>
+    /// The regression. An se= we cannot read must not be reported as a valid token - we have no
+    /// basis for saying so, and the restore is the wrong place to find out.
+    /// </summary>
+    [Theory]
+    [InlineData("not-a-date")]
+    [InlineData("2026-13-45T99:99:99Z")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AnUnreadableExpiryCountsAsExpired(string se)
+    {
+        var expiry = Container().ReadSasExpiry($"sv=2024-11-04&se={Uri.EscapeDataString(se)}&sig=abc");
+
+        Assert.True(expiry.IsExpired);
+        Assert.Null(expiry.ExpiresAt);
+    }
+
+    [Fact]
+    public void NoExpiryAtAllIsUnknownRatherThanExpired()
+    {
+        // A SAS built on a stored access policy legitimately carries no se= of its own. Calling
+        // that expired would condemn a perfectly good token.
+        var expiry = Container().ReadSasExpiry("sv=2024-11-04&sr=c&si=my-policy&sig=abc");
+
+        Assert.False(expiry.IsExpired);
+        Assert.False(expiry.CouldNotParse);
+        Assert.Null(expiry.ExpiresAt);
+    }
+
+    [Fact]
+    public void NoTokenAtAllIsUnknown()
+    {
+        var expiry = Container().ReadSasExpiry("");
+
+        Assert.False(expiry.IsExpired);
+        Assert.Null(expiry.ExpiresAt);
+    }
+
+    [Fact]
+    public void ALeadingQuestionMarkIsAccepted()
+    {
+        var expiry = Container().ReadSasExpiry("?sv=2024-11-04&se=2026-03-09T17:45:00Z&sig=abc");
+
+        Assert.Equal(new DateTime(2026, 3, 9, 17, 45, 0, DateTimeKind.Utc), expiry.ExpiresAt);
+    }
+
+    [Fact]
+    public void DisplayTextMarksAContainerWithAnUnreadableExpiryAsExpired()
+    {
+        var container = Container();
+        container.CacheSasToken("sv=2024-11-04&se=not-a-date&sig=abc");
+
+        Assert.True(container.IsExpired);
+        Assert.Contains("[EXPIRED]", container.DisplayText);
+    }
+
+    // ── #18: the copied URL carries no credential ───────────────────────────────
+
+    [Fact]
+    public void TheCopyableBlobUrlCarriesNoSasToken()
+    {
+        // Copying a SAS-bearing URL puts a live credential on the Windows clipboard, where
+        // clipboard history and cloud sync can keep it long after the app has closed. The
+        // token-free URL is what the generated scripts use anyway - RESTORE FROM URL
+        // authenticates with the server-side credential, not with anything in the URL.
+        var url = BlobStorageService.BuildBlobUrl(Container(), "FULL/SRV01/MyDb/MyDb_20260305.bak");
+
+        Assert.Equal(
+            "https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/MyDb_20260305.bak",
+            url);
+        Assert.DoesNotContain("?", url);
+        Assert.DoesNotContain("sig=", url);
+    }
+
+    [Fact]
+    public void TheCopyableBlobUrlDoesNotDoubleUpSlashes()
+    {
+        var container = new BlobContainerConfig
+        {
+            ContainerUrl = "https://acct.blob.core.windows.net/backups/"
+        };
+
+        Assert.Equal(
+            "https://acct.blob.core.windows.net/backups/FULL/MyDb.bak",
+            BlobStorageService.BuildBlobUrl(container, "FULL/MyDb.bak"));
+    }
+}

--- a/src/NineLives.Tests/SecretKeyMigrationTests.cs
+++ b/src/NineLives.Tests/SecretKeyMigrationTests.cs
@@ -16,6 +16,7 @@ namespace Blackcat.NineLives.Tests;
 /// These write to the real Windows Credential Manager, so every key is namespaced under
 /// "ninelives-test-" plus a fresh Guid and removed in Dispose. Config goes to a temp directory.
 /// </summary>
+[Collection("CredentialManager")]
 public class SecretKeyMigrationTests : IDisposable
 {
     private readonly string _dir = Path.Combine(

--- a/src/NineLives.Tests/SecretKeyMigrationTests.cs
+++ b/src/NineLives.Tests/SecretKeyMigrationTests.cs
@@ -1,0 +1,229 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Secrets keyed by stable id rather than display name (#8).
+///
+/// The credential key used to be derived from Name. Renaming a container or server therefore
+/// pointed every lookup at a key that did not exist, and the working token stayed under the old
+/// name with no UI to recover it - which bites hardest on containers, because the edit form
+/// deliberately never shows a stored SAS and so actively invites you to leave the field blank.
+///
+/// These write to the real Windows Credential Manager, so every key is namespaced under
+/// "ninelives-test-" plus a fresh Guid and removed in Dispose. Config goes to a temp directory.
+/// </summary>
+public class SecretKeyMigrationTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-migration-tests", Guid.NewGuid().ToString("n"));
+
+    private readonly string _prefix = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8];
+    private readonly List<string> _writtenKeys = [];
+
+    private string ConfigPath => Path.Combine(_dir, "config.json");
+    private CredentialStore Store() => new(_dir);
+
+    public SecretKeyMigrationTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        var store = Store();
+        foreach (var key in _writtenKeys)
+        {
+            try { store.DeleteSecret(key); } catch { /* best effort */ }
+        }
+        try { Directory.Delete(_dir, recursive: true); } catch { /* temp dir */ }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Writes a secret under a legacy name-derived key, as a pre-#8 config would have.</summary>
+    private void GiveLegacySecret(string key, string username, string secret)
+    {
+        Store().SaveSecret(key, username, secret);
+        _writtenKeys.Add(key);
+    }
+
+    private BlobContainerConfig LegacyContainer(string name) => new()
+    {
+        Name = $"{_prefix}-{name}",
+        ContainerUrl = $"https://acct.blob.core.windows.net/{name}"
+        // No Id: this is what an entry written before #8 looks like.
+    };
+
+    private ServerConnection LegacyServer(string name) => new()
+    {
+        Name = $"{_prefix}-{name}",
+        ServerName = "SRV01",
+        AuthMode = AuthMode.SqlAuth,
+        Username = "sa"
+    };
+
+    private void TrackNewKey(string key) => _writtenKeys.Add(key);
+
+    // ── migration ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LegacyContainer_GetsAnId_AndItsTokenMovesToTheNewKey()
+    {
+        var container = LegacyContainer("prod");
+        GiveLegacySecret(container.LegacyCredentialKey, "acct", "sv=2026&sig=the-real-token");
+
+        var config = new AppConfig { BlobContainers = { container } };
+        var result = new ConfigMigrator(Store()).Migrate(config);
+        TrackNewKey(container.CredentialKey);
+
+        Assert.Null(result.Error);
+        Assert.Equal(1, result.ContainersMigrated);
+        Assert.False(string.IsNullOrEmpty(container.Id));
+        Assert.Equal("sv=2026&sig=the-real-token", Store().GetSasToken(container));
+    }
+
+    [Fact]
+    public void LegacyServer_GetsAnId_AndItsPasswordMovesToTheNewKey()
+    {
+        var server = LegacyServer("sql01");
+        GiveLegacySecret(server.LegacyCredentialKey, "sa", "correct horse battery staple");
+
+        var config = new AppConfig { Servers = { server } };
+        var result = new ConfigMigrator(Store()).Migrate(config);
+        TrackNewKey(server.CredentialKey);
+
+        Assert.Null(result.Error);
+        Assert.Equal(1, result.ServersMigrated);
+        Assert.Equal("correct horse battery staple", Store().GetSqlPassword(server));
+    }
+
+    [Fact]
+    public void Migration_RemovesTheOldKey()
+    {
+        var container = LegacyContainer("prod");
+        var legacyKey = container.LegacyCredentialKey;
+        GiveLegacySecret(legacyKey, "acct", "token");
+
+        new ConfigMigrator(Store()).Migrate(new AppConfig { BlobContainers = { container } });
+        TrackNewKey(container.CredentialKey);
+
+        Assert.Null(Store().ReadSecret(legacyKey).secret);
+    }
+
+    [Fact]
+    public void Migration_IsIdempotent()
+    {
+        var container = LegacyContainer("prod");
+        GiveLegacySecret(container.LegacyCredentialKey, "acct", "token");
+        var config = new AppConfig { BlobContainers = { container } };
+
+        new ConfigMigrator(Store()).Migrate(config);
+        TrackNewKey(container.CredentialKey);
+        var idAfterFirst = container.Id;
+
+        var second = new ConfigMigrator(Store()).Migrate(config);
+
+        Assert.Equal(0, second.ContainersMigrated);
+        Assert.Equal(idAfterFirst, container.Id);
+        Assert.Equal("token", Store().GetSasToken(container));
+    }
+
+    [Fact]
+    public void LegacyEntryWithNoStoredSecret_StillGetsAnId()
+    {
+        var container = LegacyContainer("no-token-yet");
+
+        new ConfigMigrator(Store()).Migrate(new AppConfig { BlobContainers = { container } });
+
+        Assert.False(string.IsNullOrEmpty(container.Id));
+    }
+
+    // ── the actual bug ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// #8 itself. Rename a container and the token must still be found. Before the fix the key
+    /// moved with the name and the lookup came back empty.
+    /// </summary>
+    [Fact]
+    public void RenamingAContainer_KeepsItsToken()
+    {
+        var container = LegacyContainer("prod");
+        GiveLegacySecret(container.LegacyCredentialKey, "acct", "sv=2026&sig=still-here");
+        new ConfigMigrator(Store()).Migrate(new AppConfig { BlobContainers = { container } });
+        TrackNewKey(container.CredentialKey);
+
+        container.Name = $"{_prefix}-prod-backups";
+
+        Assert.Equal("sv=2026&sig=still-here", Store().GetSasToken(container));
+    }
+
+    [Fact]
+    public void RenamingAServer_KeepsItsPassword()
+    {
+        var server = LegacyServer("sql01");
+        GiveLegacySecret(server.LegacyCredentialKey, "sa", "hunter2");
+        new ConfigMigrator(Store()).Migrate(new AppConfig { Servers = { server } });
+        TrackNewKey(server.CredentialKey);
+
+        server.Name = $"{_prefix}-sql01-renamed";
+
+        Assert.Equal("hunter2", Store().GetSqlPassword(server));
+    }
+
+    [Fact]
+    public void TwoEntriesSharingAName_DoNotShareASecret()
+    {
+        // The other half of keying on a display name: two entries called the same thing collided
+        // on one credential key, so whichever saved last silently owned both.
+        var first = new BlobContainerConfig { Id = BlobContainerConfig.NewId(), Name = $"{_prefix}-dup" };
+        var second = new BlobContainerConfig { Id = BlobContainerConfig.NewId(), Name = $"{_prefix}-dup" };
+
+        Store().SaveSasToken(first, "token-one");
+        Store().SaveSasToken(second, "token-two");
+        TrackNewKey(first.CredentialKey);
+        TrackNewKey(second.CredentialKey);
+
+        Assert.Equal("token-one", Store().GetSasToken(first));
+        Assert.Equal("token-two", Store().GetSasToken(second));
+    }
+
+    // ── failure handling ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// If the config write fails, the migration must not be half-applied: the old key has to
+    /// survive, because it is still the only thing the on-disk config points at.
+    /// </summary>
+    [Fact]
+    public void WhenTheConfigCannotBeSaved_TheOldKeySurvives_AndNoIdIsKept()
+    {
+        var container = LegacyContainer("prod");
+        var legacyKey = container.LegacyCredentialKey;
+        GiveLegacySecret(legacyKey, "acct", "token");
+
+        var config = new AppConfig { BlobContainers = { container } };
+        Store().SaveConfig(new AppConfig());
+
+        ConfigMigrator.Result result;
+        using (var _ = new FileStream(ConfigPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            result = new ConfigMigrator(Store()).Migrate(config);
+        }
+
+        Assert.NotNull(result.Error);
+        Assert.True(string.IsNullOrEmpty(container.Id));
+        Assert.Equal("token", Store().ReadSecret(legacyKey).secret);
+    }
+
+    [Fact]
+    public void AConfigThatFailedToLoad_IsNotMigrated()
+    {
+        // It holds empty defaults rather than anything real, and saving it would be refused.
+        var config = new AppConfig { LoadError = "locked" };
+
+        var result = new ConfigMigrator(Store()).Migrate(config);
+
+        Assert.Null(result.Error);
+        Assert.False(result.DidWork);
+    }
+
+}

--- a/src/NineLives.Tests/SqlSyntaxHighlighterTests.cs
+++ b/src/NineLives.Tests/SqlSyntaxHighlighterTests.cs
@@ -1,0 +1,129 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// T-SQL tokenising for the script pane.
+///
+/// The one property that must always hold is that concatenating the tokens reproduces the input
+/// exactly - the pane displays the script someone is about to run against production, and it must
+/// not be able to show something different from what will execute. Colour being wrong is cosmetic;
+/// text being wrong is not.
+/// </summary>
+public class SqlSyntaxHighlighterTests
+{
+    private static string Rebuild(string sql)
+        => string.Concat(SqlSyntaxHighlighter.Tokenise(sql).Select(t => t.Text));
+
+    [Theory]
+    [InlineData("RESTORE DATABASE [MyDb] FROM URL = N'https://acct/backups/x.bak' WITH REPLACE, STATS = 10")]
+    [InlineData("-- a comment\r\nRESTORE LOG [MyDb]\r\n  FROM URL = N'x'\r\nGO\r\n")]
+    [InlineData("SECRET = 'abc''def'")]
+    [InlineData("")]
+    [InlineData("   \r\n\t  ")]
+    [InlineData("/* block\ncomment */ SELECT 1")]
+    public void TheTokensAlwaysReproduceTheInputExactly(string sql)
+        => Assert.Equal(sql, Rebuild(sql));
+
+    [Fact]
+    public void KeywordsAreRecognised()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("RESTORE DATABASE [MyDb] WITH REPLACE");
+
+        Assert.Contains(tokens, t => t.Text == "RESTORE" && t.Kind == SqlTokenKind.Keyword);
+        Assert.Contains(tokens, t => t.Text == "DATABASE" && t.Kind == SqlTokenKind.Keyword);
+        Assert.Contains(tokens, t => t.Text == "REPLACE" && t.Kind == SqlTokenKind.Keyword);
+    }
+
+    [Fact]
+    public void KeywordsAreCaseInsensitive()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("restore Database");
+
+        Assert.All(tokens.Where(t => t.Text.Trim().Length > 0),
+            t => Assert.Equal(SqlTokenKind.Keyword, t.Kind));
+    }
+
+    [Fact]
+    public void BracketedIdentifiersAreTheirOwnKind()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("RESTORE DATABASE [My Db]");
+
+        Assert.Contains(tokens, t => t.Text == "[My Db]" && t.Kind == SqlTokenKind.Identifier);
+    }
+
+    [Fact]
+    public void AnIdentifierContainingADoubledBracketStaysOneToken()
+    {
+        // TSql.QuoteName doubles a ']', so this shape reaches the pane for real.
+        var tokens = SqlSyntaxHighlighter.Tokenise("[My]]Db]");
+
+        Assert.Contains(tokens, t => t.Text == "[My]]Db]" && t.Kind == SqlTokenKind.Identifier);
+    }
+
+    [Fact]
+    public void StringLiteralsIncludeTheNPrefixAndDoubledQuotes()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("SECRET = N'it''s here'");
+
+        Assert.Contains(tokens, t => t.Text == "N'it''s here'" && t.Kind == SqlTokenKind.Literal);
+    }
+
+    [Fact]
+    public void AKeywordInsideAStringIsNotColouredAsCode()
+    {
+        // A blob URL contains "backups" and could contain anything; it is a literal, not SQL.
+        var tokens = SqlSyntaxHighlighter.Tokenise("FROM URL = N'https://acct/RESTORE/DATABASE.bak'");
+
+        Assert.DoesNotContain(tokens, t => t.Text.Contains("https") && t.Kind == SqlTokenKind.Keyword);
+        Assert.Contains(tokens, t => t.Kind == SqlTokenKind.Literal && t.Text.Contains("RESTORE"));
+    }
+
+    [Fact]
+    public void AKeywordInsideACommentIsNotColouredAsCode()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("-- RESTORE DATABASE goes here\nSELECT 1");
+
+        var comment = Assert.Single(tokens, t => t.Kind == SqlTokenKind.Comment);
+        Assert.Contains("RESTORE DATABASE", comment.Text);
+    }
+
+    [Fact]
+    public void NumbersAreRecognised()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("WITH STATS = 10");
+
+        Assert.Contains(tokens, t => t.Text == "10" && t.Kind == SqlTokenKind.Number);
+    }
+
+    [Fact]
+    public void OrdinaryWordsStayPlain()
+    {
+        var tokens = SqlSyntaxHighlighter.Tokenise("MyDatabaseName");
+
+        Assert.Contains(tokens, t => t.Text == "MyDatabaseName" && t.Kind == SqlTokenKind.Plain);
+    }
+
+    [Fact]
+    public void ARealisticRestoreScriptTokenisesWithoutLosingAnything()
+    {
+        const string script = """
+            -- ============================================
+            -- Nine Lives - generated restore script
+            -- ============================================
+            USE [master];
+            GO
+
+            RESTORE DATABASE [MyDb]
+            FROM URL = N'https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/x.bak'
+            WITH NORECOVERY, REPLACE, STATS = 10;
+            GO
+            """;
+
+        Assert.Equal(script, Rebuild(script));
+        Assert.Contains(SqlSyntaxHighlighter.Tokenise(script), t => t.Kind == SqlTokenKind.Comment);
+        Assert.Contains(SqlSyntaxHighlighter.Tokenise(script), t => t.Kind == SqlTokenKind.Identifier);
+        Assert.Contains(SqlSyntaxHighlighter.Tokenise(script), t => t.Kind == SqlTokenKind.Literal);
+    }
+}

--- a/src/NineLives.Tests/TagNotificationTests.cs
+++ b/src/NineLives.Tests/TagNotificationTests.cs
@@ -101,8 +101,42 @@ public class TagNotificationTests
 
         var chips = server.TagChips.ToList();
 
-        Assert.Equal(["prod", "eu", "SQL Server 2022"], chips.Select(c => c.Text));
+        // Manual tags alphabetical, automatic ones after them. The manual group is sorted at
+        // display as well as on save, so a server stored before sorting existed still reads in
+        // order without being edited first.
+        Assert.Equal(["eu", "prod", "SQL Server 2022"], chips.Select(c => c.Text));
         Assert.Equal([false, false, true], chips.Select(c => c.IsAutomatic));
+    }
+
+    [Fact]
+    public void Server_TagChips_AreSortedEvenWhenTheStoredOrderIsNot()
+    {
+        // Exactly the case in an existing config: tags saved in the order they were created.
+        var server = new ServerConnection();
+        server.Tags.Add("homelab");
+        server.Tags.Add("blackcat");
+
+        Assert.Equal(["blackcat", "homelab"], server.TagChips.Select(c => c.Text));
+    }
+
+    [Fact]
+    public void Container_TagChips_AreSortedEvenWhenTheStoredOrderIsNot()
+    {
+        var container = new BlobContainerConfig();
+        container.Tags.Add("uat");
+        container.Tags.Add("archive");
+
+        Assert.Equal(["archive", "uat"], container.TagChips.Select(c => c.Text));
+    }
+
+    [Fact]
+    public void Server_TagChips_SortIgnoringCase()
+    {
+        var server = new ServerConnection();
+        server.Tags.Add("Zebra");
+        server.Tags.Add("apple");
+
+        Assert.Equal(["apple", "Zebra"], server.TagChips.Select(c => c.Text));
     }
 
     [Fact]

--- a/src/NineLives.Tests/TagPaletteTests.cs
+++ b/src/NineLives.Tests/TagPaletteTests.cs
@@ -109,7 +109,7 @@ public class TagPaletteTests
 
     [Fact]
     public void ParseTags_SplitsTrimsAndDropsBlanks()
-        => Assert.Equal(["prod", "eu-west", "critical"],
+        => Assert.Equal(["critical", "eu-west", "prod"],
             TagPalette.ParseTags("  prod ,, eu-west ,  critical  "));
 
     [Fact]
@@ -120,9 +120,31 @@ public class TagPaletteTests
     public void ParseTags_RemovesDuplicatesKeepingTheFirstSpelling()
         => Assert.Equal(["Prod"], TagPalette.ParseTags("Prod, prod, PROD"));
 
+    // Tags used to be stored in the order they were typed, so the same two tags on two servers
+    // rendered in different orders depending on how each was created. Sorted on save, and sorted
+    // again on display so entries saved before this still read correctly.
+
     [Fact]
-    public void ParseTags_PreservesOrder()
-        => Assert.Equal(["zebra", "apple"], TagPalette.ParseTags("zebra, apple"));
+    public void ParseTags_SortsAlphabetically()
+        => Assert.Equal(["apple", "zebra"], TagPalette.ParseTags("zebra, apple"));
+
+    [Fact]
+    public void ParseTags_SortsIgnoringCase()
+        => Assert.Equal(["Apple", "banana", "Cherry"], TagPalette.ParseTags("Cherry, banana, Apple"));
+
+    [Fact]
+    public void ParseTags_KeepsTheSpellingTheUserTyped()
+    {
+        // Sorting must not normalise case - a tag typed "Prod" stays "Prod".
+        Assert.Equal(["Prod", "uat"], TagPalette.ParseTags("uat, Prod"));
+    }
+
+    [Fact]
+    public void Sort_HandlesNullAndEmpty()
+    {
+        Assert.Empty(TagPalette.Sort(null));
+        Assert.Empty(TagPalette.Sort([]));
+    }
 
     [Fact]
     public void ParseTags_TruncatesOverlongTags()
@@ -141,8 +163,18 @@ public class TagPaletteTests
     [Fact]
     public void FormatTags_RoundTripsThroughParse()
     {
-        var original = new[] { "prod", "eu-west", "critical" };
+        // Already sorted, so the round trip is an identity. That is the point: once a list has
+        // been through ParseTags, formatting and reparsing it must not shuffle it again.
+        var original = new[] { "critical", "eu-west", "prod" };
         Assert.Equal(original, TagPalette.ParseTags(TagPalette.FormatTags(original)));
+    }
+
+    [Fact]
+    public void FormatTags_RoundTripSortsAnUnsortedList()
+    {
+        var original = new[] { "prod", "eu-west", "critical" };
+        Assert.Equal(["critical", "eu-west", "prod"],
+            TagPalette.ParseTags(TagPalette.FormatTags(original)));
     }
 
     [Fact]

--- a/src/NineLives.Tests/UnsavedSecretTests.cs
+++ b/src/NineLives.Tests/UnsavedSecretTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text.Json;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace Blackcat.NineLives.Tests;
@@ -121,8 +122,11 @@ public class UnsavedSecretTests : IDisposable
 
     // ── the transient secret is actually used ───────────────────────────────────
 
+    // Since #20 the password never appears in the connection string - it goes on the connection as
+    // a SqlCredential - so these assert on the credential instead.
+
     [Fact]
-    public void AnUnsavedPassword_IsUsedInTheConnectionString()
+    public void AnUnsavedPassword_IsAttachedToTheConnection()
     {
         var server = new ServerConnection
         {
@@ -134,31 +138,10 @@ public class UnsavedSecretTests : IDisposable
             UnsavedPassword = "in-memory-only"
         };
 
-        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+        using var conn = new SqlServerService(Store()).CreateConnection(server);
 
-        Assert.Contains("in-memory-only", connectionString);
-    }
-
-    [Fact]
-    public void AnUnsavedPassword_TakesPrecedenceOverTheStoredOne()
-    {
-        var server = new ServerConnection
-        {
-            Id = ServerConnection.NewId(),
-            Name = "ninelives-test-precedence",
-            ServerName = "SRV01",
-            AuthMode = AuthMode.SqlAuth,
-            Username = "sa"
-        };
-        Store().SaveSqlPassword(server, "stored");
-        _writtenKeys.Add(server.CredentialKey);
-
-        server.UnsavedPassword = "candidate";
-
-        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
-
-        Assert.Contains("candidate", connectionString);
-        Assert.DoesNotContain("stored", connectionString);
+        Assert.NotNull(conn.Credential);
+        Assert.Equal("sa", conn.Credential!.UserId);
     }
 
     [Fact]
@@ -175,9 +158,25 @@ public class UnsavedSecretTests : IDisposable
         Store().SaveSqlPassword(server, "stored-password");
         _writtenKeys.Add(server.CredentialKey);
 
-        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+        using var conn = new SqlServerService(Store()).CreateConnection(server);
 
-        Assert.Contains("stored-password", connectionString);
+        Assert.NotNull(conn.Credential);
+    }
+
+    [Fact]
+    public void WindowsAuth_GetsNoCredential()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-winauth",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.WindowsAuth
+        };
+
+        using var conn = new SqlServerService(Store()).CreateConnection(server);
+
+        Assert.Null(conn.Credential);
     }
 
     // ── never persisted ─────────────────────────────────────────────────────────

--- a/src/NineLives.Tests/UnsavedSecretTests.cs
+++ b/src/NineLives.Tests/UnsavedSecretTests.cs
@@ -1,0 +1,227 @@
+using System.IO;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Test Connection must not persist anything (#12).
+///
+/// Testing a newly typed SAS token used to write it to Credential Manager first, with
+/// CRED_PERSIST_LOCAL_MACHINE - before Save, with no undo. So: edit a container whose token works,
+/// paste one that turns out to be typo'd or expired, click Test Connection because that is exactly
+/// what the button invites, watch it fail, click Cancel expecting nothing to have changed, and the
+/// working token is gone. The form never displays stored tokens, so there is no way to get it back.
+/// Same shape on the SQL side for passwords.
+///
+/// The fix is a transient in-memory secret the services prefer over the stored one. These tests
+/// pin both halves: the transient value is used, and it never reaches disk.
+/// </summary>
+public class UnsavedSecretTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-unsaved-tests", Guid.NewGuid().ToString("n"));
+
+    private readonly List<string> _writtenKeys = [];
+
+    private CredentialStore Store() => new(_dir);
+
+    public UnsavedSecretTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        var store = Store();
+        foreach (var key in _writtenKeys)
+        {
+            try { store.DeleteSecret(key); } catch { /* best effort */ }
+        }
+        try { Directory.Delete(_dir, recursive: true); } catch { /* temp dir */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private BlobContainerConfig SavedContainer(string storedToken)
+    {
+        var container = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8],
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        };
+        Store().SaveSasToken(container, storedToken);
+        _writtenKeys.Add(container.CredentialKey);
+        return container;
+    }
+
+    // ── the stored secret survives a test ───────────────────────────────────────
+
+    /// <summary>
+    /// The regression. A throwaway config built from the edit form, carrying a candidate token,
+    /// must leave the saved container's token exactly where it was.
+    /// </summary>
+    [Fact]
+    public void TryingACandidateToken_LeavesTheStoredOneUntouched()
+    {
+        var saved = SavedContainer("sv=2026&sig=the-working-token");
+
+        // What TestConnection now builds: same name and URL, token held in memory only.
+        var candidate = new BlobContainerConfig
+        {
+            Name = saved.Name,
+            ContainerUrl = saved.ContainerUrl,
+            UnsavedSasToken = "sv=2026&sig=typo"
+        };
+
+        Assert.Equal("sv=2026&sig=typo", candidate.UnsavedSasToken);
+        Assert.Equal("sv=2026&sig=the-working-token", Store().GetSasToken(saved));
+    }
+
+    [Fact]
+    public void ACandidateTokenIsNotWrittenUnderTheLegacyKeyEither()
+    {
+        // The throwaway object has no Id, so its CredentialKey falls back to the name-derived one.
+        // Nothing should have been written there.
+        var candidate = new BlobContainerConfig
+        {
+            Name = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8],
+            UnsavedSasToken = "sv=2026&sig=candidate"
+        };
+
+        Assert.Null(Store().ReadSecret(candidate.CredentialKey).secret);
+        Assert.Null(Store().ReadSecret(candidate.LegacyCredentialKey).secret);
+    }
+
+    [Fact]
+    public void TryingACandidatePassword_LeavesTheStoredOneUntouched()
+    {
+        var saved = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-" + Guid.NewGuid().ToString("n")[..8],
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+        Store().SaveSqlPassword(saved, "the-working-password");
+        _writtenKeys.Add(saved.CredentialKey);
+
+        var candidate = new ServerConnection
+        {
+            Name = saved.Name,
+            ServerName = saved.ServerName,
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa",
+            UnsavedPassword = "typo"
+        };
+
+        Assert.Null(Store().ReadSecret(candidate.LegacyCredentialKey).secret);
+        Assert.Equal("the-working-password", Store().GetSqlPassword(saved));
+    }
+
+    // ── the transient secret is actually used ───────────────────────────────────
+
+    [Fact]
+    public void AnUnsavedPassword_IsUsedInTheConnectionString()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-unsaved",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa",
+            UnsavedPassword = "in-memory-only"
+        };
+
+        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+
+        Assert.Contains("in-memory-only", connectionString);
+    }
+
+    [Fact]
+    public void AnUnsavedPassword_TakesPrecedenceOverTheStoredOne()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-precedence",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+        Store().SaveSqlPassword(server, "stored");
+        _writtenKeys.Add(server.CredentialKey);
+
+        server.UnsavedPassword = "candidate";
+
+        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+
+        Assert.Contains("candidate", connectionString);
+        Assert.DoesNotContain("stored", connectionString);
+    }
+
+    [Fact]
+    public void WithoutAnUnsavedPassword_TheStoredOneIsStillUsed()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "ninelives-test-fallback",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "sa"
+        };
+        Store().SaveSqlPassword(server, "stored-password");
+        _writtenKeys.Add(server.CredentialKey);
+
+        var connectionString = new SqlServerService(Store()).BuildConnectionString(server);
+
+        Assert.Contains("stored-password", connectionString);
+    }
+
+    // ── never persisted ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TransientSecrets_AreNotSerialisedIntoConfigJson()
+    {
+        var config = new AppConfig
+        {
+            BlobContainers =
+            {
+                new BlobContainerConfig { Id = "c1", Name = "prod", UnsavedSasToken = "sv=2026&sig=secret" }
+            },
+            Servers =
+            {
+                new ServerConnection { Id = "s1", Name = "sql01", UnsavedPassword = "hunter2" }
+            }
+        };
+
+        Store().SaveConfig(config);
+        var json = File.ReadAllText(Path.Combine(_dir, "config.json"));
+
+        Assert.DoesNotContain("sv=2026&sig=secret", json);
+        Assert.DoesNotContain("hunter2", json);
+        Assert.DoesNotContain("UnsavedSasToken", json);
+        Assert.DoesNotContain("UnsavedPassword", json);
+    }
+
+    [Fact]
+    public void CredentialKeys_AreNotSerialisedIntoConfigJson()
+    {
+        // Derived, and now that they contain the id they are pure noise in the file.
+        var config = new AppConfig
+        {
+            BlobContainers = { new BlobContainerConfig { Id = "c1", Name = "prod" } }
+        };
+
+        Store().SaveConfig(config);
+        var json = File.ReadAllText(Path.Combine(_dir, "config.json"));
+
+        Assert.DoesNotContain("CredentialKey", json);
+
+        // ...and the round trip still works.
+        var reloaded = JsonSerializer.Deserialize<AppConfig>(json)!;
+        Assert.Equal("c1", reloaded.BlobContainers[0].Id);
+    }
+}

--- a/src/NineLives.Tests/UnsavedSecretTests.cs
+++ b/src/NineLives.Tests/UnsavedSecretTests.cs
@@ -20,6 +20,7 @@ namespace Blackcat.NineLives.Tests;
 /// The fix is a transient in-memory secret the services prefer over the stored one. These tests
 /// pin both halves: the transient value is used, and it never reaches disk.
 /// </summary>
+[Collection("CredentialManager")]
 public class UnsavedSecretTests : IDisposable
 {
     private readonly string _dir = Path.Combine(

--- a/src/NineLives.Tests/WpfFixture.cs
+++ b/src/NineLives.Tests/WpfFixture.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Windows;
+using System.Windows.Diagnostics;
+using System.Windows.Threading;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Hosts a real WPF <see cref="Application"/> on a dedicated STA thread so the views can be loaded
+/// and laid out in a test.
+///
+/// One Application per process and it belongs to the thread that created it, so everything runs on
+/// this single thread and the fixture is shared by the whole class.
+/// </summary>
+public sealed class WpfFixture : IDisposable
+{
+    private readonly Thread _thread;
+    private Dispatcher _dispatcher = null!;
+
+    public WpfFixture()
+    {
+        using var ready = new ManualResetEventSlim();
+
+        _thread = new Thread(() =>
+        {
+            _dispatcher = Dispatcher.CurrentDispatcher;
+
+            // InitializeComponent is what loads App.xaml - and therefore Themes/DarkTheme.xaml and
+            // Themes/Logo.xaml - into Application.Resources. The generated Main calls it after the
+            // constructor, so constructing App alone leaves the resources empty and every
+            // {StaticResource} in every view fails. OnStartup only runs from Run(), which is not
+            // called here, so no splash window appears.
+            var app = new App();
+            app.InitializeComponent();
+
+            ready.Set();
+            Dispatcher.Run();
+        })
+        {
+            IsBackground = true,
+            Name = "wpf-test-ui"
+        };
+
+        _thread.SetApartmentState(ApartmentState.STA);
+        _thread.Start();
+        ready.Wait(TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>Runs on the UI thread and rethrows anything it threw, with its stack intact.</summary>
+    public void Invoke(Action action)
+    {
+        Exception? captured = null;
+
+        _dispatcher.Invoke(() =>
+        {
+            try { action(); }
+            catch (Exception ex) { captured = ex; }
+        });
+
+        if (captured != null) ExceptionDispatchInfo.Capture(captured).Throw();
+    }
+
+    public void Dispose()
+    {
+        _dispatcher?.InvokeShutdown();
+        _thread.Join(TimeSpan.FromSeconds(5));
+    }
+}
+
+/// <summary>
+/// Collects WPF's own binding failures.
+///
+/// A broken binding does not throw - WPF writes it to a trace source and carries on with an empty
+/// value. That is why a wrong RelativeSource renders a button that simply does nothing when
+/// clicked, with no error anywhere. Listening to the trace source is the only way to see them.
+/// </summary>
+public sealed class BindingErrorListener : TraceListener
+{
+    private readonly List<string> _errors = [];
+
+    public IReadOnlyList<string> Errors => _errors;
+
+    public override void Write(string? message) { }
+
+    public override void WriteLine(string? message)
+    {
+        if (!string.IsNullOrWhiteSpace(message)) _errors.Add(message);
+    }
+
+    /// <summary>Starts listening, and stops when disposed. Binding failures trace at Warning.</summary>
+    public static BindingErrorListener Attach()
+    {
+        var listener = new BindingErrorListener();
+        PresentationTraceSources.Refresh();
+        PresentationTraceSources.DataBindingSource.Listeners.Add(listener);
+        PresentationTraceSources.DataBindingSource.Switch.Level = SourceLevels.Warning;
+        return listener;
+    }
+
+    public void Detach() => PresentationTraceSources.DataBindingSource.Listeners.Remove(this);
+
+    public void AssertNone(string what)
+    {
+        if (_errors.Count == 0) return;
+
+        Assert.Fail(
+            $"{what} produced {_errors.Count} binding failure(s):{Environment.NewLine}  " +
+            string.Join(Environment.NewLine + "  ", _errors));
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -260,6 +260,114 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
         });
     }
 
+    /// <summary>
+    /// The console renders its lines and no longer shares a slot with the generated script - both
+    /// are on screen together.
+    ///
+    /// Checked in the state AFTER a restore, which is when the inline console is the one in use:
+    /// during a restore the console lives in its own window and the inline one is deliberately
+    /// hidden.
+    /// </summary>
+    [Fact]
+    public void TheConsoleAndTheScriptAreBothVisibleTogether()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.BackupsLoaded = true;
+            vm.HasScript = true;
+            vm.GeneratedScript = "RESTORE DATABASE [MyDb] FROM URL = N'https://acct/backups/x.bak'";
+            vm.ConsoleLines =
+            [
+                new ConsoleLine("Beginning restore execution...", ConsoleLineKind.Step),
+                new ConsoleLine("50 percent processed."),
+                new ConsoleLine("ERROR: something went wrong", ConsoleLineKind.Error)
+            ];
+            vm.HasConsoleOutput = true;
+            vm.IsExecuting = false;
+            vm.ExecutionComplete = true;
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.Contains(texts, t => t.Contains("50 percent processed", StringComparison.Ordinal));
+                Assert.Contains(texts, t => t.Contains("Beginning restore execution", StringComparison.Ordinal));
+
+                // The script pane used to be hidden the moment execution started, so the two
+                // shared one slot. Both must now be on screen at the same time.
+                var script = Assert.Single(FindAll<SqlTextBlock>(view));
+                Assert.Contains("RESTORE DATABASE [MyDb]", script.Sql, StringComparison.Ordinal);
+
+                // ...and it is actually highlighted, not one undifferentiated run.
+                var runs = script.Inlines.OfType<System.Windows.Documents.Run>().ToList();
+                Assert.True(runs.Count > 1, "The script rendered as a single run - no highlighting applied.");
+                Assert.Contains(runs, r => r.Text == "RESTORE");
+
+                listener.AssertNone("RestoreView console");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The inline console and the execution window are mutually exclusive: while the console is
+    /// showing in its own window the inline one must be gone, not sitting behind it.
+    /// </summary>
+    [Fact]
+    public void TheInlineConsoleHidesWhileTheConsoleIsInItsOwnWindow()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.BackupsLoaded = true;
+            vm.ConsoleLines = [new ConsoleLine("Beginning restore execution...")];
+            vm.HasConsoleOutput = true;
+
+            var view = new RestoreView { DataContext = vm };
+
+            vm.IsConsoleDetached = false;
+            Realise(view);
+            Assert.True(FindAll<ListBox>(view).Any(IsShown),
+                "The inline console should be visible when it is not shown in its own window.");
+
+            vm.IsConsoleDetached = true;
+            Realise(view);
+            Assert.False(FindAll<ListBox>(view).Any(IsShown),
+                "The inline console is still on screen behind the execution window.");
+        });
+    }
+
+    /// <summary>
+    /// The belt-and-braces half: while a restore is running the console is always in its own
+    /// window, so the inline one must be gone even if the detach flag never got set.
+    /// </summary>
+    [Fact]
+    public void TheInlineConsoleHidesWhileARestoreIsRunning()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.BackupsLoaded = true;
+            vm.ConsoleLines = [new ConsoleLine("Beginning restore execution...")];
+            vm.HasConsoleOutput = true;
+            vm.IsConsoleDetached = false;   // as if the wiring failed
+            vm.IsExecuting = true;
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            Assert.False(FindAll<ListBox>(view).Any(IsShown),
+                "Two consoles would be on screen at once during a restore.");
+        });
+    }
+
     /// <summary>The inventory warnings panel added with #46 - separate from the chain issues one.</summary>
     [Fact]
     public void TheInventoryPanelShowsItsFindings()

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -1,0 +1,291 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Loads every view against a real viewmodel and lays it out, so the two failure modes that
+/// otherwise need a human looking at the running app get caught here instead.
+///
+/// 1. A XAML parse failure or a missing {StaticResource} key - throws, so any of these tests fail.
+/// 2. A broken binding - does NOT throw. WPF traces it and carries on with an empty value, which
+///    is why a wrong RelativeSource renders a perfectly normal-looking button that does nothing
+///    when clicked. BindingErrorListener is what makes those visible.
+///
+/// What this deliberately does not check is whether the result LOOKS right - colours, spacing,
+/// whether a panel is where you expect. That still needs eyes on the running app.
+/// </summary>
+public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private CredentialStore Store() => new(_dir);
+
+    /// <summary>Realises the visual tree. Bindings are not evaluated until something lays out.</summary>
+    private static void Realise(FrameworkElement element)
+    {
+        element.Measure(new Size(1600, 1200));
+        element.Arrange(new Rect(0, 0, 1600, 1200));
+        element.UpdateLayout();
+    }
+
+    private void Check(string what, Func<FrameworkElement> build)
+    {
+        wpf.Invoke(() =>
+        {
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(build());
+                listener.AssertNone(what);
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    // ── every view loads and binds ──────────────────────────────────────────────
+
+    [Fact]
+    public void AboutViewLoads()
+        => Check("AboutView", () => new AboutView { DataContext = new AboutViewModel() });
+
+    [Fact]
+    public void BlobConfigViewLoads()
+        => Check("BlobConfigView", () =>
+            new BlobConfigView { DataContext = new BlobConfigViewModel(Store(), new BlobStorageService(Store())) });
+
+    [Fact]
+    public void ServerManagerViewLoads()
+        => Check("ServerManagerView", () =>
+            new ServerManagerView { DataContext = new ServerManagerViewModel(Store(), new SqlServerService(Store())) });
+
+    [Fact]
+    public void BlobBrowserViewLoads()
+        => Check("BlobBrowserView", () =>
+            new BlobBrowserView { DataContext = new BlobBrowserViewModel(new BlobStorageService(Store()), Store()) });
+
+    [Fact]
+    public void RestoreViewLoads()
+        => Check("RestoreView", () => new RestoreView { DataContext = NewRestoreViewModel() });
+
+    [Fact]
+    public void SplashWindowLoads()
+    {
+        // Borderless, transparent and animated - the shape of window most likely to be affected by
+        // a runtime change. Constructed but never shown.
+        wpf.Invoke(() =>
+        {
+            var splash = new SplashWindow();
+            Realise(splash);
+        });
+    }
+
+    [Fact]
+    public void MainWindowLoads()
+    {
+        wpf.Invoke(() =>
+        {
+            var window = new MainWindow();
+            Realise(window);
+        });
+    }
+
+    // ── the panels that only appear in a particular state ───────────────────────
+
+    /// <summary>
+    /// The recovery panel after a failed restore (#14). Its buttons reach the viewmodel's commands
+    /// through RelativeSource AncestorType=ItemsControl from inside a DataTemplate - the exact
+    /// shape that renders fine and quietly does nothing when it is wrong.
+    ///
+    /// The items have to be present and the panel visible, because a collapsed element is never
+    /// laid out and its template is never realised, so the binding would never be evaluated.
+    /// </summary>
+    [Fact]
+    public void TheRecoveryPanelBindsItsCommands()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.RecoveryStateMessage = "[MyDb] is in RESTORING state.";
+            vm.RecoveryActions =
+            [
+                new RecoveryAction("Bring the database online", "RESTORE DATABASE [MyDb] WITH RECOVERY", "Ends the sequence."),
+                new RecoveryAction("Allow other connections again", "ALTER DATABASE [MyDb] SET MULTI_USER", "Safe at any point.")
+            ];
+            vm.HasRecoveryActions = true;
+            vm.ExecutionComplete = true;
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                // Both buttons must have found a command. A failed RelativeSource leaves Command
+                // null, which is exactly the silent failure this test exists for.
+                var buttons = FindAll<Button>(view)
+                    .Where(b => b.Content as string is "Run this" or "Copy")
+                    .ToList();
+
+                Assert.Equal(4, buttons.Count);   // two actions, two buttons each
+                Assert.All(buttons, b => Assert.NotNull(b.Command));
+                Assert.All(buttons, b => Assert.NotNull(b.CommandParameter));
+
+                listener.AssertNone("RestoreView recovery panel");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The credential button relabels itself through a DataTrigger once the credential is valid
+    /// (#78). If that trigger is wrong the button keeps saying "Create credential on server" when
+    /// what it would actually do is refresh an existing one.
+    /// </summary>
+    [Fact]
+    public void TheCredentialButtonRelabelsWhenTheCredentialIsValid()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.SelectedContainer = new BlobContainerConfig
+            {
+                Id = BlobContainerConfig.NewId(),
+                Name = "prod",
+                ContainerUrl = "https://acct.blob.core.windows.net/backups"
+            };
+            vm.IsConnectedToServer = true;
+            vm.CredentialSectionVisible = true;
+
+            var view = new RestoreView { DataContext = vm };
+
+            vm.CredentialExistsOnServer = false;
+            vm.CredentialIsValidSas = false;
+            Realise(view);
+            Assert.Contains(FindAll<Button>(view), b => (b.Content as string) == "Create credential on server");
+
+            vm.CredentialExistsOnServer = true;
+            vm.CredentialIsValidSas = true;
+            Realise(view);
+            Assert.Contains(FindAll<Button>(view),
+                b => (b.Content as string) == "Refresh credential with stored SAS token");
+        });
+    }
+
+    /// <summary>The inventory warnings panel added with #46 - separate from the chain issues one.</summary>
+    [Fact]
+    public void TheInventoryPanelShowsItsFindings()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.InventoryIssues =
+            [
+                new ChainIssue(ChainIssueSeverity.Warning, "2 log backup(s) are not reachable", "Detail here.")
+            ];
+            vm.HasInventoryIssues = true;
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.True(
+                    texts.Any(t => t.Contains("Detail here.", StringComparison.Ordinal)),
+                    "The inventory panel did not render its findings. TextBlocks found: " +
+                    string.Join(" | ", texts.Where(t => !string.IsNullOrWhiteSpace(t))));
+
+                listener.AssertNone("RestoreView inventory panel");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    /// <summary>Tag pills render through one wrapping template; they used to clip (#67).</summary>
+    [Fact]
+    public void TagPillsRenderForAServerRow()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new ServerManagerViewModel(Store(), new SqlServerService(Store()));
+            var server = new ServerConnection
+            {
+                Id = ServerConnection.NewId(),
+                Name = "SRV01",
+                ServerName = "SRV01",
+                DetectedVersion = "SQL Server 2022"
+            };
+            server.Tags.Add("prod");
+            server.Tags.Add("uk-south");
+            vm.Servers = [server];
+            vm.SelectedServer = server;
+
+            var view = new ServerManagerView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.Contains("prod", texts);
+                Assert.Contains("uk-south", texts);
+                Assert.Contains("SQL Server 2022", texts);
+
+                listener.AssertNone("ServerManagerView tag pills");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private RestoreViewModel NewRestoreViewModel()
+    {
+        var store = Store();
+        return new RestoreViewModel(
+            new BlobStorageService(store),
+            new SqlServerService(store),
+            new BackupChainBuilder(),
+            new RestoreScriptGenerator(),
+            store);
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is T match) yield return match;
+            foreach (var descendant in FindAll<T>(child)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -192,6 +192,74 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
         });
     }
 
+    /// <summary>
+    /// The Stop button that appears while a restore is running (#25). It is the only way to
+    /// interrupt a restore aimed at the wrong server, so a binding that silently failed would
+    /// leave the user back at killing the process.
+    /// </summary>
+    [Fact]
+    public void TheStopRestoreButtonAppearsAndBindsWhileExecuting()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            // The execute card only exists once backups are loaded, which is correct - there is
+            // no script to run before then.
+            vm.BackupsLoaded = true;
+            vm.HasScript = true;
+            vm.IsConnectedToServer = true;
+            var view = new RestoreView { DataContext = vm };
+
+            // Not running: nothing to stop, so the button must not be offered.
+            vm.CanCancelExecute = false;
+            Realise(view);
+            Assert.DoesNotContain(VisibleButtons(view), b => (b.Content as string) == "Stop restore");
+
+            vm.CanCancelExecute = true;
+            Realise(view);
+
+            var stop = Assert.Single(VisibleButtons(view), b => (b.Content as string) == "Stop restore");
+            Assert.NotNull(stop.Command);
+        });
+    }
+
+    /// <summary>The Cancel button over the loading overlay, for a long container listing (#25).</summary>
+    [Fact]
+    public void TheCancelLoadButtonAppearsAndBindsWhileLoading()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.IsBusy = true;
+            vm.CanCancelLoad = true;
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            var cancel = Assert.Single(VisibleButtons(view), b => (b.Content as string) == "Cancel");
+            Assert.NotNull(cancel.Command);
+        });
+    }
+
+    [Fact]
+    public void TheBrowserCancelButtonAppearsAndBindsWhileLoading()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BlobBrowserViewModel(new BlobStorageService(Store()), Store())
+            {
+                IsBusy = true,
+                CanCancelLoad = true
+            };
+
+            var view = new BlobBrowserView { DataContext = vm };
+            Realise(view);
+
+            var cancel = Assert.Single(VisibleButtons(view), b => (b.Content as string) == "Cancel");
+            Assert.NotNull(cancel.Command);
+        });
+    }
+
     /// <summary>The inventory warnings panel added with #46 - separate from the chain issues one.</summary>
     [Fact]
     public void TheInventoryPanelShowsItsFindings()
@@ -276,6 +344,26 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
             new BackupChainBuilder(),
             new RestoreScriptGenerator(),
             store);
+    }
+
+    /// <summary>
+    /// Buttons that would be on screen. A collapsed element still exists in the visual tree, so
+    /// asserting a button is absent means asserting it is not shown, not that it is missing.
+    ///
+    /// Uses Visibility rather than IsVisible: IsVisible is false for everything until the element
+    /// is attached to a rendered window, and these tests never show one.
+    /// </summary>
+    private static List<Button> VisibleButtons(DependencyObject root)
+        => FindAll<Button>(root).Where(IsShown).ToList();
+
+    private static bool IsShown(FrameworkElement element)
+    {
+        for (DependencyObject? node = element; node != null;
+             node = System.Windows.Media.VisualTreeHelper.GetParent(node))
+        {
+            if (node is UIElement { Visibility: not Visibility.Visible }) return false;
+        }
+        return true;
     }
 
     private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject

--- a/src/NineLives.Tests/packages.lock.json
+++ b/src/NineLives.Tests/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows7.0": {
+    "net10.0-windows7.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.8.1, )",
@@ -40,10 +40,7 @@
           "Microsoft.Identity.Client": "4.83.1",
           "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
           "System.ClientModel": "1.11.0",
-          "System.Diagnostics.DiagnosticSource": "10.0.3",
-          "System.Memory.Data": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3",
-          "System.Text.Json": "10.0.3"
+          "System.Memory.Data": "10.0.3"
         }
       },
       "Azure.Storage.Blobs": {
@@ -76,8 +73,8 @@
       },
       "Microsoft.Bcl.Cryptography": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "Y3t/c7C5XHJGFDnohjf1/9SYF3ZOfEU1fkNQuKg/dGf9hN18yrQj2owHITGfNS3+lKJdW6J4vY98jYu57jCO8A=="
+        "resolved": "9.0.13",
+        "contentHash": "5T+bH3Lb1nEe8Hf/ixMxLmhlrx5wRi53wv7OhVwG2F1ZviW1ejFRS1NHur3uqPpJRGtkQwUchtY6zhVK2R+v+w=="
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -89,16 +86,14 @@
         "resolved": "7.0.2",
         "contentHash": "zwv76lANFQQI6Gmp6ntkzMWIWVqm8Wf4Mz00AeGCk1n8HCi5afi6bNynSe18uI0xeL0n6J+Myjk9AiIsL5oSqw==",
         "dependencies": {
-          "Microsoft.Bcl.Cryptography": "8.0.0",
+          "Microsoft.Bcl.Cryptography": "9.0.13",
           "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
           "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
           "Microsoft.Data.SqlClient.SNI.runtime": "[6.0.2, 7.0.0)",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "9.0.13",
           "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
-          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)",
-          "System.Configuration.ConfigurationManager": "8.0.1",
-          "System.Security.Cryptography.Pkcs": "8.0.1"
+          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)"
         }
       },
       "Microsoft.Data.SqlClient.Extensions.Abstractions": {
@@ -121,22 +116,22 @@
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "resolved": "9.0.13",
+        "contentHash": "nTT90JYIpcXEy6fcU8LPVycONkO6wipROgP9pyC4uxBif4fazu2rDzlWSntqtzr5p8GbQL2EopsYuTZR3yoeag==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "8.0.0"
+          "Microsoft.Extensions.Primitives": "9.0.13"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "resolved": "9.0.13",
+        "contentHash": "OdQmN8LYcUEu20Fxii9mk68nHJGL+JPXF3w0+hxenf0oDDdDBA+ZV/S92FmIgAWAElowIiFA/g0x+8YB1g80Hg==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Options": "8.0.2",
-          "Microsoft.Extensions.Primitives": "8.0.0"
+          "Microsoft.Extensions.Caching.Abstractions": "9.0.13",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.13",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.13",
+          "Microsoft.Extensions.Options": "9.0.13",
+          "Microsoft.Extensions.Primitives": "9.0.13"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -158,8 +153,7 @@
         "contentHash": "mQiTzAj7PIJ2A9YXR5QhgulS1fTWhmQc3ckd1Mrf3hKW07d03fBDqx8vVaFw+cRTebDOeB6pNqdWdnRxsi1hBA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Options": "10.0.3",
-          "System.Diagnostics.DiagnosticSource": "10.0.3"
+          "Microsoft.Extensions.Options": "10.0.3"
         }
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
@@ -187,8 +181,7 @@
         "resolved": "10.0.3",
         "contentHash": "lxl0WLk7ROgBFAsjcOYjQ8/DVK+VMszxGBzUhgtQmAsTNldLL5pk9NG/cWTsXHq0lUhUEAtZkEE7jOGOA8bGKQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "System.Diagnostics.DiagnosticSource": "10.0.3"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3"
         }
       },
       "Microsoft.Extensions.Options": {
@@ -210,9 +203,7 @@
         "resolved": "4.83.1",
         "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.14.0",
-          "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.ValueTuple": "4.5.0"
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
         }
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
@@ -220,8 +211,7 @@
         "resolved": "4.83.1",
         "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
         "dependencies": {
-          "Microsoft.Identity.Client": "4.83.1",
-          "System.Security.Cryptography.ProtectedData": "4.5.0"
+          "Microsoft.Identity.Client": "4.83.1"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
@@ -267,7 +257,7 @@
         "resolved": "8.16.0",
         "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
           "Microsoft.IdentityModel.Logging": "8.16.0"
         }
       },
@@ -279,10 +269,7 @@
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.8.1",
-        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw==",
-        "dependencies": {
-          "System.Reflection.Metadata": "8.0.0"
-        }
+        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
@@ -300,34 +287,8 @@
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
-          "System.Diagnostics.DiagnosticSource": "10.0.3",
-          "System.Memory.Data": "10.0.3",
-          "System.Text.Json": "10.0.3"
+          "System.Memory.Data": "10.0.3"
         }
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
-      },
-      "System.Configuration.ConfigurationManager": {
-        "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "8.0.1",
-          "System.Security.Cryptography.ProtectedData": "8.0.0"
-        }
-      },
-      "System.Diagnostics.DiagnosticSource": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "IuZXyF3K5X+mCsBKIQ87Cn/V4Nyb39vyCbzfH/AkoneSWNV/ExGQ/I0m4CEaVAeFh9fW6kp2NVObkmevd1Ys7A=="
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg=="
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
@@ -343,55 +304,10 @@
         "resolved": "10.0.3",
         "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
       },
-      "System.IO.Pipelines": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
-      },
       "System.Memory.Data": {
         "type": "Transitive",
         "resolved": "10.0.3",
-        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig==",
-        "dependencies": {
-          "System.Text.Json": "10.0.3"
-        }
-      },
-      "System.Reflection.Metadata": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
-        "dependencies": {
-          "System.Collections.Immutable": "8.0.0"
-        }
-      },
-      "System.Security.Cryptography.Pkcs": {
-        "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
-      },
-      "System.Security.Cryptography.ProtectedData": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
-      },
-      "System.Text.Encodings.Web": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
-        "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
-        }
-      },
-      "System.ValueTuple": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
       },
       "xunit.abstractions": {
         "type": "Transitive",

--- a/src/NineLives.Tests/packages.lock.json
+++ b/src/NineLives.Tests/packages.lock.json
@@ -1,0 +1,446 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0-windows7.0": {
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.8.1, )",
+        "resolved": "18.8.1",
+        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.8.1",
+          "Microsoft.TestPlatform.TestHost": "18.8.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.11.0",
+          "System.Diagnostics.DiagnosticSource": "10.0.3",
+          "System.Memory.Data": "10.0.3",
+          "System.Text.Encodings.Web": "10.0.3",
+          "System.Text.Json": "10.0.3"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "Transitive",
+        "resolved": "12.29.1",
+        "contentHash": "pWh7xZBto8YcwiO853AB3uijTfVqs9PDte0Bu9/Zd8O9nwKiitWm0Jej1vsNkmYUzeG1552f8vJPjmtW30pBUQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
+        }
+      },
+      "CommunityToolkit.Mvvm": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "WadCzGEc2U+3e20avRLng4qNtt4zoOGWrdUISqJWrHe3/FSnrYjuM5Sb4yQb09LhkBXrrI4Zt3dLKgRMbItsrg=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "Y3t/c7C5XHJGFDnohjf1/9SYF3ZOfEU1fkNQuKg/dGf9hN18yrQj2owHITGfNS3+lKJdW6J4vY98jYu57jCO8A=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "zwv76lANFQQI6Gmp6ntkzMWIWVqm8Wf4Mz00AeGCk1n8HCi5afi6bNynSe18uI0xeL0n6J+Myjk9AiIsL5oSqw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "8.0.0",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.SNI.runtime": "[6.0.2, 7.0.0)",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
+          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)",
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "Microsoft.Data.SqlClient.Extensions.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "Zx7z61fG2Nc6LdDn4jA7b5Aj1ABrljkOPRE31RvVUdjF6IgbG60leDUhMCafsnWFgaheiK3iqpLe+kbf5Z5L8Q==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)"
+        }
+      },
+      "Microsoft.Data.SqlClient.Internal.Logging": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "iqgYBbGSVy/DIYWjzmQOa964Kn4rs4wW5vg2IamqVK0fQqfTiILVR5hMK27XWqoyONtAZs+VxH354cPJBtSnbg=="
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "xVDHL0+SIgemfh95fTO9cGLe17TWv/ZP0n7m01z8X6pzt2DmQpucioWR/mYZA1sRlkWnkXzfl0JweLNWmE9WMg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "bwGMrRcAMWx2s/RDgja97p27rxSz2pEQW0+rX5cWAUWVETVJ/eyxGfjAl8vuG5a+lckWmPIE+vcuaZNVB5YDdw=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "mQiTzAj7PIJ2A9YXR5QhgulS1fTWhmQc3ckd1Mrf3hKW07d03fBDqx8vVaFw+cRTebDOeB6pNqdWdnRxsi1hBA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "System.Diagnostics.DiagnosticSource": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "4TD9AXDRsipTmaemwnjt/DM5Ri0de2JzHQhvZ4woBTjUtL4XrPNsMrOk5oiLJAx1gTrE6pOIhxv+lEde5F6CZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "GdMpC10Jf6poxSvUJ4lgYpJ5F/kJeaAoJmrPufjBoPYyCTKKY5Dyl0rZA+LBNvFqTq1cZa/lhlptlUhNvU6xrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "lxl0WLk7ROgBFAsjcOYjQ8/DVK+VMszxGBzUhgtQmAsTNldLL5pk9NG/cWTsXHq0lUhUEAtZkEE7jOGOA8bGKQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "System.Diagnostics.DiagnosticSource": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hU6WzGTPvPoLA2ng1ILvWQb3g0qORdlHNsxI8IcPLumJb3suimYUl+bbDzdo1V4KFsvVhnMWzysHpKbZaoDQPQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "GEcpTwo7sUoLGGNTqV1FZEuL+tTD9m81NX/mh099dqGNna07/UGZShKQNZRw4hv6nlliSUwYQgSYc7OR99Jufg=="
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.1",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "h4yVXyJsEBBX5lg2G5ftMsi5JzcNEGAzrNphA6DQ6eOd8P0s+cDCOyPwVTYLePZvJL5unbPvYIvzrbTXzFjXnQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "System.IdentityModel.Tokens.Jwt": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.16.0"
+        }
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw==",
+        "dependencies": {
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+        }
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Diagnostics.DiagnosticSource": "10.0.3",
+          "System.Memory.Data": "10.0.3",
+          "System.Text.Json": "10.0.3"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "8.0.1",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "IuZXyF3K5X+mCsBKIQ87Cn/V4Nyb39vyCbzfH/AkoneSWNV/ExGQ/I0m4CEaVAeFh9fW6kp2NVObkmevd1Ys7A=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rrs2u7DRMXQG2yh0oVyF/vLwosfRv20Ld2iEpYcKwQWXHjfV+gFXNQsQ9p008kR9Ou4pxBs68Q6/9zC8Gi1wjg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig==",
+        "dependencies": {
+          "System.Text.Json": "10.0.3"
+        }
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.3",
+          "System.Text.Encodings.Web": "10.0.3"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "ninelives": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Storage.Blobs": "[12.29.1, )",
+          "CommunityToolkit.Mvvm": "[8.4.2, )",
+          "Microsoft.Data.SqlClient": "[7.0.2, )"
+        }
+      }
+    }
+  }
+}

--- a/src/NineLives/App.xaml.cs
+++ b/src/NineLives/App.xaml.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using Blackcat.NineLives.Services;
 using Blackcat.NineLives.Views;
 
 namespace Blackcat.NineLives;
@@ -7,6 +8,12 @@ public partial class App : Application
 {
     /// <summary>How long the splash stays up once the main window has been built.</summary>
     private static readonly TimeSpan SplashDwell = TimeSpan.FromMilliseconds(2500);
+
+    /// <summary>
+    /// One log for the whole app. Static because the exception handlers here and the viewmodels
+    /// both need it, and there is no container to resolve it from.
+    /// </summary>
+    public static OperationLog Log { get; } = new();
 
     protected override async void OnStartup(StartupEventArgs e)
     {
@@ -19,6 +26,9 @@ public partial class App : Application
         DispatcherUnhandledException += OnDispatcherUnhandledException;
         AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
         TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+
+        Log.Prune();
+        Log.Info($"Nine Lives {AppVersion.Display} starting on {Environment.OSVersion}");
 
         // Explicit for the whole startup sequence: while the splash is briefly the only window,
         // the default OnLastWindowClose would quit the app the moment it closed. Handed back to
@@ -79,6 +89,7 @@ public partial class App : Application
         object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
     {
         e.Handled = true;
+        Log.Error("Unhandled exception on the UI thread", e.Exception);
 
         MessageBox.Show(
             "Nine Lives hit an unexpected error.\n\n" +
@@ -98,6 +109,8 @@ public partial class App : Application
         var message = e.ExceptionObject is Exception ex
             ? $"{ex.GetType().Name}: {ex.Message}"
             : "Unknown error.";
+
+        Log.Error($"Fatal unhandled exception: {message}");
 
         MessageBox.Show(
             $"Nine Lives has to close.\n\n{message}",

--- a/src/NineLives/App.xaml.cs
+++ b/src/NineLives/App.xaml.cs
@@ -12,6 +12,14 @@ public partial class App : Application
     {
         base.OnStartup(e);
 
+        // Before anything else. An unhandled exception on the dispatcher thread otherwise takes
+        // the process down instantly, and the worst moment for that is mid-restore: the execution
+        // log is the only record of how far the chain got, and it exists only in the window that
+        // just vanished (#13).
+        DispatcherUnhandledException += OnDispatcherUnhandledException;
+        AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
+        TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+
         // Explicit for the whole startup sequence: while the splash is briefly the only window,
         // the default OnLastWindowClose would quit the app the moment it closed. Handed back to
         // the main window once that exists.
@@ -58,4 +66,48 @@ public partial class App : Application
             ShutdownMode = ShutdownMode.OnMainWindowClose;
         }
     }
+
+    /// <summary>
+    /// Keeps the app alive after an unhandled UI-thread exception.
+    ///
+    /// Staying up is the right call here specifically because of what this tool does. If a restore
+    /// has partially run, the execution log on screen is the only record of which statements
+    /// completed - and that is exactly what someone needs in order to work out what state the
+    /// target database is in. Killing the window to be tidy destroys it.
+    /// </summary>
+    private void OnDispatcherUnhandledException(
+        object sender, System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
+    {
+        e.Handled = true;
+
+        MessageBox.Show(
+            "Nine Lives hit an unexpected error.\n\n" +
+            $"{e.Exception.GetType().Name}: {e.Exception.Message}\n\n" +
+            "The app is still running. If a restore was in progress, the execution log on screen " +
+            "is still the record of how far it got - check the target database's state before " +
+            "retrying.",
+            "Nine Lives", MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+
+    /// <summary>
+    /// A non-UI-thread exception cannot be swallowed - the runtime is already tearing down - so
+    /// this only makes sure the user sees something rather than the window disappearing silently.
+    /// </summary>
+    private void OnAppDomainUnhandledException(object sender, UnhandledExceptionEventArgs e)
+    {
+        var message = e.ExceptionObject is Exception ex
+            ? $"{ex.GetType().Name}: {ex.Message}"
+            : "Unknown error.";
+
+        MessageBox.Show(
+            $"Nine Lives has to close.\n\n{message}",
+            "Nine Lives", MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+
+    /// <summary>
+    /// Fire-and-forget work - the update check, the arm countdown - should not be able to bring
+    /// the process down when its exception is finally collected. Observing it is enough.
+    /// </summary>
+    private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        => e.SetObserved();
 }

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -265,8 +265,11 @@
                            VerticalAlignment="Center"
                            Margin="0,0,24,0" />
 
+                <!-- From the assembly, not a literal. This said v1.0.0 while the About box read
+                     v1.1.0 from AppVersion - #35 fixed the About box and missed the status bar,
+                     which is the version most people would glance at. -->
                 <TextBlock Grid.Column="2"
-                           Text="v1.0.0"
+                           Text="{Binding VersionText, Mode=OneWay}"
                            Style="{StaticResource SecondaryText}"
                            VerticalAlignment="Center" />
             </Grid>

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -79,21 +79,7 @@ public class BackupFileInfo
         _ => "Unknown"
     };
 
-    public string SizeDisplay
-    {
-        get
-        {
-            string[] units = ["B", "KB", "MB", "GB", "TB"];
-            double size = SizeBytes;
-            int unit = 0;
-            while (size >= 1024 && unit < units.Length - 1)
-            {
-                size /= 1024;
-                unit++;
-            }
-            return $"{size:F1} {units[unit]}";
-        }
-    }
+    public string SizeDisplay => ByteSize.Format(SizeBytes);
 
     public override string ToString()
         => $"[{TypeDisplay}] {BlobName} ({SizeDisplay}) - {EffectiveDate:yyyy-MM-dd HH:mm:ss}";
@@ -137,21 +123,7 @@ public class BackupSet
     public int FileCount => Files.Count;
     public bool IsStriped => Files.Count > 1;
 
-    public string SizeDisplay
-    {
-        get
-        {
-            string[] units = ["B", "KB", "MB", "GB", "TB"];
-            double size = TotalSizeBytes;
-            int unit = 0;
-            while (size >= 1024 && unit < units.Length - 1)
-            {
-                size /= 1024;
-                unit++;
-            }
-            return $"{size:F1} {units[unit]}";
-        }
-    }
+    public string SizeDisplay => ByteSize.Format(TotalSizeBytes);
 
     public string TypeDisplay => Type switch
     {
@@ -261,21 +233,7 @@ public class RestorePoint
         }
     }
 
-    public string SizeDisplay
-    {
-        get
-        {
-            string[] units = ["B", "KB", "MB", "GB", "TB"];
-            double size = TotalSizeBytes;
-            int unit = 0;
-            while (size >= 1024 && unit < units.Length - 1)
-            {
-                size /= 1024;
-                unit++;
-            }
-            return $"{size:F1} {units[unit]}";
-        }
-    }
+    public string SizeDisplay => ByteSize.Format(TotalSizeBytes);
 
     public string ChainDescription
     {

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -24,6 +24,22 @@ public enum BackupSourceType
 /// </summary>
 public class BlobContainerConfig : INotifyPropertyChanged
 {
+    /// <summary>
+    /// Stable identity for the stored SAS token, assigned once and never changed.
+    ///
+    /// The credential key used to derive from Name, so renaming a container pointed it at a key
+    /// that did not exist and the working token was stranded under the old one with no way to get
+    /// it back (#8).
+    ///
+    /// Null on entries written before this existed. It is deliberately NOT defaulted to a new Guid:
+    /// an absent value in JSON leaves the property at its initialiser, so defaulting would hand
+    /// every legacy entry a fresh id on load and lose its secret immediately. ConfigMigrator
+    /// assigns ids and moves the secrets; NewId() is what callers creating a container use.
+    /// </summary>
+    public string? Id { get; set; }
+
+    public static string NewId() => Guid.NewGuid().ToString("n");
+
     public string Name { get; set; } = string.Empty;
     public string ContainerUrl { get; set; } = string.Empty;
 
@@ -95,9 +111,29 @@ public class BlobContainerConfig : INotifyPropertyChanged
         => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
     /// <summary>
-    /// Key used to look up SAS token in Windows Credential Manager.
+    /// Key used to look up the SAS token in Windows Credential Manager. Keyed on the immutable
+    /// <see cref="Id"/> so renaming the container does not strand its token; falls back to the
+    /// old name-derived key only for entries that have not been migrated yet.
     /// </summary>
-    public string CredentialKey => $"NineLives:Blob:{Name}";
+    [JsonIgnore]
+    public string CredentialKey =>
+        string.IsNullOrEmpty(Id) ? LegacyCredentialKey : $"NineLives:Blob:{Id}";
+
+    /// <summary>The pre-#8 name-derived key. Only ConfigMigrator should need this.</summary>
+    [JsonIgnore]
+    public string LegacyCredentialKey => $"NineLives:Blob:{Name}";
+
+    /// <summary>
+    /// A SAS token held in memory for this object only, never written anywhere. When set, the
+    /// blob service uses it in place of the stored one.
+    ///
+    /// This exists for Test Connection (#12). Testing a newly typed token used to persist it to
+    /// Credential Manager first - so pasting a typo'd or expired token, testing it, watching it
+    /// fail and clicking Cancel destroyed the working token that was there before, with no way
+    /// to get it back because the form never displays stored tokens.
+    /// </summary>
+    [JsonIgnore]
+    public string? UnsavedSasToken { get; set; }
 
     public bool IsExpired => GetSasExpiry() is DateTime expiry && expiry < DateTime.UtcNow;
 

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Globalization;
 using System.Text.Json.Serialization;
 using System.Web;
 
@@ -135,7 +136,7 @@ public class BlobContainerConfig : INotifyPropertyChanged
     [JsonIgnore]
     public string? UnsavedSasToken { get; set; }
 
-    public bool IsExpired => GetSasExpiry() is DateTime expiry && expiry < DateTime.UtcNow;
+    public bool IsExpired => ReadSasExpiry().IsExpired;
 
     public DateTime? SasExpiry => GetSasExpiry();
 
@@ -172,26 +173,55 @@ public class BlobContainerConfig : INotifyPropertyChanged
 
     private string? _cachedSasTokenValue;
 
-    public DateTime? GetSasExpiry(string? sasToken = null)
+    public DateTime? GetSasExpiry(string? sasToken = null) => ReadSasExpiry(sasToken).ExpiresAt;
+
+    /// <summary>
+    /// Reads the SAS <c>se=</c> expiry, distinguishing "there isn't one" from "there is one and it
+    /// is not readable" (#21).
+    ///
+    /// That distinction is the point. The old version parsed with the ambient culture and returned
+    /// null on any failure, and every caller reads null as "not expired" - so on a non-invariant
+    /// locale an expired token could be presented as perfectly fine, and the user found out when
+    /// the restore failed. An se= that will not parse now counts as expired, because the honest
+    /// answer is "this token cannot be trusted to be valid".
+    ///
+    /// A token with no se= at all is a different case and stays "unknown, not expired": a SAS
+    /// built on a stored access policy legitimately has no expiry of its own.
+    /// </summary>
+    public SasExpiryInfo ReadSasExpiry(string? sasToken = null)
     {
         var token = sasToken ?? _cachedSasTokenValue;
         if (string.IsNullOrEmpty(token))
-            return null;
+            return SasExpiryInfo.None;
 
+        string? se;
         try
         {
             var query = token.StartsWith("?") ? token : "?" + token;
-            var parsed = HttpUtility.ParseQueryString(query);
-            var se = parsed["se"];
-            if (se != null && DateTime.TryParse(se, out var expiry))
-                return expiry.ToUniversalTime();
+            se = HttpUtility.ParseQueryString(query)["se"];
         }
         catch
         {
-            // Malformed token
+            return SasExpiryInfo.Unreadable;
         }
 
-        return null;
+        // No se= at all is "this token does not state an expiry". An se= that is present but empty
+        // is a different thing: it claims one and supplies nothing, which is unreadable, not absent.
+        if (se == null)
+            return SasExpiryInfo.None;
+
+        if (string.IsNullOrWhiteSpace(se))
+            return SasExpiryInfo.Unreadable;
+
+        // Invariant, and treating the value as UTC whether or not it carries a zone. Azure writes
+        // ISO-8601 here; the ambient culture has no business interpreting it.
+        var parsed = DateTime.TryParse(
+            se,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal,
+            out var expiry);
+
+        return parsed ? new SasExpiryInfo(expiry, false) : SasExpiryInfo.Unreadable;
     }
 
     public void CacheSasToken(string sasToken)
@@ -200,6 +230,29 @@ public class BlobContainerConfig : INotifyPropertyChanged
     }
 
     public override string ToString() => DisplayText;
+}
+
+/// <summary>
+/// What a SAS token says about its own expiry. Three states rather than a nullable DateTime,
+/// because "no expiry stated" and "expiry stated but unreadable" mean opposite things and both
+/// used to come back as null (#21).
+/// </summary>
+/// <param name="ExpiresAt">When the token expires, in UTC. Null if it does not say.</param>
+/// <param name="CouldNotParse">The token carries an se= value that could not be read.</param>
+public readonly record struct SasExpiryInfo(DateTime? ExpiresAt, bool CouldNotParse)
+{
+    /// <summary>No se= parameter. Legitimate for a SAS built on a stored access policy.</summary>
+    public static SasExpiryInfo None => new(null, false);
+
+    /// <summary>There is an se=, and it is not readable. Treated as expired.</summary>
+    public static SasExpiryInfo Unreadable => new(null, true);
+
+    /// <summary>
+    /// Unreadable counts as expired. The alternative is presenting a token we cannot vouch for as
+    /// valid, and finding out mid-restore.
+    /// </summary>
+    public bool IsExpired =>
+        CouldNotParse || (ExpiresAt.HasValue && ExpiresAt.Value < DateTime.UtcNow);
 }
 
 /// <summary>

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 using System.Text.Json.Serialization;
 using System.Web;
 
+using Blackcat.NineLives.Services;
+
 namespace Blackcat.NineLives.Models;
 
 /// <summary>
@@ -93,9 +95,12 @@ public class BlobContainerConfig : INotifyPropertyChanged
     /// <summary>
     /// Tags as chips, matching the server list. Containers have no automatic tags yet, but going
     /// through the same shape keeps one rendering path.
+    ///
+    /// Alphabetical. Sorted here as well as in ParseTags so containers saved before this change
+    /// display in order straight away, rather than waiting to be edited and re-saved.
     /// </summary>
     [JsonIgnore]
-    public IEnumerable<TagChip> TagChips => Tags.Select(TagChip.Manual);
+    public IEnumerable<TagChip> TagChips => TagPalette.Sort(Tags).Select(TagChip.Manual);
 
     private void OnTagsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         => RaiseTagMembersChanged();

--- a/src/NineLives/Models/ByteSize.cs
+++ b/src/NineLives/Models/ByteSize.cs
@@ -1,0 +1,31 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// One place that turns a byte count into something readable (#42).
+///
+/// The same while-loop was copied into four SizeDisplay properties across three files. Nothing had
+/// gone wrong with it yet, but four copies is four chances for them to drift and start disagreeing
+/// about the size of the same backup on different screens.
+/// </summary>
+public static class ByteSize
+{
+    private static readonly string[] Units = ["B", "KB", "MB", "GB", "TB"];
+
+    /// <summary>e.g. 1536 becomes "1.5 KB". Binary units, matching what SSMS and Explorer show.</summary>
+    public static string Format(long bytes)
+    {
+        // Negative sizes are not physically meaningful, but a subtraction bug upstream should show
+        // as an odd number rather than looping forever or printing "-0.0 B".
+        if (bytes < 0) return $"{bytes} B";
+
+        double size = bytes;
+        var unit = 0;
+        while (size >= 1024 && unit < Units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+
+        return $"{size:F1} {Units[unit]}";
+    }
+}

--- a/src/NineLives/Models/ConsoleLine.cs
+++ b/src/NineLives/Models/ConsoleLine.cs
@@ -1,0 +1,68 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>How a console line should read at a glance.</summary>
+public enum ConsoleLineKind
+{
+    /// <summary>Ordinary output.</summary>
+    Normal,
+
+    /// <summary>A step starting - the app narrating what it is about to do.</summary>
+    Step,
+
+    /// <summary>Something completed.</summary>
+    Success,
+
+    /// <summary>Worth noticing but not fatal.</summary>
+    Warning,
+
+    /// <summary>The restore failed or was stopped.</summary>
+    Error
+}
+
+/// <summary>
+/// One line in the execution console.
+///
+/// A collection of these replaced a single ever-growing string. Appending to a bound string
+/// rebuilds the whole thing and re-renders the entire TextBox on every message, which is O(n^2)
+/// and was a large part of why a restore emitting progress every few percent looked like it was
+/// arriving in bursts rather than live.
+/// </summary>
+/// <param name="Text">The line as written.</param>
+/// <param name="Kind">Drives the colour, nothing else.</param>
+public sealed record ConsoleLine(string Text, ConsoleLineKind Kind = ConsoleLineKind.Normal)
+{
+    /// <summary>
+    /// Classifies a raw message so the console reads at a glance without every call site having to
+    /// think about it. Deliberately conservative: anything unrecognised stays Normal rather than
+    /// guessing and colouring an ordinary line red.
+    /// </summary>
+    public static ConsoleLine From(string message)
+    {
+        var trimmed = message.TrimStart();
+
+        if (trimmed.StartsWith("ERROR", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("CANCELLED", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("FAILED", StringComparison.OrdinalIgnoreCase))
+            return new ConsoleLine(message, ConsoleLineKind.Error);
+
+        if (trimmed.StartsWith("Note:", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Warning", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Contains("is in RESTORING", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Contains("SINGLE_USER", StringComparison.OrdinalIgnoreCase))
+            return new ConsoleLine(message, ConsoleLineKind.Warning);
+
+        if (trimmed.Contains("completed successfully", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Completed", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Contains("100 percent processed", StringComparison.OrdinalIgnoreCase))
+            return new ConsoleLine(message, ConsoleLineKind.Success);
+
+        if (trimmed.StartsWith("Executing statement", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Beginning", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Running:", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Using the existing", StringComparison.OrdinalIgnoreCase)
+            || trimmed.StartsWith("Credential", StringComparison.OrdinalIgnoreCase))
+            return new ConsoleLine(message, ConsoleLineKind.Step);
+
+        return new ConsoleLine(message);
+    }
+}

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -30,6 +30,15 @@ public enum EncryptMode
 /// </summary>
 public class ServerConnection : INotifyPropertyChanged
 {
+    /// <summary>
+    /// Stable identity for the stored password, assigned once and never changed. See the note on
+    /// <see cref="BlobContainerConfig.Id"/> - same bug (#8), same reason it is not defaulted to a
+    /// new Guid, same migration.
+    /// </summary>
+    public string? Id { get; set; }
+
+    public static string NewId() => Guid.NewGuid().ToString("n");
+
     public string Name { get; set; } = string.Empty;
     public string ServerName { get; set; } = string.Empty;
     public AuthMode AuthMode { get; set; } = AuthMode.WindowsAuth;
@@ -129,7 +138,21 @@ public class ServerConnection : INotifyPropertyChanged
     /// Key used to look up password in Windows Credential Manager.
     /// Only used when AuthMode is SqlAuth.
     /// </summary>
-    public string CredentialKey => $"NineLives:SQL:{Name}";
+    [JsonIgnore]
+    public string CredentialKey =>
+        string.IsNullOrEmpty(Id) ? LegacyCredentialKey : $"NineLives:SQL:{Id}";
+
+    /// <summary>The pre-#8 name-derived key. Only ConfigMigrator should need this.</summary>
+    [JsonIgnore]
+    public string LegacyCredentialKey => $"NineLives:SQL:{Name}";
+
+    /// <summary>
+    /// A password held in memory for this object only, never written anywhere. When set, the
+    /// connection string uses it in place of the stored one. Same purpose as
+    /// <see cref="BlobContainerConfig.UnsavedSasToken"/> - see the note there (#12).
+    /// </summary>
+    [JsonIgnore]
+    public string? UnsavedPassword { get; set; }
 
     public string DisplayText => AuthMode == AuthMode.WindowsAuth
         ? $"{ServerName} (Windows Auth)"

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -3,6 +3,8 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
 
+using Blackcat.NineLives.Services;
+
 namespace Blackcat.NineLives.Models;
 
 public enum AuthMode
@@ -125,10 +127,16 @@ public class ServerConnection : INotifyPropertyChanged
     /// Manual and automatic tags as one sequence, so the UI can render them from a SINGLE
     /// wrapping panel. Two adjacent ItemsControls inside a WrapPanel cannot wrap - each is
     /// measured with infinite width - and their pills get clipped by the row instead.
+    ///
+    /// Each group is alphabetical, and manual tags come before automatic ones. Sorting here as
+    /// well as in ParseTags means entries saved before this change display in order straight away,
+    /// without waiting to be edited and re-saved. Automatic tags stay in their own group at the
+    /// end so a derived fact is not shuffled in among the user's own labels.
     /// </summary>
     [JsonIgnore]
     public IEnumerable<TagChip> TagChips =>
-        Tags.Select(TagChip.Manual).Concat(AutoTags.Select(TagChip.Automatic));
+        TagPalette.Sort(Tags).Select(TagChip.Manual)
+            .Concat(TagPalette.Sort(AutoTags).Select(TagChip.Automatic));
 
     /// <summary>True when any tag marks this as a production-like environment.</summary>
     [JsonIgnore]

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -18,13 +18,20 @@
     <!-- Publish-time settings (single-file, self-contained, win-x64) live in
          Properties/PublishProfiles/SingleFileExe.pubxml and the publish commands in
          build_standalone.cmd / README - not here, so NineLives.Tests can reference
-         this project and plain builds stay RID-agnostic. -->
+         this project and plain builds stay RID-agnostic.
+
+         RuntimeIdentifiers (plural) is the exception. It does not make a plain build
+         RID-specific; it tells restore to resolve the win-x64 graph too, so
+         packages.lock.json covers what "dotnet publish -r win-x64" needs. Without it the
+         publish restore finds packages the lock file has never seen and rewrites it,
+         which quietly defeats locked mode for the one build that actually ships. -->
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.*" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.*" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/Properties/PublishProfiles/SingleFileExe.pubxml
+++ b/src/NineLives/Properties/PublishProfiles/SingleFileExe.pubxml
@@ -10,5 +10,11 @@
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <PublishTrimmed>false</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>
+    <!-- Same reasoning as Directory.Build.props: a single-file publish restore drags in an
+         SDK-versioned tool pack, so it must not rewrite the committed lock file. Repeated
+         here because a publish profile is imported after Directory.Build.props, too late
+         for the condition there to see PublishSingleFile. -->
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+    <NuGetLockFilePath>$(MSBuildProjectDirectory)\obj\publish-packages.lock.json</NuGetLockFilePath>
   </PropertyGroup>
 </Project>

--- a/src/NineLives/Services/BackupChainValidator.cs
+++ b/src/NineLives/Services/BackupChainValidator.cs
@@ -125,14 +125,86 @@ public class BackupChainValidator
                 "restored and are not offered as restore points. Usually means the full they belong to has " +
                 "been removed by retention."));
 
+        // Strictly before, not at. A log sharing the earliest full's exact timestamp has not
+        // "predated" anything - it is the same-timestamp collision, which ValidateReachability
+        // describes accurately instead of filing it under retention.
         var orphanedLogs = sets
-            .Where(s => s.Type == BackupType.TransactionLog && s.Timestamp <= earliestFull)
+            .Where(s => s.Type == BackupType.TransactionLog && s.Timestamp < earliestFull)
             .ToList();
         if (orphanedLogs.Count > 0)
             issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
                 $"{orphanedLogs.Count} log backup(s) predate the earliest full",
                 $"Log backups at or before {earliestFull:yyyy-MM-dd HH:mm} have nothing to roll forward from " +
                 "and are not offered as restore points."));
+
+        return issues;
+    }
+
+    /// <summary>
+    /// Reports log backups that were discovered but reach no chain at all - present in the browse
+    /// list, counted in the header, and absent from every restore point (#46).
+    ///
+    /// The known cause is a log whose timestamp exactly equals a full's. The chain builder bounds
+    /// each full's log range with strict inequalities at both ends, so such a log falls outside the
+    /// earlier full's range and outside the colliding full's own, and belongs to neither.
+    ///
+    /// Timestamps come from filenames, and the seconds group is optional - so under HHMM naming
+    /// any full and log starting in the same minute collide, which a nightly full plus
+    /// quarter-hourly logs manages every single day.
+    ///
+    /// This reports rather than repairs, deliberately. Simply widening the bound to include the
+    /// log would force it to restore after the full always, and that is wrong whenever the log job
+    /// fired first and completed before the full's checkpoint - SQL Server rejects a log whose
+    /// range ends before the restore point. A filename timestamp cannot tell those two apart; only
+    /// the LSNs can, which needs RESTORE HEADERONLY. Until then the honest move is to stop the
+    /// omission being silent, so the header count and the timeline cannot disagree without saying
+    /// why.
+    /// </summary>
+    public List<ChainIssue> ValidateReachability(
+        IReadOnlyList<BackupSet> sets, IReadOnlyList<RestorePoint> restorePoints)
+    {
+        var issues = new List<ChainIssue>();
+
+        var logs = sets.Where(s => s.Type == BackupType.TransactionLog).ToList();
+        if (logs.Count == 0 || restorePoints.Count == 0) return issues;
+
+        var reachable = new HashSet<BackupSet>();
+        foreach (var point in restorePoints)
+        {
+            if (point.PrimarySet != null) reachable.Add(point.PrimarySet);
+            foreach (var log in point.RequiredLogSets) reachable.Add(log);
+        }
+
+        // Logs strictly before the first full are already explained by ValidateInventory; saying it
+        // twice in different words would just make both messages easier to ignore. A log AT the
+        // earliest full is this check's business, not that one's - it is the collision.
+        var fulls = sets.Where(s => s.Type == BackupType.Full).OrderBy(s => s.Timestamp).ToList();
+        var earliestFull = fulls.Count > 0 ? fulls[0].Timestamp : DateTime.MaxValue;
+
+        var unreachable = logs
+            .Where(l => !reachable.Contains(l) && l.Timestamp >= earliestFull)
+            .OrderBy(l => l.Timestamp)
+            .ToList();
+
+        if (unreachable.Count == 0) return issues;
+
+        var collisions = unreachable
+            .Where(l => fulls.Any(f => f.Timestamp == l.Timestamp))
+            .ToList();
+
+        var detail =
+            $"These log backups were found but appear in no restore point, so the timeline offers " +
+            $"fewer recovery points than the backup count suggests. Earliest: " +
+            $"{unreachable[0].Timestamp:yyyy-MM-dd HH:mm:ss}.";
+
+        if (collisions.Count > 0)
+            detail +=
+                $" {collisions.Count} of them share an exact timestamp with a full backup, which is " +
+                "usually a log job and a full job starting in the same minute. Verify Chain will " +
+                "read the LSNs and tell you whether the log is genuinely needed.";
+
+        issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
+            $"{unreachable.Count} log backup(s) are not reachable by any restore point", detail));
 
         return issues;
     }

--- a/src/NineLives/Services/BlobListingScope.cs
+++ b/src/NineLives/Services/BlobListingScope.cs
@@ -1,0 +1,18 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Narrows a blob listing to one server and/or database, so the filter can be pushed down to Azure
+/// as a prefix rather than applied after everything has been downloaded (#28).
+///
+/// A hint, never a contract. Passing a scope the container's layout cannot honour is safe - the
+/// listing falls back to a full scan and returns the same files it always did. What must never
+/// happen is the reverse: a scope that quietly excludes backups that do exist, because on the
+/// restore screen a missing backup is a missing restore point.
+/// </summary>
+/// <param name="ServerName">Server as it appears in the path, or null for all.</param>
+/// <param name="DatabaseName">Database as it appears in the path, or null for all.</param>
+public sealed record BlobListingScope(string? ServerName = null, string? DatabaseName = null)
+{
+    public bool HasAnything =>
+        !string.IsNullOrWhiteSpace(ServerName) || !string.IsNullOrWhiteSpace(DatabaseName);
+}

--- a/src/NineLives/Services/BlobPrefix.cs
+++ b/src/NineLives/Services/BlobPrefix.cs
@@ -1,0 +1,118 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Works out which Azure blob prefixes can serve a given filter, so listing does not have to walk
+/// the whole container and throw most of it away client-side (#28).
+///
+/// Measured against a real 4,440-blob container: an unprefixed listing takes about 1,075 ms, while
+/// listing one database across the three backup-type folders takes about 233 ms. The ratio is not
+/// the interesting part - the scaling is. A full scan grows with every server, database and day of
+/// retention; a scoped listing grows only with the one database being restored.
+///
+/// Everything here is pure string work so it can be tested without touching Azure. Getting it
+/// wrong silently returns FEWER backups than exist, which on this screen means a restore point
+/// quietly disappearing - so the rule throughout is to return null (meaning "scan everything")
+/// whenever a safe prefix cannot be proven.
+/// </summary>
+public static class BlobPrefix
+{
+    /// <summary>
+    /// The prefixes to list for a filter, or null when no safe prefix exists and the caller must
+    /// scan the whole container.
+    /// </summary>
+    /// <param name="pathPattern">The container's configured pattern, e.g. {BackupType}/{ServerName}/{DatabaseName}/{FileName}.</param>
+    /// <param name="serverName">Selected server, or null for all.</param>
+    /// <param name="databaseName">Selected database, or null for all.</param>
+    /// <param name="backupTypeFolders">
+    /// Folder names standing in for {BackupType} - normally the container's top-level folders. When
+    /// the pattern needs {BackupType} and this is empty, no prefix can be derived.
+    /// </param>
+    public static IReadOnlyList<string>? Derive(
+        string? pathPattern,
+        string? serverName,
+        string? databaseName,
+        IReadOnlyCollection<string>? backupTypeFolders = null)
+    {
+        if (string.IsNullOrWhiteSpace(pathPattern)) return null;
+
+        var segments = pathPattern.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0) return null;
+
+        // One prefix under construction, or several once {BackupType} fans out.
+        var prefixes = new List<string> { string.Empty };
+        var anythingKnown = false;
+
+        foreach (var segment in segments)
+        {
+            // {FileName} is the leaf. Everything after it is meaningless as a prefix, and the leaf
+            // itself is never known in advance.
+            if (Is(segment, "{FileName}")) break;
+
+            if (!IsToken(segment))
+            {
+                // A literal path element - always known.
+                prefixes = Append(prefixes, segment);
+                anythingKnown = true;
+                continue;
+            }
+
+            if (Is(segment, "{BackupType}"))
+            {
+                if (backupTypeFolders is not { Count: > 0 }) break;
+
+                // Fan out: one prefix per backup-type folder. This is what makes the default
+                // pattern usable at all, since {BackupType} leads it and would otherwise stop the
+                // derivation on the very first segment.
+                prefixes = backupTypeFolders
+                    .SelectMany(folder => Append(prefixes, folder))
+                    .ToList();
+                anythingKnown = true;
+                continue;
+            }
+
+            if (Is(segment, "{ServerName}") || Is(segment, "{ClusterName$AgName}") || Is(segment, "{ClusterName_AgName}"))
+            {
+                if (string.IsNullOrWhiteSpace(serverName)) break;
+                prefixes = Append(prefixes, serverName);
+                anythingKnown = true;
+                continue;
+            }
+
+            if (Is(segment, "{DatabaseName}"))
+            {
+                if (string.IsNullOrWhiteSpace(databaseName)) break;
+                prefixes = Append(prefixes, databaseName);
+                anythingKnown = true;
+                continue;
+            }
+
+            // Any other token - {InstanceName}, {AgName}, something new - has no value to hand, so
+            // the path stops being predictable here.
+            break;
+        }
+
+        if (!anythingKnown) return null;
+
+        // A single empty prefix is the same as no prefix; say so plainly rather than issuing a
+        // listing that pretends to be scoped.
+        var result = prefixes.Where(p => p.Length > 0).Distinct(StringComparer.Ordinal).ToList();
+        return result.Count > 0 ? result : null;
+    }
+
+    /// <summary>
+    /// True when a container's layout can be prefix-scoped at all. Flat Ola AG naming puts every
+    /// file at the container root with the structure encoded in the filename, so there is nothing
+    /// to prefix on.
+    /// </summary>
+    public static bool SupportsPrefixes(Models.BackupSourceType sourceType) =>
+        sourceType == Models.BackupSourceType.Standalone;
+
+    private static List<string> Append(List<string> prefixes, string segment)
+        => prefixes.Select(p => $"{p}{segment}/").ToList();
+
+    private static bool IsToken(string segment)
+        => segment.StartsWith('{') && segment.EndsWith('}');
+
+    private static bool Is(string segment, string token)
+        => segment.Equals(token, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -259,11 +259,17 @@ public class BlobStorageService
         return idx >= 0 ? blobName[..idx] : string.Empty;
     }
 
-    public string BuildBlobUrlWithSas(BlobContainerConfig config, string blobName)
-    {
-        var sasToken = _credentialStore.GetSasToken(config);
-        return $"{config.ContainerUrl.TrimEnd('/')}/{blobName}?{sasToken?.TrimStart('?')}";
-    }
+    /// <summary>
+    /// The plain HTTPS URL of a blob, with no SAS token on it.
+    ///
+    /// This replaced BuildBlobUrlWithSas, which existed only to feed the two "copy HTTPS path"
+    /// buttons and put a live credential on the Windows clipboard - where clipboard history
+    /// (Win+V) and cloud clipboard sync can keep it long after the app has closed (#18). The
+    /// token-free URL is what the generated scripts use anyway, since RESTORE FROM URL
+    /// authenticates with the server-side credential rather than anything in the URL.
+    /// </summary>
+    public static string BuildBlobUrl(BlobContainerConfig config, string blobName)
+        => $"{config.ContainerUrl.TrimEnd('/')}/{blobName}";
 
     private static void ParseBlobPath(BackupFileInfo file, string pathPattern)
     {

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -385,31 +385,75 @@ public class BlobStorageService
         };
     }
 
-    private static BackupType InferBackupTypeFromExtension(string blobName)
+    /// <summary>
+    /// Last-resort type inference from the filename, reached only when the path structure did not
+    /// say what a backup is.
+    ///
+    /// Getting this wrong is not cosmetic. A log misread as a full enters the fulls collection in
+    /// BackupChainBuilder and becomes a chain root, so the timeline offers a log file as a
+    /// restorable Full point and every earlier log is dropped from the chain (#44). A full misread
+    /// as a differential never enters that collection at all, and if it is the only full in the
+    /// container the database gets no restore points whatsoever (#45).
+    /// </summary>
+    internal static BackupType InferBackupTypeFromExtension(string blobName)
     {
         var name = blobName.ToLowerInvariant();
 
         if (name.EndsWith(".trn") || name.EndsWith(".log"))
             return BackupType.TransactionLog;
 
-        if (name.EndsWith(".bak") || name.EndsWith(".bkp"))
-        {
-            if (ContainsDiffIndicator(name))
-                return BackupType.Differential;
-            return BackupType.Full;
-        }
-
         if (name.EndsWith(".diff"))
             return BackupType.Differential;
+
+        if (name.EndsWith(".bak") || name.EndsWith(".bkp"))
+        {
+            // Indicators are read from the filename only, never the folders above it - those are
+            // the primary path's job, and a container called "logs" should not retype every file
+            // underneath it.
+            var fileName = name[(name.LastIndexOf('/') + 1)..];
+
+            if (ContainsDiffIndicator(fileName))
+                return BackupType.Differential;
+
+            // A log written as .bak used to land here as Full. Ola and maintenance plans both emit
+            // .trn so this needs a hand-rolled job, but the failure was bad enough to be worth
+            // catching (#44).
+            if (ContainsLogIndicator(fileName))
+                return BackupType.TransactionLog;
+
+            return BackupType.Full;
+        }
 
         return BackupType.Unknown;
     }
 
-    private static bool ContainsDiffIndicator(string name)
-    {
-        string[] diffIndicators = ["diff", "differential", "_diff", "-diff", ".diff"];
-        return diffIndicators.Any(name.Contains);
-    }
+    // Delimited, not a bare substring. The old version tested name.Contains("diff"), which made
+    // every other entry in its list redundant and classified DiffusionDb's FULL backups as
+    // differentials (#45). Same anchoring as CopyOnlyRegex above.
+    private static readonly Regex DiffIndicatorRegex = new(
+        @"(?:^|[_\-.])(?:diff|differential)(?:$|[_\-.])",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // Deliberately delimited for the same reason, and more sharply here: a bare "log" substring
+    // would retype CatalogDb, BlogDb and DialogDb backups as transaction logs.
+    private static readonly Regex LogIndicatorRegex = new(
+        @"(?:^|[_\-.])(?:log|tlog|trn|translog|transactionlog)(?:$|[_\-.])",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>True when a filename carries a delimited differential marker. Public for testing.</summary>
+    public static bool ContainsDiffIndicator(string fileName)
+        => !string.IsNullOrEmpty(fileName) && DiffIndicatorRegex.IsMatch(fileName);
+
+    /// <summary>
+    /// True when a filename carries a delimited transaction-log marker. Public for testing.
+    ///
+    /// Known limitation: a database actually named "Log" or "Diff" would match on its own name.
+    /// Nothing in a filename can settle that, and the alternative - a bare substring - is the bug
+    /// being fixed. Path-based typing takes precedence anyway, so this only bites a flat container
+    /// holding a database with one of those names.
+    /// </summary>
+    public static bool ContainsLogIndicator(string fileName)
+        => !string.IsNullOrEmpty(fileName) && LogIndicatorRegex.IsMatch(fileName);
 
     /// <summary>
     /// For path-based AG files, extract backup set id from the filename segment (e.g. 20260226_200032_1.bak → 20260226_200032).

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -478,19 +478,5 @@ public class ContainerSummary
     public DateTimeOffset? EarliestBackup { get; set; }
     public DateTimeOffset? LatestBackup { get; set; }
 
-    public string TotalSizeDisplay
-    {
-        get
-        {
-            string[] units = ["B", "KB", "MB", "GB", "TB"];
-            double size = TotalSizeBytes;
-            int unit = 0;
-            while (size >= 1024 && unit < units.Length - 1)
-            {
-                size /= 1024;
-                unit++;
-            }
-            return $"{size:F1} {units[unit]}";
-        }
-    }
+    public string TotalSizeDisplay => ByteSize.Format(TotalSizeBytes);
 }

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -42,14 +42,92 @@ public class BlobStorageService
         return true;
     }
 
-    public async Task<List<BackupFileInfo>> ListBackupFilesAsync(
+    /// <summary>The container's top-level folders, read without listing a single blob.</summary>
+    public async Task<List<string>> ListTopLevelFoldersAsync(
         BlobContainerConfig config, CancellationToken ct = default)
+    {
+        var client = CreateClient(config);
+        var folders = new List<string>();
+
+        await foreach (var item in client.GetBlobsByHierarchyAsync(
+            BlobTraits.None, BlobStates.None, delimiter: "/", prefix: null, cancellationToken: ct))
+        {
+            if (item.IsPrefix) folders.Add(item.Prefix.TrimEnd('/'));
+        }
+
+        return folders;
+    }
+
+    public Task<List<BackupFileInfo>> ListBackupFilesAsync(
+        BlobContainerConfig config, CancellationToken ct = default)
+        => ListBackupFilesAsync(config, scope: null, progress: null, ct);
+
+    /// <summary>
+    /// Lists backup files, optionally scoped to a server and database so the listing is pushed
+    /// down to Azure as a prefix instead of walking the container and filtering afterwards (#28).
+    ///
+    /// A scope is a hint, not a promise: when the container's layout cannot produce a safe prefix -
+    /// flat Ola AG naming, a pattern whose leading segments are not known - this falls back to the
+    /// full scan and returns exactly what it always did. Returning too FEW backups would silently
+    /// remove restore points, so anything short of a provable prefix scans everything.
+    /// </summary>
+    /// <param name="progress">Reports the running blob count, for containers big enough to wait on.</param>
+    public async Task<List<BackupFileInfo>> ListBackupFilesAsync(
+        BlobContainerConfig config,
+        BlobListingScope? scope,
+        IProgress<int>? progress,
+        CancellationToken ct = default)
     {
         var client = CreateClient(config);
         var files = new List<BackupFileInfo>();
 
-        await foreach (var blob in client.GetBlobsAsync(
-            BlobTraits.Metadata, BlobStates.None, prefix: null, cancellationToken: ct))
+        var prefixes = await ResolvePrefixesAsync(config, scope, ct);
+
+        foreach (var prefix in prefixes)
+        {
+            await foreach (var blob in client.GetBlobsAsync(
+                BlobTraits.Metadata, BlobStates.None, prefix, cancellationToken: ct))
+            {
+                ReadBlob(config, blob, files);
+                if (files.Count % 250 == 0) progress?.Report(files.Count);
+            }
+        }
+
+        progress?.Report(files.Count);
+        return files.OrderBy(f => f.LastModified).ToList();
+    }
+
+    /// <summary>
+    /// Turns a scope into the prefixes to list. A single null prefix means "scan everything".
+    /// </summary>
+    private async Task<IReadOnlyList<string?>> ResolvePrefixesAsync(
+        BlobContainerConfig config, BlobListingScope? scope, CancellationToken ct)
+    {
+        if (scope is null || !scope.HasAnything) return [null];
+        if (!BlobPrefix.SupportsPrefixes(config.BackupSourceType)) return [null];
+
+        // {BackupType} leads the default pattern, so without the real folder names no prefix can
+        // be built at all. One cheap hierarchy call buys the whole optimisation.
+        IReadOnlyCollection<string>? folders = null;
+        if (config.PathPattern.Contains("{BackupType}", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                folders = await ListTopLevelFoldersAsync(config, ct);
+            }
+            catch (Exception) when (!ct.IsCancellationRequested)
+            {
+                // Cannot discover the folders - fall back rather than guess at names.
+                return [null];
+            }
+        }
+
+        var prefixes = BlobPrefix.Derive(config.PathPattern, scope.ServerName, scope.DatabaseName, folders);
+        return prefixes is { Count: > 0 } ? [.. prefixes] : [null];
+    }
+
+    private void ReadBlob(BlobContainerConfig config, BlobItem blob, List<BackupFileInfo> files)
+    {
         {
             var blobUrl = $"{config.ContainerUrl.TrimEnd('/')}/{blob.Name}";
 
@@ -113,8 +191,6 @@ public class BlobStorageService
 
             files.Add(file);
         }
-
-        return files.OrderBy(f => f.LastModified).ToList();
     }
 
     public ContainerSummary GetContainerSummary(List<BackupFileInfo> files)

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -16,7 +16,9 @@ public class BlobStorageService
 
     private BlobContainerClient CreateClient(BlobContainerConfig config)
     {
-        var sasToken = _credentialStore.GetSasToken(config);
+        // An unsaved token wins, so Test Connection can try one without it having to be persisted
+        // first (#12). Null for every ordinary operation, which falls through to the stored token.
+        var sasToken = config.UnsavedSasToken ?? _credentialStore.GetSasToken(config);
         if (string.IsNullOrEmpty(sasToken))
             throw new InvalidOperationException(
                 "No SAS token found. Please configure the SAS token for this container.");

--- a/src/NineLives/Services/ConfigMigrator.cs
+++ b/src/NineLives/Services/ConfigMigrator.cs
@@ -1,0 +1,117 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Moves stored secrets off name-derived keys and onto stable per-entry ids (#8).
+///
+/// Runs once at startup. Entries saved before ids existed have no <c>Id</c>, and their SAS token
+/// or password sits under <c>NineLives:Blob:{Name}</c> / <c>NineLives:SQL:{Name}</c>. This assigns
+/// an id, copies the secret to the new key, saves the config, and only then removes the old key.
+///
+/// The ordering is the whole point, because this runs against the only copy of someone's
+/// credentials and can be interrupted by a crash, a power cut or a refused config write:
+///
+///   1. copy secrets to the new keys, leaving the old ones in place
+///   2. save the config carrying the new ids
+///   3. delete the old keys
+///
+/// Interrupted after 1, the config still has no ids, so the next run reads the same old keys and
+/// starts over - the stray new-key entries are orphans, not losses. Interrupted after 2, the
+/// secrets are already where the ids point. There is no window in which a secret exists only under
+/// a key nothing references.
+/// </summary>
+public class ConfigMigrator(CredentialStore store)
+{
+    public record Result(int ContainersMigrated, int ServersMigrated, string? Error)
+    {
+        public bool DidWork => ContainersMigrated > 0 || ServersMigrated > 0;
+    }
+
+    /// <summary>
+    /// Assigns ids to any entry lacking one and relocates its secret. Returns what happened rather
+    /// than throwing: a migration that cannot complete must not stop the app from starting, since
+    /// everything still works off the old keys until it succeeds.
+    /// </summary>
+    public Result Migrate(AppConfig config)
+    {
+        // A config that failed to load holds empty defaults, so there is nothing to migrate and
+        // saving it would be refused anyway.
+        if (config.LoadError != null)
+            return new Result(0, 0, null);
+
+        var containers = config.BlobContainers.Where(c => string.IsNullOrEmpty(c.Id)).ToList();
+        var servers = config.Servers.Where(s => string.IsNullOrEmpty(s.Id)).ToList();
+
+        if (containers.Count == 0 && servers.Count == 0)
+            return new Result(0, 0, null);
+
+        // Step 1: copy each secret to its new key while the old key still exists.
+        var oldKeys = new List<string>();
+        var newKeys = new List<string>();
+        try
+        {
+            foreach (var container in containers)
+            {
+                var legacyKey = container.LegacyCredentialKey;
+                var (username, secret) = store.ReadSecret(legacyKey);
+                container.Id = BlobContainerConfig.NewId();
+
+                if (secret == null) continue;   // nothing stored; the id alone is the migration
+                store.SaveSecret(container.CredentialKey, username ?? "azure", secret);
+                oldKeys.Add(legacyKey);
+                newKeys.Add(container.CredentialKey);
+            }
+
+            foreach (var server in servers)
+            {
+                var legacyKey = server.LegacyCredentialKey;
+                var (username, secret) = store.ReadSecret(legacyKey);
+                server.Id = ServerConnection.NewId();
+
+                if (secret == null) continue;
+                store.SaveSecret(server.CredentialKey, username ?? server.Username ?? "sa", secret);
+                oldKeys.Add(legacyKey);
+                newKeys.Add(server.CredentialKey);
+            }
+        }
+        catch (Exception ex)
+        {
+            return Abandon($"Could not copy stored secrets: {ex.Message}");
+        }
+
+        // Step 2: persist the ids. Until this lands the migration has not really happened.
+        try
+        {
+            store.SaveConfig(config);
+        }
+        catch (Exception ex)
+        {
+            return Abandon($"Could not save the updated configuration: {ex.Message}");
+        }
+
+        // Step 3: the old keys are now unreferenced. Failing to remove one leaves a harmless
+        // orphan in Credential Manager, which is not worth failing a completed migration over.
+        foreach (var key in oldKeys)
+        {
+            try { store.DeleteSecret(key); } catch { /* orphan, not a failure */ }
+        }
+
+        return new Result(containers.Count, servers.Count, null);
+
+        // Give up cleanly: put the in-memory objects back to matching what is on disk, and remove
+        // the new-key copies written before the failure. Those ids are freshly generated and were
+        // never persisted, so nothing else can be referring to them. The old keys are untouched
+        // throughout and remain the ones the saved config points at.
+        Result Abandon(string error)
+        {
+            foreach (var key in newKeys)
+            {
+                try { store.DeleteSecret(key); } catch { /* orphan, not a failure */ }
+            }
+            foreach (var container in containers) container.Id = null;
+            foreach (var server in servers) server.Id = null;
+            return new Result(0, 0, error);
+        }
+    }
+}

--- a/src/NineLives/Services/CredentialChange.cs
+++ b/src/NineLives/Services/CredentialChange.cs
@@ -1,0 +1,20 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// What <see cref="SqlServerService.EnsureCredentialExistsAsync"/> actually did to the server.
+///
+/// Callers report this in the execution log. Modifying a server-scoped credential is a change to
+/// shared state on someone's production instance, made by a tool that was only asked to run a
+/// restore - so it should never happen without a line saying it happened.
+/// </summary>
+public enum CredentialChange
+{
+    /// <summary>Nothing was sent to the server; a usable credential was already there.</summary>
+    None,
+
+    /// <summary>The credential did not exist and was created.</summary>
+    Created,
+
+    /// <summary>The credential existed and its secret (and identity) were updated in place.</summary>
+    Updated
+}

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
@@ -13,10 +14,21 @@ namespace Blackcat.NineLives.Services;
 public class CredentialStore
 {
     private const string AppPrefix = "NineLives";
-    private static readonly string ConfigDir = Path.Combine(
+    private static readonly string DefaultConfigDir = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "NineLives");
-    private static readonly string ConfigPath = Path.Combine(ConfigDir, "config.json");
+
+    private readonly string _configDir;
+    private readonly string _configPath;
+
+    public CredentialStore() : this(DefaultConfigDir) { }
+
+    /// <summary>Lets the tests point config persistence at a temp directory instead of the real profile.</summary>
+    internal CredentialStore(string configDir)
+    {
+        _configDir = configDir;
+        _configPath = Path.Combine(configDir, "config.json");
+    }
 
     #region Windows Credential Manager P/Invoke
 
@@ -182,38 +194,98 @@ public class CredentialStore
 
     #region Config Persistence (non-secret data)
 
+    /// <summary>
+    /// Reads config.json. Never throws, so startup cannot be bricked by a bad file - but a file
+    /// that exists and could not be read comes back carrying <see cref="AppConfig.LoadError"/>,
+    /// and <see cref="SaveConfig"/> refuses to overwrite anything in that state.
+    ///
+    /// The distinction matters. "No file" means a fresh install, where empty defaults are exactly
+    /// right. "File is there but I could not read it" used to produce the same empty defaults,
+    /// which is how a transient lock - antivirus, a backup agent, a sync client mid-upload -
+    /// turned into permanent data loss: the UI showed no containers, the user re-added one, and
+    /// the save wrote that single entry over everything they had.
+    /// </summary>
     public AppConfig LoadConfig()
     {
+        if (!File.Exists(_configPath))
+            return new AppConfig();
+
         try
         {
-            if (File.Exists(ConfigPath))
+            var json = File.ReadAllText(_configPath);
+            var config = JsonSerializer.Deserialize<AppConfig>(json);
+            if (config != null)
+                return config;
+
+            return new AppConfig
             {
-                var json = File.ReadAllText(ConfigPath);
-                return JsonSerializer.Deserialize<AppConfig>(json) ?? new AppConfig();
-            }
+                LoadError = $"{_configPath} does not contain valid configuration."
+            };
         }
-        catch
+        catch (Exception ex)
         {
-            // Config corrupted, return defaults
+            return new AppConfig
+            {
+                LoadError = $"{_configPath} could not be read: {ex.Message}"
+            };
         }
-        return new AppConfig();
     }
 
+    /// <summary>
+    /// Writes config.json, or throws. Callers must report the failure rather than telling the
+    /// user their work was saved - the old version swallowed everything and the UI said
+    /// "saved successfully" regardless.
+    /// </summary>
+    /// <exception cref="ConfigSaveRefusedException">
+    /// The config being saved came from a failed load, so writing it would destroy whatever is
+    /// still on disk.
+    /// </exception>
     public void SaveConfig(AppConfig config)
     {
-        try
+        if (config.LoadError != null)
+            throw new ConfigSaveRefusedException(config.LoadError);
+
+        Directory.CreateDirectory(_configDir);
+        var json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
+
+        // Write beside the real file and swap it in, so a crash or a full disk part-way through
+        // cannot leave a truncated config.json where a complete one used to be. File.Replace is
+        // atomic and keeps the previous contents as .bak, which is a free undo for the case
+        // where something else has gone wrong.
+        var tempPath = _configPath + ".tmp";
+        File.WriteAllText(tempPath, json);
+
+        if (File.Exists(_configPath))
         {
-            Directory.CreateDirectory(ConfigDir);
-            var json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(ConfigPath, json);
+            try
+            {
+                File.Replace(tempPath, _configPath, _configPath + ".bak", ignoreMetadataErrors: true);
+                return;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Some filesystems (a few network shares) cannot do the atomic swap. Fall through
+                // to the plain move, which is still better than writing over the file in place.
+            }
+            File.Delete(_configPath);
         }
-        catch
-        {
-            // Silently fail config save
-        }
+
+        File.Move(tempPath, _configPath);
     }
 
     #endregion
+}
+
+/// <summary>
+/// Thrown when a save is refused because the configuration in hand was never successfully loaded.
+/// Writing it would replace real saved servers and containers with an empty list.
+/// </summary>
+public class ConfigSaveRefusedException(string loadError)
+    : InvalidOperationException(
+        $"Configuration was not saved, because it could not be read in the first place and " +
+        $"saving now would overwrite the copy on disk. {loadError}")
+{
+    public string LoadError { get; } = loadError;
 }
 
 public class AppConfig
@@ -228,4 +300,13 @@ public class AppConfig
 
     /// <summary>Last release tag the user was told about, so the banner does not nag.</summary>
     public string? LastNotifiedReleaseTag { get; set; }
+
+    /// <summary>
+    /// Set when config.json existed but could not be read or parsed. Not persisted - it describes
+    /// this load attempt, not the configuration. While it is set, this object holds empty defaults
+    /// that do NOT reflect what is on disk, so <see cref="CredentialStore.SaveConfig"/> will
+    /// refuse to write it.
+    /// </summary>
+    [JsonIgnore]
+    public string? LoadError { get; set; }
 }

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -165,14 +165,17 @@ public class CredentialStore
     {
         var sasToken = GetSasToken(config);
         if (sasToken == null) return true;
-        var expiry = config.GetSasExpiry(sasToken);
-        return expiry.HasValue && expiry.Value < DateTime.UtcNow;
+        return config.ReadSasExpiry(sasToken).IsExpired;
     }
 
     public DateTime? GetSasTokenExpiry(BlobContainerConfig config)
+        => ReadSasTokenExpiry(config).ExpiresAt;
+
+    /// <summary>Full expiry state, so callers can tell "no expiry" from "unreadable" (#21).</summary>
+    public SasExpiryInfo ReadSasTokenExpiry(BlobContainerConfig config)
     {
         var sasToken = GetSasToken(config);
-        return sasToken != null ? config.GetSasExpiry(sasToken) : null;
+        return sasToken != null ? config.ReadSasExpiry(sasToken) : SasExpiryInfo.None;
     }
 
     #endregion

--- a/src/NineLives/Services/DatabaseRecoveryState.cs
+++ b/src/NineLives/Services/DatabaseRecoveryState.cs
@@ -1,0 +1,110 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// What a restore left behind, and what to do about it (#14).
+///
+/// When a chain fails partway through, the target database is still mid-restore - and if
+/// "Disconnect sessions" was on it is also stuck in SINGLE_USER, because the closing
+/// ALTER DATABASE ... SET MULTI_USER never ran. Both states block other connections.
+///
+/// This is the worst possible moment to leave someone guessing: a restore has just failed during
+/// an incident, and the database is now in a state that keeps everyone else out. A DBA who knows
+/// the remedy will type it into SSMS from memory. The people this tool is aimed at may not, and
+/// the app is already holding the connection that could fix it.
+/// </summary>
+/// <param name="Exists">False when the database is not on the server at all.</param>
+/// <param name="StateDescription">sys.databases.state_desc, e.g. ONLINE, RESTORING, RECOVERY_PENDING.</param>
+/// <param name="UserAccessDescription">sys.databases.user_access_desc, e.g. MULTI_USER, SINGLE_USER.</param>
+public sealed record DatabaseRecoveryState(
+    bool Exists,
+    string? StateDescription,
+    string? UserAccessDescription)
+{
+    public static DatabaseRecoveryState Missing => new(false, null, null);
+
+    /// <summary>Mid-restore: the database is not usable until it is recovered or restored further.</summary>
+    public bool IsRestoring =>
+        string.Equals(StateDescription, "RESTORING", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Restore ended badly enough that SQL Server could not bring the database up.</summary>
+    public bool IsRecoveryPending =>
+        string.Equals(StateDescription, "RECOVERY_PENDING", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Locked to one connection - usually a leftover from Disconnect sessions.</summary>
+    public bool IsSingleUser =>
+        string.Equals(UserAccessDescription, "SINGLE_USER", StringComparison.OrdinalIgnoreCase);
+
+    public bool NeedsAttention => Exists && (IsRestoring || IsRecoveryPending || IsSingleUser);
+
+    /// <summary>
+    /// Plain-language account of where the database is, written for someone reading it just after
+    /// a restore failed rather than someone browsing documentation.
+    /// </summary>
+    public string Explain(string databaseName)
+    {
+        if (!Exists)
+            return $"[{databaseName}] is not on the server. The restore failed before it was created, " +
+                   "so nothing has been left behind.";
+
+        var lines = new List<string>();
+
+        if (IsRestoring)
+            lines.Add(
+                $"[{databaseName}] is in RESTORING state. That is what a database looks like " +
+                "part-way through a chain: it is waiting for more log or differential backups and " +
+                "cannot be used until it is either restored further or brought online as-is.");
+
+        if (IsRecoveryPending)
+            lines.Add(
+                $"[{databaseName}] is in RECOVERY_PENDING. SQL Server could not finish recovery - " +
+                "usually the restore was interrupted. It will need attention before the database " +
+                "can be used.");
+
+        if (IsSingleUser)
+            lines.Add(
+                $"[{databaseName}] is in SINGLE_USER. \"Disconnect sessions\" set that before the " +
+                "restore, and the statement that puts it back never ran because the chain stopped " +
+                "first. Only one connection can reach the database until it is changed back.");
+
+        if (lines.Count == 0)
+            lines.Add($"[{databaseName}] is {StateDescription} / {UserAccessDescription}.");
+
+        return string.Join("\n\n", lines);
+    }
+
+    /// <summary>
+    /// The statements that would put this right, in the order they should be run. Empty when there
+    /// is nothing to do.
+    ///
+    /// WITH RECOVERY is offered rather than performed silently: it ends the restore sequence, so
+    /// any log backup not yet applied can never be applied afterwards. Whether that is the right
+    /// move depends on what the user was trying to reach, and only they know that.
+    /// </summary>
+    public IReadOnlyList<RecoveryAction> SuggestedActions(string databaseName)
+    {
+        var actions = new List<RecoveryAction>();
+        if (!Exists) return actions;
+
+        if (IsRestoring || IsRecoveryPending)
+            actions.Add(new RecoveryAction(
+                "Bring the database online",
+                $"RESTORE DATABASE {TSql.QuoteName(databaseName)} WITH RECOVERY",
+                "Finishes the restore with what has already been applied. Any remaining log " +
+                "backups cannot be applied after this - if you meant to reach a later point in " +
+                "time, fix the chain and restore again instead."));
+
+        if (IsSingleUser)
+            actions.Add(new RecoveryAction(
+                "Allow other connections again",
+                $"ALTER DATABASE {TSql.QuoteName(databaseName)} SET MULTI_USER",
+                "Undoes the SINGLE_USER that Disconnect sessions applied. Safe at any point."));
+
+        return actions;
+    }
+}
+
+/// <summary>One remediation the user can read, copy, or run.</summary>
+/// <param name="Title">Short label for the button.</param>
+/// <param name="Sql">The exact statement - shown before it is run, never hidden.</param>
+/// <param name="Caution">What running it commits them to.</param>
+public sealed record RecoveryAction(string Title, string Sql, string Caution);

--- a/src/NineLives/Services/LogRedactor.cs
+++ b/src/NineLives/Services/LogRedactor.cs
@@ -1,0 +1,55 @@
+using System.Text.RegularExpressions;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Strips secrets out of anything on its way to the log file (#40).
+///
+/// This runs at the logging boundary, not at the call sites, and that is the whole design. Asking
+/// every caller to remember to redact means it takes exactly one forgetful caller - or one new one
+/// - to write a live SAS token into a file that then gets attached to a bug report. Everything
+/// passes through here, so a new call site is safe by default.
+///
+/// The rule is deliberately blunt: if something looks like it might be a secret, it goes. A log
+/// line that is over-redacted is a mild annoyance. A log line with a working SAS token in it is a
+/// credential leak with a filename.
+/// </summary>
+public static class LogRedactor
+{
+    private const string Mask = "[redacted]";
+
+    // The SAS signature - the part that actually grants access. Matched first and on its own so a
+    // URL keeps enough shape to stay useful for diagnosis.
+    private static readonly Regex SasSignature = new(
+        @"(?<key>\b(?:sig|sv|se|st|sp|sr|si|skoid|sktid|ske|skt|sks|spr|srt|ss)=)(?<value>[^&\s'"";]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // T-SQL: CREATE/ALTER CREDENTIAL ... SECRET = 'the token'
+    private static readonly Regex TsqlSecret = new(
+        @"(?<key>\bSECRET\s*=\s*)(?<quote>N?')(?:[^']|'')*'",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // Connection-string style: Password=..., Pwd=...
+    private static readonly Regex ConnectionPassword = new(
+        @"(?<key>\b(?:password|pwd)\s*=\s*)(?<value>[^;\s]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>Returns the text with anything secret-shaped replaced. Never throws.</summary>
+    public static string Redact(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return string.Empty;
+
+        try
+        {
+            var result = TsqlSecret.Replace(text, m => $"{m.Groups["key"].Value}{m.Groups["quote"].Value}{Mask}'");
+            result = SasSignature.Replace(result, m => $"{m.Groups["key"].Value}{Mask}");
+            result = ConnectionPassword.Replace(result, m => $"{m.Groups["key"].Value}{Mask}");
+            return result;
+        }
+        catch
+        {
+            // A redaction failure must never let the raw text through.
+            return Mask;
+        }
+    }
+}

--- a/src/NineLives/Services/OperationCancellation.cs
+++ b/src/NineLives/Services/OperationCancellation.cs
@@ -1,0 +1,66 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// The token source behind one cancellable operation, and the bookkeeping that goes with it (#25).
+///
+/// Every service method in this app already takes a CancellationToken; none of them were ever
+/// given a real one. This is the missing half - a viewmodel holds one of these per long-running
+/// operation, hands <see cref="Begin"/> to the service, and exposes <see cref="Cancel"/> to a
+/// button.
+///
+/// Kept as its own type rather than a loose CancellationTokenSource field because the lifecycle is
+/// where the bugs are: reusing a cancelled source silently cancels the next run before it starts,
+/// and disposing one that a callback still holds throws. Doing it once, here, means the viewmodels
+/// cannot each get it subtly wrong.
+///
+/// Not thread-safe by design: it is driven from the UI thread.
+/// </summary>
+public sealed class OperationCancellation
+{
+    private CancellationTokenSource? _current;
+
+    /// <summary>True while an operation is running and has not already been asked to stop.</summary>
+    public bool CanCancel => _current is { IsCancellationRequested: false };
+
+    /// <summary>True once Cancel has been called and before the operation has finished unwinding.</summary>
+    public bool IsCancelling => _current is { IsCancellationRequested: true };
+
+    /// <summary>
+    /// Starts a new operation and returns its token. Any previous source is cancelled and disposed
+    /// first, so a run that was somehow left open cannot outlive the one replacing it.
+    /// </summary>
+    public CancellationToken Begin()
+    {
+        Cancel();
+        Dispose();
+
+        _current = new CancellationTokenSource();
+        return _current.Token;
+    }
+
+    /// <summary>Asks the running operation to stop. Safe to call when nothing is running.</summary>
+    public void Cancel()
+    {
+        if (_current is { IsCancellationRequested: false } cts)
+        {
+            // Between the check and the call the source could already be disposed by a racing
+            // End(); the operation is over either way, which is what Cancel wanted.
+            try { cts.Cancel(); } catch (ObjectDisposedException) { }
+        }
+    }
+
+    /// <summary>
+    /// Marks the operation finished. Called from a finally block, so it must not throw whatever
+    /// state things are in.
+    /// </summary>
+    public void End()
+    {
+        Dispose();
+        _current = null;
+    }
+
+    private void Dispose()
+    {
+        try { _current?.Dispose(); } catch (ObjectDisposedException) { }
+    }
+}

--- a/src/NineLives/Services/OperationLog.cs
+++ b/src/NineLives/Services/OperationLog.cs
@@ -58,6 +58,9 @@ public sealed class OperationLog
     public void ServerChange(string serverName, string what)
         => Write("CHANGE", $"[{serverName}] {what}");
 
+    private string? _ensuredDirectory;
+    private int _writesSinceRollCheck;
+
     private void Write(string level, string message)
     {
         try
@@ -66,15 +69,29 @@ public sealed class OperationLog
 
             lock (_gate)
             {
-                System.IO.Directory.CreateDirectory(_directory);
-                RollIfTooBig();
+                // Creating the directory and stat-ing the file on EVERY line meant three
+                // filesystem calls per message. A restore reporting progress every few percent
+                // does that hundreds of times from the UI thread, which is a real part of why the
+                // console stuttered. The directory is created once, and the size is only checked
+                // periodically - a log overshooting the roll threshold by a few hundred lines
+                // costs nothing, and the check is not free.
+                if (_ensuredDirectory != _directory)
+                {
+                    System.IO.Directory.CreateDirectory(_directory);
+                    _ensuredDirectory = _directory;
+                }
+
+                if (_writesSinceRollCheck++ % 200 == 0) RollIfTooBig();
+
                 File.AppendAllText(CurrentFile, line + Environment.NewLine, Encoding.UTF8);
             }
         }
         catch
         {
             // Logging is never worth failing an operation over. A locked file, a full disk or a
-            // redirected profile all end up here and are all survivable.
+            // redirected profile all end up here and are all survivable. Forget the cached
+            // directory so a transient failure is retried rather than assumed permanent.
+            _ensuredDirectory = null;
         }
     }
 

--- a/src/NineLives/Services/OperationLog.cs
+++ b/src/NineLives/Services/OperationLog.cs
@@ -1,0 +1,117 @@
+using System.IO;
+using System.Text;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// A small append-only log on disk (#40).
+///
+/// The app had no logging of any kind, which for a tool that executes restores against production
+/// databases means a bug report can contain nothing but a screenshot, and a server-state change -
+/// creating or altering a credential - leaves no trace whatsoever.
+///
+/// Hand-rolled rather than a logging framework: the requirement is a few lines of text per
+/// operation, and a self-contained single-file exe should not grow a dependency tree for that.
+///
+/// Two rules it must never break:
+///   - it never throws, because a logging failure must not break a restore
+///   - everything goes through LogRedactor, so a new call site cannot leak a token by forgetting
+/// </summary>
+public sealed class OperationLog
+{
+    /// <summary>Files older than this are removed on startup.</summary>
+    private const int RetentionDays = 30;
+
+    /// <summary>A single day's file is rolled once it passes this, so one runaway loop cannot fill the disk.</summary>
+    private const long MaxFileBytes = 5 * 1024 * 1024;
+
+    private readonly string _directory;
+    // Plain object rather than System.Threading.Lock, which is .NET 9+. Swap it when the .NET 10
+    // retarget lands (#34).
+    private readonly object _gate = new();
+
+    public OperationLog() : this(Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "NineLives", "logs"))
+    { }
+
+    /// <summary>Lets the tests write somewhere disposable instead of the real profile.</summary>
+    internal OperationLog(string directory) => _directory = directory;
+
+    public string Directory => _directory;
+
+    /// <summary>Today's log file. The name is stable within a day so it is easy to find and attach.</summary>
+    public string CurrentFile =>
+        Path.Combine(_directory, $"ninelives-{DateTime.Now:yyyyMMdd}.log");
+
+    public void Info(string message) => Write("INFO ", message);
+    public void Warn(string message) => Write("WARN ", message);
+    public void Error(string message) => Write("ERROR", message);
+
+    public void Error(string message, Exception ex)
+        => Write("ERROR", $"{message} | {ex.GetType().Name}: {ex.Message}");
+
+    /// <summary>
+    /// Records something the app changed on a server, as opposed to something it read. These are
+    /// the lines that matter when someone asks why a credential on their instance changed.
+    /// </summary>
+    public void ServerChange(string serverName, string what)
+        => Write("CHANGE", $"[{serverName}] {what}");
+
+    private void Write(string level, string message)
+    {
+        try
+        {
+            var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {level} {LogRedactor.Redact(message)}";
+
+            lock (_gate)
+            {
+                System.IO.Directory.CreateDirectory(_directory);
+                RollIfTooBig();
+                File.AppendAllText(CurrentFile, line + Environment.NewLine, Encoding.UTF8);
+            }
+        }
+        catch
+        {
+            // Logging is never worth failing an operation over. A locked file, a full disk or a
+            // redirected profile all end up here and are all survivable.
+        }
+    }
+
+    private void RollIfTooBig()
+    {
+        var current = CurrentFile;
+        if (!File.Exists(current) || new FileInfo(current).Length < MaxFileBytes) return;
+
+        for (var i = 1; i < 100; i++)
+        {
+            var rolled = Path.ChangeExtension(current, $".{i}.log");
+            if (File.Exists(rolled)) continue;
+            File.Move(current, rolled);
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Drops files past the retention window. Called once at startup rather than on every write -
+    /// enumerating a directory to append one line would be silly.
+    /// </summary>
+    public void Prune()
+    {
+        try
+        {
+            if (!System.IO.Directory.Exists(_directory)) return;
+
+            var cutoff = DateTime.Now.AddDays(-RetentionDays);
+            foreach (var file in System.IO.Directory.EnumerateFiles(_directory, "ninelives-*.log"))
+            {
+                if (File.GetLastWriteTime(file) < cutoff)
+                    File.Delete(file);
+            }
+        }
+        catch
+        {
+            // Same rule: never worth failing over.
+        }
+    }
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -206,51 +206,31 @@ public class SqlServerService
         return databases;
     }
 
-    public async Task<List<BackupFileInfo>> RestoreHeaderOnlyAsync(
-        ServerConnection server, string blobUrl, string credentialName, CancellationToken ct = default)
-    {
-        await using var conn = CreateConnection(server);
-        await conn.OpenAsync(ct);
-        await using var cmd = conn.CreateCommand();
-        cmd.CommandTimeout = 120;
-        cmd.CommandText = $"RESTORE HEADERONLY FROM URL = N'{TSql.EscapeLiteral(blobUrl)}' WITH CREDENTIAL = N'{TSql.EscapeLiteral(credentialName)}'";
+    // These two read backup metadata off blob URLs, and neither takes a credential name any more.
+    //
+    // They used to, and passing one could never work. SQL Server rejects WITH CREDENTIAL against a
+    // SAS-backed credential outright:
+    //
+    //     Msg 3225: Use of WITH CREDENTIAL syntax is not valid for credentials containing a
+    //     Shared Access Signature.
+    //
+    // A SAS credential is the only kind this app ever creates - EnsureCredentialExistsAsync
+    // hardcodes WITH IDENTITY = 'SHARED ACCESS SIGNATURE' - so the branch could not succeed in any
+    // configuration the app produces. Both production callers already passed null, which is why
+    // the shipping app worked, but the parameter was positional and required: a new caller had to
+    // pass something, and the obvious something failed with an error about syntax rather than
+    // about the real cause. Removing it makes the wrong call unrepresentable rather than merely
+    // unused (#60).
+    //
+    // The server-side credential still does the authenticating. It is matched by URL prefix, which
+    // is exactly how the generated restore script has always worked.
+    //
+    // If a non-SAS credential is ever supported (managed identity, #29), bring the option back
+    // keyed off the identity type that CredentialExistsAsync already reports - not off a flag.
 
-        var results = new List<BackupFileInfo>();
-        await using var reader = await cmd.ExecuteReaderAsync(ct);
-        while (await reader.ReadAsync(ct))
-        {
-            int? backupTypeCode = GetIntFromReader(reader, "BackupType");
-            results.Add(new BackupFileInfo
-            {
-                DatabaseName = GetStringFromReader(reader, "DatabaseName"),
-                BackupStartDate = GetDateTimeFromReader(reader, "BackupStartDate"),
-                BackupFinishDate = GetDateTimeFromReader(reader, "BackupFinishDate"),
-                BackupTypeCode = backupTypeCode,
-                Type = (backupTypeCode ?? 0) switch
-                {
-                    1 => BackupType.Full,
-                    5 => BackupType.Differential,
-                    2 => BackupType.TransactionLog,
-                    _ => BackupType.Unknown
-                },
-                FirstLsn = GetDecimalFromReader(reader, "FirstLSN"),
-                LastLsn = GetDecimalFromReader(reader, "LastLSN"),
-                DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN"),
-            CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN")
-            });
-        }
-        return results;
-    }
-
+    /// <summary>RESTORE FILELISTONLY across the files of one backup set, striped or not.</summary>
     public async Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
-        ServerConnection server, string blobUrl, string credentialName, CancellationToken ct = default)
-    {
-        return await RestoreFileListOnlyAsync(server, [blobUrl], credentialName, urlsContainSas: false, ct);
-    }
-
-    /// <summary>RESTORE FILELISTONLY for striped backup. When urlsContainSas is true, omit WITH CREDENTIAL (SQL Server does not allow WITH CREDENTIAL for SAS credentials).</summary>
-    public async Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
-        ServerConnection server, IReadOnlyList<string> blobUrls, string? credentialName, bool urlsContainSas = false, CancellationToken ct = default)
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
     {
         if (blobUrls.Count == 0) return [];
 
@@ -260,10 +240,7 @@ public class SqlServerService
         cmd.CommandTimeout = 120;
 
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
-        var withCredential = !urlsContainSas && !string.IsNullOrEmpty(credentialName)
-            ? $" WITH CREDENTIAL = N'{TSql.EscapeLiteral(credentialName)}'"
-            : "";
-        cmd.CommandText = $"RESTORE FILELISTONLY FROM {urlClauses}{withCredential}";
+        cmd.CommandText = $"RESTORE FILELISTONLY FROM {urlClauses}";
 
         var files = new List<FileMoveOption>();
         await using var reader = await cmd.ExecuteReaderAsync(ct);
@@ -280,9 +257,9 @@ public class SqlServerService
         return files;
     }
 
-    /// <summary>RESTORE HEADERONLY for striped backup. When urlsContainSas is true, omit WITH CREDENTIAL (SQL Server does not allow WITH CREDENTIAL for SAS credentials).</summary>
+    /// <summary>RESTORE HEADERONLY across the files of one backup set, striped or not.</summary>
     public async Task<BackupFileInfo?> RestoreHeaderOnlyMultiAsync(
-        ServerConnection server, IReadOnlyList<string> blobUrls, string? credentialName, bool urlsContainSas = false, CancellationToken ct = default)
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
     {
         if (blobUrls.Count == 0) return null;
 
@@ -292,10 +269,7 @@ public class SqlServerService
         cmd.CommandTimeout = 120;
 
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
-        var withCredential = !urlsContainSas && !string.IsNullOrEmpty(credentialName)
-            ? $" WITH CREDENTIAL = N'{TSql.EscapeLiteral(credentialName)}'"
-            : "";
-        cmd.CommandText = $"RESTORE HEADERONLY FROM {urlClauses}{withCredential}";
+        cmd.CommandText = $"RESTORE HEADERONLY FROM {urlClauses}";
 
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         if (!await reader.ReadAsync(ct)) return null;

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Security;
 using Microsoft.Data.SqlClient;
 using Blackcat.NineLives.Models;
 
@@ -30,32 +31,118 @@ public class SqlServerService
             MultipleActiveResultSets = false
         };
 
-        if (server.AuthMode == AuthMode.WindowsAuth)
-        {
-            builder.IntegratedSecurity = true;
-        }
-        else
-        {
-            builder.IntegratedSecurity = false;
-            builder.UserID = server.Username;
-            // An unsaved password wins, so Test Connection can try one without it having to be
-            // persisted first (#12). Null for every ordinary connection.
-            builder.Password = server.UnsavedPassword ?? _credentialStore.GetSqlPassword(server);
-        }
+        builder.IntegratedSecurity = server.AuthMode == AuthMode.WindowsAuth;
 
+        // No UserID or Password here - SQL auth credentials go on the SqlConnection as a
+        // SqlCredential instead (#20). A connection string is a long-lived managed string that
+        // cannot be zeroed and turns up in crash dumps and memory captures; SqlCredential holds
+        // the password in a SecureString the driver disposes. It also means anything that logs or
+        // displays a connection string cannot leak the password by accident.
+        //
+        // SqlCredential refuses to attach to a connection string that already carries either, so
+        // leaving them out is required rather than merely tidy.
         return builder.ConnectionString;
+    }
+
+    /// <summary>
+    /// Opens nothing; builds the connection with the password attached out-of-band.
+    /// Every SQL operation in this class goes through here.
+    /// </summary>
+    public SqlConnection CreateConnection(ServerConnection server)
+    {
+        var conn = new SqlConnection(BuildConnectionString(server));
+
+        if (server.AuthMode != AuthMode.SqlAuth)
+            return conn;
+
+        // Unsaved wins, so Test Connection can try a password without persisting it first (#12).
+        var password = server.UnsavedPassword ?? _credentialStore.GetSqlPassword(server);
+        if (string.IsNullOrEmpty(server.Username) || password == null)
+            return conn;
+
+        var secure = new SecureString();
+        foreach (var c in password) secure.AppendChar(c);
+        secure.MakeReadOnly();
+
+        conn.Credential = new SqlCredential(server.Username, secure);
+        return conn;
     }
 
     public async Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         return conn.State == ConnectionState.Open;
     }
 
+    /// <summary>
+    /// Would this server connect with certificate validation switched on?
+    ///
+    /// TrustServerCertificate defaults to true, which is the pragmatic default for a DBA tool -
+    /// self-signed certificates are what a stock SQL Server install has, and a tool that refuses
+    /// to connect out of the box gets uninstalled. But it means the app accepts any certificate
+    /// without validation, and it sends the SQL password and the SAS token over that connection
+    /// (#17).
+    ///
+    /// Rather than nag about it, this answers the question that actually matters: is the setting
+    /// doing anything? A great many instances have a properly issued certificate and are trusting
+    /// blindly for no reason at all. When that is the case the UI can say so and the user can turn
+    /// it off with real information rather than a warning they will learn to ignore.
+    ///
+    /// Returns null when the answer is not knowable - the probe failed for some reason other than
+    /// the certificate.
+    /// </summary>
+    public async Task<bool?> WouldConnectWithCertificateValidationAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        if (!server.TrustServerCertificate)
+            return true;   // already validating
+
+        var validated = new ServerConnection
+        {
+            Id = server.Id,
+            Name = server.Name,
+            ServerName = server.ServerName,
+            AuthMode = server.AuthMode,
+            Username = server.Username,
+            ConnectionTimeoutSeconds = server.ConnectionTimeoutSeconds,
+            Encrypt = server.Encrypt,
+            TrustServerCertificate = false,
+            UnsavedPassword = server.UnsavedPassword
+        };
+
+        try
+        {
+            await using var conn = CreateConnection(validated);
+            await conn.OpenAsync(ct);
+            return true;
+        }
+        catch (SqlException ex) when (IsCertificateFailure(ex))
+        {
+            return false;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// SQL Server surfaces a rejected certificate as a generic SSL provider error, so this matches
+    /// on the message. Getting it wrong only costs a "could not determine" instead of a definite
+    /// answer, which is why the caller treats null as "say nothing".
+    /// </summary>
+    private static bool IsCertificateFailure(SqlException ex)
+    {
+        var message = ex.ToString();
+        return message.Contains("certificate", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("trust relationship", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("SSL", StringComparison.OrdinalIgnoreCase);
+    }
+
     public async Task<string> GetServerVersionAsync(ServerConnection server, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT @@VERSION";
@@ -65,7 +152,7 @@ public class SqlServerService
 
     public async Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT name FROM sys.databases ORDER BY name";
@@ -79,7 +166,7 @@ public class SqlServerService
     public async Task<List<BackupFileInfo>> RestoreHeaderOnlyAsync(
         ServerConnection server, string blobUrl, string credentialName, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
@@ -124,7 +211,7 @@ public class SqlServerService
     {
         if (blobUrls.Count == 0) return [];
 
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
@@ -156,7 +243,7 @@ public class SqlServerService
     {
         if (blobUrls.Count == 0) return null;
 
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
@@ -263,7 +350,7 @@ public class SqlServerService
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         if (messageCallback != null)
         {
             conn.InfoMessage += (_, e) => messageCallback(e.Message);
@@ -280,7 +367,7 @@ public class SqlServerService
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         if (messageCallback != null)
         {
             conn.InfoMessage += (_, e) => messageCallback(e.Message);
@@ -328,7 +415,7 @@ public class SqlServerService
         if (string.IsNullOrWhiteSpace(credentialName))
             return (false, false);
 
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
 
         await using var cmd = conn.CreateCommand();
@@ -371,7 +458,7 @@ public class SqlServerService
         TSql.ValidateIdentifier(credentialName, nameof(credentialName));
         var quotedName = TSql.QuoteName(credentialName);
 
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
 
         await using var checkCmd = conn.CreateCommand();
@@ -395,7 +482,7 @@ public class SqlServerService
     public async Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(
         ServerConnection server, CancellationToken ct = default)
     {
-        await using var conn = new SqlConnection(BuildConnectionString(server));
+        await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = @"SELECT

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -356,7 +356,13 @@ public class SqlServerService
     //
     // It also broke benignly: an IPv6-literal endpoint such as https://[fe80::1]:10000/... is a
     // legal URL containing ']' and failed with an opaque syntax error.
-    public async Task EnsureCredentialExistsAsync(
+    //
+    // An existing credential is now ALTERed rather than dropped and recreated. A credential is
+    // server-scoped shared state: dropping it, even for the moment between two statements,
+    // breaks anything else relying on it at that instant - a backup job writing to the same
+    // container, most obviously. ALTER updates the secret in place with no such window, and
+    // leaves create_date intact, which is how the tests tell the two apart.
+    public async Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
         CancellationToken ct = default)
     {
@@ -371,20 +377,17 @@ public class SqlServerService
         checkCmd.Parameters.AddWithValue("@name", credentialName);
         var exists = (int)(await checkCmd.ExecuteScalarAsync(ct))! > 0;
 
-        if (exists)
-        {
-            await using var dropCmd = conn.CreateCommand();
-            dropCmd.CommandText = $"DROP CREDENTIAL {quotedName}";
-            await dropCmd.ExecuteNonQueryAsync(ct);
-        }
-
+        // ALTER also resets IDENTITY, so a credential that exists under some other identity is
+        // converted rather than left in place to fail the restore later.
         var cleanSas = sasToken.TrimStart('?');
-        await using var createCmd = conn.CreateCommand();
-        createCmd.CommandText = $@"
-            CREATE CREDENTIAL {quotedName}
+        await using var writeCmd = conn.CreateCommand();
+        writeCmd.CommandText = $@"
+            {(exists ? "ALTER" : "CREATE")} CREDENTIAL {quotedName}
             WITH IDENTITY = 'SHARED ACCESS SIGNATURE',
             SECRET = '{TSql.EscapeLiteral(cleanSas)}'";
-        await createCmd.ExecuteNonQueryAsync(ct);
+        await writeCmd.ExecuteNonQueryAsync(ct);
+
+        return exists ? CredentialChange.Updated : CredentialChange.Created;
     }
 
     public async Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -150,6 +150,49 @@ public class SqlServerService
         return result?.ToString() ?? "Unknown";
     }
 
+    /// <summary>
+    /// Reads what state a database is in, so a failed restore can say what it left behind (#14).
+    /// Parameterised - the name comes from a text box.
+    /// </summary>
+    public async Task<DatabaseRecoveryState> GetDatabaseRecoveryStateAsync(
+        ServerConnection server, string databaseName, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(databaseName))
+            return DatabaseRecoveryState.Missing;
+
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "SELECT state_desc, user_access_desc FROM sys.databases WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", databaseName);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        if (!await reader.ReadAsync(ct))
+            return DatabaseRecoveryState.Missing;
+
+        return new DatabaseRecoveryState(
+            true,
+            reader["state_desc"]?.ToString(),
+            reader["user_access_desc"]?.ToString());
+    }
+
+    /// <summary>
+    /// Runs a single remediation statement chosen by the user from
+    /// <see cref="DatabaseRecoveryState.SuggestedActions"/>. Deliberately takes the whole statement
+    /// rather than building one - the user has already been shown exactly what will run.
+    /// </summary>
+    public async Task ExecuteRecoveryActionAsync(
+        ServerConnection server, string sql, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandTimeout = 0;
+        cmd.CommandText = sql;
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
     public async Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
     {
         await using var conn = CreateConnection(server);

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -38,7 +38,9 @@ public class SqlServerService
         {
             builder.IntegratedSecurity = false;
             builder.UserID = server.Username;
-            builder.Password = _credentialStore.GetSqlPassword(server);
+            // An unsaved password wins, so Test Connection can try one without it having to be
+            // persisted first (#12). Null for every ordinary connection.
+            builder.Password = server.UnsavedPassword ?? _credentialStore.GetSqlPassword(server);
         }
 
         return builder.ConnectionString;

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Security;
+using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
 using Blackcat.NineLives.Models;
 
@@ -436,8 +437,20 @@ public class SqlServerService
         }
     }
 
+    /// <summary>
+    /// A one-line preview of a statement for the console.
+    ///
+    /// Whitespace is collapsed FIRST. Taking the first 80 characters raw pulled in the newlines
+    /// and blank lines of the script's comment banner, so a single "Executing statement 1 of 22"
+    /// message arrived as several lines with gaps between them.
+    /// </summary>
     private static string Summarize(string statement)
-        => statement[..Math.Min(80, statement.Length)].Trim();
+    {
+        var flattened = WhitespaceRun.Replace(statement, " ").Trim();
+        return flattened.Length <= 80 ? flattened : flattened[..80] + "...";
+    }
+
+    private static readonly Regex WhitespaceRun = new(@"\s+", RegexOptions.Compiled);
 
     /// <summary>Checks if a credential with the given name exists on the server and has identity SHARED ACCESS SIGNATURE (for blob URL restores).</summary>
     public async Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -410,6 +410,20 @@ public class SqlServerService
             {
                 await cmd.ExecuteNonQueryAsync(ct);
             }
+            catch (SqlException) when (ct.IsCancellationRequested)
+            {
+                // SqlClient reports a command cancelled mid-flight as a SqlException - "A severe
+                // error occurred on the current command. The results, if any, should be discarded.
+                // Operation cancelled by user." - and NOT as an OperationCanceledException. Left
+                // alone, a caller who catches OperationCanceledException to show "cancelled"
+                // misses it entirely and tells the user their own Stop was a severe error.
+                //
+                // Only when the token was actually signalled, so a genuine severe error still
+                // propagates as the failure it is.
+                messageCallback?.Invoke(
+                    $"Cancelled during statement {i + 1} of {executable.Count}: {Summarize(statement)}");
+                throw new OperationCanceledException("The restore was cancelled.", ct);
+            }
             catch (SqlException)
             {
                 // Say WHICH step of the chain failed before it propagates. Without this the

--- a/src/NineLives/Services/SqlSyntaxHighlighter.cs
+++ b/src/NineLives/Services/SqlSyntaxHighlighter.cs
@@ -1,0 +1,87 @@
+using System.Text.RegularExpressions;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>What a span of a T-SQL script is, for colouring.</summary>
+public enum SqlTokenKind
+{
+    Plain,
+    Keyword,
+    /// <summary>A string literal, N'...' included.</summary>
+    Literal,
+    Comment,
+    Number,
+    /// <summary>A [bracketed identifier] - the database and credential names.</summary>
+    Identifier
+}
+
+/// <summary>One coloured span.</summary>
+public sealed record SqlToken(string Text, SqlTokenKind Kind);
+
+/// <summary>
+/// Splits a T-SQL script into coloured spans.
+///
+/// Hand-rolled rather than pulling in an editor component. The script pane is read-only and a few
+/// kilobytes at most, so a tokeniser is a hundred lines against a dependency the single-file exe
+/// would have to carry - and #16 pinned the dependency graph deliberately.
+///
+/// Not a parser and does not need to be. It gets comments, strings, bracketed identifiers, numbers
+/// and keywords right, in that order of precedence, which is everything a restore script contains.
+/// Anything it cannot classify stays plain, so the worst case is uncoloured text rather than
+/// mangled text.
+/// </summary>
+public static class SqlSyntaxHighlighter
+{
+    private static readonly HashSet<string> Keywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "RESTORE", "DATABASE", "LOG", "FROM", "URL", "DISK", "WITH", "FILE", "MOVE", "TO",
+        "REPLACE", "RECOVERY", "NORECOVERY", "STANDBY", "STATS", "STOPAT", "CHECKSUM",
+        "CONTINUE_AFTER_ERROR", "KEEP_REPLICATION", "ENABLE_BROKER", "NEW_BROKER",
+        "ERROR_BROKER_CONVERSATIONS", "CREDENTIAL", "HEADERONLY", "FILELISTONLY", "VERIFYONLY",
+        "ALTER", "SET", "SINGLE_USER", "MULTI_USER", "ROLLBACK", "IMMEDIATE", "GO",
+        "CREATE", "DROP", "IDENTITY", "SECRET", "USE", "MASTER", "IF", "EXISTS", "BEGIN", "END",
+        "SELECT", "WHERE", "AND", "OR", "NOT", "NULL", "AS", "ON", "OFF", "PRINT", "DECLARE",
+        "EXEC", "NORECOVERY,", "MEDIANAME", "MEDIADESCRIPTION", "BLOCKSIZE", "MAXTRANSFERSIZE"
+    };
+
+    // Order matters: comments and strings first, so a keyword inside either is not coloured as
+    // code, and a bracketed identifier containing a quote does not open a string.
+    private static readonly Regex Tokeniser = new(
+        @"(?<comment>--[^\r\n]*|/\*.*?\*/)" +
+        @"|(?<literal>N?'(?:[^']|'')*')" +
+        @"|(?<identifier>\[(?:[^\]]|\]\])*\])" +
+        @"|(?<number>\b\d+(?:\.\d+)?\b)" +
+        @"|(?<word>[A-Za-z_][A-Za-z0-9_]*)",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
+    /// <summary>Splits the script. Concatenating the results reproduces the input exactly.</summary>
+    public static IReadOnlyList<SqlToken> Tokenise(string? sql)
+    {
+        if (string.IsNullOrEmpty(sql)) return [];
+
+        var tokens = new List<SqlToken>();
+        var position = 0;
+
+        foreach (Match match in Tokeniser.Matches(sql))
+        {
+            if (match.Index > position)
+                tokens.Add(new SqlToken(sql[position..match.Index], SqlTokenKind.Plain));
+
+            var kind = SqlTokenKind.Plain;
+            if (match.Groups["comment"].Success) kind = SqlTokenKind.Comment;
+            else if (match.Groups["literal"].Success) kind = SqlTokenKind.Literal;
+            else if (match.Groups["identifier"].Success) kind = SqlTokenKind.Identifier;
+            else if (match.Groups["number"].Success) kind = SqlTokenKind.Number;
+            else if (match.Groups["word"].Success)
+                kind = Keywords.Contains(match.Value) ? SqlTokenKind.Keyword : SqlTokenKind.Plain;
+
+            tokens.Add(new SqlToken(match.Value, kind));
+            position = match.Index + match.Length;
+        }
+
+        if (position < sql.Length)
+            tokens.Add(new SqlToken(sql[position..], SqlTokenKind.Plain));
+
+        return tokens;
+    }
+}

--- a/src/NineLives/Services/TagPalette.cs
+++ b/src/NineLives/Services/TagPalette.cs
@@ -101,8 +101,22 @@ public static class TagPalette
     }
 
     /// <summary>
+    /// Alphabetical, ignoring case.
+    ///
+    /// Ordinal rather than culture-aware so two people looking at the same server see the same
+    /// order. Tags are short ASCII labels in practice - prod, uat, homelab - so the collation
+    /// differences that would favour a culture-aware comparison do not arise.
+    /// </summary>
+    public static IEnumerable<string> Sort(IEnumerable<string>? tags)
+        => tags is null ? [] : tags.OrderBy(t => t, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Splits and normalises a user-entered tag list. Trims, drops blanks, removes duplicates
-    /// case-insensitively while keeping the first spelling the user chose, and preserves order.
+    /// case-insensitively while keeping the first spelling the user chose, and sorts.
+    ///
+    /// Sorted rather than in entry order so the stored list is canonical: two servers carrying the
+    /// same tags then read identically instead of differing by the order someone happened to type
+    /// them in.
     /// </summary>
     public static List<string> ParseTags(string? input)
     {
@@ -119,7 +133,7 @@ public static class TagPalette
             if (seen.Add(tag)) result.Add(tag);
         }
 
-        return result;
+        return [.. Sort(result)];
     }
 
     public static string FormatTags(IEnumerable<string>? tags)

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -2,6 +2,12 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
 
+    <!-- Declared here rather than per-view. It was repeated in five views, and AboutView - the one
+         that did not have it - threw a XamlParseException the moment a {StaticResource BoolToVis}
+         was added to it. Views that still declare their own simply shadow this with an identical
+         instance, so both work. -->
+    <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+
     <!-- Color Palette -->
     <Color x:Key="WindowBackgroundColor">#1B1E2B</Color>
     <Color x:Key="SidebarBackgroundColor">#141722</Color>

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -8,6 +8,93 @@
          instance, so both work. -->
     <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
 
+    <!-- Terminal console. Darker than the cards on purpose, so the console reads as a separate
+         surface the way a real terminal does rather than as another panel in the form. -->
+    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#0C0E14" />
+    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#2A3040" />
+    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#161A24" />
+    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#C9D1D9" />
+    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#6E7681" />
+    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#79C0FF" />
+    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#3FB950" />
+    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#D29922" />
+    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#F85149" />
+
+    <FontFamily x:Key="ConsoleFont">Cascadia Code, Cascadia Mono, Consolas, Courier New</FontFamily>
+
+    <!-- Console rows. A ListBox for the virtualisation, stripped of every ListBox affordance:
+         no selection highlight, no hover, no focus rectangle, tight line spacing. -->
+    <Style x:Key="ConsoleListBoxItem" TargetType="ListBoxItem">
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="MinHeight" Value="0" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListBoxItem">
+                    <ContentPresenter />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ConsoleListBox" TargetType="ListBox">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="12,8,12,10" />
+        <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource ConsoleListBoxItem}" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+        <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="True" />
+        <Setter Property="VirtualizingStackPanel.VirtualizationMode" Value="Recycling" />
+        <Setter Property="ItemTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Text}"
+                               FontFamily="{StaticResource ConsoleFont}"
+                               FontSize="12"
+                               TextWrapping="NoWrap"
+                               Padding="0"
+                               Margin="0"
+                               LineHeight="16"
+                               LineStackingStrategy="BlockLineHeight">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Kind}" Value="Step">
+                                        <Setter Property="Foreground" Value="{StaticResource ConsoleStepBrush}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Kind}" Value="Success">
+                                        <Setter Property="Foreground" Value="{StaticResource ConsoleSuccessBrush}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Kind}" Value="Warning">
+                                        <Setter Property="Foreground" Value="{StaticResource ConsoleWarningBrush}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Kind}" Value="Error">
+                                        <Setter Property="Foreground" Value="{StaticResource ConsoleErrorBrush}" />
+                                        <Setter Property="FontWeight" Value="SemiBold" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- T-SQL syntax colouring, same family as the console so the two panes belong together. -->
+    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#FF7B9EFF" />
+    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#A5D6A7" />
+    <SolidColorBrush x:Key="SqlCommentBrush" Color="#5C6773" />
+    <SolidColorBrush x:Key="SqlNumberBrush" Color="#F0B457" />
+    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#E2C08D" />
+
     <!-- Color Palette -->
     <Color x:Key="WindowBackgroundColor">#1B1E2B</Color>
     <Color x:Key="SidebarBackgroundColor">#141722</Color>

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -1,3 +1,7 @@
+using System.Diagnostics;
+using System.IO;
+using CommunityToolkit.Mvvm.Input;
+
 namespace Blackcat.NineLives.ViewModels;
 
 public partial class AboutViewModel : ViewModelBase
@@ -9,4 +13,25 @@ public partial class AboutViewModel : ViewModelBase
     public string Company => "Blackcat Data Solutions Ltd";
     public string Website => "https://blackcat.wales";
     public string Description => "Every database deserves nine lives. A production-ready utility for restoring SQL Server databases from Azure Blob Storage backups with full support for point-in-time recovery using Full, Differential, and Transaction Log backup chains.";
+
+    /// <summary>Shown so the path can be read even if opening the folder fails.</summary>
+    public string LogFolder => App.Log.Directory;
+
+    /// <summary>
+    /// Opens the log folder in Explorer. The logs are what someone attaches to a bug report, so
+    /// there needs to be a way to find them that is not "know where LocalAppData is" (#40).
+    /// </summary>
+    [RelayCommand]
+    private void OpenLogFolder()
+    {
+        try
+        {
+            Directory.CreateDirectory(App.Log.Directory);
+            Process.Start(new ProcessStartInfo(App.Log.Directory) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not open the log folder: {ex.Message}. It is at {App.Log.Directory}");
+        }
+    }
 }

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -256,16 +256,9 @@ public partial class BlobBrowserViewModel : ViewModelBase
     {
         var target = file ?? SelectedFile;
         if (target == null || SelectedContainer == null) return;
-        try
-        {
-            var url = BlobStorageService.BuildBlobUrl(SelectedContainer, target.BlobName);
-            Clipboard.SetText(url);
-            SetStatus("HTTPS path copied to clipboard (no SAS token).");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        TryCopyToClipboard(
+            BlobStorageService.BuildBlobUrl(SelectedContainer, target.BlobName),
+            "HTTPS path copied to clipboard (no SAS token).");
     }
 
     [RelayCommand]
@@ -273,16 +266,7 @@ public partial class BlobBrowserViewModel : ViewModelBase
     {
         var target = file ?? SelectedFile;
         if (target == null || SelectedContainer == null) return;
-        try
-        {
-            var containerName = SelectedContainer.ContainerName ?? "container";
-            var path = $"{containerName}/{target.BlobName}";
-            Clipboard.SetText(path);
-            SetStatus("Container path copied to clipboard.");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        var containerName = SelectedContainer.ContainerName ?? "container";
+        TryCopyToClipboard($"{containerName}/{target.BlobName}", "Container path copied to clipboard.");
     }
 }

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -258,9 +258,9 @@ public partial class BlobBrowserViewModel : ViewModelBase
         if (target == null || SelectedContainer == null) return;
         try
         {
-            var url = _blobService.BuildBlobUrlWithSas(SelectedContainer, target.BlobName);
+            var url = BlobStorageService.BuildBlobUrl(SelectedContainer, target.BlobName);
             Clipboard.SetText(url);
-            SetStatus("HTTPS path copied to clipboard.");
+            SetStatus("HTTPS path copied to clipboard (no SAS token).");
         }
         catch (Exception ex)
         {

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -11,6 +11,11 @@ public partial class BlobBrowserViewModel : ViewModelBase
 {
     private readonly BlobStorageService _blobService;
     private readonly CredentialStore _credentialStore;
+    private readonly OperationCancellation _loadCancellation = new();
+
+    /// <summary>True while a listing is running and has not been asked to stop (#25).</summary>
+    [ObservableProperty]
+    private bool _canCancelLoad;
 
     private List<BackupFileInfo> _allFiles = [];
     private List<BackupSet> _allSets = [];
@@ -135,11 +140,13 @@ public partial class BlobBrowserViewModel : ViewModelBase
             return;
         }
 
+        var ct = _loadCancellation.Begin();
         IsBusy = true;
+        CanCancelLoad = true;
         ClearStatus();
         try
         {
-            _allFiles = await _blobService.ListBackupFilesAsync(SelectedContainer);
+            _allFiles = await _blobService.ListBackupFilesAsync(SelectedContainer, ct);
             _allSets = _blobService.GroupIntoBackupSets(_allFiles);
             HasFiles = _allFiles.Count > 0;
 
@@ -158,6 +165,12 @@ public partial class BlobBrowserViewModel : ViewModelBase
             UpdateFilteredSummary();
             SetStatus($"Loaded {_allFiles.Count} files in {_allSets.Count} backup set(s) across {dbs.Count} database(s).");
         }
+        catch (OperationCanceledException)
+        {
+            // Listing is read-only, so there is nothing to undo or explain - just say it stopped.
+            SetStatus("Loading cancelled.");
+            HasFiles = false;
+        }
         catch (Exception ex)
         {
             SetError($"Failed to load backups: {ex.Message}");
@@ -165,8 +178,22 @@ public partial class BlobBrowserViewModel : ViewModelBase
         }
         finally
         {
+            _loadCancellation.End();
             IsBusy = false;
+            CanCancelLoad = false;
         }
+    }
+
+    /// <summary>
+    /// Stops an in-progress listing. A container with a large number of blobs is enumerated a page
+    /// at a time with no natural end, and until now there was no way out of it (#25).
+    /// </summary>
+    [RelayCommand]
+    private void CancelLoad()
+    {
+        _loadCancellation.Cancel();
+        CanCancelLoad = false;
+        SetStatus("Cancelling...");
     }
 
     private void RefreshDatabasesForServer()

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Models;
@@ -463,6 +464,18 @@ public partial class BlobConfigViewModel : ViewModelBase
     private void Delete()
     {
         if (SelectedContainer == null) return;
+
+        // Deleting takes the SAS token out of Credential Manager, and the token is never displayed
+        // anywhere in the app - so if it was the only copy, it is gone for good. That deserves a
+        // question rather than a single click (#42).
+        var confirm = MessageBox.Show(
+            $"Remove the container \"{SelectedContainer.Name}\"?\n\n" +
+            "Its stored SAS token will be deleted from Windows Credential Manager. The app never " +
+            "displays stored tokens, so if this is the only copy you will need to obtain a new one.\n\n" +
+            "Nothing in Azure is affected - no backups are deleted.",
+            "Nine Lives", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
+
+        if (confirm != MessageBoxResult.Yes) return;
 
         // Remove from the config first and only destroy the secret once that write has actually
         // landed. The other order threw the SAS token away and then, if the save failed, left the

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -189,18 +189,28 @@ public partial class BlobConfigViewModel : ViewModelBase
 
     private void UpdateSasExpiryStatus(BlobContainerConfig container)
     {
-        var expiry = _credentialStore.GetSasTokenExpiry(container);
-        if (expiry.HasValue)
+        var expiry = _credentialStore.ReadSasTokenExpiry(container);
+
+        if (expiry.CouldNotParse)
         {
-            IsSasExpired = expiry.Value < DateTime.UtcNow;
-            var remaining = expiry.Value - DateTime.UtcNow;
+            // The token states an expiry we cannot read, so we cannot say it is still valid.
+            // Showing this as "unknown" alongside everything else that is fine would be a lie of
+            // omission - the restore is the wrong place to discover it (#21).
+            SasExpiryText = "SAS token expiry could not be read - treat this token as expired and replace it";
+            IsSasExpired = true;
+        }
+        else if (expiry.ExpiresAt is { } expiresAt)
+        {
+            IsSasExpired = expiresAt < DateTime.UtcNow;
+            var remaining = expiresAt - DateTime.UtcNow;
             SasExpiryText = IsSasExpired
                 ? $"SAS token expired {-remaining.TotalHours:F0}h ago"
-                : $"SAS token expires in {remaining.TotalHours:F0}h ({expiry.Value:yyyy-MM-dd HH:mm} UTC)";
+                : $"SAS token expires in {remaining.TotalHours:F0}h ({expiresAt:yyyy-MM-dd HH:mm} UTC)";
         }
         else
         {
-            SasExpiryText = "SAS token expiry unknown";
+            // No se= at all, which is legitimate for a SAS built on a stored access policy.
+            SasExpiryText = "SAS token states no expiry";
             IsSasExpired = false;
         }
     }

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -122,11 +122,25 @@ public partial class BlobConfigViewModel : ViewModelBase
         }
     }
 
-    private void SaveContainers()
+    /// <summary>
+    /// Persists the container list. Returns false and sets the error when the write failed, so
+    /// callers do not go on to report success - the config save used to swallow everything and
+    /// the UI said "saved successfully" whether or not anything reached the disk.
+    /// </summary>
+    private bool SaveContainers()
     {
-        var config = _credentialStore.LoadConfig();
-        config.BlobContainers = [.. Containers];
-        _credentialStore.SaveConfig(config);
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            config.BlobContainers = [.. Containers];
+            _credentialStore.SaveConfig(config);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not save configuration: {ex.Message}");
+            return false;
+        }
     }
 
     partial void OnSelectedContainerChanged(BlobContainerConfig? value)
@@ -417,7 +431,14 @@ public partial class BlobConfigViewModel : ViewModelBase
         if (haveTokenToSave)
             _credentialStore.SaveSasToken(container, EditSasToken);
         // When editing and leaving SAS field empty, existing token is kept (never re-read or shown)
-        SaveContainers();
+        if (!SaveContainers())
+        {
+            // Nothing reached the disk, so do not leave the list showing a container that is not
+            // really there. Stay in the edit form so the save can be retried once whatever was
+            // holding the file has let go.
+            if (IsNew) Containers.Remove(container);
+            return;
+        }
 
         SelectedContainer = container;
         IsEditing = false;
@@ -430,9 +451,20 @@ public partial class BlobConfigViewModel : ViewModelBase
     private void Delete()
     {
         if (SelectedContainer == null) return;
-        _credentialStore.DeleteSecret(SelectedContainer.CredentialKey);
-        Containers.Remove(SelectedContainer);
-        SaveContainers();
+
+        // Remove from the config first and only destroy the secret once that write has actually
+        // landed. The other order threw the SAS token away and then, if the save failed, left the
+        // container in config.json pointing at a credential that no longer exists.
+        var removed = SelectedContainer;
+        Containers.Remove(removed);
+        if (!SaveContainers())
+        {
+            Containers.Add(removed);
+            SelectedContainer = removed;
+            return;
+        }
+
+        _credentialStore.DeleteSecret(removed.CredentialKey);
         SelectedContainer = Containers.FirstOrDefault();
         SetStatus("Container removed.");
     }

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -11,6 +11,11 @@ public partial class BlobConfigViewModel : ViewModelBase
 {
     private readonly CredentialStore _credentialStore;
     private readonly BlobStorageService _blobService;
+    private readonly OperationCancellation _testCancellation = new();
+
+    /// <summary>True while a connection test is running and has not been asked to stop (#25).</summary>
+    [ObservableProperty]
+    private bool _canCancelTest;
 
     [ObservableProperty]
     private ObservableCollection<BlobContainerConfig> _containers = [];
@@ -540,16 +545,26 @@ public partial class BlobConfigViewModel : ViewModelBase
 
         if (config == null) return;
 
+        // Test Connection sounds quick, but it enumerates the whole container to build the summary
+        // - 4000+ blobs on a real one - so it needs the same escape as the other listings (#25).
+        var ct = _testCancellation.Begin();
         IsBusy = true;
+        CanCancelTest = true;
         TestResult = string.Empty;
         try
         {
-            await _blobService.VerifyConnectionAsync(config);
-            var files = await _blobService.ListBackupFilesAsync(config);
+            await _blobService.VerifyConnectionAsync(config, ct);
+            var files = await _blobService.ListBackupFilesAsync(config, ct);
             var summary = _blobService.GetContainerSummary(files);
             ContainerSummary = summary;
             TestSuccess = true;
             TestResult = $"Connected! {summary.TotalFiles} files found ({summary.TotalSizeDisplay})";
+        }
+        catch (OperationCanceledException)
+        {
+            TestSuccess = false;
+            TestResult = "Cancelled.";
+            ContainerSummary = null;
         }
         catch (Exception ex)
         {
@@ -559,7 +574,18 @@ public partial class BlobConfigViewModel : ViewModelBase
         }
         finally
         {
+            _testCancellation.End();
             IsBusy = false;
+            CanCancelTest = false;
         }
+    }
+
+    /// <summary>Stops an in-progress connection test.</summary>
+    [RelayCommand]
+    private void CancelTest()
+    {
+        _testCancellation.Cancel();
+        CanCancelTest = false;
+        TestResult = "Cancelling...";
     }
 }

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -406,6 +406,8 @@ public partial class BlobConfigViewModel : ViewModelBase
             var agPattern = IsAgPathSectionVisible ? PathElement.BuildPattern(AgActivePathElements) : null;
             container = new BlobContainerConfig
             {
+                // Assigned here rather than defaulted on the model - see the note on Id.
+                Id = BlobContainerConfig.NewId(),
                 Name = EditName,
                 ContainerUrl = EditContainerUrl.TrimEnd('/'),
                 PathPattern = EditPathPattern,
@@ -498,9 +500,16 @@ public partial class BlobConfigViewModel : ViewModelBase
                 config = SelectedContainer; // Use stored token for test
             else
             {
-                config = new BlobContainerConfig { Name = EditName, ContainerUrl = EditContainerUrl };
-                if (!string.IsNullOrWhiteSpace(EditSasToken))
-                    _credentialStore.SaveSasToken(config, EditSasToken);
+                // In memory only. This used to call SaveSasToken, which is a durable write to
+                // Credential Manager - so pasting a typo'd or expired token, testing it, and
+                // clicking Cancel destroyed the working token that was there before, with no way
+                // to get it back because the form never displays stored tokens (#12).
+                config = new BlobContainerConfig
+                {
+                    Name = EditName,
+                    ContainerUrl = EditContainerUrl,
+                    UnsavedSasToken = string.IsNullOrWhiteSpace(EditSasToken) ? null : EditSasToken
+                };
             }
         }
         else

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -38,6 +38,12 @@ public partial class MainViewModel : ViewModelBase
     private string _updateUrl = UpdateChecker.ReleasesPage;
     private string? _updateTag;
 
+    /// <summary>
+    /// Shown in the status bar. Read from the assembly so it cannot go stale.
+    /// Not named AppVersion - that would shadow the class of the same name inside this type.
+    /// </summary>
+    public string VersionText => Services.AppVersion.Display;
+
     public BlobConfigViewModel BlobConfig { get; }
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -47,6 +47,12 @@ public partial class MainViewModel : ViewModelBase
     public MainViewModel()
     {
         _credentialStore = new CredentialStore();
+
+        // Before anything reads the config: move secrets from name-derived keys onto stable ids
+        // (#8). Must happen ahead of the child viewmodels, which load containers and servers in
+        // their constructors and would otherwise look up keys the migration is about to change.
+        MigrateSecretKeys();
+
         _blobService = new BlobStorageService(_credentialStore);
         _sqlService = new SqlServerService(_credentialStore);
         _chainBuilder = new BackupChainBuilder();
@@ -64,6 +70,29 @@ public partial class MainViewModel : ViewModelBase
 
         // Fire and forget - startup must not wait on the network.
         _ = CheckForUpdatesAsync();
+    }
+
+    /// <summary>
+    /// One-off relocation of stored secrets onto stable ids. A no-op on every launch after the
+    /// first, and never fatal - if it cannot complete, the old keys are untouched and everything
+    /// still works, so the app starts normally and tries again next time.
+    /// </summary>
+    private void MigrateSecretKeys()
+    {
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            var result = new ConfigMigrator(_credentialStore).Migrate(config);
+
+            if (result.Error != null)
+                GlobalStatus = $"Stored credentials could not be updated: {result.Error}";
+            else if (result.DidWork)
+                GlobalStatus = "Ready";
+        }
+        catch
+        {
+            // Startup must not depend on this.
+        }
     }
 
     private async Task CheckForUpdatesAsync()

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -208,6 +208,13 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isCancelling;
 
+    /// <summary>
+    /// Running count during a listing. A container of any size takes long enough that "Loading..."
+    /// on its own gives no sense of whether it is progressing or hung (#28).
+    /// </summary>
+    [ObservableProperty]
+    private string _loadProgressText = string.Empty;
+
     /// <summary>Pushes the cancellation sources' state onto the bound properties.</summary>
     private void RefreshCancelState()
     {
@@ -557,11 +564,22 @@ public partial class RestoreViewModel : ViewModelBase
 
         var ct = _loadCancellation.Begin();
         IsBusy = true;
+        LoadProgressText = "Scanning container...";
         RefreshCancelState();
         ClearStatus();
         try
         {
-            _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer, ct);
+            // If a database is already chosen - a reload after taking a fresh backup, say - push
+            // that down to Azure as a prefix instead of walking the whole container and discarding
+            // most of it. Measured on a real 4,440-blob container: about 1,075 ms unscoped versus
+            // about 233 ms for one database (#28).
+            //
+            // The FIRST load has no selection yet and stays a full scan, which it has to be: the
+            // server and database lists are built from what it finds.
+            var scope = BuildListingScope();
+            var progress = new Progress<int>(n => LoadProgressText = $"Scanned {n:N0} blobs...");
+
+            _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer, scope, progress, ct);
             _allSets = _blobService.GroupIntoBackupSets(_allBackups);
 
             var servers = _blobService.GetDiscoveredServers(_allBackups);
@@ -607,8 +625,29 @@ public partial class RestoreViewModel : ViewModelBase
         {
             _loadCancellation.End();
             IsBusy = false;
+            LoadProgressText = string.Empty;
             RefreshCancelState();
         }
+    }
+
+    /// <summary>
+    /// The scope to push down to Azure, or null to scan everything.
+    ///
+    /// Only offered when a database is chosen. A server on its own narrows far less and the
+    /// database list is built from the previous scan anyway, so scoping to a server alone would
+    /// mostly re-fetch what is already in memory.
+    /// </summary>
+    private BlobListingScope? BuildListingScope()
+    {
+        if (string.IsNullOrWhiteSpace(SelectedDatabaseName)) return null;
+
+        // ServerName here is the identity used in the PATH, which for an instance is the host
+        // part - "SRV01\PROD" lives under "SRV01". ServerIdentity knows how to split it.
+        var pathServer = string.IsNullOrWhiteSpace(SelectedServerName)
+            ? null
+            : SelectedServerName.Split('\\')[0];
+
+        return new BlobListingScope(pathServer, SelectedDatabaseName);
     }
 
     /// <summary>Stops an in-progress backup listing.</summary>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1393,9 +1393,19 @@ public partial class RestoreViewModel : ViewModelBase
                         AppendLog(change == CredentialChange.Created
                             ? "Credential created on the server."
                             : "Credential updated on the server.");
+
+                        // Changing a credential is a change to shared state on someone's instance.
+                        // It belongs in the file, not only in a console that closes with the app.
+                        App.Log.ServerChange(server.ServerName,
+                            $"credential [{SqlCredentialName}] {change.ToString().ToLowerInvariant()}");
                     }
                 }
             }
+
+            App.Log.ServerChange(server.ServerName,
+                $"restore starting: target [{TargetDatabaseName}], " +
+                $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={WithReplace}, " +
+                $"recovery={RecoveryMode}, stopAt={EffectiveStopAt?.ToString("s") ?? "none"}");
 
             AppendLog("Beginning restore execution...\n");
 
@@ -1498,9 +1508,17 @@ public partial class RestoreViewModel : ViewModelBase
             TryCopyToClipboard(action.Sql, "Recovery statement copied to clipboard.");
     }
 
+    /// <summary>
+    /// Appends to the on-screen console and to the log file at the same time.
+    ///
+    /// One call rather than two so the file cannot drift from what the user was shown - and so a
+    /// restore that ends with the window being closed still leaves a record of how far it got.
+    /// Redaction happens inside the log, not here (#40).
+    /// </summary>
     private void AppendLog(string message)
     {
         ExecutionLog += message + "\n";
+        App.Log.Info($"[execute] {message.Trim()}");
     }
 
     private async Task RunArmCountdownAsync(CancellationToken ct)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -155,6 +155,18 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _chainIssueSummary = string.Empty;
 
+    /// <summary>
+    /// Findings about the discovered backups as a whole rather than the selected chain - backups
+    /// that exist but can never be offered as a restore point. Kept apart from ChainIssues because
+    /// they do not change when the selection does, and because they explain a gap between what the
+    /// browse list shows and what the timeline offers.
+    /// </summary>
+    [ObservableProperty]
+    private ObservableCollection<ChainIssue> _inventoryIssues = [];
+
+    [ObservableProperty]
+    private bool _hasInventoryIssues;
+
     /// <summary>True once the chain has been checked against RESTORE HEADERONLY metadata.</summary>
     [ObservableProperty]
     private bool _chainLsnVerified;
@@ -542,6 +554,17 @@ public partial class RestoreViewModel : ViewModelBase
     private void ComputeAndDisplayRestorePoints()
     {
         var points = _chainBuilder.ComputeRestorePoints(_dbSets);
+
+        // Inventory-level findings: backups that exist but can never be offered. These belong to
+        // the discovered set rather than to any one chain, so they are held separately and survive
+        // changing the selected restore point.
+        //
+        // ValidateInventory was written for #62 and then never called, so orphaned differentials,
+        // orphaned logs and "no full backup at all" were being computed nowhere and shown nowhere.
+        InventoryIssues = new ObservableCollection<ChainIssue>(
+            _chainValidator.ValidateInventory(_dbSets)
+                .Concat(_chainValidator.ValidateReachability(_dbSets, points)));
+        HasInventoryIssues = InventoryIssues.Count > 0;
 
         // Compute timeline positions (0-1)
         if (points.Count > 1)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1375,6 +1375,14 @@ public partial class RestoreViewModel : ViewModelBase
                             ? $"Credential [{SqlCredentialName}] exists but is not a SAS credential - updating it..."
                             : $"Credential [{SqlCredentialName}] is missing - creating it...");
 
+                        // This statement carries the SAS token to the server. It is the one moment
+                        // in a restore where a secret crosses the wire, so if the connection is
+                        // encrypted but unverified, say so here rather than only in settings (#17).
+                        if (server.TrustServerCertificate)
+                            AppendLog(
+                                "  Note: this connection trusts the server certificate without validating it, " +
+                                "and the SAS token is sent over it.");
+
                         var change = await _sqlService.EnsureCredentialExistsAsync(
                             server, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Windows;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Win32;
@@ -215,6 +216,28 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _loadProgressText = string.Empty;
 
+    // ── Execution console ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The console, one line per entry. A collection rather than one growing string so appending
+    /// costs the same on the thousandth line as on the first.
+    /// </summary>
+    [ObservableProperty]
+    private ObservableCollection<ConsoleLine> _consoleLines = [];
+
+    [ObservableProperty]
+    private bool _hasConsoleOutput;
+
+    /// <summary>
+    /// True while the console is showing in its own window.
+    ///
+    /// The inline console hides itself for the duration, so the output is only ever in one place.
+    /// It comes back when the window closes, so the record of what happened is still reachable
+    /// from the main view afterwards.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isConsoleDetached;
+
     /// <summary>Pushes the cancellation sources' state onto the bound properties.</summary>
     private void RefreshCancelState()
     {
@@ -386,9 +409,6 @@ public partial class RestoreViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _isExecuting;
-
-    [ObservableProperty]
-    private string _executionLog = string.Empty;
 
     [ObservableProperty]
     private bool _executionComplete;
@@ -873,6 +893,12 @@ public partial class RestoreViewModel : ViewModelBase
 
     private void UpdateRestoreSummary()
     {
+        // Every option change already funnels through here, so it is also where the script is kept
+        // in step. It used to be built only when Generate Script was pressed, which meant the
+        // script on screen could quietly disagree with the settings above it - and the script is
+        // the thing people read before running a restore against production.
+        RegenerateScript();
+
         if (RestoreChain == null || string.IsNullOrWhiteSpace(TargetDatabaseName))
         {
             RestoreSummaryText = string.Empty;
@@ -1126,6 +1152,10 @@ public partial class RestoreViewModel : ViewModelBase
         CopyHeaderOnlyCommandCommand.NotifyCanExecuteChanged();
     }
 
+    /// <summary>
+    /// Explicit Generate. Same work as the live rebuild, but it says why nothing was produced -
+    /// the live path stays silent because reporting an error on every keystroke would be noise.
+    /// </summary>
     [RelayCommand]
     private void GenerateScript()
     {
@@ -1146,6 +1176,35 @@ public partial class RestoreViewModel : ViewModelBase
         if (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null)
         {
             SetError($"Point-in-time target is not valid. {PointInTimeMessage}");
+            return;
+        }
+
+        RegenerateScript();
+        if (HasScript) SetStatus("Script generated successfully.");
+    }
+
+    /// <summary>
+    /// Rebuilds the script from the current settings, silently.
+    ///
+    /// Called from UpdateRestoreSummary, so every option change keeps the script in step. It used
+    /// to be built only when Generate Script was pressed, which meant the script on screen could
+    /// quietly disagree with the settings above it - and that script is what people read before
+    /// running a restore against production.
+    ///
+    /// When the settings cannot produce a valid script the script is cleared rather than left
+    /// stale. A stale script is worse than none: it looks authoritative and is not.
+    /// </summary>
+    private void RegenerateScript()
+    {
+        // Leave the script alone mid-restore - it is the record of what is actually running.
+        if (IsExecuting) return;
+
+        if (RestoreChain == null
+            || string.IsNullOrWhiteSpace(TargetDatabaseName)
+            || (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null))
+        {
+            GeneratedScript = string.Empty;
+            HasScript = false;
             return;
         }
 
@@ -1192,7 +1251,6 @@ public partial class RestoreViewModel : ViewModelBase
 
         GeneratedScript = _scriptGenerator.Generate(RestoreChain, options);
         HasScript = true;
-        SetStatus("Script generated successfully.");
     }
 
     /// <summary>Create or update the blob credential on the connected server (optional; not included in generated script).</summary>
@@ -1432,7 +1490,8 @@ public partial class RestoreViewModel : ViewModelBase
         var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
         ExecutionComplete = false;
-        ExecutionLog = string.Empty;
+        ConsoleLines.Clear();
+        HasConsoleOutput = false;
         RecoveryActions = [];
         HasRecoveryActions = false;
         RefreshCancelState();
@@ -1511,7 +1570,12 @@ public partial class RestoreViewModel : ViewModelBase
             await _sqlService.ExecuteRestoreWithProgressAsync(
                 server,
                 GeneratedScript,
-                msg => Application.Current.Dispatcher.Invoke(() => AppendLog(msg)),
+                // InvokeAsync, not Invoke. This callback runs on the connection's thread when SQL
+                // Server sends an info message, and a synchronous Invoke BLOCKS that thread until
+                // the UI has finished handling it. With the UI busy re-rendering, progress backed
+                // up and then arrived in bursts - which is precisely what "not live" looked like.
+                // Posting instead lets the restore keep streaming while the UI catches up.
+                msg => Application.Current.Dispatcher.InvokeAsync(() => AppendLog(msg)),
                 executeToken);
 
             ExecutionSuccess = true;
@@ -1552,6 +1616,7 @@ public partial class RestoreViewModel : ViewModelBase
             _executeCancellation.End();
             IsExecuting = false;
             ExecutionComplete = true;
+            FlushConsole();   // nothing buffered may outlive the run
             RefreshCancelState();
         }
     }
@@ -1652,11 +1717,86 @@ public partial class RestoreViewModel : ViewModelBase
     /// restore that ends with the window being closed still leaves a record of how far it got.
     /// Redaction happens inside the log, not here (#40).
     /// </summary>
+    /// <summary>
+    /// Appends to the on-screen console and to the log file at the same time, so the file cannot
+    /// drift from what the user was shown.
+    ///
+    /// Writes to a COLLECTION rather than concatenating a bound string. Appending to a bound string
+    /// rebuilds it and re-renders the whole TextBox on every message - O(n^2) - which was a large
+    /// part of why a restore reporting progress every few percent looked like it arrived in bursts
+    /// rather than live.
+    /// </summary>
     private void AppendLog(string message)
     {
-        ExecutionLog += message + "\n";
+        foreach (var raw in message.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+
+            // Messages routinely arrive with a leading or trailing newline for spacing, and SQL
+            // Server's own output has its own blank lines. Left alone that produced a gap between
+            // almost every line. One blank line is allowed as a separator; runs of them are not.
+            if (line.Trim().Length == 0)
+            {
+                if (_pending.Count > 0 && _pending[^1].Text.Length == 0) continue;
+                if (_pending.Count == 0 && (ConsoleLines.Count == 0 || ConsoleLines[^1].Text.Length == 0)) continue;
+                _pending.Add(new ConsoleLine(string.Empty));
+                continue;
+            }
+
+            _pending.Add(ConsoleLine.From(line));
+        }
+
         App.Log.Info($"[execute] {message.Trim()}");
+        ScheduleConsoleFlush();
     }
+
+    /// <summary>
+    /// Moves buffered lines onto the bound collection on a timer rather than as they arrive.
+    ///
+    /// SQL Server emits progress in clusters - several messages within a millisecond, then nothing
+    /// for a second. Adding each one individually meant a layout pass and a scroll per message, in
+    /// bursts, which is what made the console judder. Flushing on a fixed tick turns any arrival
+    /// pattern into a steady redraw, and a whole cluster costs one layout pass instead of ten.
+    /// </summary>
+    private void ScheduleConsoleFlush()
+    {
+        if (_consoleFlushTimer != null) return;
+
+        _consoleFlushTimer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(60)
+        };
+        _consoleFlushTimer.Tick += (_, _) => FlushConsole();
+        _consoleFlushTimer.Start();
+    }
+
+    private void FlushConsole()
+    {
+        if (_pending.Count == 0)
+        {
+            // Nothing arriving and nothing running - stop ticking rather than spin forever.
+            if (!IsExecuting)
+            {
+                _consoleFlushTimer?.Stop();
+                _consoleFlushTimer = null;
+            }
+            return;
+        }
+
+        foreach (var line in _pending) ConsoleLines.Add(line);
+        _pending.Clear();
+        HasConsoleOutput = true;
+    }
+
+    private readonly List<ConsoleLine> _pending = [];
+    private DispatcherTimer? _consoleFlushTimer;
+
+    /// <summary>The console as plain text, for copying into a bug report.</summary>
+    public string ConsoleText => string.Join(Environment.NewLine, ConsoleLines.Select(l => l.Text));
+
+    [RelayCommand]
+    private void CopyConsole()
+        => TryCopyToClipboard(ConsoleText, "Execution log copied to clipboard.");
 
     private async Task RunArmCountdownAsync(CancellationToken ct)
     {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1081,10 +1081,12 @@ public partial class RestoreViewModel : ViewModelBase
 
         try
         {
-            await _sqlService.EnsureCredentialExistsAsync(
+            var change = await _sqlService.EnsureCredentialExistsAsync(
                 ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
             await RefreshCredentialStatusAsync();
-            SetStatus("Credential created or updated on server.");
+            SetStatus(change == CredentialChange.Created
+                ? "Credential created on server."
+                : "Credential updated on server with the stored SAS token.");
         }
         catch (Exception ex)
         {
@@ -1092,9 +1094,12 @@ public partial class RestoreViewModel : ViewModelBase
         }
     }
 
-    private bool CanCreateCredential() =>
-        IsConnectedToServer && SelectedContainer != null &&
-        (CredentialExistsOnServer != true || !CredentialIsValidSas);
+    // Deliberately available even when the credential is present and valid. SQL Server will not
+    // hand back a credential's secret, so "present and SAS" says nothing about whether the token
+    // inside it still works - a SAS that was rotated or has expired looks identical from here.
+    // Since Execute no longer rewrites the credential on every run, this button is the only way
+    // to push a fresh token, and hiding it left users with no route at all.
+    private bool CanCreateCredential() => IsConnectedToServer && SelectedContainer != null;
 
     [RelayCommand]
     private void CopyScript()
@@ -1331,11 +1336,16 @@ public partial class RestoreViewModel : ViewModelBase
 
         try
         {
-            var config = _credentialStore.LoadConfig();
-            var server = config.Servers.FirstOrDefault(s => s.ServerName == ConnectedServerName);
+            // Execute against the server we are actually connected to, not one looked up by name.
+            // This used to re-read config.json and take the first entry whose ServerName matched,
+            // which is a different object whenever two entries share a host and differ in auth,
+            // port or encryption - a Windows-auth and a SQL-auth entry for the same box, say. The
+            // restore would then run under credentials the user never connected with or tested.
+            // Every other server call on this screen already uses ConnectedServer.
+            var server = ConnectedServer;
             if (server == null)
             {
-                SetError("Connected server not found in config.");
+                SetError("Not connected to a server.");
                 return;
             }
 
@@ -1344,10 +1354,34 @@ public partial class RestoreViewModel : ViewModelBase
                 var sasToken = _credentialStore.GetSasToken(SelectedContainer);
                 if (!string.IsNullOrEmpty(sasToken))
                 {
-                    AppendLog("Creating SQL Server credential for blob access...");
-                    await _sqlService.EnsureCredentialExistsAsync(
-                        server, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
-                    AppendLog("Credential created successfully.");
+                    // Only write to the server when the credential is genuinely missing or is not
+                    // a SAS credential. This used to drop and recreate on every single execute,
+                    // regardless of the status the panel above was displaying, which contradicted
+                    // the UI's own "creating it is optional" wording and briefly removed a
+                    // credential that other sessions may have been using.
+                    //
+                    // A credential that exists and is SAS is left alone. Its secret could still be
+                    // a rotated SAS that no longer works - that is unknowable from here, since the
+                    // secret cannot be read back - so the fix for that case is the explicit
+                    // refresh button, not silently rewriting server state on every run.
+                    var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
+                    if (exists && isSas)
+                    {
+                        AppendLog($"Using the existing SQL credential [{SqlCredentialName}]. Server state not modified.");
+                    }
+                    else
+                    {
+                        AppendLog(exists
+                            ? $"Credential [{SqlCredentialName}] exists but is not a SAS credential - updating it..."
+                            : $"Credential [{SqlCredentialName}] is missing - creating it...");
+
+                        var change = await _sqlService.EnsureCredentialExistsAsync(
+                            server, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
+
+                        AppendLog(change == CredentialChange.Created
+                            ? "Credential created on the server."
+                            : "Credential updated on the server.");
+                    }
                 }
             }
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -62,6 +62,14 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _restoreWindowText = string.Empty;
 
+    /// <summary>
+    /// Left-hand label under the timeline. A plain property rather than the old
+    /// {Binding RestorePoints[0].Timestamp}, which threw an index error into WPF's binding trace
+    /// on every layout while the collection was empty.
+    /// </summary>
+    [ObservableProperty]
+    private string _timelineStartText = string.Empty;
+
     [ObservableProperty]
     private ObservableCollection<TimelineTick> _timelineTicks = [];
 
@@ -605,6 +613,7 @@ public partial class RestoreViewModel : ViewModelBase
             var first = points.First().Timestamp;
             var last = points.Last().Timestamp;
             RestoreWindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
+            TimelineStartText = $"{first:yyyy-MM-dd HH:mm}";
 
             // Compute time-interval tick marks
             TimelineTicks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -167,6 +167,20 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _hasInventoryIssues;
 
+    // ── Aftermath of a failed restore (#14) ─────────────────────────────────────
+    // A chain that stops part-way leaves the target in RESTORING, and in SINGLE_USER too if
+    // Disconnect sessions was on, because the closing SET MULTI_USER never ran. Both block other
+    // connections, at the worst possible moment.
+
+    [ObservableProperty]
+    private string _recoveryStateMessage = string.Empty;
+
+    [ObservableProperty]
+    private ObservableCollection<RecoveryAction> _recoveryActions = [];
+
+    [ObservableProperty]
+    private bool _hasRecoveryActions;
+
     /// <summary>True once the chain has been checked against RESTORE HEADERONLY metadata.</summary>
     [ObservableProperty]
     private bool _chainLsnVerified;
@@ -1126,45 +1140,23 @@ public partial class RestoreViewModel : ViewModelBase
 
     [RelayCommand]
     private void CopyScript()
-    {
-        if (!string.IsNullOrEmpty(GeneratedScript))
-        {
-            Clipboard.SetText(GeneratedScript);
-            SetStatus("Script copied to clipboard.");
-        }
-    }
+        => TryCopyToClipboard(GeneratedScript, "Script copied to clipboard.");
 
     [RelayCommand]
     private void CopyPathHttps(BackupFileInfo? file)
     {
         if (file == null || SelectedContainer == null) return;
-        try
-        {
-            var url = BlobStorageService.BuildBlobUrl(SelectedContainer, file.BlobName);
-            Clipboard.SetText(url);
-            SetStatus("HTTPS path copied to clipboard (no SAS token).");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        TryCopyToClipboard(
+            BlobStorageService.BuildBlobUrl(SelectedContainer, file.BlobName),
+            "HTTPS path copied to clipboard (no SAS token).");
     }
 
     [RelayCommand]
     private void CopyPathContainer(BackupFileInfo? file)
     {
         if (file == null || SelectedContainer == null) return;
-        try
-        {
-            var containerName = SelectedContainer.ContainerName ?? "container";
-            var path = $"{containerName}/{file.BlobName}";
-            Clipboard.SetText(path);
-            SetStatus("Container path copied to clipboard.");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        var containerName = SelectedContainer.ContainerName ?? "container";
+        TryCopyToClipboard($"{containerName}/{file.BlobName}", "Container path copied to clipboard.");
     }
 
     [RelayCommand(CanExecute = nameof(CanFetchLogicalNames))]
@@ -1270,15 +1262,7 @@ public partial class RestoreViewModel : ViewModelBase
         var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
         var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var sql = $"RESTORE FILELISTONLY FROM {urlClauses}";
-        try
-        {
-            Clipboard.SetText(sql);
-            SetStatus("RESTORE FILELISTONLY command copied to clipboard. Paste into SSMS to run.");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        TryCopyToClipboard(sql, "RESTORE FILELISTONLY command copied to clipboard. Paste into SSMS to run.");
     }
 
     /// <summary>Builds the exact T-SQL for RESTORE HEADERONLY (encoded URLs, no WITH CREDENTIAL) for pasting into SSMS.</summary>
@@ -1289,15 +1273,7 @@ public partial class RestoreViewModel : ViewModelBase
         var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
         var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var sql = $"RESTORE HEADERONLY FROM {urlClauses}";
-        try
-        {
-            Clipboard.SetText(sql);
-            SetStatus("RESTORE HEADERONLY command copied to clipboard. Paste into SSMS to run.");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to copy: {ex.Message}");
-        }
+        TryCopyToClipboard(sql, "RESTORE HEADERONLY command copied to clipboard. Paste into SSMS to run.");
     }
 
     [RelayCommand]
@@ -1312,10 +1288,18 @@ public partial class RestoreViewModel : ViewModelBase
             FileName = $"restore_{TargetDatabaseName}_{DateTime.Now:yyyyMMdd_HHmmss}.sql"
         };
 
-        if (dialog.ShowDialog() == true)
+        if (dialog.ShowDialog() != true) return;
+
+        try
         {
             File.WriteAllText(dialog.FileName, GeneratedScript);
             SetStatus($"Script saved to {dialog.FileName}");
+        }
+        catch (Exception ex)
+        {
+            // Read-only location, full disk, or a path the database name made invalid. Any of
+            // those used to take the whole app down from inside a synchronous command (#13).
+            SetError($"Could not save the script: {ex.Message}");
         }
     }
 
@@ -1432,12 +1416,89 @@ public partial class RestoreViewModel : ViewModelBase
             ExecutionSuccess = false;
             AppendLog($"\nERROR: {ex.Message}");
             SetError($"Restore failed: {ex.Message}");
+
+            // The restore has stopped part-way and the target is almost certainly not usable.
+            // Find out exactly how, and say so, while the connection is still open (#14).
+            if (ConnectedServer != null)
+                await ReportRecoveryStateAsync(ConnectedServer);
         }
         finally
         {
             IsExecuting = false;
             ExecutionComplete = true;
         }
+    }
+
+    /// <summary>
+    /// After a failed restore, works out what state the target database was left in and offers the
+    /// statements that put it right.
+    ///
+    /// This is the moment of maximum stress - a restore has failed mid-incident and the database is
+    /// now in a state that blocks other connections. Leaving someone to work that out from a raw
+    /// SQL error, when the app is still holding the connection that could tell them, is the wrong
+    /// place to stop.
+    /// </summary>
+    private async Task ReportRecoveryStateAsync(ServerConnection server)
+    {
+        RecoveryActions = [];
+        HasRecoveryActions = false;
+        RecoveryStateMessage = string.Empty;
+
+        try
+        {
+            var state = await _sqlService.GetDatabaseRecoveryStateAsync(server, TargetDatabaseName);
+            if (!state.NeedsAttention)
+            {
+                if (!state.Exists)
+                    AppendLog($"\n[{TargetDatabaseName}] is not on the server - nothing was left behind.");
+                return;
+            }
+
+            RecoveryStateMessage = state.Explain(TargetDatabaseName);
+            RecoveryActions = new ObservableCollection<RecoveryAction>(
+                state.SuggestedActions(TargetDatabaseName));
+            HasRecoveryActions = RecoveryActions.Count > 0;
+
+            AppendLog($"\n{RecoveryStateMessage}");
+            foreach (var action in RecoveryActions)
+                AppendLog($"\n  {action.Title}:  {action.Sql}");
+        }
+        catch (Exception ex)
+        {
+            // Best effort. The restore failure is the news; failing to describe the aftermath must
+            // not replace the error the user actually needs to read.
+            AppendLog($"\nCould not check the state of [{TargetDatabaseName}]: {ex.Message}");
+        }
+    }
+
+    /// <summary>Runs one remediation the user picked, then re-reads the state.</summary>
+    [RelayCommand]
+    private async Task RunRecoveryActionAsync(RecoveryAction? action)
+    {
+        if (action == null || ConnectedServer == null) return;
+
+        try
+        {
+            AppendLog($"\nRunning: {action.Sql}");
+            await _sqlService.ExecuteRecoveryActionAsync(ConnectedServer, action.Sql);
+            AppendLog("Completed.");
+            await ReportRecoveryStateAsync(ConnectedServer);
+
+            if (!HasRecoveryActions)
+                SetStatus($"[{TargetDatabaseName}] is back to a usable state.");
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"\nERROR: {ex.Message}");
+            SetError($"Recovery step failed: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    private void CopyRecoveryAction(RecoveryAction? action)
+    {
+        if (action != null)
+            TryCopyToClipboard(action.Sql, "Recovery statement copied to clipboard.");
     }
 
     private void AppendLog(string message)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -23,6 +23,11 @@ public partial class RestoreViewModel : ViewModelBase
     private List<BackupSet> _allSets = [];
     private List<BackupSet> _dbSets = [];
 
+    // Two separate operations, two separate sources: browsing a container and running a restore
+    // can both be in flight, and cancelling one must not touch the other (#25).
+    private readonly OperationCancellation _loadCancellation = new();
+    private readonly OperationCancellation _executeCancellation = new();
+
     #region Observable Properties
 
     [ObservableProperty]
@@ -188,6 +193,28 @@ public partial class RestoreViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _hasRecoveryActions;
+
+    // ── Cancellation (#25) ──────────────────────────────────────────────────────
+
+    /// <summary>True while a backup listing is running and has not been asked to stop.</summary>
+    [ObservableProperty]
+    private bool _canCancelLoad;
+
+    /// <summary>True while a restore is running and has not been asked to stop.</summary>
+    [ObservableProperty]
+    private bool _canCancelExecute;
+
+    /// <summary>True between asking to stop and the operation actually unwinding.</summary>
+    [ObservableProperty]
+    private bool _isCancelling;
+
+    /// <summary>Pushes the cancellation sources' state onto the bound properties.</summary>
+    private void RefreshCancelState()
+    {
+        CanCancelLoad = _loadCancellation.CanCancel;
+        CanCancelExecute = _executeCancellation.CanCancel;
+        IsCancelling = _loadCancellation.IsCancelling || _executeCancellation.IsCancelling;
+    }
 
     /// <summary>True once the chain has been checked against RESTORE HEADERONLY metadata.</summary>
     [ObservableProperty]
@@ -528,11 +555,13 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
+        var ct = _loadCancellation.Begin();
         IsBusy = true;
+        RefreshCancelState();
         ClearStatus();
         try
         {
-            _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer);
+            _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer, ct);
             _allSets = _blobService.GroupIntoBackupSets(_allBackups);
 
             var servers = _blobService.GetDiscoveredServers(_allBackups);
@@ -562,6 +591,13 @@ public partial class RestoreViewModel : ViewModelBase
 
             SetStatus($"Loaded {_allBackups.Count} files in {_allSets.Count} backup set(s) across {dbs.Count} database(s).");
         }
+        catch (OperationCanceledException)
+        {
+            // Asked for, not a failure. Nothing was written anywhere - listing is read-only - so
+            // there is nothing to explain beyond saying it stopped.
+            SetStatus("Loading cancelled.");
+            BackupsLoaded = false;
+        }
         catch (Exception ex)
         {
             SetError($"Failed to load backups: {ex.Message}");
@@ -569,8 +605,19 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _loadCancellation.End();
             IsBusy = false;
+            RefreshCancelState();
         }
+    }
+
+    /// <summary>Stops an in-progress backup listing.</summary>
+    [RelayCommand]
+    private void CancelLoad()
+    {
+        _loadCancellation.Cancel();
+        RefreshCancelState();
+        SetStatus("Cancelling...");
     }
 
     private void ComputeAndDisplayRestorePoints()
@@ -1343,9 +1390,13 @@ public partial class RestoreViewModel : ViewModelBase
         IsExecuteArmed = false;
         ExecuteButtonText = "Execute on Server";
 
+        var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
         ExecutionComplete = false;
         ExecutionLog = string.Empty;
+        RecoveryActions = [];
+        HasRecoveryActions = false;
+        RefreshCancelState();
 
         try
         {
@@ -1421,11 +1472,30 @@ public partial class RestoreViewModel : ViewModelBase
             await _sqlService.ExecuteRestoreWithProgressAsync(
                 server,
                 GeneratedScript,
-                msg => Application.Current.Dispatcher.Invoke(() => AppendLog(msg)));
+                msg => Application.Current.Dispatcher.Invoke(() => AppendLog(msg)),
+                executeToken);
 
             ExecutionSuccess = true;
             AppendLog("\nRestore completed successfully!");
             SetStatus("Restore execution completed successfully.");
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancelling a restore is not the same as never having run it. SqlCommand.Cancel stops
+            // the client waiting and SQL Server rolls back the statement that was in flight, but
+            // the target stays mid-restore - so this must be as loud as a failure, and it goes
+            // through the same recovery guidance (#14, #25).
+            ExecutionSuccess = false;
+            AppendLog("\nCANCELLED. The statement in flight was rolled back by SQL Server, but the " +
+                      "restore stopped part-way through the chain.");
+
+            App.Log.ServerChange(ConnectedServer?.ServerName ?? "unknown",
+                $"restore CANCELLED by user, target [{TargetDatabaseName}]");
+
+            SetError("Restore cancelled. The target database has been left mid-restore - see below.");
+
+            if (ConnectedServer != null)
+                await ReportRecoveryStateAsync(ConnectedServer);
         }
         catch (Exception ex)
         {
@@ -1440,9 +1510,28 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _executeCancellation.End();
             IsExecuting = false;
             ExecutionComplete = true;
+            RefreshCancelState();
         }
+    }
+
+    /// <summary>
+    /// Stops a running restore.
+    ///
+    /// Deliberately worded as a warning rather than a neutral action: stopping a restore part-way
+    /// leaves the target database in RESTORING, which is not a state anyone wants to discover by
+    /// accident. The recovery panel that appears afterwards explains how to get out of it.
+    /// </summary>
+    [RelayCommand]
+    private void CancelExecute()
+    {
+        if (!_executeCancellation.CanCancel) return;
+
+        _executeCancellation.Cancel();
+        RefreshCancelState();
+        AppendLog("\nCancellation requested - waiting for SQL Server to roll back the current statement...");
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1117,9 +1117,9 @@ public partial class RestoreViewModel : ViewModelBase
         if (file == null || SelectedContainer == null) return;
         try
         {
-            var url = _blobService.BuildBlobUrlWithSas(SelectedContainer, file.BlobName);
+            var url = BlobStorageService.BuildBlobUrl(SelectedContainer, file.BlobName);
             Clipboard.SetText(url);
-            SetStatus("HTTPS path copied to clipboard.");
+            SetStatus("HTTPS path copied to clipboard (no SAS token).");
         }
         catch (Exception ex)
         {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -872,10 +872,7 @@ public partial class RestoreViewModel : ViewModelBase
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 try
                 {
-                    // credentialName is null on purpose: WITH CREDENTIAL is invalid for a SAS
-                    // credential, which is the only kind this app creates.
-                    var header = await _sqlService.RestoreHeaderOnlyMultiAsync(
-                        ConnectedServer, urls, credentialName: null);
+                    var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls);
                     headers.Add(new ChainHeader(set, header));
                 }
                 catch (Exception)
@@ -1170,7 +1167,7 @@ public partial class RestoreViewModel : ViewModelBase
         {
             // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
             var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls, credentialName: null, urlsContainSas: false);
+            var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls);
 
             var dataDir = Path.GetDirectoryName(MoveDataFilePath) ?? @"C:\SQL\Data";
             var logDir = Path.GetDirectoryName(MoveLogFilePath) ?? dataDir;
@@ -1218,7 +1215,7 @@ public partial class RestoreViewModel : ViewModelBase
         {
             // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
             var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls, credentialName: null, urlsContainSas: false);
+            var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls);
 
             if (header == null)
             {

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -301,6 +301,25 @@ public partial class ServerManagerViewModel : ViewModelBase
             TestSuccess = true;
             TestResult = $"Connected successfully!\n{firstLine}";
 
+            // While we are here, find out whether trusting the certificate is actually needed.
+            // See WouldConnectWithCertificateValidationAsync - the point is to replace a warning
+            // people learn to ignore with a fact they can act on (#17).
+            if (server.TrustServerCertificate)
+            {
+                var wouldValidate = await _sqlService.WouldConnectWithCertificateValidationAsync(server);
+                TestResult += wouldValidate switch
+                {
+                    true => "\n\nThis server's certificate validates. You can untick "
+                          + "\"Trust server certificate\" - nothing will break, and the password "
+                          + "and SAS token will no longer be sent over an unverified connection.",
+                    false => "\n\nNote: the certificate does not validate, so \"Trust server "
+                           + "certificate\" is doing real work here. The connection is still "
+                           + "encrypted, but it is not verified - a machine-in-the-middle on the "
+                           + "network path could read the password and SAS token.",
+                    null => string.Empty
+                };
+            }
+
             // Test Connection already proves the server and reads the banner, so record the
             // version tag from it too. BuildCurrentServer returns a throwaway object built from
             // the edit form, so the value has to be written back to the SAVED entry - otherwise

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Models;
@@ -252,6 +253,19 @@ public partial class ServerManagerViewModel : ViewModelBase
     private void Delete()
     {
         if (SelectedServer == null) return;
+
+        // Same reasoning as deleting a container: a stored SQL password is removed from Credential
+        // Manager and the app never displays it, so a single click should not be enough (#42).
+        var secretNote = SelectedServer.AuthMode == AuthMode.SqlAuth
+            ? "\n\nIts stored SQL password will be deleted from Windows Credential Manager."
+            : string.Empty;
+
+        var confirm = MessageBox.Show(
+            $"Remove the server \"{SelectedServer.Name}\"?{secretNote}\n\n" +
+            "Nothing on the SQL Server itself is affected.",
+            "Nine Lives", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
+
+        if (confirm != MessageBoxResult.Yes) return;
 
         // Take the server out of the config first and only destroy its stored password once that
         // write has landed. The other order threw the password away and then, if the save failed,

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -85,11 +85,25 @@ public partial class ServerManagerViewModel : ViewModelBase
         Servers = new ObservableCollection<ServerConnection>(config.Servers);
     }
 
-    private void SaveServers()
+    /// <summary>
+    /// Persists the server list. Returns false and sets the error when the write failed, so
+    /// callers do not go on to report success - the config save used to swallow everything and
+    /// the UI said "saved successfully" whether or not anything reached the disk.
+    /// </summary>
+    private bool SaveServers()
     {
-        var config = _credentialStore.LoadConfig();
-        config.Servers = [.. Servers];
-        _credentialStore.SaveConfig(config);
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            config.Servers = [.. Servers];
+            _credentialStore.SaveConfig(config);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not save configuration: {ex.Message}");
+            return false;
+        }
     }
 
     /// <summary>
@@ -220,7 +234,14 @@ public partial class ServerManagerViewModel : ViewModelBase
             _credentialStore.SaveSqlPassword(server, EditPassword);
         }
 
-        SaveServers();
+        if (!SaveServers())
+        {
+            // Nothing reached the disk, so do not leave the list showing a server that is not
+            // really there. Stay in the edit form so the save can be retried.
+            if (IsNew) Servers.Remove(server);
+            return;
+        }
+
         SelectedServer = server;
         IsEditing = false;
         SetStatus("Server saved successfully.");
@@ -231,10 +252,23 @@ public partial class ServerManagerViewModel : ViewModelBase
     {
         if (SelectedServer == null) return;
 
-        if (SelectedServer.AuthMode == AuthMode.SqlAuth)
-            _credentialStore.DeleteSecret(SelectedServer.CredentialKey);
+        // Take the server out of the config first and only destroy its stored password once that
+        // write has landed. The other order threw the password away and then, if the save failed,
+        // left the server in config.json with no credential behind it.
+        var removed = SelectedServer;
+        var index = Servers.IndexOf(removed);
+        Servers.Remove(removed);
+        if (!SaveServers())
+        {
+            Servers.Insert(Math.Clamp(index, 0, Servers.Count), removed);
+            SelectedServer = removed;
+            return;
+        }
 
-        if (IsConnected && ConnectedServerDisplay == SelectedServer.DisplayText)
+        if (removed.AuthMode == AuthMode.SqlAuth)
+            _credentialStore.DeleteSecret(removed.CredentialKey);
+
+        if (IsConnected && ConnectedServerDisplay == removed.DisplayText)
         {
             IsConnected = false;
             ConnectedServerDisplay = string.Empty;
@@ -245,8 +279,6 @@ public partial class ServerManagerViewModel : ViewModelBase
             });
         }
 
-        Servers.Remove(SelectedServer);
-        SaveServers();
         SelectedServer = Servers.FirstOrDefault();
         SetStatus("Server removed.");
     }

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -210,7 +210,8 @@ public partial class ServerManagerViewModel : ViewModelBase
                 SetError("A server with this name already exists.");
                 return;
             }
-            server = new ServerConnection();
+            // Id assigned here rather than defaulted on the model - see the note on it.
+            server = new ServerConnection { Id = ServerConnection.NewId() };
             Servers.Add(server);
         }
         else
@@ -386,8 +387,15 @@ public partial class ServerManagerViewModel : ViewModelBase
                 TrustServerCertificate = EditTrustServerCert,
                 Encrypt = EditEncrypt
             };
+            // In memory only. This used to call SaveSqlPassword, which is a durable write to
+            // Credential Manager - so testing a mistyped password overwrote the working one
+            // before the user had agreed to anything, and Cancel could not undo it (#12).
             if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
-                _credentialStore.SaveSqlPassword(server, EditPassword);
+                server.UnsavedPassword = EditPassword;
+            else if (EditAuthMode == AuthMode.SqlAuth && !IsNew)
+                // No new password typed: test against the one already saved for this entry.
+                server.Id = SelectedServer?.Id;
+
             return server;
         }
         return SelectedServer;

--- a/src/NineLives/ViewModels/ViewModelBase.cs
+++ b/src/NineLives/ViewModels/ViewModelBase.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Blackcat.NineLives.ViewModels;
@@ -51,5 +52,33 @@ public abstract partial class ViewModelBase : ObservableObject
         StatusMessage = string.Empty;
         HasError = false;
         ErrorMessage = string.Empty;
+    }
+
+    /// <summary>
+    /// Puts text on the clipboard, reporting failure through the status surface instead of
+    /// throwing out of a synchronous command and taking the process with it (#13).
+    ///
+    /// Clipboard.SetText throwing is an ordinary Windows condition, not an exceptional one -
+    /// another process holding the clipboard lock is routine with remote desktop sessions and
+    /// clipboard managers, and it was reproduced while the issue was being written. A failed copy
+    /// deserves a line in the status bar, not a crash.
+    /// </summary>
+    protected bool TryCopyToClipboard(string? text, string successMessage)
+    {
+        if (string.IsNullOrEmpty(text)) return false;
+
+        try
+        {
+            Clipboard.SetText(text);
+            SetStatus(successMessage);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            SetError(
+                $"Could not copy to the clipboard: {ex.Message}. " +
+                "Another application may be holding it - try again in a moment.");
+            return false;
+        }
     }
 }

--- a/src/NineLives/Views/AboutView.xaml
+++ b/src/NineLives/Views/AboutView.xaml
@@ -54,6 +54,23 @@
                     </Hyperlink>
                 </TextBlock>
 
+                <!-- The logs are what someone attaches to a bug report, so there has to be a way
+                     to find them that is not "know where LocalAppData lives" (#40). -->
+                <Button Content="Open log folder"
+                        Command="{Binding OpenLogFolderCommand}"
+                        Style="{StaticResource SecondaryButton}"
+                        Padding="10,6"
+                        HorizontalAlignment="Center"
+                        Margin="0,0,0,12"
+                        ToolTip="{Binding LogFolder}" />
+
+                <TextBlock Text="{Binding ErrorMessage}"
+                           Style="{StaticResource SecondaryText}"
+                           TextWrapping="Wrap"
+                           HorizontalAlignment="Center"
+                           Margin="0,0,0,12"
+                           Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}" />
+
                 <TextBlock HorizontalAlignment="Center"
                            Style="{StaticResource SecondaryText}">
                     <Run Text="&#x00A9; " />

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -243,6 +243,14 @@
                         <TextBlock Text="Loading backup files..."
                                    Style="{StaticResource BodyText}"
                                    HorizontalAlignment="Center" />
+                        <!-- A container with a large number of blobs is enumerated a page at a
+                             time and there was previously no way out of it (#25). -->
+                        <Button Content="Cancel"
+                                Style="{StaticResource SecondaryButton}"
+                                Command="{Binding CancelLoadCommand}"
+                                Visibility="{Binding CanCancelLoad, Converter={StaticResource BoolToVis}}"
+                                Padding="10,6" Margin="0,10,0,0"
+                                HorizontalAlignment="Center" />
                     </StackPanel>
                 </Border>
             </Grid>

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -204,6 +204,13 @@
                                             Style="{StaticResource PrimaryButton}"
                                             Command="{Binding TestConnectionCommand}"
                                             Margin="0,0,8,0" />
+                                    <!-- "Stop test" rather than "Cancel": there is already a
+                                         Cancel on this screen and it means cancel the edit. -->
+                                    <Button Content="Stop test"
+                                            Style="{StaticResource SecondaryButton}"
+                                            Command="{Binding CancelTestCommand}"
+                                            Visibility="{Binding CanCancelTest, Converter={StaticResource BoolToVis}}"
+                                            Margin="0,0,8,0" />
                                     <Button Content="Delete"
                                             Style="{StaticResource DangerButton}"
                                             Command="{Binding DeleteCommand}" />
@@ -606,6 +613,11 @@
                                 <Button Content="Test Connection"
                                         Style="{StaticResource PrimaryButton}"
                                         Command="{Binding TestConnectionCommand}"
+                                        Margin="0,0,8,0" />
+                                <Button Content="Stop test"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Command="{Binding CancelTestCommand}"
+                                        Visibility="{Binding CanCancelTest, Converter={StaticResource BoolToVis}}"
                                         Margin="0,0,8,0" />
                                 <Button Content="Cancel"
                                         Style="{StaticResource SecondaryButton}"

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -1,0 +1,155 @@
+<Window x:Class="Blackcat.NineLives.Views.ExecutionWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
+        Title="Nine Lives - restore in progress"
+        Width="980" Height="620"
+        MinWidth="640" MinHeight="380"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        Background="{StaticResource WindowBackgroundBrush}"
+        Closing="OnClosing">
+
+    <Window.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+    </Window.Resources>
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- What is being restored, and where. The one thing worth reading at a glance. -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,12">
+            <TextBlock Text="RESTORE IN PROGRESS" Style="{StaticResource LabelText}" />
+            <TextBlock Text="{Binding RestoreSummaryText}"
+                       Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap" Margin="0,4,0,0" />
+        </StackPanel>
+
+        <Border Grid.Row="1" CornerRadius="6"
+                Background="{StaticResource ConsoleBackgroundBrush}"
+                BorderBrush="{StaticResource ConsoleBorderBrush}"
+                BorderThickness="1">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0"
+                        Background="{StaticResource ConsoleChromeBrush}"
+                        CornerRadius="5,5,0,0"
+                        BorderBrush="{StaticResource ConsoleBorderBrush}"
+                        BorderThickness="0,0,0,1"
+                        Padding="12,7">
+                    <Grid>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <Ellipse Width="9" Height="9" Margin="0,0,7,0">
+                                <Ellipse.Style>
+                                    <Style TargetType="Ellipse">
+                                        <Setter Property="Fill" Value="{StaticResource ConsoleMutedBrush}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsExecuting}" Value="True">
+                                                <Setter Property="Fill" Value="{StaticResource ConsoleSuccessBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Ellipse.Style>
+                            </Ellipse>
+                            <TextBlock Text="restore console"
+                                       Foreground="{StaticResource ConsoleMutedBrush}"
+                                       FontFamily="{StaticResource ConsoleFont}"
+                                       FontSize="11" VerticalAlignment="Center" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                            <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
+                                       Foreground="{StaticResource ConsoleMutedBrush}"
+                                       FontFamily="{StaticResource ConsoleFont}"
+                                       FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0" />
+                            <Button Content="Copy output"
+                                    Command="{Binding CopyConsoleCommand}"
+                                    Style="{StaticResource SecondaryButton}"
+                                    Padding="8,2" FontSize="11" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
+
+                <!-- ListBox, not an ItemsControl inside a ScrollViewer: an ItemsControl given
+                     unbounded height realises every row and virtualisation silently does nothing.
+                     A ListBox brings its own virtualising scroll viewer. -->
+                <ListBox Grid.Row="1" x:Name="ConsoleList"
+                         ItemsSource="{Binding ConsoleLines}"
+                         Style="{StaticResource ConsoleListBox}" />
+            </Grid>
+        </Border>
+
+        <!-- What a failed or cancelled restore left behind (#14). -->
+        <Border Grid.Row="2" CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1"
+                Visibility="{Binding HasRecoveryActions, Converter={StaticResource BoolToVis}}">
+            <StackPanel>
+                <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
+                           Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                <TextBlock Text="{Binding RecoveryStateMessage}"
+                           Style="{StaticResource BodyText}"
+                           TextWrapping="Wrap" Margin="0,0,0,10" />
+                <ItemsControl ItemsSource="{Binding RecoveryActions}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="{StaticResource InputBackgroundBrush}"
+                                    CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
+                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                               TextWrapping="Wrap" />
+                                    <TextBox Text="{Binding Sql, Mode=OneWay}"
+                                             Style="{StaticResource DarkTextBox}"
+                                             IsReadOnly="True" TextWrapping="Wrap"
+                                             FontFamily="{StaticResource ConsoleFont}"
+                                             FontSize="12" Margin="0,6,0,6" />
+                                    <TextBlock Text="{Binding Caution}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap" Margin="0,0,0,8" />
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Content="Run this"
+                                                Command="{Binding DataContext.RunRecoveryActionCommand,
+                                                          RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="10,6" Margin="0,0,8,0" />
+                                        <Button Content="Copy"
+                                                Command="{Binding DataContext.CopyRecoveryActionCommand,
+                                                          RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="10,6" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Stop restore"
+                    Command="{Binding CancelExecuteCommand}"
+                    Style="{StaticResource DangerButton}"
+                    Visibility="{Binding CanCancelExecute, Converter={StaticResource BoolToVis}}"
+                    Padding="14,7" Margin="0,0,8,0"
+                    ToolTip="Asks SQL Server to abort the statement in flight. It rolls that statement back, but the target database is left mid-restore." />
+            <!-- Enabled only once it has finished. Closing mid-restore would hide the one thing
+                 worth watching without stopping anything. -->
+            <Button Content="Close"
+                    Click="OnClose"
+                    Style="{StaticResource SecondaryButton}"
+                    IsEnabled="{Binding ExecutionComplete}"
+                    Padding="20,7" MinWidth="90" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/NineLives/Views/ExecutionWindow.xaml.cs
+++ b/src/NineLives/Views/ExecutionWindow.xaml.cs
@@ -1,0 +1,91 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Blackcat.NineLives.ViewModels;
+
+namespace Blackcat.NineLives.Views;
+
+/// <summary>
+/// The console, front and centre while a restore runs.
+///
+/// Modal on purpose. A restore is the one operation in this app that cannot be undone and should
+/// not be competing for attention with the form behind it - and it stops someone changing the
+/// options that produced the script currently executing.
+/// </summary>
+public partial class ExecutionWindow : Window
+{
+    private const double FollowThreshold = 40;
+
+    private readonly RestoreViewModel _viewModel;
+    private ScrollViewer? _scroller;
+    private bool _follow = true;
+
+    public ExecutionWindow(RestoreViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = _viewModel = viewModel;
+
+        viewModel.ConsoleLines.CollectionChanged += OnConsoleLinesChanged;
+        ConsoleList.Loaded += (_, _) => HookScroller();
+        Closed += (_, _) => viewModel.ConsoleLines.CollectionChanged -= OnConsoleLinesChanged;
+    }
+
+    private void HookScroller()
+    {
+        _scroller = FindScroller(ConsoleList);
+        if (_scroller != null) _scroller.ScrollChanged += OnScrollChanged;
+    }
+
+    private static ScrollViewer? FindScroller(DependencyObject root)
+    {
+        if (root is ScrollViewer found) return found;
+
+        var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var result = FindScroller(System.Windows.Media.VisualTreeHelper.GetChild(root, i));
+            if (result != null) return result;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Follows the tail while the user is at the bottom, and stops the moment they scroll up.
+    ///
+    /// One scroll per batch of arrivals, not one per line - the viewmodel already flushes output on
+    /// a timer, so this rides that rhythm instead of fighting it.
+    /// </summary>
+    private void OnConsoleLinesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action != NotifyCollectionChangedAction.Add || !_follow) return;
+
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            if (ConsoleList.Items.Count > 0)
+                ConsoleList.ScrollIntoView(ConsoleList.Items[^1]);
+        }), DispatcherPriority.Background);
+    }
+
+    private void OnScrollChanged(object sender, ScrollChangedEventArgs e)
+    {
+        if (sender is not ScrollViewer viewer) return;
+
+        // Only reconsider when the user moved, not when new output changed the extent.
+        if (e.ExtentHeightChange != 0) return;
+
+        _follow = viewer.ExtentHeight - viewer.VerticalOffset - viewer.ViewportHeight <= FollowThreshold;
+    }
+
+    private void OnClose(object sender, RoutedEventArgs e) => Close();
+
+    /// <summary>
+    /// Refuses to close mid-restore. Closing would not stop anything - it would just hide it - and
+    /// the Stop button is right there for someone who actually wants it to end.
+    /// </summary>
+    private void OnClosing(object? sender, CancelEventArgs e)
+    {
+        if (_viewModel.IsExecuting) e.Cancel = true;
+    }
+}

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -766,15 +766,31 @@
                                         </Border>
                                         <TextBlock Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
-                                            <Run Text="Restore from URL requires a SQL credential (SHARED ACCESS SIGNATURE) for the container. Creating it is optional: you can create it from here or ensure it exists on the server before running the script. The SAS token is never included in the generated script." />
+                                            <Run Text="Restore from URL requires a SQL credential (SHARED ACCESS SIGNATURE) for the container. You can create it from here, or create it on the server yourself before running the script. Execute will create it for you if it is missing. The SAS token is never included in the generated script." />
                                         </TextBlock>
-                                        <Button Content="Create credential on server"
-                                                Command="{Binding CreateCredentialOnServerCommand}"
-                                                Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                        <!-- Stays available once the credential is valid, because "valid" only means a SAS
+                                             credential of that name exists. SQL Server will not return its secret, so a
+                                             rotated or expired token is indistinguishable from a working one, and this is
+                                             the only way to push a fresh one. -->
+                                        <TextBlock Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}}"
+                                                   Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
+                                            <Run Text="Execute will leave this credential alone. If the SAS token has been rotated or has expired since the credential was created, the restore will fail on blob access - refresh it below to push the token currently stored for this container." />
+                                        </TextBlock>
+                                        <Button Command="{Binding CreateCredentialOnServerCommand}"
                                                 Margin="0,0,0,0" Padding="10,6"
-                                                Style="{StaticResource SecondaryButton}"
-                                                ToolTip="Creates or updates a SQL Server credential for this blob container URL so that RESTORE FROM URL can access the backups. Optional; the credential can also be created manually on the server. The SAS token is not included in the generated script."
-                                                HorizontalAlignment="Left" />
+                                                ToolTip="Creates the SQL Server credential for this blob container URL, or updates an existing one with the SAS token currently stored for the container, so that RESTORE FROM URL can access the backups. An existing credential is altered in place, never dropped. The SAS token is not included in the generated script."
+                                                HorizontalAlignment="Left">
+                                            <Button.Style>
+                                                <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
+                                                    <Setter Property="Content" Value="Create credential on server" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding CredentialIsValidSas}" Value="True">
+                                                            <Setter Property="Content" Value="Refresh credential with stored SAS token" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Button.Style>
+                                        </Button>
                                     </StackPanel>
                                 </StackPanel>
                             </Border>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -114,6 +114,42 @@
                 </StackPanel>
             </Border>
 
+            <!-- Findings about the discovered backups rather than the selected chain: things that
+                 exist in the container but can never be offered as a restore point (#46).
+
+                 Deliberately OUTSIDE the restore-point card below. It used to be nested inside it,
+                 which hid it exactly when it mattered most - "no full backup found" is precisely
+                 the case where there are no restore points, so the user got an empty screen and no
+                 explanation. A XAML load test caught that. -->
+            <Border CornerRadius="4" Padding="12" Margin="0,0,0,16"
+                    Background="#332B1A" BorderBrush="#8A6D2F" BorderThickness="1"
+                    Visibility="{Binding HasInventoryIssues, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Text="About the backups found in this container"
+                               FontWeight="SemiBold"
+                               Foreground="{StaticResource PrimaryTextBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,8" />
+                    <ItemsControl ItemsSource="{Binding InventoryIssues}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Margin="0,0,0,8">
+                                    <TextBlock TextWrapping="Wrap" FontWeight="SemiBold">
+                                        <Run Text="{Binding SeverityDisplay, Mode=OneWay}" />
+                                        <Run Text="  " />
+                                        <Run Text="{Binding Title, Mode=OneWay}" />
+                                    </TextBlock>
+                                    <TextBlock Text="{Binding Detail}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap"
+                                               Margin="0,2,0,0" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
             <!-- Step 2: Restore Point Selection -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
                     Visibility="{Binding HasRestorePoints, Converter={StaticResource BoolToVis}}">
@@ -259,7 +295,7 @@
                             <!-- Start/End date labels -->
                             <Grid Grid.Row="3" Margin="7,2,7,0">
                                 <TextBlock Style="{StaticResource SecondaryText}" HorizontalAlignment="Left"
-                                           Text="{Binding RestorePoints[0].Timestamp, StringFormat='{}{0:yyyy-MM-dd HH:mm}', FallbackValue=''}"
+                                           Text="{Binding TimelineStartText}"
                                            FontSize="10" />
                                 <TextBlock Style="{StaticResource SecondaryText}" HorizontalAlignment="Right"
                                            FontSize="10">
@@ -420,35 +456,6 @@
                          things that exist in the container but can never be offered as a restore
                          point. Shown whether or not a point is selected, because they explain why
                          the timeline has fewer entries than the browse list has files (#46). -->
-                    <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
-                            Background="#332B1A" BorderBrush="#8A6D2F" BorderThickness="1"
-                            Visibility="{Binding HasInventoryIssues, Converter={StaticResource BoolToVis}}">
-                        <StackPanel>
-                            <TextBlock Text="About the backups found in this container"
-                                       FontWeight="SemiBold"
-                                       Foreground="{StaticResource PrimaryTextBrush}"
-                                       TextWrapping="Wrap"
-                                       Margin="0,0,0,8" />
-                            <ItemsControl ItemsSource="{Binding InventoryIssues}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Margin="0,0,0,8">
-                                            <TextBlock TextWrapping="Wrap" FontWeight="SemiBold">
-                                                <Run Text="{Binding SeverityDisplay, Mode=OneWay}" />
-                                                <Run Text="  " />
-                                                <Run Text="{Binding Title, Mode=OneWay}" />
-                                            </TextBlock>
-                                            <TextBlock Text="{Binding Detail}"
-                                                       Style="{StaticResource SecondaryText}"
-                                                       TextWrapping="Wrap"
-                                                       Margin="0,2,0,0" />
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-
                     <!-- Restore Chain Detail (togglable) -->
                     <Border Background="{StaticResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="12" Margin="0,12,0,0"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="Blackcat.NineLives.Views.RestoreView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
+             xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
+             xmlns:views="clr-namespace:Blackcat.NineLives.Views">
 
     <UserControl.Resources>
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
@@ -936,45 +937,121 @@
                                Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
                                Margin="0,0,0,12" TextWrapping="Wrap" />
 
-                    <!-- Script Output (hidden during execution) -->
+                    <!-- The generated script. Stays visible during and after execution: it used to
+                         be hidden the moment Execute was pressed, so the script and the console
+                         shared one slot and you could not see what was running while it ran. -->
                     <Border Background="{StaticResource InputBackgroundBrush}"
-                            CornerRadius="4" Padding="0">
+                            CornerRadius="4" Padding="0"
+                            Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <Grid Margin="12,8,12,4">
+                                <TextBlock Text="GENERATED SCRIPT" Style="{StaticResource LabelText}" />
+                                <TextBlock Text="updates as you change options"
+                                           Style="{StaticResource SecondaryText}"
+                                           FontSize="11"
+                                           HorizontalAlignment="Right" />
+                            </Grid>
+                            <ScrollViewer MaxHeight="320"
+                                          VerticalScrollBarVisibility="Auto"
+                                          HorizontalScrollBarVisibility="Auto"
+                                          Padding="12,4,12,10">
+                                <views:SqlTextBlock Sql="{Binding GeneratedScript}"
+                                                    FontFamily="{StaticResource ConsoleFont}"
+                                                    FontSize="12"
+                                                    TextWrapping="NoWrap"
+                                                    Foreground="{StaticResource ConsoleTextBrush}" />
+                            </ScrollViewer>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Execution console.
+                         Its own surface, darker than the cards, so it reads as a terminal rather
+                         than another form panel. Lines come from a collection rather than one
+                         growing string: appending to a bound string re-rendered the whole control
+                         on every message, which is why progress arrived in bursts. -->
+                    <Border CornerRadius="6" Margin="0,12,0,0"
+                            Background="{StaticResource ConsoleBackgroundBrush}"
+                            BorderBrush="{StaticResource ConsoleBorderBrush}"
+                            BorderThickness="1">
+                        <!-- Shown only when the console is NOT in its own window - the two are
+                             mutually exclusive, so the output is never rendered twice. -->
                         <Border.Style>
                             <Style TargetType="Border">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <MultiDataTrigger>
                                         <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding HasScript}" Value="True" />
+                                            <Condition Binding="{Binding HasConsoleOutput}" Value="True" />
+                                            <Condition Binding="{Binding IsConsoleDetached}" Value="False" />
+                                            <!-- Belt and braces. While a restore runs the console
+                                                 is always in its own window, so the inline one
+                                                 must be gone even if the detach flag never got
+                                                 set - a wiring failure should not put two
+                                                 consoles on screen. -->
                                             <Condition Binding="{Binding IsExecuting}" Value="False" />
-                                            <Condition Binding="{Binding ExecutionComplete}" Value="False" />
                                         </MultiDataTrigger.Conditions>
                                         <Setter Property="Visibility" Value="Visible" />
                                     </MultiDataTrigger>
                                 </Style.Triggers>
                             </Style>
                         </Border.Style>
-                        <TextBox Text="{Binding GeneratedScript, Mode=OneWay}"
-                                 Style="{StaticResource DarkTextBox}"
-                                 IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True"
-                                 VerticalScrollBarVisibility="Auto" MaxHeight="400"
-                                 FontFamily="Cascadia Code, Consolas, Courier New" FontSize="12" />
-                    </Border>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
 
-                    <!-- Execution Log -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
-                            CornerRadius="4" Padding="0" Margin="0,12,0,0"
-                            Visibility="{Binding ExecutionLog, Converter={StaticResource NullToVis}}">
-                        <StackPanel>
-                            <TextBlock Text="EXECUTION LOG" Style="{StaticResource LabelText}" Margin="12,8,0,4" />
-                            <TextBox x:Name="ExecutionLogBox"
-                                     Text="{Binding ExecutionLog, Mode=OneWay}"
-                                     Style="{StaticResource DarkTextBox}"
-                                     IsReadOnly="True" TextWrapping="Wrap" AcceptsReturn="True"
-                                     VerticalScrollBarVisibility="Auto" MaxHeight="300"
-                                     FontFamily="Cascadia Code, Consolas, Courier New" FontSize="12"
-                                     TextChanged="ExecutionLogBox_TextChanged" />
-                        </StackPanel>
+                            <!-- Chrome strip: title, live indicator, copy. -->
+                            <Border Grid.Row="0"
+                                    Background="{StaticResource ConsoleChromeBrush}"
+                                    CornerRadius="5,5,0,0"
+                                    BorderBrush="{StaticResource ConsoleBorderBrush}"
+                                    BorderThickness="0,0,0,1"
+                                    Padding="12,7">
+                                <Grid>
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <Ellipse Width="9" Height="9" Margin="0,0,7,0">
+                                            <Ellipse.Style>
+                                                <Style TargetType="Ellipse">
+                                                    <Setter Property="Fill" Value="{StaticResource ConsoleMutedBrush}" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsExecuting}" Value="True">
+                                                            <Setter Property="Fill" Value="{StaticResource ConsoleSuccessBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Ellipse.Style>
+                                        </Ellipse>
+                                        <TextBlock Text="restore console"
+                                                   Foreground="{StaticResource ConsoleMutedBrush}"
+                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                   FontSize="11"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+
+                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                        <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
+                                                   Foreground="{StaticResource ConsoleMutedBrush}"
+                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                   FontSize="11"
+                                                   VerticalAlignment="Center"
+                                                   Margin="0,0,12,0" />
+                                        <Button Content="Copy output"
+                                                Command="{Binding CopyConsoleCommand}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="8,2" FontSize="11"
+                                                ToolTip="Copies the whole console, which is what to attach to a bug report." />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+
+                            <!-- Virtualised so a long restore stays responsive. Auto-follows the
+                                 last line unless the user has scrolled up to read something. -->
+                            <ListBox Grid.Row="1" x:Name="ConsoleList"
+                                     ItemsSource="{Binding ConsoleLines}"
+                                     Style="{StaticResource ConsoleListBox}"
+                                     MaxHeight="360" />
+                        </Grid>
                     </Border>
 
                     <!-- What a failed restore left behind, and how to undo it (#14). A chain that
@@ -983,8 +1060,23 @@
                          worst moment to be left working that out from a raw SQL error. Each action
                          shows the exact statement before it runs. -->
                     <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
-                            Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1"
-                            Visibility="{Binding HasRecoveryActions, Converter={StaticResource BoolToVis}}">
+                            Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1">
+                        <!-- Same rule as the console: not while it is showing in its own window,
+                             where the recovery actions already appear. -->
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding HasRecoveryActions}" Value="True" />
+                                            <Condition Binding="{Binding IsConsoleDetached}" Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
                         <StackPanel>
                             <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
                                        Style="{StaticResource LabelText}" Margin="0,0,0,8" />

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -416,6 +416,39 @@
                         </StackPanel>
                     </Border>
 
+                    <!-- Findings about the discovered backups rather than the selected chain:
+                         things that exist in the container but can never be offered as a restore
+                         point. Shown whether or not a point is selected, because they explain why
+                         the timeline has fewer entries than the browse list has files (#46). -->
+                    <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                            Background="#332B1A" BorderBrush="#8A6D2F" BorderThickness="1"
+                            Visibility="{Binding HasInventoryIssues, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <TextBlock Text="About the backups found in this container"
+                                       FontWeight="SemiBold"
+                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8" />
+                            <ItemsControl ItemsSource="{Binding InventoryIssues}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Margin="0,0,0,8">
+                                            <TextBlock TextWrapping="Wrap" FontWeight="SemiBold">
+                                                <Run Text="{Binding SeverityDisplay, Mode=OneWay}" />
+                                                <Run Text="  " />
+                                                <Run Text="{Binding Title, Mode=OneWay}" />
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Detail}"
+                                                       Style="{StaticResource SecondaryText}"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,2,0,0" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
+
                     <!-- Restore Chain Detail (togglable) -->
                     <Border Background="{StaticResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="12" Margin="0,12,0,0"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -884,6 +884,17 @@
                                 Command="{Binding ExecuteScriptCommand}"
                                 IsEnabled="{Binding IsConnectedToServer}"
                                 MinWidth="140" />
+
+                        <!-- Only while a restore is actually running. Until now the only way to
+                             stop one aimed at the wrong server was to kill the process, which
+                             leaves the database mid-restore with nothing written down (#25). -->
+                        <Button Content="Stop restore"
+                                Style="{StaticResource SecondaryButton}"
+                                Command="{Binding CancelExecuteCommand}"
+                                Visibility="{Binding CanCancelExecute, Converter={StaticResource BoolToVis}}"
+                                Margin="8,0,0,0"
+                                MinWidth="110"
+                                ToolTip="Asks SQL Server to abort the statement in flight. It rolls that statement back, but the target database is left mid-restore and will need recovering - the app will tell you how." />
                     </StackPanel>
 
                     <!-- Execute armed warning. The server's tags appear here deliberately: this is
@@ -1025,7 +1036,15 @@
             <!-- Loading -->
             <Border Background="#80000000" CornerRadius="6"
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}" Padding="20">
-                <TextBlock Text="Loading..." Style="{StaticResource BodyText}" HorizontalAlignment="Center" />
+                <StackPanel HorizontalAlignment="Center">
+                    <TextBlock Text="Loading..." Style="{StaticResource BodyText}" HorizontalAlignment="Center" />
+                    <Button Content="Cancel"
+                            Style="{StaticResource SecondaryButton}"
+                            Command="{Binding CancelLoadCommand}"
+                            Visibility="{Binding CanCancelLoad, Converter={StaticResource BoolToVis}}"
+                            Padding="10,6" Margin="0,10,0,0"
+                            HorizontalAlignment="Center" />
+                </StackPanel>
             </Border>
 
             <!-- Status -->

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -958,6 +958,60 @@
                                      TextChanged="ExecutionLogBox_TextChanged" />
                         </StackPanel>
                     </Border>
+
+                    <!-- What a failed restore left behind, and how to undo it (#14). A chain that
+                         stops part-way leaves the target in RESTORING, and in SINGLE_USER too if
+                         Disconnect sessions was on. Both block other connections, and this is the
+                         worst moment to be left working that out from a raw SQL error. Each action
+                         shows the exact statement before it runs. -->
+                    <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                            Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1"
+                            Visibility="{Binding HasRecoveryActions, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
+                                       Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                            <TextBlock Text="{Binding RecoveryStateMessage}"
+                                       Style="{StaticResource BodyText}"
+                                       TextWrapping="Wrap" Margin="0,0,0,12" />
+                            <ItemsControl ItemsSource="{Binding RecoveryActions}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="{StaticResource InputBackgroundBrush}"
+                                                CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Title}"
+                                                           FontWeight="SemiBold"
+                                                           Foreground="{StaticResource PrimaryTextBrush}"
+                                                           TextWrapping="Wrap" />
+                                                <TextBox Text="{Binding Sql, Mode=OneWay}"
+                                                         Style="{StaticResource DarkTextBox}"
+                                                         IsReadOnly="True" TextWrapping="Wrap"
+                                                         FontFamily="Cascadia Code, Consolas, Courier New"
+                                                         FontSize="12" Margin="0,6,0,6" />
+                                                <TextBlock Text="{Binding Caution}"
+                                                           Style="{StaticResource SecondaryText}"
+                                                           TextWrapping="Wrap" Margin="0,0,0,8" />
+                                                <StackPanel Orientation="Horizontal">
+                                                    <Button Content="Run this"
+                                                            Command="{Binding DataContext.RunRecoveryActionCommand,
+                                                                      RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                            CommandParameter="{Binding}"
+                                                            Style="{StaticResource SecondaryButton}"
+                                                            Padding="10,6" Margin="0,0,8,0" />
+                                                    <Button Content="Copy"
+                                                            Command="{Binding DataContext.CopyRecoveryActionCommand,
+                                                                      RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                            CommandParameter="{Binding}"
+                                                            Style="{StaticResource SecondaryButton}"
+                                                            Padding="10,6" />
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
                 </StackPanel>
             </Border>
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1038,6 +1038,10 @@
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}" Padding="20">
                 <StackPanel HorizontalAlignment="Center">
                     <TextBlock Text="Loading..." Style="{StaticResource BodyText}" HorizontalAlignment="Center" />
+                    <TextBlock Text="{Binding LoadProgressText}"
+                               Style="{StaticResource SecondaryText}"
+                               HorizontalAlignment="Center"
+                               Margin="0,4,0,0" />
                     <Button Content="Cancel"
                             Style="{StaticResource SecondaryButton}"
                             Command="{Binding CancelLoadCommand}"

--- a/src/NineLives/Views/RestoreView.xaml.cs
+++ b/src/NineLives/Views/RestoreView.xaml.cs
@@ -1,20 +1,107 @@
+using System.Collections.Specialized;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Threading;
+using Blackcat.NineLives.ViewModels;
 
 namespace Blackcat.NineLives.Views;
 
 public partial class RestoreView : UserControl
 {
+    /// <summary>
+    /// How close to the bottom still counts as "following". A couple of lines of slack, so a
+    /// trackpad nudge or scrollbar rounding does not silently stop the console following.
+    /// </summary>
+    private const double FollowThreshold = 40;
+
+    private INotifyCollectionChanged? _observedLines;
+    private RestoreViewModel? _viewModel;
+    private ExecutionWindow? _executionWindow;
+    private bool _follow = true;
+
     public RestoreView()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+        Unloaded += (_, _) => Detach();
     }
 
-    private void ExecutionLogBox_TextChanged(object sender, TextChangedEventArgs e)
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
     {
-        if (sender is TextBox textBox)
+        Detach();
+
+        if (e.NewValue is RestoreViewModel vm)
         {
-            textBox.CaretIndex = textBox.Text.Length;
-            textBox.ScrollToEnd();
+            _viewModel = vm;
+            _observedLines = vm.ConsoleLines;
+            _observedLines.CollectionChanged += OnConsoleLinesChanged;
+            vm.PropertyChanged += OnViewModelPropertyChanged;
         }
+    }
+
+    private void Detach()
+    {
+        if (_observedLines != null)
+            _observedLines.CollectionChanged -= OnConsoleLinesChanged;
+        if (_viewModel != null)
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+
+        _observedLines = null;
+        _viewModel = null;
+    }
+
+    /// <summary>
+    /// Brings the console up as a modal window when a restore starts.
+    ///
+    /// Showing a window is the view's job, not the viewmodel's - which is why this watches a
+    /// property rather than the viewmodel calling out to a dialog service. The window is modal
+    /// because a restore is the one operation here that cannot be undone: it should not compete
+    /// with the form behind it, and nobody should be editing the options that produced the script
+    /// currently running.
+    ///
+    /// The inline console stays behind it, so the record is still there once the window is closed.
+    /// </summary>
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(RestoreViewModel.IsExecuting)) return;
+        if (_viewModel is not { IsExecuting: true } vm || _executionWindow != null) return;
+
+        _executionWindow = new ExecutionWindow(vm) { Owner = Window.GetWindow(this) };
+
+        // The inline console hides while the window is up, so the output is only ever in one
+        // place, and comes back afterwards so the record stays reachable from the main view.
+        vm.IsConsoleDetached = true;
+
+        // ShowDialog blocks, so it must not run inside the property-changed notification that the
+        // restore itself is unwinding through. Posting lets the execution carry on underneath.
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            try { _executionWindow?.ShowDialog(); }
+            finally
+            {
+                _executionWindow = null;
+                vm.IsConsoleDetached = false;
+            }
+        }), DispatcherPriority.Background);
+    }
+
+    /// <summary>
+    /// Follows the tail as output arrives, but only while the user is already at the bottom.
+    ///
+    /// A console that always jumps to the end is unusable during a long restore: scroll up to read
+    /// the statement that just failed and the next progress message yanks you away again. Scrolling
+    /// back to the bottom resumes following, which is what a terminal does.
+    /// </summary>
+    private void OnConsoleLinesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action != NotifyCollectionChangedAction.Add || !_follow) return;
+
+        // At Background priority, so the new rows have been realised by the time this runs.
+        // Scrolling first would land short of the real end.
+        Dispatcher.BeginInvoke(new Action(() =>
+        {
+            if (ConsoleList.Items.Count > 0)
+                ConsoleList.ScrollIntoView(ConsoleList.Items[^1]);
+        }), DispatcherPriority.Background);
     }
 }

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -280,8 +280,19 @@
                             <CheckBox Content="Trust Server Certificate"
                                       IsChecked="{Binding EditTrustServerCert}"
                                       Style="{StaticResource DarkCheckBox}"
-                                      Margin="0,0,0,16"
+                                      Margin="0,0,0,4"
                                       ToolTip="When enabled, the server certificate is accepted without validation. Common for development and self-signed certificates. Disable for production environments with valid CA-issued certificates." />
+
+                            <!-- Shown only while the box is ticked. The default is on, which is the
+                                 pragmatic choice for a DBA tool, but it should be a decision rather
+                                 than something that happens quietly - this connection carries the
+                                 SQL password and the SAS token. Test Connection follows up with
+                                 whether the certificate would actually have validated (#17). -->
+                            <TextBlock Style="{StaticResource SecondaryText}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,16"
+                                       Visibility="{Binding EditTrustServerCert, Converter={StaticResource BoolToVis}}"
+                                       Text="The connection is encrypted but the certificate is not verified, and both the SQL password and the SAS token travel over it. Run Test Connection and it will tell you whether this server's certificate validates - if it does, you can untick this." />
 
                             <TextBlock Text="CONNECTION TIMEOUT (SECONDS)" Style="{StaticResource LabelText}" />
                             <TextBox Text="{Binding EditTimeout, UpdateSourceTrigger=PropertyChanged}"

--- a/src/NineLives/Views/SqlTextBlock.cs
+++ b/src/NineLives/Views/SqlTextBlock.cs
@@ -1,0 +1,63 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Media;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Views;
+
+/// <summary>
+/// A read-only TextBlock that renders T-SQL with syntax colouring.
+///
+/// A TextBlock of Runs rather than a RichTextBox: the script is display-only, and a RichTextBox
+/// brings an editing surface, its own scrolling model and a FlowDocument to keep in sync for no
+/// benefit here. Selection is not needed either - Copy to Clipboard already exists.
+/// </summary>
+public sealed class SqlTextBlock : TextBlock
+{
+    public static readonly DependencyProperty SqlProperty = DependencyProperty.Register(
+        nameof(Sql), typeof(string), typeof(SqlTextBlock),
+        new PropertyMetadata(string.Empty, OnSqlChanged));
+
+    public string Sql
+    {
+        get => (string)GetValue(SqlProperty);
+        set => SetValue(SqlProperty, value);
+    }
+
+    private static void OnSqlChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        => ((SqlTextBlock)d).Rebuild();
+
+    private void Rebuild()
+    {
+        Inlines.Clear();
+
+        foreach (var token in SqlSyntaxHighlighter.Tokenise(Sql))
+        {
+            var run = new Run(token.Text);
+            var brush = BrushFor(token.Kind);
+            if (brush != null) run.Foreground = brush;
+            if (token.Kind == SqlTokenKind.Keyword) run.FontWeight = FontWeights.SemiBold;
+            Inlines.Add(run);
+        }
+    }
+
+    /// <summary>
+    /// Resolved from the theme rather than hardcoded, so the script pane and the console stay in
+    /// the same palette. Falls back to inheriting the foreground if a key is missing.
+    /// </summary>
+    private Brush? BrushFor(SqlTokenKind kind)
+    {
+        var key = kind switch
+        {
+            SqlTokenKind.Keyword => "SqlKeywordBrush",
+            SqlTokenKind.Literal => "SqlLiteralBrush",
+            SqlTokenKind.Comment => "SqlCommentBrush",
+            SqlTokenKind.Number => "SqlNumberBrush",
+            SqlTokenKind.Identifier => "SqlIdentifierBrush",
+            _ => null
+        };
+
+        return key != null ? TryFindResource(key) as Brush : null;
+    }
+}

--- a/src/NineLives/packages.lock.json
+++ b/src/NineLives/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows7.0": {
+    "net10.0-windows7.0": {
       "Azure.Storage.Blobs": {
         "type": "Direct",
         "requested": "[12.29.1, )",
@@ -24,16 +24,14 @@
         "resolved": "7.0.2",
         "contentHash": "zwv76lANFQQI6Gmp6ntkzMWIWVqm8Wf4Mz00AeGCk1n8HCi5afi6bNynSe18uI0xeL0n6J+Myjk9AiIsL5oSqw==",
         "dependencies": {
-          "Microsoft.Bcl.Cryptography": "8.0.0",
+          "Microsoft.Bcl.Cryptography": "9.0.13",
           "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
           "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
           "Microsoft.Data.SqlClient.SNI.runtime": "[6.0.2, 7.0.0)",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "9.0.13",
           "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
-          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)",
-          "System.Configuration.ConfigurationManager": "8.0.1",
-          "System.Security.Cryptography.Pkcs": "8.0.1"
+          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)"
         }
       },
       "Azure.Core": {
@@ -47,10 +45,7 @@
           "Microsoft.Identity.Client": "4.83.1",
           "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
           "System.ClientModel": "1.11.0",
-          "System.Diagnostics.DiagnosticSource": "10.0.3",
-          "System.Memory.Data": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3",
-          "System.Text.Json": "10.0.3"
+          "System.Memory.Data": "10.0.3"
         }
       },
       "Azure.Storage.Common": {
@@ -69,8 +64,8 @@
       },
       "Microsoft.Bcl.Cryptography": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "Y3t/c7C5XHJGFDnohjf1/9SYF3ZOfEU1fkNQuKg/dGf9hN18yrQj2owHITGfNS3+lKJdW6J4vY98jYu57jCO8A=="
+        "resolved": "9.0.13",
+        "contentHash": "5T+bH3Lb1nEe8Hf/ixMxLmhlrx5wRi53wv7OhVwG2F1ZviW1ejFRS1NHur3uqPpJRGtkQwUchtY6zhVK2R+v+w=="
       },
       "Microsoft.Data.SqlClient.Extensions.Abstractions": {
         "type": "Transitive",
@@ -92,22 +87,22 @@
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "resolved": "9.0.13",
+        "contentHash": "nTT90JYIpcXEy6fcU8LPVycONkO6wipROgP9pyC4uxBif4fazu2rDzlWSntqtzr5p8GbQL2EopsYuTZR3yoeag==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "8.0.0"
+          "Microsoft.Extensions.Primitives": "9.0.13"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "resolved": "9.0.13",
+        "contentHash": "OdQmN8LYcUEu20Fxii9mk68nHJGL+JPXF3w0+hxenf0oDDdDBA+ZV/S92FmIgAWAElowIiFA/g0x+8YB1g80Hg==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Options": "8.0.2",
-          "Microsoft.Extensions.Primitives": "8.0.0"
+          "Microsoft.Extensions.Caching.Abstractions": "9.0.13",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.13",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.13",
+          "Microsoft.Extensions.Options": "9.0.13",
+          "Microsoft.Extensions.Primitives": "9.0.13"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -129,8 +124,7 @@
         "contentHash": "mQiTzAj7PIJ2A9YXR5QhgulS1fTWhmQc3ckd1Mrf3hKW07d03fBDqx8vVaFw+cRTebDOeB6pNqdWdnRxsi1hBA==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Options": "10.0.3",
-          "System.Diagnostics.DiagnosticSource": "10.0.3"
+          "Microsoft.Extensions.Options": "10.0.3"
         }
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
@@ -158,8 +152,7 @@
         "resolved": "10.0.3",
         "contentHash": "lxl0WLk7ROgBFAsjcOYjQ8/DVK+VMszxGBzUhgtQmAsTNldLL5pk9NG/cWTsXHq0lUhUEAtZkEE7jOGOA8bGKQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "System.Diagnostics.DiagnosticSource": "10.0.3"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3"
         }
       },
       "Microsoft.Extensions.Options": {
@@ -181,9 +174,7 @@
         "resolved": "4.83.1",
         "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "8.14.0",
-          "System.Diagnostics.DiagnosticSource": "6.0.1",
-          "System.ValueTuple": "4.5.0"
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
         }
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
@@ -191,8 +182,7 @@
         "resolved": "4.83.1",
         "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
         "dependencies": {
-          "Microsoft.Identity.Client": "4.83.1",
-          "System.Security.Cryptography.ProtectedData": "4.5.0"
+          "Microsoft.Identity.Client": "4.83.1"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
@@ -238,7 +228,7 @@
         "resolved": "8.16.0",
         "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
           "Microsoft.IdentityModel.Logging": "8.16.0"
         }
       },
@@ -255,29 +245,8 @@
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
-          "System.Diagnostics.DiagnosticSource": "10.0.3",
-          "System.Memory.Data": "10.0.3",
-          "System.Text.Json": "10.0.3"
+          "System.Memory.Data": "10.0.3"
         }
-      },
-      "System.Configuration.ConfigurationManager": {
-        "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "8.0.1",
-          "System.Security.Cryptography.ProtectedData": "8.0.0"
-        }
-      },
-      "System.Diagnostics.DiagnosticSource": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "IuZXyF3K5X+mCsBKIQ87Cn/V4Nyb39vyCbzfH/AkoneSWNV/ExGQ/I0m4CEaVAeFh9fW6kp2NVObkmevd1Ys7A=="
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg=="
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
@@ -293,87 +262,33 @@
         "resolved": "10.0.3",
         "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
       },
-      "System.IO.Pipelines": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
-      },
       "System.Memory.Data": {
         "type": "Transitive",
         "resolved": "10.0.3",
-        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig==",
-        "dependencies": {
-          "System.Text.Json": "10.0.3"
-        }
-      },
-      "System.Security.Cryptography.Pkcs": {
-        "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
-      },
-      "System.Security.Cryptography.ProtectedData": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
-      },
-      "System.Text.Encodings.Web": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
-        "dependencies": {
-          "System.IO.Pipelines": "10.0.3",
-          "System.Text.Encodings.Web": "10.0.3"
-        }
-      },
-      "System.ValueTuple": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
       }
     },
-    "net8.0-windows7.0/win-x64": {
+    "net10.0-windows7.0/win-x64": {
       "Microsoft.Data.SqlClient": {
         "type": "Direct",
         "requested": "[7.0.2, )",
         "resolved": "7.0.2",
         "contentHash": "zwv76lANFQQI6Gmp6ntkzMWIWVqm8Wf4Mz00AeGCk1n8HCi5afi6bNynSe18uI0xeL0n6J+Myjk9AiIsL5oSqw==",
         "dependencies": {
-          "Microsoft.Bcl.Cryptography": "8.0.0",
+          "Microsoft.Bcl.Cryptography": "9.0.13",
           "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
           "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
           "Microsoft.Data.SqlClient.SNI.runtime": "[6.0.2, 7.0.0)",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "9.0.13",
           "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
-          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)",
-          "System.Configuration.ConfigurationManager": "8.0.1",
-          "System.Security.Cryptography.Pkcs": "8.0.1"
+          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)"
         }
       },
       "Microsoft.Data.SqlClient.SNI.runtime": {
         "type": "Transitive",
         "resolved": "6.0.2",
         "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
-      },
-      "System.Diagnostics.EventLog": {
-        "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg=="
-      },
-      "System.Security.Cryptography.Pkcs": {
-        "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
-      },
-      "System.Text.Encodings.Web": {
-        "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
       }
     }
   }

--- a/src/NineLives/packages.lock.json
+++ b/src/NineLives/packages.lock.json
@@ -1,0 +1,380 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0-windows7.0": {
+      "Azure.Storage.Blobs": {
+        "type": "Direct",
+        "requested": "[12.29.1, )",
+        "resolved": "12.29.1",
+        "contentHash": "pWh7xZBto8YcwiO853AB3uijTfVqs9PDte0Bu9/Zd8O9nwKiitWm0Jej1vsNkmYUzeG1552f8vJPjmtW30pBUQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
+      "CommunityToolkit.Mvvm": {
+        "type": "Direct",
+        "requested": "[8.4.2, )",
+        "resolved": "8.4.2",
+        "contentHash": "WadCzGEc2U+3e20avRLng4qNtt4zoOGWrdUISqJWrHe3/FSnrYjuM5Sb4yQb09LhkBXrrI4Zt3dLKgRMbItsrg=="
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "Direct",
+        "requested": "[7.0.2, )",
+        "resolved": "7.0.2",
+        "contentHash": "zwv76lANFQQI6Gmp6ntkzMWIWVqm8Wf4Mz00AeGCk1n8HCi5afi6bNynSe18uI0xeL0n6J+Myjk9AiIsL5oSqw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "8.0.0",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.SNI.runtime": "[6.0.2, 7.0.0)",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
+          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)",
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.11.0",
+          "System.Diagnostics.DiagnosticSource": "10.0.3",
+          "System.Memory.Data": "10.0.3",
+          "System.Text.Encodings.Web": "10.0.3",
+          "System.Text.Json": "10.0.3"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "Y3t/c7C5XHJGFDnohjf1/9SYF3ZOfEU1fkNQuKg/dGf9hN18yrQj2owHITGfNS3+lKJdW6J4vY98jYu57jCO8A=="
+      },
+      "Microsoft.Data.SqlClient.Extensions.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "Zx7z61fG2Nc6LdDn4jA7b5Aj1ABrljkOPRE31RvVUdjF6IgbG60leDUhMCafsnWFgaheiK3iqpLe+kbf5Z5L8Q==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)"
+        }
+      },
+      "Microsoft.Data.SqlClient.Internal.Logging": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "iqgYBbGSVy/DIYWjzmQOa964Kn4rs4wW5vg2IamqVK0fQqfTiILVR5hMK27XWqoyONtAZs+VxH354cPJBtSnbg=="
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "HFDnhYLccngrzyGgHkjEDU5FMLn4MpOsr5ElgsBMC4yx6lJh4jeWO7fHS8+TXPq+dgxCmUa/Trl8svObmwW4QA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "xVDHL0+SIgemfh95fTO9cGLe17TWv/ZP0n7m01z8X6pzt2DmQpucioWR/mYZA1sRlkWnkXzfl0JweLNWmE9WMg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "bwGMrRcAMWx2s/RDgja97p27rxSz2pEQW0+rX5cWAUWVETVJ/eyxGfjAl8vuG5a+lckWmPIE+vcuaZNVB5YDdw=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "mQiTzAj7PIJ2A9YXR5QhgulS1fTWhmQc3ckd1Mrf3hKW07d03fBDqx8vVaFw+cRTebDOeB6pNqdWdnRxsi1hBA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3",
+          "System.Diagnostics.DiagnosticSource": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "4TD9AXDRsipTmaemwnjt/DM5Ri0de2JzHQhvZ4woBTjUtL4XrPNsMrOk5oiLJAx1gTrE6pOIhxv+lEde5F6CZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "GdMpC10Jf6poxSvUJ4lgYpJ5F/kJeaAoJmrPufjBoPYyCTKKY5Dyl0rZA+LBNvFqTq1cZa/lhlptlUhNvU6xrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "lxl0WLk7ROgBFAsjcOYjQ8/DVK+VMszxGBzUhgtQmAsTNldLL5pk9NG/cWTsXHq0lUhUEAtZkEE7jOGOA8bGKQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "System.Diagnostics.DiagnosticSource": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hU6WzGTPvPoLA2ng1ILvWQb3g0qORdlHNsxI8IcPLumJb3suimYUl+bbDzdo1V4KFsvVhnMWzysHpKbZaoDQPQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "GEcpTwo7sUoLGGNTqV1FZEuL+tTD9m81NX/mh099dqGNna07/UGZShKQNZRw4hv6nlliSUwYQgSYc7OR99Jufg=="
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.1",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1",
+          "System.Security.Cryptography.ProtectedData": "4.5.0"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "h4yVXyJsEBBX5lg2G5ftMsi5JzcNEGAzrNphA6DQ6eOd8P0s+cDCOyPwVTYLePZvJL5unbPvYIvzrbTXzFjXnQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "System.IdentityModel.Tokens.Jwt": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.16.0"
+        }
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Diagnostics.DiagnosticSource": "10.0.3",
+          "System.Memory.Data": "10.0.3",
+          "System.Text.Json": "10.0.3"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "8.0.1",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "IuZXyF3K5X+mCsBKIQ87Cn/V4Nyb39vyCbzfH/AkoneSWNV/ExGQ/I0m4CEaVAeFh9fW6kp2NVObkmevd1Ys7A=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rrs2u7DRMXQG2yh0oVyF/vLwosfRv20Ld2iEpYcKwQWXHjfV+gFXNQsQ9p008kR9Ou4pxBs68Q6/9zC8Gi1wjg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig==",
+        "dependencies": {
+          "System.Text.Json": "10.0.3"
+        }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "NTUt9DL+maqbgrIYCAmeZUbX0NoXaueySyjW/bdOlFdSUDC1l51XnsbVEuj5tuad12vdq5Sviskp9uMVGgCNLw==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.3",
+          "System.Text.Encodings.Web": "10.0.3"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
+      }
+    },
+    "net8.0-windows7.0/win-x64": {
+      "Microsoft.Data.SqlClient": {
+        "type": "Direct",
+        "requested": "[7.0.2, )",
+        "resolved": "7.0.2",
+        "contentHash": "zwv76lANFQQI6Gmp6ntkzMWIWVqm8Wf4Mz00AeGCk1n8HCi5afi6bNynSe18uI0xeL0n6J+Myjk9AiIsL5oSqw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "8.0.0",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.SNI.runtime": "[6.0.2, 7.0.0)",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
+          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)",
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "l8QNBPp92bVzl9Kw8nNtm1uYRNNhUrdulZjM4a8YK/QGNa8z9utKsC0bDoPB+Vq8LOlbD3fIyGlabtz80jT7cw=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release v1.2.0. Promotes `dev` to `main`.

Version bumped to 1.2.0 in `NineLives.csproj` (#98). **587 tests**, up from 345 at v1.1.0.

## Correctness — the restore could target the wrong thing

- **Execute ran against a server looked up by name** (#11). It re-read `config.json` and took the first entry whose `ServerName` matched, rather than the connection you were actually using. Two saved entries for one host differing in auth, port or encryption is an ordinary setup — so a restore could run under credentials you never tested with. Every other call on the screen already used the held connection.
- **Every Execute dropped and recreated the blob credential** (#10), whether or not anything needed changing, and regardless of the status shown directly above it. A credential is server-scoped, so that removed it out from under anything else using it — a backup job writing to the same container, for instance. It now only writes when the credential is missing or isn't a SAS credential, uses `ALTER` rather than drop-and-recreate, and says what it did.
- **`"diff"` matched as a substring** (#45), so a database whose *name* contained it had its **full** backups classified as differentials. If it was the only full in the container, that database got no restore points at all — an empty timeline with no explanation. Live on the default path.
- **A log backup written as `.bak`** was classified as a full (#44), became a chain root, and silently truncated every earlier log chain.
- **Logs that reach no restore point are now reported** (#46), instead of vanishing from the timeline while still being counted in the header.

## Data loss

- **A briefly locked `config.json` wiped every saved server and container** (#7). Load swallowed the error and returned empty defaults; the next save wrote that empty list over everything. Antivirus, a backup agent or a sync client was enough. Load now distinguishes "no file" from "can't read it", refuses to overwrite in that state, and writes atomically with a `.bak`.
- **Renaming a container stranded its SAS token** (#8). Keys derived from the display name, so a rename pointed every lookup at a key that had never been written — and the edit form never shows a stored token, so leaving that field blank on a rename is the normal thing to do. Secrets are keyed by a stable id now, with a crash-safe migration.
- **Test Connection persisted secrets before you saved** (#12). Pasting a token that turned out to be wrong, testing it, and clicking Cancel destroyed the working one.

## Safety and recovery

- **A running restore can be stopped** (#25). Previously the only way out was killing the process, which left the database mid-restore with nothing written down.
- **A failed or cancelled restore explains itself** (#14). It reads the target's state and offers the statements that fix it — `RESTORE ... WITH RECOVERY`, `ALTER DATABASE ... SET MULTI_USER` — each shown in full with what it commits you to.
- **Unhandled errors no longer kill the app** (#13). The worst moment for that was mid-restore, when the execution log is the only record of how far it got.
- **Delete asks first** on both config screens (#42) — it removes a stored secret the app never displays.

## Security

- SQL passwords go via `SqlCredential`, never the connection string (#20)
- Test Connection reports whether certificate validation would actually work, so `TrustServerCertificate` becomes an informed choice (#17)
- An unreadable SAS expiry counts as expired rather than valid (#21)
- Copied blob URLs no longer carry the SAS token (#18)
- Actions pinned by commit SHA (#19); `SECURITY.md` added (#36)

## Platform and interface

- **.NET 10** (#34) — .NET 8 is end-of-support in November, and this ships self-contained so the runtime is in the exe. Also **20 MB smaller**.
- **Execution console rewritten** — its own window while a restore runs, terminal styled, following the tail, updating fluidly rather than in bursts
- **Generated script is syntax highlighted** and updates as you change options, instead of only when Generate is pressed
- **Operation log on disk** (#40) with secret redaction at the write boundary
- Blob listings pushed down to Azure as prefixes (#28); tag pills sorted (#92)

## Supply chain

- Every package pinned with `packages.lock.json`, CI restores `--locked-mode` (#16)
- Build provenance attestation on release assets (#33) — **first release to carry it**

## Known limitations

- The binary is **unsigned**; SmartScreen will warn (#33, blocked on SignPath Foundation)
- SAS tokens only — no Entra ID yet (#29)
