### PR TITLE
Make the update banner impossible to miss

### DIFF
--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -38,6 +38,10 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
     /// <summary>Realises the visual tree. Bindings are not evaluated until something lays out.</summary>
     private static void Realise(FrameworkElement element)
     {
+        // A Window builds nothing under itself until its template is applied - measuring alone
+        // leaves the content unrealised, so nothing inside it can be found or asserted on.
+        element.ApplyTemplate();
+
         element.Measure(new Size(1600, 1200));
         element.Arrange(new Rect(0, 0, 1600, 1200));
         element.UpdateLayout();
@@ -106,6 +110,14 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
             Realise(window);
         });
     }
+
+    // The update banner is not asserted on beyond MainWindowLoads above, which does cover what
+    // can break silently: it parses the banner's markup, its storyboard and its drop shadow, and
+    // resolves every {StaticResource} it uses - a missing key would throw there.
+    //
+    // Whether it is VISIBLE cannot be checked this way. A Window builds nothing under itself until
+    // it is shown, and showing one would flash a real window and run the actual startup path. Not
+    // worth contorting the harness for a banner whose appearance needs eyes anyway.
 
     // ── the panels that only appear in a particular state ───────────────────────
 
@@ -469,6 +481,10 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
         for (DependencyObject? node = element; node != null;
              node = System.Windows.Media.VisualTreeHelper.GetParent(node))
         {
+            // A Window that has never been shown reports itself as not visible, which would make
+            // every element inside it look hidden. What is being asked here is whether the content
+            // would be on screen, so the window itself is not part of the question.
+            if (node is Window) break;
             if (node is UIElement { Visibility: not Visibility.Visible }) return false;
         }
         return true;

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -46,37 +46,65 @@
              because something is on fire, and a popup between the DBA and the restore button
              would be exactly wrong. -->
         <Border Grid.Row="0"
-                Background="#1B2A44"
-                BorderBrush="#2E4468"
+                Background="{StaticResource UpdateBannerBrush}"
+                BorderBrush="{StaticResource UpdateBannerEdgeBrush}"
                 BorderThickness="0,0,0,1"
-                Padding="16,8"
+                Padding="16,10"
                 Visibility="{Binding UpdateAvailable, Converter={StaticResource BoolToVis}}">
+            <!-- Lifts the band off the window rather than letting it read as another dark stripe. -->
+            <Border.Effect>
+                <DropShadowEffect Color="#000000" BlurRadius="12" ShadowDepth="2" Opacity="0.45" Direction="270" />
+            </Border.Effect>
             <Grid>
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0"
+                <!-- Badge. Pulses slowly - enough to catch the eye on a screen someone is already
+                     looking at, slow enough not to nag while they work. -->
+                <Grid Grid.Column="0" Width="24" Height="24" Margin="0,0,12,0" VerticalAlignment="Center">
+                    <Ellipse Fill="#1A1205" Opacity="0.92" />
+                    <TextBlock Text="&#x2191;"
+                               Foreground="#FFC24B"
+                               FontSize="15"
+                               FontWeight="Bold"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center" />
+                    <Grid.Triggers>
+                        <EventTrigger RoutedEvent="Loaded">
+                            <BeginStoryboard>
+                                <Storyboard>
+                                    <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                     From="1.0" To="0.45" Duration="0:0:1.1"
+                                                     AutoReverse="True" RepeatBehavior="Forever" />
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </EventTrigger>
+                    </Grid.Triggers>
+                </Grid>
+
+                <TextBlock Grid.Column="1"
                            Text="{Binding UpdateMessage}"
                            VerticalAlignment="Center"
-                           Foreground="{StaticResource PrimaryTextBrush}"
+                           Foreground="{StaticResource UpdateBannerTextBrush}"
                            FontFamily="Segoe UI"
-                           FontSize="12.5" />
-
-                <Button Grid.Column="1"
-                        Content="View release"
-                        Command="{Binding OpenReleasesPageCommand}"
-                        Style="{StaticResource SecondaryButton}"
-                        Padding="12,4"
-                        Margin="12,0,8,0" />
+                           FontSize="13.5"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap" />
 
                 <Button Grid.Column="2"
+                        Content="View release"
+                        Command="{Binding OpenReleasesPageCommand}"
+                        Style="{StaticResource UpdateBannerPrimaryButton}"
+                        Margin="12,0,8,0" />
+
+                <Button Grid.Column="3"
                         Content="Dismiss"
                         Command="{Binding DismissUpdateCommand}"
-                        Style="{StaticResource SecondaryButton}"
-                        Padding="12,4" />
+                        Style="{StaticResource UpdateBannerGhostButton}" />
             </Grid>
         </Border>
 

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -22,6 +22,79 @@
 
     <FontFamily x:Key="ConsoleFont">Cascadia Code, Cascadia Mono, Consolas, Courier New</FontFamily>
 
+    <!-- Update banner.
+         Amber rather than red: a new release is worth noticing, not an emergency, and this app
+         uses red for things that have actually gone wrong. Against a dark navy UI a bright amber
+         band is unmissable without pretending to be a failure. Dark text on it, because pale text
+         on amber is the one combination that would undo the contrast. -->
+    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Color="#FFC24B" Offset="0" />
+        <GradientStop Color="#F59E0B" Offset="0.55" />
+        <GradientStop Color="#EA8C04" Offset="1" />
+    </LinearGradientBrush>
+
+    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#B36F00" />
+
+    <!-- Solid dark on amber: the one thing to click, and it inverts the banner's own contrast. -->
+    <Style x:Key="UpdateBannerPrimaryButton" TargetType="Button">
+        <Setter Property="Background" Value="#1B1E2B" />
+        <Setter Property="Foreground" Value="#FFE9B8" />
+        <Setter Property="FontFamily" Value="Segoe UI" />
+        <Setter Property="FontSize" Value="12.5" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Padding" Value="14,6" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="#000000" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Deliberately quieter than the primary: dismissing should be available, not inviting. -->
+    <Style x:Key="UpdateBannerGhostButton" TargetType="Button">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="#4A3308" />
+        <Setter Property="FontFamily" Value="Segoe UI" />
+        <Setter Property="FontSize" Value="12.5" />
+        <Setter Property="Padding" Value="12,6" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="#A96B05"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="#33FFFFFF" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Console rows. A ListBox for the virtualisation, stripped of every ListBox affordance:
          no selection highlight, no hover, no focus rectangle, tight line spacing. -->
     <Style x:Key="ConsoleListBoxItem" TargetType="ListBoxItem">


### PR DESCRIPTION
The banner was a dark navy strip on a dark navy app - the same visual weight as the chrome around it, so it read as decoration rather than news.

## Now

- **Bright amber gradient band with near-black text** - the highest contrast available against this UI
- **Amber rather than red**, deliberately. A new release is worth noticing, not an emergency, and red already means something has gone wrong in this app.
- **A dark badge with an up arrow**, pulsing slowly - enough to catch the eye on a screen someone is already looking at, slow enough not to nag while they work
- **A drop shadow** so the band lifts off the window rather than sitting flush with it
- **`View release` is a solid dark button**, inverting the band's own contrast so the one thing worth clicking is the one thing that stands out. **`Dismiss` is a quiet outline** - available, not inviting.

## Testing, honestly

Covered by `MainWindowLoads` only, which does catch what breaks silently: the markup, the storyboard, the drop shadow and every `{StaticResource}` key resolve at construction, so a wrong key throws there.

**Whether it is visible cannot be checked that way.** A `Window` builds nothing under itself until it is shown, and showing one in a test would flash a real window and run the actual startup path. Not worth contorting the harness for something whose appearance needs eyes regardless.

Two harness fixes rode along: templates are applied before measuring, and an unshown `Window` no longer makes everything inside it look hidden.

**587 tests pass.**