### PR TITLE
Verify the backups before restoring them (#26)

### DIFF
--- a/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
+++ b/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
@@ -382,6 +382,43 @@ public class RestoreScriptGeneratorTests
     }
 
     [Fact]
+    public void Generate_ChecksumAndContinueAfterError_OffByDefault()
+    {
+        // CONTINUE_AFTER_ERROR produces a database SQL Server has already reported as damaged, and
+        // CHECKSUM fails outright against a backup that was taken without checksums. Neither is a
+        // safe default for a restore that runs unattended.
+        var script = _generator.Generate(FullOnlyChain(), Options());
+
+        Assert.DoesNotContain("CHECKSUM", script);
+        Assert.DoesNotContain("CONTINUE_AFTER_ERROR", script);
+    }
+
+    [Fact]
+    public void Generate_ChecksumAndContinueAfterError_EmittedOnEveryStatementWhenSet()
+    {
+        var script = _generator.Generate(FullDiffLogChain(), Options(o =>
+        {
+            o.WithChecksum = true;
+            o.ContinueAfterError = true;
+        }));
+
+        // Full + diff + two logs. An option applied to only the first statement would leave the
+        // rest of the chain restoring under different rules from the one the user chose.
+        Assert.Equal(4, CountOccurrences(script, "         CHECKSUM,"));
+        Assert.Equal(4, CountOccurrences(script, "         CONTINUE_AFTER_ERROR,"));
+    }
+
+    [Fact]
+    public void Generate_ContinueAfterError_WarnsInTheScriptItself()
+    {
+        // The script gets pasted into SSMS and run by someone who never saw the checkbox.
+        var script = _generator.Generate(FullOnlyChain(), Options(o => o.ContinueAfterError = true));
+
+        Assert.Contains("WARNING: CONTINUE_AFTER_ERROR", script);
+        Assert.Contains("DBCC CHECKDB", script);
+    }
+
+    [Fact]
     public void Generate_HeaderAndFooter_DescribeTheRestore()
     {
         var script = _generator.Generate(FullDiffLogChain(), Options());

--- a/src/NineLives.Tests/VerifyOnlyTests.cs
+++ b/src/NineLives.Tests/VerifyOnlyTests.cs
@@ -1,0 +1,100 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// RESTORE VERIFYONLY as a pre-flight: does each backup in the chain actually read back, before
+/// an hour is spent finding out that it does not (#26).
+///
+/// The statement shape is tested here without a server. The failure CONTRACT - a bad backup comes
+/// back as a result rather than an exception, so one bad member does not abort the rest - needs a
+/// real instance and is gated on NINELIVES_TEST_SQL.
+/// </summary>
+public class VerifyOnlyTests
+{
+    private const string Url1 = "https://mystorageaccount.blob.core.windows.net/backups/FULL/MyDb_1.bak";
+    private const string Url2 = "https://mystorageaccount.blob.core.windows.net/backups/FULL/MyDb_2.bak";
+
+    [Fact]
+    public void ASingleFileVerifiesWithOneUrl()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url1], withChecksum: false);
+
+        Assert.Equal($"RESTORE VERIFYONLY FROM URL = N'{Url1}'", sql);
+    }
+
+    [Fact]
+    public void EveryStripeGoesIntoOneStatement()
+    {
+        // A stripe on its own is not a readable backup. Verifying them one at a time would report
+        // failures that are not there.
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url1, Url2], withChecksum: false);
+
+        Assert.Equal($"RESTORE VERIFYONLY FROM URL = N'{Url1}', URL = N'{Url2}'", sql);
+    }
+
+    [Fact]
+    public void ChecksumIsAddedOnlyWhenAskedFor()
+    {
+        // Left off, SQL Server's own default applies. Forcing NO_CHECKSUM would be a different
+        // instruction from saying nothing.
+        Assert.EndsWith("WITH CHECKSUM", SqlServerService.BuildVerifyOnlyStatement([Url1], true));
+        Assert.DoesNotContain("CHECKSUM", SqlServerService.BuildVerifyOnlyStatement([Url1], false));
+    }
+
+    [Fact]
+    public void NoCredentialClauseIsEmitted()
+    {
+        // SQL Server rejects WITH CREDENTIAL for a SAS credential (Msg 3225) and matches by URL
+        // instead - the defect behind #60, which must not come back through this path.
+        Assert.DoesNotContain(
+            "CREDENTIAL",
+            SqlServerService.BuildVerifyOnlyStatement([Url1, Url2], withChecksum: true));
+    }
+
+    [Fact]
+    public void AUrlWithAnApostropheCannotTerminateTheLiteral()
+    {
+        var awkward = "https://mystorageaccount.blob.core.windows.net/backups/it's/MyDb.bak";
+
+        var sql = SqlServerService.BuildVerifyOnlyStatement([awkward], withChecksum: false);
+
+        Assert.Equal("RESTORE VERIFYONLY FROM URL = N'https://mystorageaccount.blob.core.windows.net/backups/it''s/MyDb.bak'", sql);
+    }
+
+    [Fact]
+    public async Task NoFilesIsReportedRatherThanRun()
+    {
+        var result = await new SqlServerService(new CredentialStore())
+            .RestoreVerifyOnlyAsync(new ServerConnection(), []);
+
+        Assert.False(result.IsValid);
+    }
+
+    // ---- Live SQL ----------------------------------------------------------
+
+    private static ServerConnection TestServer() => new()
+    {
+        Name = "ninelives-test",
+        ServerName = SqlExecutionFailureTests.TestServerName!,
+        AuthMode = AuthMode.WindowsAuth,
+        Encrypt = EncryptMode.No,
+        TrustServerCertificate = true,
+        ConnectionTimeoutSeconds = 15
+    };
+
+    [RequiresSqlFact]
+    public async Task AnUnreadableBackupComesBackAsAResultNotAnException()
+    {
+        // The whole point of the pre-flight is to check every member of a chain. If one bad blob
+        // threw, the loop would stop at the first problem and the user would fix them one round
+        // trip at a time.
+        var result = await new SqlServerService(new CredentialStore())
+            .RestoreVerifyOnlyAsync(TestServer(), [Url1]);
+
+        Assert.False(result.IsValid);
+        Assert.NotEmpty(result.Message);
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -414,6 +414,63 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
         });
     }
 
+    /// <summary>
+    /// The VERIFYONLY results panel (#26). Its rows colour the status through a Style on a Run,
+    /// which is only ever built when the template is realised - so an empty collection would leave
+    /// that markup completely unexercised.
+    /// </summary>
+    [Fact]
+    public void TheVerifyPanelShowsWhatSqlServerSaidAboutEachBackup()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            var good = new BackupSet { SetId = "20260110_220000", Type = BackupType.Full };
+            var bad = new BackupSet { SetId = "20260110_230000", Type = BackupType.TransactionLog };
+
+            vm.ChainVerifyResults.Add(new ChainVerifyResult
+            {
+                Set = good,
+                Result = new VerifyOnlyResult(true, "The backup set on file 1 is valid.")
+            });
+            vm.ChainVerifyResults.Add(new ChainVerifyResult
+            {
+                Set = bad,
+                Result = new VerifyOnlyResult(false, "Cannot open backup device.")
+            });
+            vm.HasVerifyResults = true;
+            vm.HasVerifyFailures = true;
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.True(
+                    texts.Any(t => t.Contains("Cannot open backup device.", StringComparison.Ordinal)),
+                    "The verify panel did not render its results. TextBlocks found: " +
+                    string.Join(" | ", texts.Where(t => !string.IsNullOrWhiteSpace(t))));
+                // The status sits in its own Run so it can be coloured, so look at the inlines
+                // rather than the TextBlock's flattened text.
+                var runs = FindAll<TextBlock>(view)
+                    .SelectMany(t => t.Inlines.OfType<System.Windows.Documents.Run>())
+                    .Select(r => r.Text)
+                    .ToList();
+
+                Assert.True(runs.Contains("FAILED"), "A failed backup did not read as failed.");
+                Assert.True(runs.Contains("Valid"), "A good backup did not read as valid.");
+
+                listener.AssertNone("RestoreView verify panel");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
     /// <summary>Tag pills render through one wrapping template; they used to clip (#67).</summary>
     [Fact]
     public void TagPillsRenderForAServerRow()

--- a/src/NineLives/Models/RestoreOptions.cs
+++ b/src/NineLives/Models/RestoreOptions.cs
@@ -19,6 +19,21 @@ public class RestoreOptions
     public bool KeepReplication { get; set; }
     public bool EnableBroker { get; set; }
     public bool NewBroker { get; set; }
+
+    /// <summary>
+    /// Verify backup checksums as each page is read. Only meaningful if the backup was taken
+    /// WITH CHECKSUM - against one that was not, SQL Server fails the restore rather than
+    /// skipping the check, which is why this is off by default.
+    /// </summary>
+    public bool WithChecksum { get; set; }
+
+    /// <summary>
+    /// Carry on restoring after a checksum or page error instead of stopping.
+    ///
+    /// This produces a database that SQL Server has already told you is damaged. It exists for
+    /// the case where a partial recovery beats none, and is not something to leave switched on.
+    /// </summary>
+    public bool ContinueAfterError { get; set; }
     public string? CredentialName { get; set; }
 
     public List<FileMoveOption> FileMoves { get; set; } = [];

--- a/src/NineLives/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives/Services/RestoreScriptGenerator.cs
@@ -51,6 +51,17 @@ public class RestoreScriptGenerator
         if (options.StopAt.HasValue)
             sb.AppendLine($"-- Point-in-Time: {options.StopAt.Value:yyyy-MM-dd HH:mm:ss}");
         sb.AppendLine("-- ============================================================");
+
+        // Worth saying in the script itself, not just the checkbox tooltip - the script gets
+        // copied into SSMS and run by someone who never saw the checkbox.
+        if (options.ContinueAfterError)
+        {
+            sb.AppendLine();
+            sb.AppendLine("-- WARNING: CONTINUE_AFTER_ERROR is set. If SQL Server hits a damaged");
+            sb.AppendLine("-- page or a failed checksum it will keep going and finish anyway, so");
+            sb.AppendLine("-- a database this produces may be corrupt. Run DBCC CHECKDB on it.");
+        }
+
         sb.AppendLine();
     }
 
@@ -171,6 +182,10 @@ public class RestoreScriptGenerator
             sb.AppendLine("         ENABLE_BROKER,");
         if (options.NewBroker)
             sb.AppendLine("         NEW_BROKER,");
+        if (options.WithChecksum)
+            sb.AppendLine("         CHECKSUM,");
+        if (options.ContinueAfterError)
+            sb.AppendLine("         CONTINUE_AFTER_ERROR,");
         sb.AppendLine($"         STATS = {options.StatsPercent};");
     }
 

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -296,6 +296,83 @@ public class SqlServerService
         };
     }
 
+    /// <summary>
+    /// RESTORE VERIFYONLY across the files of one backup set, striped or not.
+    ///
+    /// This is the check a DBA runs before committing to a long restore: it reads the backup and
+    /// reports whether it is complete and readable, in seconds rather than after an hour of
+    /// restoring. It does NOT check the data inside - that needs a restore and DBCC CHECKDB.
+    ///
+    /// A failure is returned rather than thrown, so one unreadable member of a chain does not
+    /// abort verification of the rest. Cancellation still propagates.
+    /// </summary>
+    /// <param name="withChecksum">
+    /// Adds WITH CHECKSUM. Left off, SQL Server applies its own default; a backup taken without
+    /// checksums FAILS this rather than skipping the check, so it is the caller's choice.
+    /// </param>
+    public async Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
+        ServerConnection server,
+        IReadOnlyList<string> blobUrls,
+        bool withChecksum = false,
+        CancellationToken ct = default)
+    {
+        if (blobUrls.Count == 0)
+            return new VerifyOnlyResult(false, "No files to verify.");
+
+        var messages = new List<string>();
+
+        await using var conn = CreateConnection(server);
+
+        // VERIFYONLY says what it found through info messages - "The backup set on file 1 is
+        // valid." - and reports a bad backup by throwing. Both halves are wanted.
+        conn.InfoMessage += (_, e) => messages.Add(e.Message);
+
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandTimeout = 0;
+
+        cmd.CommandText = BuildVerifyOnlyStatement(blobUrls, withChecksum);
+
+        try
+        {
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+        catch (SqlException) when (ct.IsCancellationRequested)
+        {
+            // Same trap as the restore path: a cancelled command surfaces as SqlException, and
+            // reporting that as a verification failure would tell the user their backup is bad.
+            throw new OperationCanceledException("Verification was cancelled.", ct);
+        }
+        catch (SqlException ex)
+        {
+            return new VerifyOnlyResult(false, ex.Message);
+        }
+
+        return new VerifyOnlyResult(
+            true,
+            messages.Count > 0
+                ? string.Join(" ", messages.Select(m => m.Trim()))
+                : "The backup set is valid.");
+    }
+
+    /// <summary>
+    /// The exact T-SQL a verification runs. Every file of a striped set goes into one statement -
+    /// a stripe on its own is not a readable backup, so verifying them one at a time would report
+    /// failures that are not there.
+    ///
+    /// No WITH CREDENTIAL clause: SQL Server rejects that for SAS credentials with Msg 3225, and
+    /// it matches the credential by URL anyway (#60).
+    /// </summary>
+    public static string BuildVerifyOnlyStatement(IReadOnlyList<string> blobUrls, bool withChecksum)
+    {
+        var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
+
+        // Omitted rather than set to NO_CHECKSUM when off, so SQL Server's own default applies.
+        return withChecksum
+            ? $"RESTORE VERIFYONLY FROM {urlClauses} WITH CHECKSUM"
+            : $"RESTORE VERIFYONLY FROM {urlClauses}";
+    }
+
     private static string? GetStringFromReader(SqlDataReader reader, string columnName)
     {
         var ordinal = reader.GetOrdinal(columnName);

--- a/src/NineLives/Services/VerifyOnlyResult.cs
+++ b/src/NineLives/Services/VerifyOnlyResult.cs
@@ -1,0 +1,33 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// What RESTORE VERIFYONLY said about one backup set.
+/// </summary>
+/// <param name="IsValid">True when SQL Server read the whole set without complaint.</param>
+/// <param name="Message">
+/// SQL Server's own words, either the info message it emits on success or the error it raised.
+/// Kept verbatim - a DBA reading "The backup set on file 1 is valid." or "Cannot open backup
+/// device" knows exactly what happened, and a paraphrase would only lose detail.
+/// </param>
+public sealed record VerifyOnlyResult(bool IsValid, string Message);
+
+/// <summary>
+/// One member of a restore chain paired with its verification result, for display.
+/// </summary>
+public sealed class ChainVerifyResult
+{
+    public required BackupSet Set { get; init; }
+    public required VerifyOnlyResult Result { get; init; }
+
+    public string TypeDisplay => Set.TypeDisplay;
+    public string SetId => Set.SetId;
+    public bool IsValid => Result.IsValid;
+    public string Message => Result.Message;
+
+    /// <summary>Short label for the row, so the grid reads without needing the message column.</summary>
+    public string StatusDisplay => Result.IsValid ? "Valid" : "FAILED";
+
+    public string Summary => $"{TypeDisplay} {SetId}: {StatusDisplay}";
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -254,6 +254,18 @@ public partial class RestoreViewModel : ViewModelBase
     private bool _isValidatingChain;
 
     [ObservableProperty]
+    private bool _isVerifyingChain;
+
+    /// <summary>Per-set RESTORE VERIFYONLY results for the selected chain.</summary>
+    public ObservableCollection<ChainVerifyResult> ChainVerifyResults { get; } = [];
+
+    [ObservableProperty]
+    private bool _hasVerifyResults;
+
+    [ObservableProperty]
+    private bool _hasVerifyFailures;
+
+    [ObservableProperty]
     private bool _disconnectSessions = true;
 
     [ObservableProperty]
@@ -267,6 +279,12 @@ public partial class RestoreViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _newBroker;
+
+    [ObservableProperty]
+    private bool _withChecksum;
+
+    [ObservableProperty]
+    private bool _continueAfterError;
 
     [ObservableProperty]
     private bool _useWithMove;
@@ -535,6 +553,11 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnSelectedRestorePointChanged(RestorePoint? value)
     {
         ShowChainDetails = false;
+
+        // Verification belongs to the chain that was verified. Leaving the results on screen
+        // after the selection moves would show a green tick against backups nothing has read.
+        ClearVerifyResults();
+
         if (value == null)
         {
             RestoreChain = null;
@@ -566,6 +589,7 @@ public partial class RestoreViewModel : ViewModelBase
         ChainLsnVerified = false;
         UpdateChainIssues(chain);
         ValidateChainCommand.NotifyCanExecuteChanged();
+        VerifyChainCommand.NotifyCanExecuteChanged();
         UpdateRestoreSummary();
         FetchLogicalNamesCommand.NotifyCanExecuteChanged();
         InspectBackupMetadataCommand.NotifyCanExecuteChanged();
@@ -1024,6 +1048,72 @@ public partial class RestoreViewModel : ViewModelBase
     private bool CanValidateChain() =>
         IsConnectedToServer && RestoreChain != null && !IsValidatingChain;
 
+    /// <summary>
+    /// Runs RESTORE VERIFYONLY over every set in the chain: does each backup actually read back,
+    /// before an hour is spent finding out that it does not.
+    ///
+    /// This asks a different question from Validate chain. That one reads headers and checks the
+    /// LSNs line up - whether these backups belong together. This one reads the whole backup and
+    /// checks it is intact - whether they are usable at all. A truncated or half-uploaded blob
+    /// passes the first and fails this.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanVerifyChain))]
+    private async Task VerifyChainAsync()
+    {
+        if (RestoreChain == null || ConnectedServer == null) return;
+
+        IsVerifyingChain = true;
+        ClearStatus();
+        ChainVerifyResults.Clear();
+        HasVerifyResults = false;
+
+        try
+        {
+            var sets = RestoreChain.AllSets;
+            for (int i = 0; i < sets.Count; i++)
+            {
+                var set = sets[i];
+                SetStatus($"Verifying {i + 1} of {sets.Count}: {set.TypeDisplay} {set.SetId}...");
+
+                var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+                var result = await _sqlService.RestoreVerifyOnlyAsync(
+                    ConnectedServer, urls, WithChecksum);
+
+                ChainVerifyResults.Add(new ChainVerifyResult { Set = set, Result = result });
+                HasVerifyResults = true;
+            }
+
+            var failed = ChainVerifyResults.Count(r => !r.IsValid);
+            HasVerifyFailures = failed > 0;
+
+            SetStatus(failed > 0
+                ? $"{failed} of {ChainVerifyResults.Count} backup(s) failed verification - see below. Do not rely on this chain."
+                : $"All {ChainVerifyResults.Count} backup(s) in the chain verified.");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Verification cancelled.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Verification could not run: {ex.Message}");
+        }
+        finally
+        {
+            IsVerifyingChain = false;
+        }
+    }
+
+    private bool CanVerifyChain() =>
+        IsConnectedToServer && RestoreChain != null && !IsVerifyingChain && !IsExecuting;
+
+    private void ClearVerifyResults()
+    {
+        ChainVerifyResults.Clear();
+        HasVerifyResults = false;
+        HasVerifyFailures = false;
+    }
+
     private void UpdateChainIssues(BackupChain? chain, IReadOnlyList<ChainHeader>? headers = null)
     {
         var issues = _chainValidator.Validate(chain);
@@ -1135,6 +1225,12 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnKeepReplicationChanged(bool value) => UpdateRestoreSummary();
     partial void OnEnableBrokerChanged(bool value) => UpdateRestoreSummary();
     partial void OnNewBrokerChanged(bool value) => UpdateRestoreSummary();
+    partial void OnWithChecksumChanged(bool value) => UpdateRestoreSummary();
+    partial void OnContinueAfterErrorChanged(bool value) => UpdateRestoreSummary();
+
+    // Verification opens its own connection and reads whole backups. Letting it start while a
+    // restore is running would put a second heavy reader on the same server at the worst moment.
+    partial void OnIsExecutingChanged(bool value) => VerifyChainCommand.NotifyCanExecuteChanged();
     partial void OnTargetDatabaseNameChanged(string value) => UpdateRestoreSummary();
 
     partial void OnIsConnectedToServerChanged(bool value)
@@ -1146,6 +1242,7 @@ public partial class RestoreViewModel : ViewModelBase
         HasConnectedServerTags = ConnectedServerTags.Count > 0;
 
         ValidateChainCommand.NotifyCanExecuteChanged();
+        VerifyChainCommand.NotifyCanExecuteChanged();
         FetchLogicalNamesCommand.NotifyCanExecuteChanged();
         InspectBackupMetadataCommand.NotifyCanExecuteChanged();
         CopyFileListOnlyCommandCommand.NotifyCanExecuteChanged();
@@ -1243,6 +1340,8 @@ public partial class RestoreViewModel : ViewModelBase
             KeepReplication = KeepReplication,
             EnableBroker = EnableBroker,
             NewBroker = NewBroker,
+            WithChecksum = WithChecksum,
+            ContinueAfterError = ContinueAfterError,
             SqlCredentialName = SqlCredentialName,
             SasToken = sasToken,
             StorageAccountUrl = SelectedContainer?.ContainerUrl,

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -366,6 +366,7 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
@@ -406,7 +407,39 @@
                             </Button.Content>
                         </Button>
 
+                        <!-- A different question from Validate Chain: that one reads headers and
+                             checks the LSNs line up, this one reads each backup end to end and
+                             checks it is intact. A truncated blob passes the first and fails this. -->
                         <Button Grid.Column="2"
+                                Style="{StaticResource SecondaryButton}"
+                                Command="{Binding VerifyChainCommand}"
+                                Padding="12,6" Margin="0,0,8,0"
+                                ToolTip="Run RESTORE VERIFYONLY over every backup in the chain to check each one reads back intact, before committing to the restore. Requires a connected server.">
+                            <Button.Content>
+                                <TextBlock>
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="Verify Backups" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsVerifyingChain}" Value="True">
+                                                    <Setter Property="Text" Value="Verifying..." />
+                                                </DataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding HasVerifyResults}" Value="True" />
+                                                        <Condition Binding="{Binding HasVerifyFailures}" Value="False" />
+                                                        <Condition Binding="{Binding IsVerifyingChain}" Value="False" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Text" Value="Backups Verified" />
+                                                </MultiDataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Button.Content>
+                        </Button>
+
+                        <Button Grid.Column="3"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding ToggleChainDetailsCommand}"
                                 Padding="12,6">
@@ -426,6 +459,59 @@
                             </Button.Content>
                         </Button>
                     </Grid>
+
+                    <!-- Per-set VERIFYONLY results. Green while everything reads back, red the
+                         moment one does not - a failed member here means the chain cannot restore,
+                         whatever the timeline and the LSNs say about it. -->
+                    <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                            Visibility="{Binding HasVerifyResults, Converter={StaticResource BoolToVis}}">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Background" Value="#1A2A1E" />
+                                <Setter Property="BorderBrush" Value="{StaticResource SuccessBrush}" />
+                                <Setter Property="BorderThickness" Value="1" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasVerifyFailures}" Value="True">
+                                        <Setter Property="Background" Value="#3A1E1E" />
+                                        <Setter Property="BorderBrush" Value="#A33F3F" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="RESTORE VERIFYONLY" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                            <ItemsControl ItemsSource="{Binding ChainVerifyResults}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Margin="0,0,0,8">
+                                            <TextBlock TextWrapping="Wrap" FontWeight="SemiBold">
+                                                <Run Text="{Binding TypeDisplay, Mode=OneWay}" />
+                                                <Run Text=" " />
+                                                <Run Text="{Binding SetId, Mode=OneWay}" />
+                                                <Run Text="  " />
+                                                <Run Text="{Binding StatusDisplay, Mode=OneWay}">
+                                                    <Run.Style>
+                                                        <Style TargetType="Run">
+                                                            <Setter Property="Foreground" Value="{StaticResource SuccessBrush}" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsValid}" Value="False">
+                                                                    <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </Run.Style>
+                                                </Run>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Message}"
+                                                       Style="{StaticResource SecondaryText}"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,2,0,0" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
 
                     <!-- Chain gap detection: always visible when something is wrong, so a missing
                          stripe or a hole in the log sequence is seen BEFORE the script is run,
@@ -577,6 +663,25 @@
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Creates a new Service Broker identifier." />
+
+                            <CheckBox Content="CHECKSUM"
+                                      IsChecked="{Binding WithChecksum}"
+                                      Style="{StaticResource DarkCheckBox}"
+                                      Margin="0,0,0,12"
+                                      ToolTip="Verify backup checksums while restoring. Only works if the backup was taken WITH CHECKSUM - against one that was not, SQL Server fails the restore rather than skipping the check." />
+
+                            <CheckBox Content="CONTINUE_AFTER_ERROR"
+                                      IsChecked="{Binding ContinueAfterError}"
+                                      Style="{StaticResource DarkCheckBox}"
+                                      Margin="0,0,0,4"
+                                      ToolTip="Keep restoring past a damaged page or a failed checksum instead of stopping. The database this produces may be corrupt." />
+
+                            <TextBlock Style="{StaticResource SecondaryText}"
+                                       FontSize="10" TextWrapping="Wrap"
+                                       Foreground="{StaticResource WarningBrush}"
+                                       Margin="0,0,0,12"
+                                       Visibility="{Binding ContinueAfterError, Converter={StaticResource BoolToVis}}"
+                                       Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
 
                             <CheckBox Content="WITH MOVE (relocate files)"
                                       IsChecked="{Binding UseWithMove}"


### PR DESCRIPTION
Closes #26.

## Verify Backups

A new action next to Validate Chain that runs `RESTORE VERIFYONLY` over every set in the selected chain and shows what SQL Server said about each one.

The two answer different questions, which is why both exist:

| | reads | catches |
|---|---|---|
| **Validate Chain** | headers, then the LSNs | these backups don't belong together |
| **Verify Backups** | each backup, end to end | this backup isn't readable at all |

A half-uploaded or truncated blob passes the first and fails the second. That's the case worth catching in seconds rather than an hour into a restore.

Every stripe of a set goes into one statement — a stripe on its own isn't a readable backup, so verifying them individually would report failures that aren't there. No `WITH CREDENTIAL` clause, which SQL Server rejects for SAS credentials (the #60 defect, kept out of this path deliberately).

A failure comes back as a **result rather than an exception**, so one bad member doesn't abort verification of the rest — otherwise a broken chain gets fixed one round trip at a time. Cancellation still propagates: a cancelled command surfaces as `SqlException`, and reporting that as a verification failure would tell the user their backup is bad when they'd just pressed Stop.

Results clear when the selected restore point changes. A green tick against backups nothing has read would be worse than no tick at all.

## CHECKSUM and CONTINUE_AFTER_ERROR

Both in the options panel and in generated scripts, and both **off by default**:

- `CHECKSUM` fails outright against a backup that was taken without checksums, rather than skipping the check — so it can't be a silent default.
- `CONTINUE_AFTER_ERROR` finishes a restore SQL Server has already reported as damaged. Ticking it shows an inline warning, and the generated script carries the warning in its own header — it gets pasted into SSMS and run by people who never saw the checkbox.

Both are emitted on **every** statement in the chain, not just the first, so the whole restore runs under the rules that were chosen.

## Tests

11 new; **610 total**, build clean at `-warnaserror`.

The statement shape is unit tested (stripes in one statement, checksum only when asked, no credential clause, apostrophe in a URL can't terminate the literal). The failure *contract* needs a real instance and is gated on `NINELIVES_TEST_SQL` like the other live tests — **that one has not been run against a server yet.**

The results panel has its own XAML test rather than relying on the view loading: its rows colour the status through a `Style` on a `Run`, and that markup is only built when the template is realised, so an empty collection would leave it completely unexercised.

## Not included

If verification fails and Execute is pressed anyway, nothing stops it or mentions it. Worth wiring into the execute confirmation, but that's a separate change to the confirm flow.

