### PR TITLE
Keep a record of every restore, and let the log be saved (#31)

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -106,6 +106,20 @@ public sealed class FakeBlobStorageService : IBlobStorageService
     public List<string> GetDiscoveredServers(List<BackupFileInfo> files) => _real.GetDiscoveredServers(files);
 }
 
+/// <summary>An in-memory restore history, so the tests never touch the real one.</summary>
+public sealed class FakeRestoreHistoryStore : IRestoreHistoryStore
+{
+    public List<RestoreHistoryEntry> Entries { get; } = [];
+
+    public string FilePath => "(in memory)";
+
+    public List<RestoreHistoryEntry> Load() => Entries.ToList();
+
+    public void Append(RestoreHistoryEntry entry) => Entries.Insert(0, entry);
+
+    public void Clear() => Entries.Clear();
+}
+
 /// <summary>
 /// A SQL Server that records what it was asked to do. Nothing opens a connection.
 /// </summary>

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -47,13 +47,15 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
 
     /// <summary>Loads one full backup and arms the execute button, ready to fire.</summary>
     private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> ReadyToExecute(
-        ServerConnection connected, FakeCredentialStore store)
+        ServerConnection connected, FakeCredentialStore store,
+        FakeRestoreHistoryStore? history = null)
     {
         var blob = new FakeBlobStorageService { Files = [FullBackup()] };
         var sql = new FakeSqlServerService();
 
         var vm = new RestoreViewModel(
-            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store, ThrowawayLog())
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            ThrowawayLog(), history ?? new FakeRestoreHistoryStore())
         {
             SelectedContainer = Container()
         };
@@ -202,6 +204,87 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
         });
 
         Assert.True(hasError, "A restore that threw was not reported as a failure.");
+    }
+
+    /// <summary>
+    /// Every execution is filed, so the record exists after the app closes (#31).
+    /// </summary>
+    [Fact]
+    public void ASuccessfulRestoreIsRecordedWithEnoughToPutInATicket()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var history = new FakeRestoreHistoryStore();
+
+        RunOnUi(async () =>
+        {
+            var (vm, _) = await ReadyToExecute(server, new FakeCredentialStore(), history);
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+        });
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(RestoreOutcome.Succeeded, entry.Outcome);
+        Assert.Equal("SRV01", entry.ServerName);
+        Assert.Equal("MyDb_Restored", entry.TargetDatabase);
+        Assert.Contains("RESTORE DATABASE [MyDb_Restored]", entry.Script);
+
+        // The log is captured AFTER the console flush, so it is the whole thing rather than
+        // whatever had escaped the batching buffer at the moment the run ended.
+        Assert.Contains("Restore completed successfully", entry.Log);
+        Assert.True(entry.CompletedAt >= entry.StartedAt);
+    }
+
+    [Fact]
+    public void AFailedRestoreIsRecordedAsFailedWithTheReason()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var history = new FakeRestoreHistoryStore();
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, new FakeCredentialStore(), history);
+            sql.ExecuteThrows = new InvalidOperationException("RESTORE terminating abnormally.");
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+        });
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(RestoreOutcome.Failed, entry.Outcome);
+        Assert.Contains("terminating abnormally", entry.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Pressing Execute once only arms the button. Nothing ran, so nothing belongs in the history -
+    /// otherwise it fills with entries for restores that never happened.
+    /// </summary>
+    [Fact]
+    public void ArmingTheButtonRecordsNothing()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var history = new FakeRestoreHistoryStore();
+
+        RunOnUi(async () =>
+        {
+            await ReadyToExecute(server, new FakeCredentialStore(), history);
+        });
+
+        Assert.Empty(history.Entries);
     }
 
     /// <summary>

--- a/src/NineLives.Tests/RestoreHistoryTests.cs
+++ b/src/NineLives.Tests/RestoreHistoryTests.cs
@@ -1,0 +1,232 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The record of what was restored, kept so it survives the app closing (#31).
+///
+/// Two properties matter more than the rest: it must never lose entries it already holds, and
+/// recording must never be able to fail the restore it is recording.
+/// </summary>
+public class RestoreHistoryTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-history-tests", Guid.NewGuid().ToString("n"));
+
+    private RestoreHistoryStore Store() => new(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private static RestoreHistoryEntry Entry(string target = "MyDb", RestoreOutcome outcome = RestoreOutcome.Succeeded)
+        => new()
+        {
+            StartedAt = new DateTime(2026, 1, 10, 22, 0, 0),
+            CompletedAt = new DateTime(2026, 1, 10, 22, 4, 30),
+            ServerName = "SRV01",
+            TargetDatabase = target,
+            ChainSummary = "1 Full + 2 Log(s)",
+            Outcome = outcome,
+            Script = "RESTORE DATABASE [MyDb] FROM URL = N'https://mystorageaccount.blob.core.windows.net/backups/x.bak'",
+            Log = "Beginning restore execution..."
+        };
+
+    [Fact]
+    public void NoHistoryYetReadsAsEmptyRatherThanFailing()
+    {
+        Assert.Empty(Store().Load());
+    }
+
+    [Fact]
+    public void AnEntrySurvivesBeingWrittenAndReadBack()
+    {
+        Store().Append(Entry());
+
+        var loaded = Assert.Single(Store().Load());
+        Assert.Equal("MyDb", loaded.TargetDatabase);
+        Assert.Equal("SRV01", loaded.ServerName);
+        Assert.Equal(RestoreOutcome.Succeeded, loaded.Outcome);
+        Assert.Contains("RESTORE DATABASE", loaded.Script);
+    }
+
+    [Fact]
+    public void TheNewestIsFirst()
+    {
+        var store = Store();
+        store.Append(Entry("First"));
+        store.Append(Entry("Second"));
+        store.Append(Entry("Third"));
+
+        var loaded = store.Load();
+        Assert.Equal(["Third", "Second", "First"], loaded.Select(e => e.TargetDatabase));
+    }
+
+    [Fact]
+    public void AnUnreadableHistoryIsLeftAloneRatherThanOverwritten()
+    {
+        // The config-loss shape (#7): read fails, the caller carries on with an empty list, and the
+        // next save writes that over everything. Here the file is left exactly as it was.
+        Directory.CreateDirectory(_dir);
+        var path = Path.Combine(_dir, "restore-history.json");
+        File.WriteAllText(path, "{ this is not the history file }");
+
+        var store = Store();
+        Assert.Empty(store.Load());
+
+        store.Append(Entry());
+
+        Assert.Equal("{ this is not the history file }", File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void AFailureToRecordCannotFailTheRestore()
+    {
+        // A directory where the file should be: every write fails. Append must still return.
+        Directory.CreateDirectory(Path.Combine(_dir, "restore-history.json"));
+
+        var ex = Record.Exception(() => Store().Append(Entry()));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void SecretsAreStrippedOnTheWayIn()
+    {
+        // Redaction happens at the writing boundary, so a future caller cannot leak a token by
+        // forgetting to redact - the same rule OperationLog follows.
+        var entry = Entry();
+        entry.Log = "Using URL https://mystorageaccount.blob.core.windows.net/backups/x.bak?sv=2024-01-01&sig=SECRETVALUE";
+
+        Store().Append(entry);
+
+        var loaded = Assert.Single(Store().Load());
+        Assert.DoesNotContain("SECRETVALUE", loaded.Log);
+    }
+
+    [Fact]
+    public void ClearingRemovesEverything()
+    {
+        var store = Store();
+        store.Append(Entry());
+        store.Clear();
+
+        Assert.Empty(store.Load());
+    }
+
+    [Fact]
+    public void OldEntriesFallOffTheEnd()
+    {
+        var store = Store();
+        for (int i = 0; i < 205; i++) store.Append(Entry($"Db{i}"));
+
+        var loaded = store.Load();
+        Assert.Equal(200, loaded.Count);
+
+        // The ones kept are the recent ones.
+        Assert.Equal("Db204", loaded[0].TargetDatabase);
+        Assert.DoesNotContain(loaded, e => e.TargetDatabase == "Db0");
+    }
+
+    // ── display ─────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0, "<1s")]
+    [InlineData(45, "45s")]
+    [InlineData(90, "1m 30s")]
+    [InlineData(3700, "1h 1m")]
+    public void DurationReadsAtHumanScale(int seconds, string expected)
+    {
+        var entry = Entry();
+        entry.CompletedAt = entry.StartedAt.AddSeconds(seconds);
+
+        Assert.Equal(expected, entry.DurationDisplay);
+    }
+
+    [Fact]
+    public void ARecordFormatsAsASelfContainedDocument()
+    {
+        var text = HistoryViewModel.Format(Entry(outcome: RestoreOutcome.Failed));
+
+        // Everything needed to read it a week later without the app open.
+        Assert.Contains("SRV01", text);
+        Assert.Contains("MyDb", text);
+        Assert.Contains("Failed", text);
+        Assert.Contains("1 Full + 2 Log(s)", text);
+        Assert.Contains("RESTORE DATABASE", text);
+        Assert.Contains("Beginning restore execution", text);
+    }
+
+    // ── the view model over it ──────────────────────────────────────────────────
+
+    [Fact]
+    public void TheViewSelectsTheMostRecentSoItIsWhatYouJustRan()
+    {
+        var store = Store();
+        store.Append(Entry("Older"));
+        store.Append(Entry("Newer"));
+
+        var vm = new HistoryViewModel(store);
+
+        Assert.True(vm.HasEntries);
+        Assert.Equal("Newer", vm.SelectedEntry!.TargetDatabase);
+    }
+
+    [Fact]
+    public void FilteringMatchesDatabaseServerAndOutcome()
+    {
+        var store = Store();
+        store.Append(Entry("Sales"));
+        store.Append(Entry("Payroll", RestoreOutcome.Failed));
+
+        var vm = new HistoryViewModel(store);
+
+        vm.FilterText = "payroll";
+        Assert.Equal("Payroll", Assert.Single(vm.Entries).TargetDatabase);
+
+        vm.FilterText = "failed";
+        Assert.Equal("Payroll", Assert.Single(vm.Entries).TargetDatabase);
+
+        vm.FilterText = "SRV01";
+        Assert.Equal(2, vm.Entries.Count);
+
+        vm.FilterText = "";
+        Assert.Equal(2, vm.Entries.Count);
+    }
+
+    [Fact]
+    public void ClearingTakesTwoPresses()
+    {
+        var store = Store();
+        store.Append(Entry());
+        var vm = new HistoryViewModel(store);
+
+        vm.ClearHistoryCommand.Execute(null);
+        Assert.True(vm.IsClearArmed);
+        Assert.True(vm.HasEntries);            // still there after one press
+
+        vm.ClearHistoryCommand.Execute(null);
+        Assert.False(vm.HasEntries);
+        Assert.Empty(store.Load());
+    }
+
+    [Fact]
+    public void BackingOutOfAClearLeavesTheHistoryAlone()
+    {
+        var store = Store();
+        store.Append(Entry());
+        var vm = new HistoryViewModel(store);
+
+        vm.ClearHistoryCommand.Execute(null);
+        vm.CancelClearCommand.Execute(null);
+
+        Assert.False(vm.IsClearArmed);
+        Assert.Single(store.Load());
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -509,6 +509,66 @@ public class XamlLoadTests(WpfFixture wpf)
         });
     }
 
+    /// <summary>
+    /// The restore history view (#31). Populated, because its rows colour the outcome through a
+    /// Style on a Run and the detail pane only exists once something is selected - none of which
+    /// is built when the list is empty.
+    /// </summary>
+    [Fact]
+    public void TheHistoryViewShowsWhatEachRestoreDid()
+    {
+        wpf.Invoke(() =>
+        {
+            var history = new FakeRestoreHistoryStore();
+            history.Append(new RestoreHistoryEntry
+            {
+                StartedAt = new DateTime(2026, 1, 10, 22, 0, 0),
+                CompletedAt = new DateTime(2026, 1, 10, 22, 4, 30),
+                ServerName = "SRV01",
+                TargetDatabase = "MyDb_Restored",
+                ChainSummary = "1 Full + 2 Log(s)",
+                Outcome = RestoreOutcome.Failed,
+                ErrorMessage = "RESTORE terminating abnormally.",
+                Script = "RESTORE DATABASE [MyDb_Restored] FROM URL = N'https://mystorageaccount.blob.core.windows.net/backups/x.bak'",
+                Log = "Beginning restore execution..."
+            });
+
+            var view = new HistoryView { DataContext = new HistoryViewModel(history) };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.True(
+                    texts.Any(t => t.Contains("RESTORE terminating abnormally.", StringComparison.Ordinal)),
+                    "The detail pane did not render. TextBlocks found: " +
+                    string.Join(" | ", texts.Where(t => !string.IsNullOrWhiteSpace(t))));
+
+                var runs = FindAll<TextBlock>(view)
+                    .SelectMany(t => t.Inlines.OfType<System.Windows.Documents.Run>())
+                    .Select(r => r.Text)
+                    .ToList();
+                Assert.Contains("Failed", runs);
+
+                // The script and the log are what someone came here for.
+                var boxes = FindAll<System.Windows.Controls.TextBox>(view).Select(b => b.Text).ToList();
+                Assert.Contains(boxes, t => t.Contains("RESTORE DATABASE", StringComparison.Ordinal));
+
+                listener.AssertNone("HistoryView");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    [Fact]
+    public void TheHistoryViewLoadsWithNothingRecorded()
+        => Check("HistoryView (empty)", () =>
+            new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) });
+
     // ── helpers ─────────────────────────────────────────────────────────────────
 
     private RestoreViewModel NewRestoreViewModel()
@@ -520,7 +580,8 @@ public class XamlLoadTests(WpfFixture wpf)
             new BackupChainBuilder(),
             new RestoreScriptGenerator(),
             store,
-            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))));
+            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))),
+            new FakeRestoreHistoryStore());
     }
 
     /// <summary>

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -31,6 +31,9 @@
         <DataTemplate DataType="{x:Type vm:RestoreViewModel}">
             <views:RestoreView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:HistoryViewModel}">
+            <views:HistoryView />
+        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:AboutViewModel}">
             <views:AboutView />
         </DataTemplate>
@@ -224,6 +227,15 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#x267B;" FontSize="15" VerticalAlignment="Center" Width="24" />
                                 <TextBlock Text="Restore" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <RadioButton Style="{StaticResource SidebarButton}"
+                                     Command="{Binding NavigateToCommand}"
+                                     CommandParameter="History">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#x1F553;" FontSize="15" VerticalAlignment="Center" Width="24" />
+                                <TextBlock Text="History" VerticalAlignment="Center" />
                             </StackPanel>
                         </RadioButton>
                     </StackPanel>

--- a/src/NineLives/Models/RestoreHistoryEntry.cs
+++ b/src/NineLives/Models/RestoreHistoryEntry.cs
@@ -1,0 +1,77 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>How a restore ended.</summary>
+public enum RestoreOutcome
+{
+    Succeeded,
+    Failed,
+
+    /// <summary>Stopped by the user. Not a failure, but the database is mid-restore either way.</summary>
+    Cancelled
+}
+
+/// <summary>
+/// One execution, kept so it can be read back after the app closes (#31).
+///
+/// A DBA who has just restored production needs this for the change ticket or the incident
+/// write-up, and reconstructing it from memory afterwards is exactly when detail goes missing.
+///
+/// Deliberately holds no secret: the script is the same token-free text the app generates and
+/// shows, and everything written here goes through <see cref="Services.LogRedactor"/> anyway.
+/// </summary>
+public sealed class RestoreHistoryEntry
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("n");
+
+    public DateTime StartedAt { get; set; }
+    public DateTime CompletedAt { get; set; }
+
+    public string ServerName { get; set; } = string.Empty;
+    public string TargetDatabase { get; set; } = string.Empty;
+
+    public string? ContainerName { get; set; }
+    public string? SourceDatabase { get; set; }
+
+    /// <summary>The point restored to, as shown on the timeline.</summary>
+    public DateTime? RestorePointTimestamp { get; set; }
+
+    /// <summary>e.g. "1 Full + 2 Log(s)".</summary>
+    public string ChainSummary { get; set; } = string.Empty;
+
+    public RestoreOutcome Outcome { get; set; }
+
+    /// <summary>What went wrong, when something did.</summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>The exact script that was run, so a repeat does not have to be rebuilt by hand.</summary>
+    public string Script { get; set; } = string.Empty;
+
+    /// <summary>The whole console output, which is what a bug report or a ticket actually wants.</summary>
+    public string Log { get; set; } = string.Empty;
+
+    public TimeSpan Duration => CompletedAt > StartedAt ? CompletedAt - StartedAt : TimeSpan.Zero;
+
+    public string OutcomeDisplay => Outcome switch
+    {
+        RestoreOutcome.Succeeded => "Succeeded",
+        RestoreOutcome.Failed => "Failed",
+        RestoreOutcome.Cancelled => "Cancelled",
+        _ => "Unknown"
+    };
+
+    public string StartedDisplay => StartedAt.ToString("yyyy-MM-dd HH:mm:ss");
+
+    public string DurationDisplay => Duration.TotalSeconds < 1
+        ? "<1s"
+        : Duration.TotalHours >= 1
+            ? $"{(int)Duration.TotalHours}h {Duration.Minutes}m"
+            : Duration.TotalMinutes >= 1
+                ? $"{(int)Duration.TotalMinutes}m {Duration.Seconds}s"
+                : $"{(int)Duration.TotalSeconds}s";
+
+    /// <summary>One line for the list: what was restored, where to, and how it went.</summary>
+    public string Summary => $"{TargetDatabase} on {ServerName} - {OutcomeDisplay}";
+
+    public string Detail =>
+        $"{ChainSummary}{(RestorePointTimestamp.HasValue ? $"  |  point {RestorePointTimestamp:yyyy-MM-dd HH:mm:ss}" : "")}  |  {DurationDisplay}";
+}

--- a/src/NineLives/Services/RestoreHistoryStore.cs
+++ b/src/NineLives/Services/RestoreHistoryStore.cs
@@ -1,0 +1,148 @@
+using System.IO;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+public interface IRestoreHistoryStore
+{
+    /// <summary>Most recent first. Never throws - an unreadable history is not worth an error dialog.</summary>
+    List<RestoreHistoryEntry> Load();
+
+    /// <summary>Adds one execution. Never throws: recording history must not be able to fail a restore.</summary>
+    void Append(RestoreHistoryEntry entry);
+
+    void Clear();
+
+    string FilePath { get; }
+}
+
+/// <summary>
+/// Past executions, kept next to the config so they survive the app closing (#31).
+///
+/// Separate from <see cref="OperationLog"/> on purpose. The log is an append-only text stream for
+/// reading and attaching to a bug report; this is structured, bounded and meant to be listed,
+/// searched and re-used.
+///
+/// Two rules, both learned from the config-loss defect (#7):
+///   - a history that cannot be read returns empty and is NOT then overwritten blindly
+///   - writes go through a temp file and an atomic swap, so a crash mid-write cannot truncate it
+/// </summary>
+public sealed class RestoreHistoryStore : IRestoreHistoryStore
+{
+    /// <summary>
+    /// Older entries fall off the end. Each carries a script and a console log, so this is a cap
+    /// on file size as much as on count - and a restore history nobody has looked at in 200
+    /// restores is not what anyone is reaching for.
+    /// </summary>
+    private const int MaxEntries = 200;
+
+    private readonly string _path;
+    private readonly object _gate = new();
+
+    public RestoreHistoryStore() : this(Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "NineLives"))
+    { }
+
+    /// <summary>Lets the tests write somewhere disposable instead of the real profile.</summary>
+    internal RestoreHistoryStore(string directory)
+        => _path = Path.Combine(directory, "restore-history.json");
+
+    public string FilePath => _path;
+
+    public List<RestoreHistoryEntry> Load()
+    {
+        lock (_gate)
+        {
+            return ReadUnlocked() ?? [];
+        }
+    }
+
+    public void Append(RestoreHistoryEntry entry)
+    {
+        try
+        {
+            lock (_gate)
+            {
+                var existing = ReadUnlocked();
+
+                // Null means the file is there and could not be read. Appending to an empty list
+                // and saving would throw away every entry it holds - the exact shape of the
+                // config-loss bug - so the honest move is to leave the file alone.
+                if (existing == null) return;
+
+                // Everything is redacted on the way IN, at the one boundary, so a future caller
+                // cannot leak a token by forgetting to.
+                entry.Script = LogRedactor.Redact(entry.Script);
+                entry.Log = LogRedactor.Redact(entry.Log);
+                if (entry.ErrorMessage != null)
+                    entry.ErrorMessage = LogRedactor.Redact(entry.ErrorMessage);
+
+                existing.Insert(0, entry);
+                if (existing.Count > MaxEntries)
+                    existing.RemoveRange(MaxEntries, existing.Count - MaxEntries);
+
+                WriteUnlocked(existing);
+            }
+        }
+        catch
+        {
+            // Recording what happened must never be able to fail the thing that happened.
+        }
+    }
+
+    public void Clear()
+    {
+        try
+        {
+            lock (_gate) { WriteUnlocked([]); }
+        }
+        catch
+        {
+        }
+    }
+
+    /// <summary>Null when the file exists but could not be read; empty list when there is no file.</summary>
+    private List<RestoreHistoryEntry>? ReadUnlocked()
+    {
+        if (!File.Exists(_path)) return [];
+
+        try
+        {
+            var json = File.ReadAllText(_path);
+            return JsonSerializer.Deserialize<List<RestoreHistoryEntry>>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void WriteUnlocked(List<RestoreHistoryEntry> entries)
+    {
+        var directory = Path.GetDirectoryName(_path)!;
+        Directory.CreateDirectory(directory);
+
+        var json = JsonSerializer.Serialize(entries, new JsonSerializerOptions { WriteIndented = true });
+
+        var temp = _path + ".tmp";
+        File.WriteAllText(temp, json);
+
+        if (File.Exists(_path))
+        {
+            try
+            {
+                File.Replace(temp, _path, null, ignoreMetadataErrors: true);
+                return;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // A few network shares cannot do the atomic swap.
+            }
+            File.Delete(_path);
+        }
+
+        File.Move(temp, _path);
+    }
+}

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -7,6 +7,7 @@
          was added to it. Views that still declare their own simply shadow this with an identical
          instance, so both work. -->
     <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+    <converters:NullToVisibilityConverter x:Key="NullToVis" />
 
     <!-- Terminal console. Darker than the cards on purpose, so the console reads as a separate
          surface the way a real terminal does rather than as another panel in the form. -->

--- a/src/NineLives/ViewModels/HistoryViewModel.cs
+++ b/src/NineLives/ViewModels/HistoryViewModel.cs
@@ -1,0 +1,174 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// Past restores, read back from disk (#31).
+///
+/// Read-only on purpose beyond clearing: this is the record of what was done, and a view that
+/// could edit it would be worth less than one that cannot.
+/// </summary>
+public partial class HistoryViewModel : ViewModelBase
+{
+    private readonly IRestoreHistoryStore _history;
+
+    public HistoryViewModel(IRestoreHistoryStore? history = null)
+    {
+        _history = history ?? new RestoreHistoryStore();
+        Refresh();
+    }
+
+    [ObservableProperty]
+    private ObservableCollection<RestoreHistoryEntry> _entries = [];
+
+    [ObservableProperty]
+    private RestoreHistoryEntry? _selectedEntry;
+
+    [ObservableProperty]
+    private bool _hasEntries;
+
+    [ObservableProperty]
+    private string _filterText = string.Empty;
+
+    /// <summary>True while a confirmation is pending, so Clear takes two presses.</summary>
+    [ObservableProperty]
+    private bool _isClearArmed;
+
+    private List<RestoreHistoryEntry> _all = [];
+
+    [RelayCommand]
+    public void Refresh()
+    {
+        _all = _history.Load();
+        ApplyFilter();
+
+        // Selecting the newest is what someone opening this view is nearly always after: the
+        // restore they just ran.
+        SelectedEntry = Entries.FirstOrDefault();
+        SetStatus(HasEntries
+            ? $"{_all.Count} restore(s) recorded."
+            : "No restores recorded yet.");
+    }
+
+    partial void OnFilterTextChanged(string value) => ApplyFilter();
+
+    private void ApplyFilter()
+    {
+        var matching = string.IsNullOrWhiteSpace(FilterText)
+            ? _all
+            : _all.Where(Matches).ToList();
+
+        Entries = new ObservableCollection<RestoreHistoryEntry>(matching);
+        HasEntries = Entries.Count > 0;
+
+        if (SelectedEntry != null && !Entries.Contains(SelectedEntry))
+            SelectedEntry = Entries.FirstOrDefault();
+    }
+
+    private bool Matches(RestoreHistoryEntry e)
+        => Contains(e.TargetDatabase) || Contains(e.ServerName)
+        || Contains(e.SourceDatabase) || Contains(e.ContainerName)
+        || Contains(e.OutcomeDisplay);
+
+    private bool Contains(string? value)
+        => value != null && value.Contains(FilterText, StringComparison.OrdinalIgnoreCase);
+
+    [RelayCommand]
+    private void CopyScript()
+    {
+        if (SelectedEntry == null) return;
+        TryCopyToClipboard(SelectedEntry.Script, "Script copied to clipboard.");
+    }
+
+    [RelayCommand]
+    private void CopyLog()
+    {
+        if (SelectedEntry == null) return;
+        TryCopyToClipboard(SelectedEntry.Log, "Execution log copied to clipboard.");
+    }
+
+    [RelayCommand]
+    private void SaveEntry()
+    {
+        if (SelectedEntry == null) return;
+
+        var dialog = new SaveFileDialog
+        {
+            Filter = "Text Files (*.txt)|*.txt|All Files (*.*)|*.*",
+            DefaultExt = ".txt",
+            FileName = $"ninelives_{SelectedEntry.TargetDatabase}_{SelectedEntry.StartedAt:yyyyMMdd_HHmmss}.txt"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, Format(SelectedEntry));
+            SetStatus($"Saved to {dialog.FileName}");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not save: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Two presses. This is the only destructive action in the view, and what it destroys is the
+    /// evidence of what was done to someone's production databases.
+    /// </summary>
+    [RelayCommand]
+    private void ClearHistory()
+    {
+        if (!IsClearArmed)
+        {
+            IsClearArmed = true;
+            SetStatus("Press Clear again to delete every recorded restore. This cannot be undone.");
+            return;
+        }
+
+        IsClearArmed = false;
+        _history.Clear();
+        Refresh();
+        SetStatus("Restore history cleared.");
+    }
+
+    [RelayCommand]
+    private void CancelClear()
+    {
+        IsClearArmed = false;
+        ClearStatus();
+    }
+
+    /// <summary>The entry as a self-contained document: what ran, where, and what came back.</summary>
+    public static string Format(RestoreHistoryEntry e)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Nine Lives - restore record");
+        sb.AppendLine($"Started:    {e.StartedAt:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"Completed:  {e.CompletedAt:yyyy-MM-dd HH:mm:ss}  ({e.DurationDisplay})");
+        sb.AppendLine($"Server:     {e.ServerName}");
+        sb.AppendLine($"Target:     {e.TargetDatabase}");
+        if (e.SourceDatabase != null) sb.AppendLine($"Source:     {e.SourceDatabase}");
+        if (e.ContainerName != null) sb.AppendLine($"Container:  {e.ContainerName}");
+        if (e.RestorePointTimestamp.HasValue)
+            sb.AppendLine($"Point:      {e.RestorePointTimestamp:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"Chain:      {e.ChainSummary}");
+        sb.AppendLine($"Outcome:    {e.OutcomeDisplay}");
+        if (e.ErrorMessage != null) sb.AppendLine($"Error:      {e.ErrorMessage}");
+
+        sb.AppendLine();
+        sb.AppendLine("--- script ---------------------------------------------------");
+        sb.AppendLine(e.Script);
+        sb.AppendLine("--- execution log --------------------------------------------");
+        sb.AppendLine(e.Log);
+
+        return sb.ToString();
+    }
+}

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -13,6 +13,7 @@ public partial class MainViewModel : ViewModelBase
     private readonly ISqlServerService _sqlService;
     private readonly BackupChainBuilder _chainBuilder;
     private readonly RestoreScriptGenerator _scriptGenerator;
+    private readonly IRestoreHistoryStore _historyStore;
 
     [ObservableProperty]
     private ViewModelBase? _currentView;
@@ -48,6 +49,7 @@ public partial class MainViewModel : ViewModelBase
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }
     public RestoreViewModel Restore { get; }
+    public HistoryViewModel History { get; }
     public AboutViewModel About { get; }
 
     /// <summary>
@@ -79,7 +81,14 @@ public partial class MainViewModel : ViewModelBase
         BlobConfig = new BlobConfigViewModel(_credentialStore, _blobService);
         ServerManager = new ServerManagerViewModel(_credentialStore, _sqlService);
         BlobBrowser = new BlobBrowserViewModel(_blobService, _credentialStore);
-        Restore = new RestoreViewModel(_blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore);
+        // One store, shared: the Restore screen writes to it and the History screen reads it back,
+        // and two instances pointed at the same file would be a way to lose an entry.
+        _historyStore = new RestoreHistoryStore();
+
+        Restore = new RestoreViewModel(
+            _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
+            log: null, history: _historyStore);
+        History = new HistoryViewModel(_historyStore);
         About = new AboutViewModel();
 
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
@@ -199,6 +208,7 @@ public partial class MainViewModel : ViewModelBase
             "SQL Servers" => ServerManager,
             "Browse Backups" => BlobBrowser,
             "Restore" => Restore,
+            "History" => History,
             "About" => About,
             _ => BlobConfig
         };
@@ -208,6 +218,10 @@ public partial class MainViewModel : ViewModelBase
             BlobBrowser.RefreshContainers();
         else if (viewName is "Restore")
             Restore.RefreshContainers();
+        else if (viewName is "History")
+            // Re-read on every visit: a restore run since the last look must be here, and the
+            // history is written by the Restore screen rather than by this one.
+            History.Refresh();
     }
 }
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Windows;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -466,8 +467,11 @@ public partial class RestoreViewModel : ViewModelBase
         BackupChainBuilder chainBuilder,
         RestoreScriptGenerator scriptGenerator,
         ICredentialStore credentialStore,
-        OperationLog? log = null)
+        OperationLog? log = null,
+        IRestoreHistoryStore? history = null)
     {
+        _history = history ?? new RestoreHistoryStore();
+
         _blobService = blobService;
         _sqlService = sqlService;
         _chainBuilder = chainBuilder;
@@ -483,6 +487,7 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     private readonly OperationLog _log;
+    private readonly IRestoreHistoryStore _history;
 
     public void RefreshContainers()
     {
@@ -1600,6 +1605,14 @@ public partial class RestoreViewModel : ViewModelBase
         IsExecuteArmed = false;
         ExecuteButtonText = "Execute on Server";
 
+        var startedAt = DateTime.Now;
+        var outcome = RestoreOutcome.Failed;
+        string? failure = null;
+
+        // Set false when the run is abandoned before anything was attempted, so history records
+        // executions rather than button presses.
+        var attempted = true;
+
         var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
         ExecutionComplete = false;
@@ -1620,6 +1633,7 @@ public partial class RestoreViewModel : ViewModelBase
             var server = ConnectedServer;
             if (server == null)
             {
+                attempted = false;
                 SetError("Not connected to a server.");
                 return;
             }
@@ -1692,11 +1706,14 @@ public partial class RestoreViewModel : ViewModelBase
                 executeToken);
 
             ExecutionSuccess = true;
+            outcome = RestoreOutcome.Succeeded;
             AppendLog("\nRestore completed successfully!");
             SetStatus("Restore execution completed successfully.");
         }
         catch (OperationCanceledException)
         {
+            outcome = RestoreOutcome.Cancelled;
+            failure = "Cancelled by the user part-way through the chain.";
             // Cancelling a restore is not the same as never having run it. SqlCommand.Cancel stops
             // the client waiting and SQL Server rolls back the statement that was in flight, but
             // the target stays mid-restore - so this must be as loud as a failure, and it goes
@@ -1716,6 +1733,8 @@ public partial class RestoreViewModel : ViewModelBase
         catch (Exception ex)
         {
             ExecutionSuccess = false;
+            outcome = RestoreOutcome.Failed;
+            failure = ex.Message;
             AppendLog($"\nERROR: {ex.Message}");
             SetError($"Restore failed: {ex.Message}");
 
@@ -1731,7 +1750,35 @@ public partial class RestoreViewModel : ViewModelBase
             ExecutionComplete = true;
             FlushConsole();   // nothing buffered may outlive the run
             RefreshCancelState();
+
+            // After the flush, so the recorded log is the whole console rather than whatever had
+            // made it out of the batching buffer. Recorded for every outcome including cancelled -
+            // "I stopped it" is exactly the kind of thing a change ticket needs to say.
+            if (attempted) RecordHistory(startedAt, outcome, failure);
         }
+    }
+
+    /// <summary>
+    /// Files this execution in the history (#31). Never throws: the store swallows its own
+    /// failures, and a restore must not be reported as failed because a record could not be kept.
+    /// </summary>
+    private void RecordHistory(DateTime startedAt, RestoreOutcome outcome, string? failure)
+    {
+        _history.Append(new RestoreHistoryEntry
+        {
+            StartedAt = startedAt,
+            CompletedAt = DateTime.Now,
+            ServerName = ConnectedServer?.ServerName ?? "unknown",
+            TargetDatabase = TargetDatabaseName,
+            ContainerName = SelectedContainer?.Name,
+            SourceDatabase = SelectedDatabaseName,
+            RestorePointTimestamp = SelectedRestorePoint?.Timestamp,
+            ChainSummary = RestoreChain?.Summary ?? "no chain",
+            Outcome = outcome,
+            ErrorMessage = failure,
+            Script = GeneratedScript,
+            Log = ConsoleText
+        });
     }
 
     /// <summary>
@@ -1910,6 +1957,65 @@ public partial class RestoreViewModel : ViewModelBase
     [RelayCommand]
     private void CopyConsole()
         => TryCopyToClipboard(ConsoleText, "Execution log copied to clipboard.");
+
+    /// <summary>
+    /// Writes the console to a file, with a header saying what it was (#31). The clipboard is fine
+    /// for pasting into a chat window; a change ticket or an incident write-up wants a file, and
+    /// wants it to say which server and which database on its own.
+    /// </summary>
+    [RelayCommand]
+    private void SaveConsole()
+    {
+        if (string.IsNullOrEmpty(ConsoleText))
+        {
+            SetError("There is no execution log to save yet.");
+            return;
+        }
+
+        var dialog = new SaveFileDialog
+        {
+            Filter = "Text Files (*.txt)|*.txt|Log Files (*.log)|*.log|All Files (*.*)|*.*",
+            DefaultExt = ".txt",
+            FileName = $"ninelives_{TargetDatabaseName}_{DateTime.Now:yyyyMMdd_HHmmss}.txt"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, BuildSavedLog());
+            SetStatus($"Execution log saved to {dialog.FileName}");
+        }
+        catch (Exception ex)
+        {
+            // Read-only location, full disk, or a path the database name made invalid. Any of
+            // those used to take the whole app down from inside a synchronous command (#13).
+            SetError($"Could not save the execution log: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The console plus the context needed to read it a week later. Redacted on the way out for
+    /// the same reason the operation log is - this file gets attached to tickets.
+    /// </summary>
+    private string BuildSavedLog()
+    {
+        var header = new StringBuilder();
+        header.AppendLine("Nine Lives - restore execution log");
+        header.AppendLine($"Saved:      {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+        header.AppendLine($"Server:     {ConnectedServer?.ServerName ?? "not connected"}");
+        header.AppendLine($"Target:     {TargetDatabaseName}");
+        if (SelectedContainer != null)
+            header.AppendLine($"Container:  {SelectedContainer.Name}");
+        if (SelectedRestorePoint != null)
+            header.AppendLine($"Point:      {SelectedRestorePoint.TimestampDisplay}");
+        header.AppendLine($"Chain:      {RestoreChain?.Summary ?? "none"}");
+        header.AppendLine($"Outcome:    {(ExecutionComplete ? (ExecutionSuccess ? "Succeeded" : "Did not succeed") : "Still running")}");
+        header.AppendLine(new string('-', 60));
+        header.AppendLine();
+
+        return LogRedactor.Redact(header + ConsoleText);
+    }
 
     private async Task RunArmCountdownAsync(CancellationToken ct)
     {

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -73,7 +73,12 @@
                             <Button Content="Copy output"
                                     Command="{Binding CopyConsoleCommand}"
                                     Style="{StaticResource SecondaryButton}"
-                                    Padding="8,2" FontSize="11" />
+                                    Padding="8,2" FontSize="11" Margin="0,0,8,0" />
+                            <Button Content="Save output"
+                                    Command="{Binding SaveConsoleCommand}"
+                                    Style="{StaticResource SecondaryButton}"
+                                    Padding="8,2" FontSize="11"
+                                    ToolTip="Writes the console to a file, with a header naming the server, the target database and the outcome." />
                         </StackPanel>
                     </Grid>
                 </Border>

--- a/src/NineLives/Views/HistoryView.xaml
+++ b/src/NineLives/Views/HistoryView.xaml
@@ -1,0 +1,207 @@
+<UserControl x:Class="Blackcat.NineLives.Views.HistoryView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Restore History" Style="{StaticResource HeaderText}" />
+            <TextBlock Text="Every restore this app has run, kept so it can go in a change ticket or an incident write-up."
+                       Style="{StaticResource SecondaryText}"
+                       Margin="0,4,0,0" />
+        </StackPanel>
+
+        <!-- Filter + refresh -->
+        <Grid Grid.Row="1" Margin="0,0,0,12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBox Grid.Column="0"
+                     Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                     Style="{StaticResource DarkTextBox}"
+                     ToolTip="Filter by database, server, container or outcome." />
+
+            <Button Grid.Column="1" Content="Refresh"
+                    Command="{Binding RefreshCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Padding="12,6" Margin="8,0,0,0" />
+        </Grid>
+
+        <!-- List + detail -->
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="360" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource CardBorder}" Margin="0,0,12,0">
+                <ListBox ItemsSource="{Binding Entries}"
+                         SelectedItem="{Binding SelectedEntry}"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Margin="0,4,0,8">
+                                <TextBlock Text="{Binding StartedDisplay}"
+                                           Style="{StaticResource SecondaryText}"
+                                           FontSize="11" />
+                                <TextBlock TextWrapping="Wrap" FontWeight="SemiBold" Margin="0,2,0,0">
+                                    <Run Text="{Binding TargetDatabase, Mode=OneWay}" />
+                                    <Run Text=" on " Foreground="{StaticResource SecondaryTextBrush}" />
+                                    <Run Text="{Binding ServerName, Mode=OneWay}"
+                                         Foreground="{StaticResource SecondaryTextBrush}" />
+                                </TextBlock>
+                                <TextBlock Margin="0,2,0,0" FontSize="11">
+                                    <Run Text="{Binding OutcomeDisplay, Mode=OneWay}">
+                                        <Run.Style>
+                                            <Style TargetType="Run">
+                                                <Setter Property="Foreground" Value="{StaticResource SuccessBrush}" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Outcome}" Value="Failed">
+                                                        <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Outcome}" Value="Cancelled">
+                                                        <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Run.Style>
+                                    </Run>
+                                    <Run Text="  " />
+                                    <Run Text="{Binding DurationDisplay, Mode=OneWay}"
+                                         Foreground="{StaticResource SecondaryTextBrush}" />
+                                </TextBlock>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Border>
+
+            <Border Grid.Column="1" Style="{StaticResource CardBorder}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <TextBlock Text="Select a restore to see what it did."
+                                   Style="{StaticResource SecondaryText}"
+                                   Visibility="{Binding SelectedEntry, Converter={StaticResource NullToVis}, ConverterParameter=Invert}" />
+
+                        <StackPanel Visibility="{Binding SelectedEntry, Converter={StaticResource NullToVis}}">
+                            <TextBlock Text="{Binding SelectedEntry.Summary}"
+                                       Style="{StaticResource HeaderText}"
+                                       FontSize="18"
+                                       TextWrapping="Wrap" />
+                            <TextBlock Text="{Binding SelectedEntry.Detail}"
+                                       Style="{StaticResource SecondaryText}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,4,0,12" />
+
+                            <TextBlock Text="{Binding SelectedEntry.ErrorMessage}"
+                                       Foreground="{StaticResource ErrorBrush}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,12"
+                                       Visibility="{Binding SelectedEntry.ErrorMessage, Converter={StaticResource NullToVis}}" />
+
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                <Button Content="Copy script"
+                                        Command="{Binding CopyScriptCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,5" Margin="0,0,8,0" />
+                                <Button Content="Copy log"
+                                        Command="{Binding CopyLogCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,5" Margin="0,0,8,0" />
+                                <Button Content="Save as file"
+                                        Command="{Binding SaveEntryCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,5"
+                                        ToolTip="Writes the whole record - details, script and execution log - to a text file." />
+                            </StackPanel>
+
+                            <TextBlock Text="SCRIPT" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
+                            <Border Background="{StaticResource InputBackgroundBrush}"
+                                    CornerRadius="4" Padding="10" Margin="0,0,0,12">
+                                <TextBox Text="{Binding SelectedEntry.Script, Mode=OneWay}"
+                                         IsReadOnly="True"
+                                         Background="Transparent"
+                                         BorderThickness="0"
+                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                         FontFamily="Cascadia Code, Consolas, Courier New"
+                                         FontSize="11"
+                                         MaxHeight="220"
+                                         VerticalScrollBarVisibility="Auto"
+                                         HorizontalScrollBarVisibility="Auto" />
+                            </Border>
+
+                            <TextBlock Text="EXECUTION LOG" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
+                            <Border Background="{StaticResource InputBackgroundBrush}"
+                                    CornerRadius="4" Padding="10">
+                                <TextBox Text="{Binding SelectedEntry.Log, Mode=OneWay}"
+                                         IsReadOnly="True"
+                                         Background="Transparent"
+                                         BorderThickness="0"
+                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                         FontFamily="Cascadia Code, Consolas, Courier New"
+                                         FontSize="11"
+                                         MaxHeight="260"
+                                         VerticalScrollBarVisibility="Auto"
+                                         HorizontalScrollBarVisibility="Auto" />
+                            </Border>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
+        </Grid>
+
+        <!-- Status + clear -->
+        <Grid Grid.Row="3" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Column="0"
+                       Text="{Binding StatusMessage}"
+                       Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap"
+                       VerticalAlignment="Center" />
+
+            <Button Grid.Column="1" Content="Keep it"
+                    Command="{Binding CancelClearCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Padding="12,6" Margin="0,0,8,0"
+                    Visibility="{Binding IsClearArmed, Converter={StaticResource BoolToVis}}" />
+
+            <Button Grid.Column="2"
+                    Command="{Binding ClearHistoryCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Padding="12,6"
+                    ToolTip="Deletes every recorded restore. Takes two presses.">
+                <Button.Content>
+                    <TextBlock>
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Text" Value="Clear history" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsClearArmed}" Value="True">
+                                        <Setter Property="Text" Value="Confirm clear" />
+                                        <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Button.Content>
+            </Button>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/NineLives/Views/HistoryView.xaml.cs
+++ b/src/NineLives/Views/HistoryView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class HistoryView : UserControl
+{
+    public HistoryView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1164,7 +1164,13 @@
                                                 Command="{Binding CopyConsoleCommand}"
                                                 Style="{StaticResource SecondaryButton}"
                                                 Padding="8,2" FontSize="11"
+                                                Margin="0,0,8,0"
                                                 ToolTip="Copies the whole console, which is what to attach to a bug report." />
+                                        <Button Content="Save output"
+                                                Command="{Binding SaveConsoleCommand}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="8,2" FontSize="11"
+                                                ToolTip="Writes the console to a file, with a header naming the server, the target database and the outcome - for a change ticket or an incident write-up." />
                                     </StackPanel>
                                 </Grid>
                             </Border>


### PR DESCRIPTION
Closes #31.

The execution console was in-memory only. Close the app and the record of what was just run — against which server, from which backup set, with what result — was gone. That's the record a change ticket or an incident write-up needs, and reconstructing it from memory afterwards is exactly when detail goes missing.

The issue's middle bullet (append to a rolling operation log) already landed with #40. This does the other two.

## Save output

Next to **Copy output**, in both the inline console and the execution window. Writes the console to a file with a header naming the server, the target database, the container, the restore point, the chain and the outcome — so the file says what it is without the app open. Redacted on the way out, same as everything else that leaves the app.

The clipboard is fine for pasting into a chat window. A ticket wants a file.

## Restore History

A new sidebar entry. Every execution is filed to `restore-history.json` next to the config: when, which server, target and source database, container, restore point, chain summary, outcome, duration, the exact script and the full console log.

- **Recorded for every outcome**, including cancelled — "I stopped it half way" is precisely what a ticket needs to say
- **Not recorded when nothing ran.** Arming the button files nothing, or the history fills with restores that never happened
- Captured **after** the console flush, so the stored log is the whole thing rather than whatever had escaped the batching buffer
- Filter by database, server, container or outcome; copy the script, copy the log, or save the whole record as a file
- Clear takes two presses. It's the only destructive action in the view and what it destroys is the evidence of what was done to someone's production databases

Bounded at 200 entries. Each carries a script and a log, so that's a cap on file size as much as on count.

## Two rules from the config-loss defect (#7)

**A history that can't be read is left alone, not overwritten.** Read fails → carry on with an empty list → next save writes that over everything is exactly how #7 destroyed people's saved servers. There's a test that corrupts the file and checks it comes back byte-identical.

**Writes go through a temp file and an atomic swap**, so a crash mid-write can't truncate it.

And a third: **recording can never fail the restore it's recording.** The store swallows its own failures; there's a test that makes every write fail and checks `Append` still returns.

Secrets are stripped at the writing boundary, not at the call sites, so a future caller can't leak a token by forgetting — the rule `OperationLog` already follows.

## Also

`NullToVis` moves into `DarkTheme.xaml` alongside `BoolToVis`. It was declared per-view, which is the exact setup that had AboutView throwing a `XamlParseException` the moment it used `BoolToVis`.

## Tests

**22 new; 646 total**, build clean at `-warnaserror`.

The history view has its own XAML test with an entry in it rather than relying on the view merely loading: the rows colour the outcome through a `Style` on a `Run`, and the detail pane only exists once something is selected — none of which is built when the list is empty.

Published build, smoke-launched (starts, window comes up, closes cleanly):

```
C:\Users\jake\AppData\Local\Temp\NineLives-31\NineLives.exe
```

The History screen's layout still needs eyeballing — the tests prove it renders and binds, not that it looks right.

