### PR TITLE
Put the I/O services behind interfaces so ViewModels can be tested (#41)

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -1,0 +1,195 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// An in-memory <see cref="ICredentialStore"/>. Nothing here reaches the Windows Credential
+/// Manager or the user's config file, which is the whole reason the interface exists (#41).
+/// </summary>
+public sealed class FakeCredentialStore : ICredentialStore
+{
+    private readonly Dictionary<string, (string username, string secret)> _secrets = [];
+
+    public AppConfig Config { get; set; } = new();
+
+    /// <summary>Set to make SaveConfig throw, standing in for a refused or locked config file.</summary>
+    public Exception? SaveConfigThrows { get; set; }
+
+    public int SaveConfigCalls { get; private set; }
+
+    public void SaveSecret(string key, string username, string secret) => _secrets[key] = (username, secret);
+
+    public (string? username, string? secret) ReadSecret(string key)
+        => _secrets.TryGetValue(key, out var v) ? (v.username, v.secret) : (null, null);
+
+    public bool DeleteSecret(string key) => _secrets.Remove(key);
+
+    public List<string> ListCredentialKeys(string prefix)
+        => _secrets.Keys.Where(k => k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    public void SaveSasToken(BlobContainerConfig config, string sasToken)
+        => SaveSecret(BlobKey(config), "sas", sasToken);
+
+    public string? GetSasToken(BlobContainerConfig config)
+        => config.UnsavedSasToken ?? ReadSecret(BlobKey(config)).secret;
+
+    public bool IsSasTokenExpired(BlobContainerConfig config) => false;
+
+    public DateTime? GetSasTokenExpiry(BlobContainerConfig config) => null;
+
+    public SasExpiryInfo ReadSasTokenExpiry(BlobContainerConfig config)
+        => config.ReadSasExpiry(GetSasToken(config));
+
+    public void SaveSqlPassword(ServerConnection connection, string password)
+        => SaveSecret(SqlKey(connection), connection.Username ?? string.Empty, password);
+
+    public string? GetSqlPassword(ServerConnection connection)
+        => connection.UnsavedPassword ?? ReadSecret(SqlKey(connection)).secret;
+
+    public AppConfig LoadConfig() => Config;
+
+    public void SaveConfig(AppConfig config)
+    {
+        SaveConfigCalls++;
+        if (SaveConfigThrows != null) throw SaveConfigThrows;
+        Config = config;
+    }
+
+    private static string BlobKey(BlobContainerConfig c) => $"NineLives:Blob:{c.Id ?? c.Name}";
+    private static string SqlKey(ServerConnection s) => $"NineLives:SQL:{s.Id ?? s.Name}";
+}
+
+/// <summary>
+/// A blob container that exists only in the test. The grouping and summary methods delegate to the
+/// real service - they are pure, and faking them would test the fake rather than the app.
+/// </summary>
+public sealed class FakeBlobStorageService : IBlobStorageService
+{
+    private readonly BlobStorageService _real = new(new FakeCredentialStore());
+
+    public List<BackupFileInfo> Files { get; set; } = [];
+
+    /// <summary>Throw instead of listing, for the failure paths.</summary>
+    public Exception? ListThrows { get; set; }
+
+    /// <summary>The scope the ViewModel pushed down on the last listing.</summary>
+    public BlobListingScope? LastScope { get; private set; }
+
+    public int ListCalls { get; private set; }
+
+    public Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
+        => Task.FromResult(true);
+
+    public Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default)
+        => Task.FromResult(new List<string>());
+
+    public Task<List<BackupFileInfo>> ListBackupFilesAsync(BlobContainerConfig config, CancellationToken ct = default)
+        => ListBackupFilesAsync(config, null, null, ct);
+
+    public Task<List<BackupFileInfo>> ListBackupFilesAsync(
+        BlobContainerConfig config, BlobListingScope? scope, IProgress<int>? progress, CancellationToken ct = default)
+    {
+        ListCalls++;
+        LastScope = scope;
+        ct.ThrowIfCancellationRequested();
+        if (ListThrows != null) throw ListThrows;
+
+        progress?.Report(Files.Count);
+        return Task.FromResult(Files.ToList());
+    }
+
+    public ContainerSummary GetContainerSummary(List<BackupFileInfo> files) => _real.GetContainerSummary(files);
+    public ContainerSummary GetSetBasedSummary(List<BackupSet> sets) => _real.GetSetBasedSummary(sets);
+    public List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files) => _real.GroupIntoBackupSets(files);
+    public List<string> GetDiscoveredDatabases(List<BackupFileInfo> files) => _real.GetDiscoveredDatabases(files);
+    public List<string> GetDiscoveredServers(List<BackupFileInfo> files) => _real.GetDiscoveredServers(files);
+}
+
+/// <summary>
+/// A SQL Server that records what it was asked to do. Nothing opens a connection.
+/// </summary>
+public sealed class FakeSqlServerService : ISqlServerService
+{
+    /// <summary>Every server instance handed to an execute call, in order.</summary>
+    public List<ServerConnection> ExecutedAgainst { get; } = [];
+
+    /// <summary>Every script handed to an execute call, in order.</summary>
+    public List<string> ExecutedScripts { get; } = [];
+
+    public List<string> VerifiedUrls { get; } = [];
+
+    public bool CredentialExists { get; set; } = true;
+    public bool CredentialIsSas { get; set; } = true;
+
+    public VerifyOnlyResult VerifyResult { get; set; } = new(true, "The backup set is valid.");
+
+    public DatabaseRecoveryState RecoveryState { get; set; } = DatabaseRecoveryState.Missing;
+
+    /// <summary>Set to make the restore fail the way a real one does.</summary>
+    public Exception? ExecuteThrows { get; set; }
+
+    public Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult(true);
+
+    public Task<bool?> WouldConnectWithCertificateValidationAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult<bool?>(true);
+
+    public Task<string> GetServerVersionAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult("Microsoft SQL Server 2022");
+
+    public Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult(new List<string>());
+
+    public Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult((@"D:\Data", @"D:\Logs"));
+
+    public Task<DatabaseRecoveryState> GetDatabaseRecoveryStateAsync(
+        ServerConnection server, string databaseName, CancellationToken ct = default)
+        => Task.FromResult(RecoveryState);
+
+    public Task ExecuteRecoveryActionAsync(ServerConnection server, string sql, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
+        => Task.FromResult(new List<FileMoveOption>());
+
+    public Task<BackupFileInfo?> RestoreHeaderOnlyMultiAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
+        => Task.FromResult<BackupFileInfo?>(null);
+
+    public Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, bool withChecksum = false, CancellationToken ct = default)
+    {
+        VerifiedUrls.AddRange(blobUrls);
+        return Task.FromResult(VerifyResult);
+    }
+
+    public Task ExecuteNonQueryAsync(
+        ServerConnection server, string sql, Action<string>? messageCallback = null, CancellationToken ct = default)
+    {
+        ExecutedAgainst.Add(server);
+        ExecutedScripts.Add(sql);
+        return Task.CompletedTask;
+    }
+
+    public Task ExecuteRestoreWithProgressAsync(
+        ServerConnection server, string sql, Action<string>? messageCallback = null, CancellationToken ct = default)
+    {
+        ExecutedAgainst.Add(server);
+        ExecutedScripts.Add(sql);
+        messageCallback?.Invoke("100 percent processed.");
+        if (ExecuteThrows != null) throw ExecuteThrows;
+        return Task.CompletedTask;
+    }
+
+    public Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+        ServerConnection server, string credentialName, CancellationToken ct = default)
+        => Task.FromResult((CredentialExists, CredentialIsSas));
+
+    public Task<CredentialChange> EnsureCredentialExistsAsync(
+        ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
+        CancellationToken ct = default)
+        => Task.FromResult(CredentialChange.None);
+}

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -37,6 +37,14 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
         LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
     };
 
+    /// <summary>
+    /// A log in a temp directory. Without this the execute path appends real restore lines to the
+    /// user's actual %LOCALAPPDATA% log - a test writing into the thing someone attaches to a bug
+    /// report.
+    /// </summary>
+    private static OperationLog ThrowawayLog() => new(System.IO.Path.Combine(
+        System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n")));
+
     /// <summary>Loads one full backup and arms the execute button, ready to fire.</summary>
     private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> ReadyToExecute(
         ServerConnection connected, FakeCredentialStore store)
@@ -45,7 +53,7 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
         var sql = new FakeSqlServerService();
 
         var vm = new RestoreViewModel(
-            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store)
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store, ThrowawayLog())
         {
             SelectedContainer = Container()
         };

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -1,0 +1,227 @@
+using System.Runtime.ExceptionServices;
+using System.Windows.Threading;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The execute path, which needs a WPF Application because it marshals progress onto the
+/// dispatcher and batches console output through a DispatcherTimer.
+///
+/// This is the path where getting it wrong is most expensive - it runs RESTORE against someone's
+/// server - and until the services were behind interfaces (#41) none of it could be tested at all.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class RestoreExecutionViewModelTests(WpfFixture wpf)
+{
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+    };
+
+    private static BackupFileInfo FullBackup() => new()
+    {
+        BlobName = "FULL/SRV01/MyDb/20260110_220000.bak",
+        BlobUrl = "https://mystorageaccount.blob.core.windows.net/backups/FULL/SRV01/MyDb/20260110_220000.bak",
+        Type = BackupType.Full,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = "MyDb",
+        SizeBytes = 1000,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    /// <summary>Loads one full backup and arms the execute button, ready to fire.</summary>
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> ReadyToExecute(
+        ServerConnection connected, FakeCredentialStore store)
+    {
+        var blob = new FakeBlobStorageService { Files = [FullBackup()] };
+        var sql = new FakeSqlServerService();
+
+        var vm = new RestoreViewModel(
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store)
+        {
+            SelectedContainer = Container()
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = connected;
+
+        // The button arms on the first press and fires on the second.
+        await vm.ExecuteScriptCommand.ExecuteAsync(null);
+        Assert.True(vm.IsExecuteArmed);
+
+        return (vm, sql);
+    }
+
+    /// <summary>
+    /// The #11 regression, now checkable by CI.
+    ///
+    /// Execute used to re-read config.json and take the first entry whose ServerName matched,
+    /// rather than the connection in use. Two entries for one host that differ in authentication -
+    /// a Windows-auth entry and a SQL-auth entry for the same box - is an ordinary setup, and the
+    /// restore would then run under credentials the user never connected with or tested.
+    /// </summary>
+    [Fact]
+    public void TheRestoreRunsAgainstTheConnectionInUseNotOneLookedUpByName()
+    {
+        ServerConnection? executedAgainst = null;
+
+        var windowsAuthEntry = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01 (Windows)",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.WindowsAuth
+        };
+        var sqlAuthEntry = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01 (SQL)",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "restoreadmin"
+        };
+
+        var store = new FakeCredentialStore();
+        // Both entries in the config, the Windows one first - which is what a name lookup returns.
+        store.Config.Servers.Add(windowsAuthEntry);
+        store.Config.Servers.Add(sqlAuthEntry);
+
+        RunOnUi(async () =>
+        {
+            // Connected as the SECOND entry.
+            var (vm, sql) = await ReadyToExecute(sqlAuthEntry, store);
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+            executedAgainst = Assert.Single(sql.ExecutedAgainst);
+        });
+
+        Assert.Same(sqlAuthEntry, executedAgainst);
+        Assert.NotSame(windowsAuthEntry, executedAgainst);
+    }
+
+    /// <summary>
+    /// The #10 regression. A credential is server-scoped, so dropping and recreating it on every
+    /// run removed it out from under anything else relying on it - a backup job writing to the
+    /// same container being the obvious casualty.
+    /// </summary>
+    [Fact]
+    public void AnExistingSasCredentialIsLeftAloneRatherThanRecreated()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var store = new FakeCredentialStore();
+        string log = string.Empty;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, store);
+            sql.CredentialExists = true;
+            sql.CredentialIsSas = true;
+            store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+            log = vm.ConsoleText;
+        });
+
+        Assert.Contains("Server state not modified", log);
+    }
+
+    /// <summary>The script that runs is the one on screen, not one rebuilt on the way out.</summary>
+    [Fact]
+    public void TheScriptExecutedIsTheScriptThatWasShown()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        string shown = string.Empty, executed = string.Empty;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, new FakeCredentialStore());
+            shown = vm.GeneratedScript;
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+            executed = Assert.Single(sql.ExecutedScripts);
+        });
+
+        Assert.Equal(shown, executed);
+        Assert.Contains("RESTORE DATABASE [MyDb_Restored]", executed);
+    }
+
+    /// <summary>
+    /// A failed restore has to report failure. The FireInfoMessageEventOnUserErrors defect (#6)
+    /// meant the app said "completed successfully" over a total failure; this pins the ViewModel
+    /// half of that contract, which the live SQL tests cannot reach.
+    /// </summary>
+    [Fact]
+    public void AFailedRestoreIsReportedAsAFailure()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        bool hasError = false;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, new FakeCredentialStore());
+            sql.ExecuteThrows = new InvalidOperationException("RESTORE terminating abnormally.");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+            hasError = vm.HasError;
+        });
+
+        Assert.True(hasError, "A restore that threw was not reported as a failure.");
+    }
+
+    /// <summary>
+    /// Runs an async body on the WPF thread and waits for it.
+    ///
+    /// Blocking the dispatcher thread with .GetAwaiter().GetResult() would deadlock: the
+    /// ViewModel's awaits resume on that same thread, and it would be sitting in the wait. Pumping
+    /// a DispatcherFrame keeps it processing until the body completes.
+    /// </summary>
+    private void RunOnUi(Func<Task> body)
+    {
+        Exception? captured = null;
+
+        wpf.Invoke(() =>
+        {
+            var frame = new DispatcherFrame();
+
+            _ = body().ContinueWith(
+                t =>
+                {
+                    captured = t.Exception?.GetBaseException();
+                    frame.Continue = false;
+                },
+                TaskScheduler.FromCurrentSynchronizationContext());
+
+            Dispatcher.PushFrame(frame);
+        });
+
+        if (captured != null) ExceptionDispatchInfo.Capture(captured).Throw();
+    }
+}

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -1,0 +1,257 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The first tests of a ViewModel rather than a service (#41).
+///
+/// Everything here used to be unreachable from a test: the ViewModels built their own
+/// <c>BlobStorageService</c>, <c>SqlServerService</c> and <c>CredentialStore</c>, so exercising any
+/// of it meant a real container, a real instance and the user's own credential vault. That is why
+/// the restore executing against a name-resolved server, and the credential being recreated on
+/// every run, both reached a release unnoticed.
+///
+/// Nothing in this file touches the network, a SQL Server, the credential vault or the config file.
+/// </summary>
+public class RestoreViewModelTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store);
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private static BackupFileInfo File(string blobName, BackupType type, DateTime lastModified)
+        => new()
+        {
+            BlobName = blobName,
+            BlobUrl = $"https://mystorageaccount.blob.core.windows.net/backups/{blobName}",
+            Type = type,
+            InferredServerName = "SRV01",
+            InferredDatabaseName = "MyDb",
+            SizeBytes = 1000,
+            LastModified = new DateTimeOffset(lastModified, TimeSpan.Zero)
+        };
+
+    /// <summary>A full at T0 plus <paramref name="logCount"/> logs at hourly intervals after it.</summary>
+    private static List<BackupFileInfo> FullPlusLogs(int logCount)
+    {
+        var files = new List<BackupFileInfo>
+        {
+            File("FULL/SRV01/MyDb/20260110_220000.bak", BackupType.Full, T0)
+        };
+
+        for (int i = 1; i <= logCount; i++)
+        {
+            var stamp = T0.AddHours(i);
+            files.Add(File(
+                $"LOG/SRV01/MyDb/{stamp:yyyyMMdd_HHmmss}.trn",
+                BackupType.TransactionLog,
+                stamp));
+        }
+
+        return files;
+    }
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+    };
+
+    // ── loading and chain selection ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadingBuildsRestorePointsAndSelectsTheMostRecent()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.True(vm.BackupsLoaded);
+        Assert.True(vm.HasRestorePoints);
+
+        // A full plus three logs: the full itself, then one point per log.
+        Assert.Equal(4, vm.RestorePoints.Count);
+
+        // The default selection is the latest point, which is what someone restoring after an
+        // incident almost always wants.
+        Assert.Equal(T0.AddHours(3), vm.SelectedRestorePoint!.Timestamp);
+        Assert.True(vm.HasValidChain);
+    }
+
+    [Fact]
+    public async Task SelectingAPointBuildsTheChainThatReachesIt()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // The second log: full + the logs up to and including it, and nothing after.
+        vm.SelectedRestorePoint = vm.RestorePoints.Single(
+            p => p.Timestamp == T0.AddHours(2) && p.Type == BackupType.TransactionLog);
+
+        Assert.NotNull(vm.RestoreChain);
+        Assert.Equal(BackupType.Full, vm.RestoreChain!.FullSet.Type);
+        Assert.Equal(2, vm.RestoreChain.LogSets.Count);
+        Assert.DoesNotContain(vm.RestoreChain.LogSets, s => s.Timestamp > T0.AddHours(2));
+    }
+
+    [Fact]
+    public async Task ChangingTheSelectionRegeneratesTheScriptForTheNewChain()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        vm.SelectedRestorePoint = vm.RestorePoints.First(p => p.Type == BackupType.Full);
+        var fullOnly = vm.GeneratedScript;
+
+        vm.SelectedRestorePoint = vm.RestorePoints.Last();
+        var withLogs = vm.GeneratedScript;
+
+        Assert.DoesNotContain("RESTORE LOG", fullOnly);
+        Assert.Contains("RESTORE LOG", withLogs);
+    }
+
+    [Fact]
+    public async Task AContainerWithNoFullBackupOffersNoRestorePointAndSaysWhy()
+    {
+        var vm = NewViewModel();
+        _blob.Files =
+        [
+            File("LOG/SRV01/MyDb/20260110_230000.trn", BackupType.TransactionLog, T0.AddHours(1))
+        ];
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.False(vm.HasRestorePoints);
+
+        // The explanation has to survive the rest of the load. It used to be overwritten by
+        // "Loaded 1 files in 1 backup set(s)...", leaving an empty timeline and a status bar
+        // reporting success.
+        Assert.True(vm.HasError);
+        Assert.Contains("full backup", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+
+        // And the inventory panel says the same thing in the place that persists.
+        Assert.True(vm.HasInventoryIssues);
+    }
+
+    // ── timeline maths ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TimelinePositionsSpanTheWholeTrack()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        var ordered = vm.RestorePoints.OrderBy(p => p.Timestamp).ToList();
+        Assert.Equal(0.0, ordered.First().TimelinePosition, 6);
+        Assert.Equal(1.0, ordered.Last().TimelinePosition, 6);
+
+        // Evenly spaced points must stay evenly spaced, and monotonic.
+        Assert.All(ordered, p => Assert.InRange(p.TimelinePosition, 0.0, 1.0));
+        for (int i = 1; i < ordered.Count; i++)
+            Assert.True(ordered[i].TimelinePosition >= ordered[i - 1].TimelinePosition);
+    }
+
+    [Fact]
+    public async Task ASinglePointSitsInTheMiddleRatherThanAtZero()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(0);
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        var only = Assert.Single(vm.RestorePoints);
+        Assert.Equal(0.5, only.TimelinePosition, 6);
+    }
+
+    [Fact]
+    public async Task PointsTooCloseToDrawSideBySideAreStackedIntoRows()
+    {
+        var vm = NewViewModel();
+
+        // 60 hourly logs over a fixed track: the gap between neighbours falls below the
+        // separation the row packer allows, so they cannot all sit on one row.
+        _blob.Files = FullPlusLogs(60);
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.True(vm.RestorePoints.Max(p => p.Row) > 0,
+            "Every point was placed on row 0, so they would be drawn on top of each other.");
+
+        // The track grows to fit however many rows were needed, otherwise the upper rows are
+        // drawn outside the control.
+        Assert.True(vm.TimelineHeight > 50);
+    }
+
+    // ── filtering ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PickingADatabaseNarrowsTheNextListingToItRatherThanRescanningEverything()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(1);
+        vm.SelectedContainer = Container();
+
+        // First load has no selection yet and must scan the whole container - the server and
+        // database lists are built from what it finds.
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        Assert.Null(_blob.LastScope);
+
+        vm.SelectedDatabaseName = "MyDb";
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.NotNull(_blob.LastScope);
+        Assert.Equal("MyDb", _blob.LastScope!.DatabaseName);
+        Assert.Equal("SRV01", _blob.LastScope.ServerName);
+    }
+
+    [Fact]
+    public async Task AnInstanceScopesToItsHostBecauseThatIsWhatThePathHolds()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(1);
+        foreach (var f in _blob.Files) f.InferredInstanceName = "PROD";
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.SelectedDatabaseName = "MyDb";
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // "SRV01\PROD" lives under "SRV01" in the container layout.
+        Assert.Equal("SRV01", _blob.LastScope!.ServerName);
+    }
+
+    [Fact]
+    public async Task AFailedListingSaysSoAndLeavesNothingLoaded()
+    {
+        var vm = NewViewModel();
+        _blob.ListThrows = new InvalidOperationException("No SAS token found.");
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.False(vm.BackupsLoaded);
+        Assert.Contains("No SAS token found.", vm.StatusMessage);
+    }
+}

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -23,7 +23,8 @@ public class RestoreViewModelTests
     private readonly FakeCredentialStore _store = new();
 
     private RestoreViewModel NewViewModel() => new(
-        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store);
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))));
 
     private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
 

--- a/src/NineLives.Tests/WpfFixture.cs
+++ b/src/NineLives.Tests/WpfFixture.cs
@@ -15,6 +15,17 @@ namespace Blackcat.NineLives.Tests;
 /// One Application per process and it belongs to the thread that created it, so everything runs on
 /// this single thread and the fixture is shared by the whole class.
 /// </summary>
+/// <summary>
+/// Shares the one Application across every class that needs it. A second WpfFixture instance would
+/// try to construct a second Application, which the runtime refuses - so classes join this
+/// collection rather than each taking their own class fixture.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class WpfCollection : ICollectionFixture<WpfFixture>
+{
+    public const string Name = "Wpf";
+}
+
 public sealed class WpfFixture : IDisposable
 {
     private readonly Thread _thread;

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -22,18 +22,14 @@ namespace Blackcat.NineLives.Tests;
 /// What this deliberately does not check is whether the result LOOKS right - colours, spacing,
 /// whether a panel is where you expect. That still needs eyes on the running app.
 /// </summary>
-public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposable
+[Collection(WpfCollection.Name)]
+public class XamlLoadTests(WpfFixture wpf)
 {
-    private readonly string _dir = Path.Combine(
-        Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"));
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_dir, recursive: true); } catch { }
-        GC.SuppressFinalize(this);
-    }
-
-    private CredentialStore Store() => new(_dir);
+    /// <summary>
+    /// In-memory throughout. These tests are about markup, so nothing here should be reading the
+    /// machine's credential vault or writing a config file anywhere (#41).
+    /// </summary>
+    private static ICredentialStore Store() => new FakeCredentialStore();
 
     /// <summary>Realises the visual tree. Bindings are not evaluated until something lays out.</summary>
     private static void Realise(FrameworkElement element)
@@ -106,7 +102,10 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
     {
         wpf.Invoke(() =>
         {
-            var window = new MainWindow();
+            // Against a fake store, not the real one. This used to construct a MainViewModel over
+            // the actual %LOCALAPPDATA% config and run the secret-key migration across it - a test
+            // reaching into the user's own data (#41).
+            var window = new MainWindow(new MainViewModel(new FakeCredentialStore()));
             Realise(window);
         });
     }

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
@@ -519,7 +519,8 @@ public class XamlLoadTests(WpfFixture wpf)
             new SqlServerService(store),
             new BackupChainBuilder(),
             new RestoreScriptGenerator(),
-            store);
+            store,
+            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))));
     }
 
     /// <summary>

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -10,9 +10,10 @@
         WindowStartupLocation="CenterScreen"
         Background="{StaticResource WindowBackgroundBrush}">
 
-    <Window.DataContext>
-        <vm:MainViewModel />
-    </Window.DataContext>
+    <!-- DataContext is set in the constructor, not here. Declaring it in XAML meant every
+         construction of this window - including a test that only wanted to check the markup -
+         built a MainViewModel against the real %LOCALAPPDATA% config and ran the secret-key
+         migration over it. -->
 
     <Window.Resources>
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />

--- a/src/NineLives/MainWindow.xaml.cs
+++ b/src/NineLives/MainWindow.xaml.cs
@@ -1,13 +1,22 @@
 using System.Windows;
 using System.Windows.Media.Imaging;
+using Blackcat.NineLives.ViewModels;
 
 namespace Blackcat.NineLives;
 
 public partial class MainWindow : Window
 {
-    public MainWindow()
+    public MainWindow() : this(new MainViewModel()) { }
+
+    /// <summary>
+    /// Takes the viewmodel so a test can supply one built against a temp config directory. The
+    /// DataContext used to be declared in XAML, which made that impossible - the real one was
+    /// constructed during InitializeComponent whatever the caller did.
+    /// </summary>
+    public MainWindow(MainViewModel viewModel)
     {
         InitializeComponent();
+        DataContext = viewModel;
         try
         {
             Icon = new BitmapImage(new Uri("pack://application:,,,/Assets/app.ico", UriKind.Absolute));

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -5,11 +5,11 @@ using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
-public class BlobStorageService
+public class BlobStorageService : IBlobStorageService
 {
-    private readonly CredentialStore _credentialStore;
+    private readonly ICredentialStore _credentialStore;
 
-    public BlobStorageService(CredentialStore credentialStore)
+    public BlobStorageService(ICredentialStore credentialStore)
     {
         _credentialStore = credentialStore;
     }

--- a/src/NineLives/Services/ConfigMigrator.cs
+++ b/src/NineLives/Services/ConfigMigrator.cs
@@ -21,7 +21,7 @@ namespace Blackcat.NineLives.Services;
 /// secrets are already where the ids point. There is no window in which a secret exists only under
 /// a key nothing references.
 /// </summary>
-public class ConfigMigrator(CredentialStore store)
+public class ConfigMigrator(ICredentialStore store)
 {
     public record Result(int ContainersMigrated, int ServersMigrated, string? Error)
     {

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -11,7 +11,7 @@ namespace Blackcat.NineLives.Services;
 /// Manages credentials via Windows Credential Manager and persists
 /// non-secret configuration (server names, container URLs) to a local JSON file.
 /// </summary>
-public class CredentialStore
+public class CredentialStore : ICredentialStore
 {
     private const string AppPrefix = "NineLives";
     private static readonly string DefaultConfigDir = Path.Combine(

--- a/src/NineLives/Services/IBlobStorageService.cs
+++ b/src/NineLives/Services/IBlobStorageService.cs
@@ -1,0 +1,30 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Reading a blob container. Implemented by <see cref="BlobStorageService"/>.
+///
+/// Covers what the ViewModels use, which is deliberately not everything the class exposes: the
+/// static filename helpers stay on the class, since nothing needs to substitute them (#41).
+/// </summary>
+public interface IBlobStorageService
+{
+    Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default);
+
+    Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default);
+
+    Task<List<BackupFileInfo>> ListBackupFilesAsync(BlobContainerConfig config, CancellationToken ct = default);
+
+    Task<List<BackupFileInfo>> ListBackupFilesAsync(
+        BlobContainerConfig config,
+        BlobListingScope? scope,
+        IProgress<int>? progress,
+        CancellationToken ct = default);
+
+    ContainerSummary GetContainerSummary(List<BackupFileInfo> files);
+    ContainerSummary GetSetBasedSummary(List<BackupSet> sets);
+    List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files);
+    List<string> GetDiscoveredDatabases(List<BackupFileInfo> files);
+    List<string> GetDiscoveredServers(List<BackupFileInfo> files);
+}

--- a/src/NineLives/Services/ICredentialStore.cs
+++ b/src/NineLives/Services/ICredentialStore.cs
@@ -1,0 +1,31 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Stored configuration and secrets. Implemented by <see cref="CredentialStore"/> against the
+/// Windows Credential Manager and a JSON file under %LOCALAPPDATA%.
+///
+/// This exists so a ViewModel can be constructed in a test without reaching the real machine.
+/// Every method here touches either the credential vault or the user's config file, which is a
+/// side effect no test should have (#41).
+/// </summary>
+public interface ICredentialStore
+{
+    void SaveSecret(string key, string username, string secret);
+    (string? username, string? secret) ReadSecret(string key);
+    bool DeleteSecret(string key);
+    List<string> ListCredentialKeys(string prefix);
+
+    void SaveSasToken(BlobContainerConfig config, string sasToken);
+    string? GetSasToken(BlobContainerConfig config);
+    bool IsSasTokenExpired(BlobContainerConfig config);
+    DateTime? GetSasTokenExpiry(BlobContainerConfig config);
+    SasExpiryInfo ReadSasTokenExpiry(BlobContainerConfig config);
+
+    void SaveSqlPassword(ServerConnection connection, string password);
+    string? GetSqlPassword(ServerConnection connection);
+
+    AppConfig LoadConfig();
+    void SaveConfig(AppConfig config);
+}

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -1,0 +1,57 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Everything the ViewModels ask of SQL Server. Implemented by <see cref="SqlServerService"/>.
+///
+/// <c>CreateConnection</c> and <c>BuildConnectionString</c> are deliberately absent: they hand
+/// back a <c>SqlConnection</c>, which would put Microsoft.Data.SqlClient in the signature of the
+/// thing a fake has to implement. They stay on the class, where the live tests use them (#41).
+/// </summary>
+public interface ISqlServerService
+{
+    Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default);
+
+    Task<bool?> WouldConnectWithCertificateValidationAsync(
+        ServerConnection server, CancellationToken ct = default);
+
+    Task<string> GetServerVersionAsync(ServerConnection server, CancellationToken ct = default);
+
+    Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default);
+
+    Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(
+        ServerConnection server, CancellationToken ct = default);
+
+    Task<DatabaseRecoveryState> GetDatabaseRecoveryStateAsync(
+        ServerConnection server, string databaseName, CancellationToken ct = default);
+
+    Task ExecuteRecoveryActionAsync(ServerConnection server, string sql, CancellationToken ct = default);
+
+    Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default);
+
+    Task<BackupFileInfo?> RestoreHeaderOnlyMultiAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default);
+
+    Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
+        ServerConnection server,
+        IReadOnlyList<string> blobUrls,
+        bool withChecksum = false,
+        CancellationToken ct = default);
+
+    Task ExecuteNonQueryAsync(
+        ServerConnection server, string sql,
+        Action<string>? messageCallback = null, CancellationToken ct = default);
+
+    Task ExecuteRestoreWithProgressAsync(
+        ServerConnection server, string sql,
+        Action<string>? messageCallback = null, CancellationToken ct = default);
+
+    Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+        ServerConnection server, string credentialName, CancellationToken ct = default);
+
+    Task<CredentialChange> EnsureCredentialExistsAsync(
+        ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
+        CancellationToken ct = default);
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -6,11 +6,11 @@ using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
-public class SqlServerService
+public class SqlServerService : ISqlServerService
 {
-    private readonly CredentialStore _credentialStore;
+    private readonly ICredentialStore _credentialStore;
 
-    public SqlServerService(CredentialStore credentialStore)
+    public SqlServerService(ICredentialStore credentialStore)
     {
         _credentialStore = credentialStore;
     }

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -9,8 +9,8 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class BlobBrowserViewModel : ViewModelBase
 {
-    private readonly BlobStorageService _blobService;
-    private readonly CredentialStore _credentialStore;
+    private readonly IBlobStorageService _blobService;
+    private readonly ICredentialStore _credentialStore;
     private readonly OperationCancellation _loadCancellation = new();
 
     /// <summary>True while a listing is running and has not been asked to stop (#25).</summary>
@@ -68,7 +68,7 @@ public partial class BlobBrowserViewModel : ViewModelBase
     [ObservableProperty]
     private string _dbSummaryText = string.Empty;
 
-    public BlobBrowserViewModel(BlobStorageService blobService, CredentialStore credentialStore)
+    public BlobBrowserViewModel(IBlobStorageService blobService, ICredentialStore credentialStore)
     {
         _blobService = blobService;
         _credentialStore = credentialStore;

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -9,8 +9,8 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class BlobConfigViewModel : ViewModelBase
 {
-    private readonly CredentialStore _credentialStore;
-    private readonly BlobStorageService _blobService;
+    private readonly ICredentialStore _credentialStore;
+    private readonly IBlobStorageService _blobService;
     private readonly OperationCancellation _testCancellation = new();
 
     /// <summary>True while a connection test is running and has not been asked to stop (#25).</summary>
@@ -109,7 +109,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     private BackupSourceType _originalBackupSourceType = BackupSourceType.Standalone;
     private string? _originalAgPathPattern;
 
-    public BlobConfigViewModel(CredentialStore credentialStore, BlobStorageService blobService)
+    public BlobConfigViewModel(ICredentialStore credentialStore, IBlobStorageService blobService)
     {
         _credentialStore = credentialStore;
         _blobService = blobService;

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -8,9 +8,9 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class MainViewModel : ViewModelBase
 {
-    private readonly CredentialStore _credentialStore;
-    private readonly BlobStorageService _blobService;
-    private readonly SqlServerService _sqlService;
+    private readonly ICredentialStore _credentialStore;
+    private readonly IBlobStorageService _blobService;
+    private readonly ISqlServerService _sqlService;
     private readonly BackupChainBuilder _chainBuilder;
     private readonly RestoreScriptGenerator _scriptGenerator;
 
@@ -50,9 +50,21 @@ public partial class MainViewModel : ViewModelBase
     public RestoreViewModel Restore { get; }
     public AboutViewModel About { get; }
 
-    public MainViewModel()
+    /// <summary>
+    /// The app's one composition point: builds the real services against the real credential
+    /// store. Deliberately not a DI container - three services and one place that wires them does
+    /// not need one (#41).
+    /// </summary>
+    public MainViewModel() : this(new CredentialStore()) { }
+
+    /// <summary>
+    /// Takes the store so a test can point the whole object graph at a temp directory instead of
+    /// the user's actual profile. Constructing this type used to migrate and read the real
+    /// %LOCALAPPDATA% config as a side effect of a XAML load test.
+    /// </summary>
+    public MainViewModel(ICredentialStore credentialStore)
     {
-        _credentialStore = new CredentialStore();
+        _credentialStore = credentialStore;
 
         // Before anything reads the config: move secrets from name-derived keys onto stable ids
         // (#8). Must happen ahead of the child viewmodels, which load containers and servers in

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -465,15 +465,24 @@ public partial class RestoreViewModel : ViewModelBase
         ISqlServerService sqlService,
         BackupChainBuilder chainBuilder,
         RestoreScriptGenerator scriptGenerator,
-        ICredentialStore credentialStore)
+        ICredentialStore credentialStore,
+        OperationLog? log = null)
     {
         _blobService = blobService;
         _sqlService = sqlService;
         _chainBuilder = chainBuilder;
         _scriptGenerator = scriptGenerator;
         _credentialStore = credentialStore;
+
+        // Defaults to the app's one log. Optional so a test can point it at a temp directory -
+        // without it, running the execute path in a test appends real restore lines to the user's
+        // actual log file, which is the same class of side effect this whole change is about.
+        _log = log ?? App.Log;
+
         RefreshContainers();
     }
+
+    private readonly OperationLog _log;
 
     public void RefreshContainers()
     {
@@ -1658,13 +1667,13 @@ public partial class RestoreViewModel : ViewModelBase
 
                         // Changing a credential is a change to shared state on someone's instance.
                         // It belongs in the file, not only in a console that closes with the app.
-                        App.Log.ServerChange(server.ServerName,
+                        _log.ServerChange(server.ServerName,
                             $"credential [{SqlCredentialName}] {change.ToString().ToLowerInvariant()}");
                     }
                 }
             }
 
-            App.Log.ServerChange(server.ServerName,
+            _log.ServerChange(server.ServerName,
                 $"restore starting: target [{TargetDatabaseName}], " +
                 $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={WithReplace}, " +
                 $"recovery={RecoveryMode}, stopAt={EffectiveStopAt?.ToString("s") ?? "none"}");
@@ -1696,7 +1705,7 @@ public partial class RestoreViewModel : ViewModelBase
             AppendLog("\nCANCELLED. The statement in flight was rolled back by SQL Server, but the " +
                       "restore stopped part-way through the chain.");
 
-            App.Log.ServerChange(ConnectedServer?.ServerName ?? "unknown",
+            _log.ServerChange(ConnectedServer?.ServerName ?? "unknown",
                 $"restore CANCELLED by user, target [{TargetDatabaseName}]");
 
             SetError("Restore cancelled. The target database has been left mid-restore - see below.");
@@ -1850,7 +1859,7 @@ public partial class RestoreViewModel : ViewModelBase
             _pending.Add(ConsoleLine.From(line));
         }
 
-        App.Log.Info($"[execute] {message.Trim()}");
+        _log.Info($"[execute] {message.Trim()}");
         ScheduleConsoleFlush();
     }
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Windows;
@@ -13,12 +13,12 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class RestoreViewModel : ViewModelBase
 {
-    private readonly BlobStorageService _blobService;
-    private readonly SqlServerService _sqlService;
+    private readonly IBlobStorageService _blobService;
+    private readonly ISqlServerService _sqlService;
     private readonly BackupChainBuilder _chainBuilder;
     private readonly RestoreScriptGenerator _scriptGenerator;
     private readonly BackupChainValidator _chainValidator = new();
-    private readonly CredentialStore _credentialStore;
+    private readonly ICredentialStore _credentialStore;
 
     private List<BackupFileInfo> _allBackups = [];
     private List<BackupSet> _allSets = [];
@@ -461,11 +461,11 @@ public partial class RestoreViewModel : ViewModelBase
     #endregion
 
     public RestoreViewModel(
-        BlobStorageService blobService,
-        SqlServerService sqlService,
+        IBlobStorageService blobService,
+        ISqlServerService sqlService,
         BackupChainBuilder chainBuilder,
         RestoreScriptGenerator scriptGenerator,
-        CredentialStore credentialStore)
+        ICredentialStore credentialStore)
     {
         _blobService = blobService;
         _sqlService = sqlService;
@@ -651,7 +651,12 @@ public partial class RestoreViewModel : ViewModelBase
                 ComputeAndDisplayRestorePoints();
             }
 
-            SetStatus($"Loaded {_allBackups.Count} files in {_allSets.Count} backup set(s) across {dbs.Count} database(s).");
+            // Only when nothing above went wrong. Selecting the first server or database runs the
+            // whole filter-and-compute cascade, which can end in "no valid restore points found" -
+            // and painting a success line over that left an empty timeline with the status bar
+            // cheerfully reporting how many files had loaded. Found by the first ViewModel test.
+            if (!HasError)
+                SetStatus($"Loaded {_allBackups.Count} files in {_allSets.Count} backup set(s) across {dbs.Count} database(s).");
         }
         catch (OperationCanceledException)
         {

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -9,8 +9,8 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class ServerManagerViewModel : ViewModelBase
 {
-    private readonly CredentialStore _credentialStore;
-    private readonly SqlServerService _sqlService;
+    private readonly ICredentialStore _credentialStore;
+    private readonly ISqlServerService _sqlService;
 
     public event EventHandler<ServerConnectionChangedEventArgs>? ConnectionChanged;
 
@@ -73,7 +73,7 @@ public partial class ServerManagerViewModel : ViewModelBase
     [ObservableProperty]
     private string _connectedServerDisplay = string.Empty;
 
-    public ServerManagerViewModel(CredentialStore credentialStore, SqlServerService sqlService)
+    public ServerManagerViewModel(ICredentialStore credentialStore, ISqlServerService sqlService)
     {
         _credentialStore = credentialStore;
         _sqlService = sqlService;


### PR DESCRIPTION
Closes #41.

`BlobStorageService`, `SqlServerService` and `CredentialStore` were concrete classes the ViewModels constructed themselves. Testing anything in a ViewModel therefore meant a real container, a real instance and the machine's credential vault — so none of it was tested. That's why the restore running against a **name-resolved server** and the credential being **recreated on every run** both reached a release with a green build.

Adds `IBlobStorageService`, `ISqlServerService` and `ICredentialStore` covering what the ViewModels use, and injects them.

**No DI container**, as the issue asks. Three services and one composition point don't need one — `MainViewModel`'s parameterless constructor is that point, and it now delegates to an overload taking the store.

Two members stay off `ISqlServerService` on purpose: `CreateConnection` and `BuildConnectionString` hand back a `SqlConnection`, which would put `Microsoft.Data.SqlClient` in the signature of anything implementing it. They remain on the class, where the live tests use them.

## MainWindow's DataContext

It was declared in XAML, so it was built during `InitializeComponent` — meaning **every** construction of the window, including a test that only wanted to check the markup, built a `MainViewModel` over the real `%LOCALAPPDATA%` config and ran the secret-key migration across it. A test reaching into the user's own data.

It's now set in the constructor, with an overload taking a viewmodel. Runtime behaviour is identical; `MainWindowLoads` passes a fake store.

**Please smoke-test this one** — it's the app's startup wiring, and it's the one change here I can't verify by test:

```
C:\Users\jake\AppData\Local\Temp\NineLives-41\NineLives.exe
```

## Tests

**14 new ViewModel tests**, the first in the project. Chain selection and what each restore point pulls into its chain; timeline positions spanning the track and stacking into rows when points crowd; listing scope push-down; and the execute path.

Three of them fail against the pre-#11 behaviour, checked by reverting the server resolution to the old config lookup — including `TheRestoreRunsAgainstTheConnectionInUseNotOneLookedUpByName`, which is the regression itself, now enforced by CI rather than by hand.

Nothing in these tests touches the network, a SQL Server, the credential vault or a config file.

`WpfFixture` becomes a collection fixture — one WPF `Application` per process, and a second class taking it as a class fixture would try to build a second one.

## A bug it found immediately

A container with **no full backup** had its "no valid restore points found" message overwritten by the load summary. That left an empty timeline and a status bar reporting `Loaded 1 files in 1 backup set(s)`. The explanation now survives the rest of the load.

**624 tests**, build clean at `-warnaserror`.

