### PR TITLE
Say which clock a backup time came from (#47)

### DIFF
--- a/src/NineLives.Tests/BackupTimestampSourceTests.cs
+++ b/src/NineLives.Tests/BackupTimestampSourceTests.cs
@@ -1,0 +1,187 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A backup's time can come from two places that are NOT on the same clock: the filename, which
+/// the backup job wrote in the SERVER's local time, and the blob's LastModified, which is UTC.
+/// Nothing in a container reconciles them.
+///
+/// The skew cannot be removed without knowing the backup server's zone, so what these tests pin
+/// is that the app knows which clock each reading came from and says so, rather than presenting
+/// a mixed set as one exact timeline.
+/// </summary>
+public class BackupTimestampSourceTests
+{
+    private readonly BlobStorageService _service = new(new CredentialStore());
+
+    private static BackupFileInfo File(string blobName, DateTimeOffset? lastModified = null)
+        => new()
+        {
+            BlobName = blobName,
+            Type = BackupType.Full,
+            InferredDatabaseName = "MyDb",
+            InferredServerName = "SRV01",
+            SizeBytes = 100,
+            LastModified = lastModified ?? new DateTimeOffset(2026, 6, 15, 22, 30, 0, TimeSpan.Zero)
+        };
+
+    [Fact]
+    public void ATimestampParsedFromTheFileNameIsRecordedAsSuch()
+    {
+        var sets = _service.GroupIntoBackupSets([File("FULL/SRV01/MyDb/20260615_220000.bak")]);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.FileName, set.TimestampSource);
+        Assert.False(set.IsTimestampApproximate);
+        Assert.Null(set.TimestampNote);
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 0, 0), set.Timestamp);
+    }
+
+    [Fact]
+    public void AFileNameWithNoTimestampFallsBackToTheBlobAndIsMarkedApproximate()
+    {
+        // Plausible before a change window: an ad-hoc backup dropped alongside the scheduled ones.
+        var sets = _service.GroupIntoBackupSets([File("FULL/SRV01/MyDb/MyDb_preupgrade.bak")]);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.BlobLastModified, set.TimestampSource);
+        Assert.True(set.IsTimestampApproximate);
+        Assert.NotNull(set.TimestampNote);
+    }
+
+    [Fact]
+    public void AMaintenancePlanNameIsAlsoApproximate()
+    {
+        // Maintenance-plan naming carries a date, but not in a shape ParseTimestamp reads - so it
+        // takes the fallback like any other unparsable name.
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/MyDb_backup_2026_01_28_114441_1234567.bak")]);
+
+        Assert.True(Assert.Single(sets).IsTimestampApproximate);
+    }
+
+    [Fact]
+    public void OneDatabaseCanHoldBothKindsAtOnce()
+    {
+        // This is the case that actually bites: homogeneous naming is consistent either way, but a
+        // mixed database renders one set hours out of position against the rest.
+        var sets = _service.GroupIntoBackupSets(
+        [
+            File("FULL/SRV01/MyDb/20260615_220000.bak"),
+            File("FULL/SRV01/MyDb/MyDb_preupgrade.bak"),
+        ]);
+
+        Assert.Equal(2, sets.Count);
+        Assert.Single(sets, s => s.TimestampSource == BackupTimestampSource.FileName);
+        Assert.Single(sets, s => s.TimestampSource == BackupTimestampSource.BlobLastModified);
+    }
+
+    [Fact]
+    public void TheFallbackReadsTheBlobsUtcClockNotTheOffsetItArrivedWith()
+    {
+        // Azure sends +00:00, but DateTimeOffset.DateTime returns the wall clock OF THE OFFSET,
+        // so anything that ever supplies a non-zero offset silently shifted the reading. Taking
+        // UTC explicitly means the fallback is always on one known clock.
+        var sets = _service.GroupIntoBackupSets(
+        [
+            File("FULL/SRV01/MyDb/adhoc.bak",
+                 new DateTimeOffset(2026, 6, 15, 23, 30, 0, TimeSpan.FromHours(1))),
+        ]);
+
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 30, 0), Assert.Single(sets).Timestamp);
+    }
+
+    [Fact]
+    public void AWallClockCarriesNoKindSoNothingCanSilentlyConvertIt()
+    {
+        // Kind=Utc would invite ToLocalTime() and DateTimeOffset conversions that reinterpret the
+        // value against the WORKSTATION's zone - which is neither clock in play.
+        var sets = _service.GroupIntoBackupSets([File("FULL/SRV01/MyDb/adhoc.bak")]);
+
+        Assert.Equal(DateTimeKind.Unspecified, Assert.Single(sets).Timestamp.Kind);
+    }
+
+    [Fact]
+    public void AnApproximateTimeIsMarkedInWhatTheUserSees()
+    {
+        var approximate = new BackupSet
+        {
+            Timestamp = new DateTime(2026, 6, 15, 22, 30, 0),
+            TimestampSource = BackupTimestampSource.BlobLastModified
+        };
+        var exact = new BackupSet
+        {
+            Timestamp = new DateTime(2026, 6, 15, 22, 30, 0),
+            TimestampSource = BackupTimestampSource.FileName
+        };
+
+        Assert.Equal("~2026-06-15 22:30:00", approximate.TimestampDisplay);
+        Assert.Equal("2026-06-15 22:30:00", exact.TimestampDisplay);
+    }
+
+    [Fact]
+    public void ARestorePointInheritsTheMarkFromTheSetThatPlacesIt()
+    {
+        var set = new BackupSet
+        {
+            Timestamp = new DateTime(2026, 6, 15, 22, 30, 0),
+            TimestampSource = BackupTimestampSource.BlobLastModified
+        };
+        var point = new RestorePoint
+        {
+            Timestamp = set.Timestamp,
+            Type = BackupType.Full,
+            PrimarySet = set,
+            RequiredFullSet = set
+        };
+
+        Assert.True(point.IsTimestampApproximate);
+        Assert.Equal("~2026-06-15 22:30:00", point.TimestampDisplay);
+        Assert.NotNull(point.TimestampNote);
+    }
+
+    [Fact]
+    public void AFilesEffectiveDatePrefersTheHeaderAndSaysWhenItDidNot()
+    {
+        var withHeader = File("FULL/SRV01/MyDb/20260615_220000.bak");
+        withHeader.BackupStartDate = new DateTime(2026, 6, 15, 22, 0, 0);
+
+        var withoutHeader = File("FULL/SRV01/MyDb/20260615_220000.bak");
+
+        Assert.Equal(BackupTimestampSource.BackupHeader, withHeader.EffectiveDateSource);
+        Assert.False(withHeader.IsEffectiveDateApproximate);
+        Assert.Null(withHeader.EffectiveDateNote);
+        Assert.Equal("2026-06-15 22:00:00", withHeader.EffectiveDateDisplay);
+
+        Assert.Equal(BackupTimestampSource.BlobLastModified, withoutHeader.EffectiveDateSource);
+        Assert.True(withoutHeader.IsEffectiveDateApproximate);
+        Assert.NotNull(withoutHeader.EffectiveDateNote);
+        Assert.Equal("~2026-06-15 22:30:00", withoutHeader.EffectiveDateDisplay);
+    }
+
+    [Fact]
+    public void AFilesFallbackDateAlsoReadsUtc()
+    {
+        var file = File("FULL/SRV01/MyDb/adhoc.bak",
+                        new DateTimeOffset(2026, 6, 15, 23, 30, 0, TimeSpan.FromHours(1)));
+
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 30, 0), file.EffectiveDate);
+        Assert.Equal(DateTimeKind.Unspecified, file.EffectiveDate.Kind);
+    }
+
+    [Fact]
+    public void TheSetSummaryCountsHowManyTimesItHadToGuess()
+    {
+        var sets = _service.GroupIntoBackupSets(
+        [
+            File("FULL/SRV01/MyDb/20260615_220000.bak"),
+            File("FULL/SRV01/MyDb/adhoc.bak"),
+            File("FULL/SRV01/MyDb/preupgrade.bak"),
+        ]);
+
+        Assert.Equal(2, _service.GetSetBasedSummary(sets).ApproximateSets);
+    }
+}

--- a/src/NineLives.Tests/BlobStorageServiceTests.cs
+++ b/src/NineLives.Tests/BlobStorageServiceTests.cs
@@ -194,8 +194,24 @@ public class BlobStorageServiceTests
         Assert.Equal(1, summary.FullBackups);
         Assert.Equal(1, summary.LogBackups);
         Assert.Equal(210, summary.TotalSizeBytes);
-        Assert.Equal(new DateTime(2026, 1, 10, 22, 0, 0), summary.EarliestBackup!.Value.DateTime);
-        Assert.Equal(new DateTime(2026, 1, 10, 23, 0, 0), summary.LatestBackup!.Value.DateTime);
+        Assert.Equal(new DateTime(2026, 1, 10, 22, 0, 0), summary.EarliestSetTimestamp);
+        Assert.Equal(new DateTime(2026, 1, 10, 23, 0, 0), summary.LatestSetTimestamp);
+        Assert.Equal(0, summary.ApproximateSets);
+    }
+
+    [Fact]
+    public void GetSetBasedSummary_DoesNotPopulateTheFileLevelRange()
+    {
+        // The set range and the file range are different kinds of value - wall clocks against
+        // instants - and were previously served through the same two properties, which is what
+        // let a wall clock get stamped with the workstation's offset.
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/Db/20260110_220000.bak", db: "Db")]);
+
+        var summary = _service.GetSetBasedSummary(sets);
+
+        Assert.Null(summary.EarliestBackup);
+        Assert.Null(summary.LatestBackup);
     }
 
     [Fact]

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -10,6 +10,61 @@ public enum BackupType
     Unknown
 }
 
+/// <summary>
+/// Where a backup's time reading came from - which also says what clock it is on.
+///
+/// These are NOT the same time base, and nothing in a container tells us the offset between
+/// them, so they can only be compared once you accept the skew. A container whose files are
+/// homogeneous is fine either way; the problem case is one database with both kinds, where a
+/// fallback-derived set can sort hours out of position.
+/// </summary>
+public enum BackupTimestampSource
+{
+    /// <summary>Parsed out of the filename, so it reads the BACKUP SERVER's local clock.</summary>
+    FileName,
+
+    /// <summary>Read from SQL Server's own header, so it reads the backup server's local clock.</summary>
+    BackupHeader,
+
+    /// <summary>
+    /// Fallback: the blob's LastModified, which is UTC, and additionally records when the file
+    /// finished uploading rather than when the backup was taken.
+    /// </summary>
+    BlobLastModified
+}
+
+/// <summary>
+/// Helpers for the app's backup time readings.
+/// </summary>
+public static class BackupTime
+{
+    /// <summary>
+    /// Reduces a blob's LastModified to a bare wall-clock reading.
+    ///
+    /// Kind is deliberately Unspecified. Every time value the app sorts on is a wall clock whose
+    /// zone is recorded separately in a <see cref="BackupTimestampSource"/>; leaving Kind unset
+    /// keeps anything from quietly converting one base into another - notably
+    /// <c>new DateTimeOffset(value)</c>, which silently assumes the WORKSTATION's offset, and
+    /// <c>ToLocalTime()</c>, which is the workstation's zone rather than the backup server's.
+    /// </summary>
+    public static DateTime WallClock(DateTimeOffset value)
+        => DateTime.SpecifyKind(value.UtcDateTime, DateTimeKind.Unspecified);
+
+    /// <summary>Explains an approximate reading. Shown as a tooltip wherever one is displayed.</summary>
+    public const string ApproximateNote =
+        "Approximate. This file's name carries no timestamp, so the time shown is when the blob "
+        + "was last modified (UTC), not when the backup was taken on the server. It may sit hours "
+        + "away from the other entries.";
+
+    /// <summary>Prefix marking a displayed time as approximate.</summary>
+    public const string ApproximateMarker = "~";
+
+    public static string Format(DateTime value, bool approximate)
+        => approximate
+            ? ApproximateMarker + value.ToString("yyyy-MM-dd HH:mm:ss")
+            : value.ToString("yyyy-MM-dd HH:mm:ss");
+}
+
 public class BackupFileInfo
 {
     public string BlobName { get; set; } = string.Empty;
@@ -69,7 +124,22 @@ public class BackupFileInfo
     public bool MatchesServer(string? serverFilter)
         => ServerIdentity.Matches(InferredServerName, InferredInstanceName, serverFilter);
 
-    public DateTime EffectiveDate => BackupStartDate ?? LastModified.DateTime;
+    /// <summary>
+    /// Best available time for this file. Prefer the header's BackupStartDate, which is the
+    /// backup server's local clock; without it fall back to the blob's LastModified, which is
+    /// UTC. <see cref="EffectiveDateSource"/> says which you got - the two are not interchangeable.
+    /// </summary>
+    public DateTime EffectiveDate => BackupStartDate ?? BackupTime.WallClock(LastModified);
+
+    public BackupTimestampSource EffectiveDateSource => BackupStartDate.HasValue
+        ? BackupTimestampSource.BackupHeader
+        : BackupTimestampSource.BlobLastModified;
+
+    public bool IsEffectiveDateApproximate => !BackupStartDate.HasValue;
+
+    public string EffectiveDateDisplay => BackupTime.Format(EffectiveDate, IsEffectiveDateApproximate);
+
+    public string? EffectiveDateNote => IsEffectiveDateApproximate ? BackupTime.ApproximateNote : null;
 
     public string TypeDisplay => Type switch
     {
@@ -94,7 +164,24 @@ public class BackupSet
     public string SetId { get; set; } = string.Empty;
     public BackupType Type { get; set; }
     public List<BackupFileInfo> Files { get; set; } = [];
+    /// <summary>
+    /// When this backup was taken, as a bare wall clock. <see cref="TimestampSource"/> says which
+    /// clock it is on - sets in one container can differ, and nothing reconciles them.
+    /// </summary>
     public DateTime Timestamp { get; set; }
+
+    public BackupTimestampSource TimestampSource { get; set; } = BackupTimestampSource.FileName;
+
+    /// <summary>
+    /// True when the time had to be taken from the blob rather than the filename, which puts it
+    /// on a different clock (UTC) from its neighbours and can sort it hours out of position.
+    /// </summary>
+    public bool IsTimestampApproximate => TimestampSource == BackupTimestampSource.BlobLastModified;
+
+    public string TimestampDisplay => BackupTime.Format(Timestamp, IsTimestampApproximate);
+
+    public string? TimestampNote => IsTimestampApproximate ? BackupTime.ApproximateNote : null;
+
     public string? DatabaseName { get; set; }
     public string? ServerName { get; set; }
 
@@ -198,6 +285,16 @@ public class RestorePoint
     /// Vertical stacking row (0 = bottom/track level, 1 = above, etc.). Computed by ViewModel.
     /// </summary>
     public int Row { get; set; }
+
+    /// <summary>
+    /// True when this point's own time is a blob-derived approximation, which is what decides
+    /// where it lands on the timeline.
+    /// </summary>
+    public bool IsTimestampApproximate => PrimarySet?.IsTimestampApproximate ?? false;
+
+    public string TimestampDisplay => BackupTime.Format(Timestamp, IsTimestampApproximate);
+
+    public string? TimestampNote => IsTimestampApproximate ? BackupTime.ApproximateNote : null;
 
     public string TypeDisplay => Type switch
     {

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -241,8 +241,14 @@ public class BlobStorageService
             LogBackups = sets.Count(s => s.Type == BackupType.TransactionLog),
             UnknownFiles = sets.Count(s => s.Type == BackupType.Unknown),
             TotalSizeBytes = sets.Sum(s => s.TotalSizeBytes),
-            EarliestBackup = sets.Count > 0 ? sets.Min(s => new DateTimeOffset(s.Timestamp)) : null,
-            LatestBackup = sets.Count > 0 ? sets.Max(s => new DateTimeOffset(s.Timestamp)) : null
+
+            // Deliberately NOT EarliestBackup/LatestBackup. A set's Timestamp is a bare wall clock
+            // whose zone varies by set, and wrapping it in a DateTimeOffset stamped it with the
+            // WORKSTATION's offset - which is nobody's clock, and double-shifted the blob-derived
+            // ones. The set range keeps its own members so the two can never be confused.
+            EarliestSetTimestamp = sets.Count > 0 ? sets.Min(s => s.Timestamp) : null,
+            LatestSetTimestamp = sets.Count > 0 ? sets.Max(s => s.Timestamp) : null,
+            ApproximateSets = sets.Count(s => s.IsTimestampApproximate)
         };
     }
 
@@ -294,14 +300,21 @@ public class BlobStorageService
         {
             var first = groupFiles[0];
             var (setId, _) = BackupSet.ParseFileName(first.FileName);
-            var timestamp = BackupSet.ParseTimestamp(setId) ?? first.LastModified.DateTime;
+
+            // The filename is the backup server's local clock; the blob's LastModified is UTC.
+            // Nothing here can reconcile them, so record WHICH one this set got and let the UI
+            // mark the fallback as approximate rather than presenting both as one timeline.
+            var parsed = BackupSet.ParseTimestamp(setId);
 
             sets.Add(new BackupSet
             {
                 SetId = setId,
                 Type = first.Type,
                 Files = groupFiles.OrderBy(f => f.FileName).ToList(),
-                Timestamp = timestamp,
+                Timestamp = parsed ?? BackupTime.WallClock(first.LastModified),
+                TimestampSource = parsed != null
+                    ? BackupTimestampSource.FileName
+                    : BackupTimestampSource.BlobLastModified,
                 DatabaseName = first.InferredDatabaseName,
                 ServerName = first.InferredServerName,
                 InstanceName = first.InferredInstanceName,
@@ -551,8 +564,24 @@ public class ContainerSummary
     public int LogBackups { get; set; }
     public int UnknownFiles { get; set; }
     public long TotalSizeBytes { get; set; }
+
+    /// <summary>
+    /// File-level range, straight from blob metadata, so genuine UTC instants. Only populated by
+    /// the file-based summary.
+    /// </summary>
     public DateTimeOffset? EarliestBackup { get; set; }
     public DateTimeOffset? LatestBackup { get; set; }
+
+    /// <summary>
+    /// Set-level range. Bare wall clocks, not instants: most read the backup server's local clock
+    /// and any counted by <see cref="ApproximateSets"/> read UTC instead. Only populated by the
+    /// set-based summary.
+    /// </summary>
+    public DateTime? EarliestSetTimestamp { get; set; }
+    public DateTime? LatestSetTimestamp { get; set; }
+
+    /// <summary>How many sets had to fall back to the blob's LastModified for their time.</summary>
+    public int ApproximateSets { get; set; }
 
     public string TotalSizeDisplay => ByteSize.Format(TotalSizeBytes);
 }

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -261,7 +261,15 @@ public partial class BlobBrowserViewModel : ViewModelBase
         {
             var earliest = filtered.Min(s => s.Timestamp);
             var latest = filtered.Max(s => s.Timestamp);
-            DbSummaryText = $"{Summary.FullBackups} Full, {Summary.DiffBackups} Diff, {Summary.LogBackups} Log sets  |  {earliest:yyyy-MM-dd} to {latest:yyyy-MM-dd}";
+
+            // Sets whose filename carried no timestamp fall back to the blob's LastModified, which
+            // is UTC rather than the backup server's clock - so the range they bound is only as
+            // good as that skew. Say so rather than presenting one exact-looking window.
+            var approximate = Summary.ApproximateSets > 0
+                ? $"  |  {Summary.ApproximateSets} approximate"
+                : string.Empty;
+
+            DbSummaryText = $"{Summary.FullBackups} Full, {Summary.DiffBackups} Diff, {Summary.LogBackups} Log sets  |  {earliest:yyyy-MM-dd} to {latest:yyyy-MM-dd}{approximate}";
         }
         else
         {

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -248,10 +248,14 @@
                                                         <TextBlock FontWeight="SemiBold">
                                                             <Run Text="{Binding TypeDisplay, Mode=OneWay}" />
                                                             <Run Text=" — " />
-                                                            <Run Text="{Binding Timestamp, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}', Mode=OneWay}" />
+                                                            <Run Text="{Binding TimestampDisplay, Mode=OneWay}" />
                                                         </TextBlock>
                                                         <TextBlock Text="{Binding ChainDescription}"
                                                                    Foreground="{StaticResource SecondaryTextBrush}" TextWrapping="Wrap" />
+                                                        <TextBlock Text="{Binding TimestampNote}"
+                                                                   Foreground="{StaticResource WarningBrush}" TextWrapping="Wrap"
+                                                                   Margin="0,4,0,0"
+                                                                   Visibility="{Binding IsTimestampApproximate, Converter={StaticResource BoolToVis}}" />
                                                     </StackPanel>
                                                 </Button.ToolTip>
                                             </Button>
@@ -330,8 +334,22 @@
 
                             <DataGridTextColumn Header="Set ID" Width="160"
                                                 Binding="{Binding SetId}" />
+                            <!-- Sorts on the underlying value, not the display string, so a "~"
+                                 prefix cannot push approximate sets to one end of the grid. -->
                             <DataGridTextColumn Header="Timestamp" Width="150"
-                                                Binding="{Binding Timestamp, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" />
+                                                SortMemberPath="Timestamp"
+                                                Binding="{Binding TimestampDisplay}">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="ToolTip" Value="{Binding TimestampNote}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsTimestampApproximate}" Value="True">
+                                                <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
                             <DataGridTextColumn Header="Files" Width="55"
                                                 Binding="{Binding FileCount}" />
                             <DataGridTextColumn Header="Striped" Width="60"
@@ -352,7 +370,7 @@
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
                             <Run Text="Selected: " Foreground="{StaticResource SecondaryTextBrush}" />
-                            <Run Text="{Binding SelectedRestorePoint.Timestamp, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}', Mode=OneWay}"
+                            <Run Text="{Binding SelectedRestorePoint.TimestampDisplay, Mode=OneWay}"
                                  FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}" />
                             <Run Text="  |  " Foreground="{StaticResource SecondaryTextBrush}" />
                             <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{StaticResource SecondaryTextBrush}" />
@@ -496,7 +514,8 @@
                                             <TextBlock Grid.Column="2" Text="{Binding SizeDisplay}"
                                                        Style="{StaticResource SecondaryText}" VerticalAlignment="Center" />
                                             <TextBlock Grid.Column="3"
-                                                       Text="{Binding EffectiveDate, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}"
+                                                       Text="{Binding EffectiveDateDisplay}"
+                                                       ToolTip="{Binding EffectiveDateNote}"
                                                        Style="{StaticResource SecondaryText}" VerticalAlignment="Center" />
                                         </Grid>
                                     </DataTemplate>


### PR DESCRIPTION
Closes #47.

A backup's time came from one of two places that are not on the same clock, and nothing said which:

- parsed from the filename — the **backup server's local** time, because that is what the backup job wrote
- the blob's `LastModified` — **UTC**, and it records when the upload finished rather than when the backup ran

They were then sorted against each other as if they were the same thing.

The skew can't be removed without knowing the backup server's timezone, and a container doesn't carry that. So the fix is to stop pretending: each set records where its time came from, and a blob-derived one is shown with a `~` and a tooltip explaining that it may sit hours away from its neighbours. It appears in the timeline tooltip, the chain grid (amber, sorting still on the real value), the selected-point line and the file list.

The blob browser's per-database summary now also says how many sets it had to guess at.

## The other half

`GetSetBasedSummary` did `new DateTimeOffset(set.Timestamp)` on a `Kind=Unspecified` value. That constructor assumes the **workstation's** offset — which is neither clock in play, and it double-shifted the UTC-derived ones. The set range now has its own `EarliestSetTimestamp` / `LatestSetTimestamp`, so a wall clock and a real instant can't be served through the same two properties again.

The fallback also now reads `UtcDateTime` rather than `DateTime`. Azure sends `+00:00` so today they agree, but `DateTimeOffset.DateTime` returns the wall clock *of whatever offset arrived*, so a non-zero one silently shifted the reading.

## What this does not do

The issue floats a per-container "backup server timezone" setting as the way to actually reconcile the two. That's a bigger change and I've left it out — filed separately. Until then the app marks an unreliable reading rather than hiding it.

## Tests

12 new. Three of them fail against the pre-fix code (checked by reverting):

- `TheFallbackReadsTheBlobsUtcClockNotTheOffsetItArrivedWith`
- `AFilesFallbackDateAlsoReadsUtc`
- `GetSetBasedSummary_DoesNotPopulateTheFileLevelRange`

The rest pin new API, so they can't fail against code that didn't have it.

**599 tests**, build clean at `-warnaserror`. The XAML load tests cover the new bindings, so a mistyped path or a missing resource key would have failed the build rather than shown up blank at runtime.

