### PR TITLE
Add a list of restore points, and a way to narrow them down (#27)

### DIFF
--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -205,6 +205,233 @@ public class RestoreViewModelTests
         Assert.True(vm.TimelineHeight > 50);
     }
 
+    // ── narrowing the restore points (#27) ──────────────────────────────────────
+
+    [Fact]
+    public async Task TurningOffATypeRemovesThosePointsFromBothSelectors()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.Equal(4, vm.RestorePoints.Count);
+
+        vm.ShowLogPoints = false;
+
+        // The list and the timeline are the same collection, so this is both.
+        var only = Assert.Single(vm.RestorePoints);
+        Assert.Equal(BackupType.Full, only.Type);
+        Assert.Contains("Showing 1 of 4", vm.PointCountText);
+    }
+
+    [Fact]
+    public async Task ADateRangeNarrowsToTheWindowAsked()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(5);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.PointsFromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
+        vm.PointsToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Equal(3, vm.RestorePoints.Count);
+        Assert.All(vm.RestorePoints, p => Assert.InRange(p.Timestamp, T0.AddHours(2), T0.AddHours(4)));
+    }
+
+    /// <summary>
+    /// The point of the range: the surviving points spread across the whole track rather than
+    /// staying bunched in the sliver they occupied before. Without this it filters but does not
+    /// zoom, and picking one of them is no easier than it was.
+    /// </summary>
+    [Fact]
+    public async Task NarrowingTheRangeSpreadsTheRemainingPointsAcrossTheTrack()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(20);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        var before = vm.RestorePoints
+            .Where(p => p.Timestamp >= T0.AddHours(2) && p.Timestamp <= T0.AddHours(4))
+            .Select(p => p.TimelinePosition)
+            .ToList();
+
+        // Before narrowing, three of twenty-one points sit inside a tenth of the track.
+        Assert.True(before.Max() - before.Min() < 0.2);
+
+        vm.PointsFromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
+        vm.PointsToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+
+        var after = vm.RestorePoints.Select(p => p.TimelinePosition).ToList();
+        Assert.Equal(0.0, after.Min(), 6);
+        Assert.Equal(1.0, after.Max(), 6);
+    }
+
+    [Fact]
+    public async Task AHalfTypedDateDoesNotBlankTheTimeline()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Mid-keystroke. Unparsable means no bound rather than an error.
+        vm.PointsFromText = "2026-01-";
+
+        Assert.Equal(4, vm.RestorePoints.Count);
+        Assert.Null(vm.PointsFrom);
+    }
+
+    [Fact]
+    public async Task ADateIsReadTheSameWayWhateverTheMachinesCulture()
+    {
+        var original = System.Globalization.CultureInfo.CurrentCulture;
+        try
+        {
+            // en-US would read 02/03 as February; en-GB as March. The box is documented as
+            // yyyy-MM-dd, which is unambiguous, and it is parsed invariantly so it stays that way.
+            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("en-US");
+
+            var vm = NewViewModel();
+            _blob.Files = FullPlusLogs(3);
+            vm.SelectedContainer = Container();
+            await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+            vm.PointsFromText = "2026-01-10 23:30:00";
+
+            Assert.Equal(new DateTime(2026, 1, 10, 23, 30, 0), vm.PointsFrom);
+        }
+        finally
+        {
+            System.Globalization.CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public async Task AFilterThatMatchesNothingSaysSoRatherThanLookingEmpty()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.ShowFullPoints = false;
+        vm.ShowLogPoints = false;
+        vm.ShowDiffPoints = false;
+
+        Assert.Empty(vm.RestorePoints);
+        Assert.False(vm.HasVisiblePoints);
+
+        // Still true - the container HAS restore points, they are just all filtered out. The two
+        // are different states and the view shows different things for them.
+        Assert.True(vm.HasRestorePoints);
+    }
+
+    [Fact]
+    public async Task AnExistingSelectionSurvivesAFilterThatStillIncludesIt()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(5);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        var chosen = vm.RestorePoints.First(p => p.Timestamp == T0.AddHours(2));
+        vm.SelectedRestorePoint = chosen;
+
+        // Narrow to a window that still contains it.
+        vm.PointsFromText = T0.AddHours(1).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Same(chosen, vm.SelectedRestorePoint);
+    }
+
+    [Fact]
+    public async Task ZoomToDayNarrowsToTheSelectedPointsDay()
+    {
+        var vm = NewViewModel();
+
+        // Two days of hourly logs.
+        _blob.Files = FullPlusLogs(30);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // T0 is 22:00, so hourly logs cross midnight - the day being zoomed to is the selected
+        // point's, not the first point's.
+        var chosen = vm.RestorePoints.First(p => p.Timestamp == T0.AddHours(5));
+        vm.SelectedRestorePoint = chosen;
+        vm.ZoomToSelectedDayCommand.Execute(null);
+
+        Assert.All(vm.RestorePoints, p => Assert.Equal(chosen.Timestamp.Date, p.Timestamp.Date));
+        Assert.True(vm.RestorePoints.Count < 31);
+        Assert.Contains(vm.RestorePoints, p => p.Timestamp == chosen.Timestamp);
+    }
+
+    [Fact]
+    public async Task ResetPutsEveryPointBack()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(5);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Logs off leaves only the full, which sits before the range - so nothing at all.
+        vm.ShowLogPoints = false;
+        vm.PointsFromText = T0.AddHours(3).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Empty(vm.RestorePoints);
+
+        vm.ResetPointFiltersCommand.Execute(null);
+
+        Assert.Equal(6, vm.RestorePoints.Count);
+        Assert.Equal(string.Empty, vm.PointsFromText);
+        Assert.True(vm.ShowLogPoints);
+    }
+
+    [Fact]
+    public async Task LoadingADifferentDatabaseDoesNotInheritThePreviousFilters()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(5);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.PointsFromText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Equal(2, vm.RestorePoints.Count);
+
+        // A range typed for one database would silently hide points belonging to the next.
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.Equal(6, vm.RestorePoints.Count);
+        Assert.Equal(string.Empty, vm.PointsFromText);
+    }
+
+    /// <summary>
+    /// Reloading with the same database still selected has to pick up backups taken since - which
+    /// is the whole reason someone presses Load again.
+    ///
+    /// The restore points were rebuilt only when the SELECTION changed. Loading again with the
+    /// same server and database raised no property change, so the working set and the timeline
+    /// kept the previous scan's contents and a backup taken in between never appeared.
+    /// </summary>
+    [Fact]
+    public async Task ReloadingPicksUpBackupsTakenSinceTheLastScan()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(2);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.Equal(3, vm.RestorePoints.Count);
+
+        // A new log arrives in the container, and the user presses Load again.
+        var fresh = T0.AddHours(3);
+        _blob.Files = FullPlusLogs(3);
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.Equal(4, vm.RestorePoints.Count);
+        Assert.Contains(vm.RestorePoints, p => p.Timestamp == fresh);
+    }
+
     // ── filtering ───────────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -510,6 +510,60 @@ public class XamlLoadTests(WpfFixture wpf)
     }
 
     /// <summary>
+    /// The restore point list and its narrowing controls (#27). The list is the only way to pick
+    /// one point out of hundreds, so a binding that silently failed would leave the timeline as
+    /// the only selector again - which is the problem being fixed.
+    /// </summary>
+    [Fact]
+    public void TheRestorePointListRendersAndBindsItsSelection()
+    {
+        wpf.Invoke(() =>
+        {
+            var full = new BackupSet
+            {
+                SetId = "20260110_220000",
+                Type = BackupType.Full,
+                Timestamp = new DateTime(2026, 1, 10, 22, 0, 0),
+                Files = [new BackupFileInfo { BlobName = "FULL/SRV01/MyDb/20260110_220000.bak", SizeBytes = 1000 }]
+            };
+
+            var vm = NewRestoreViewModel();
+            vm.HasRestorePoints = true;
+            vm.HasVisiblePoints = true;
+            vm.PointCountText = "Showing 1 of 4 restore point(s)";
+            vm.RestorePoints =
+            [
+                new RestorePoint
+                {
+                    Timestamp = full.Timestamp,
+                    Type = BackupType.Full,
+                    PrimarySet = full,
+                    RequiredFullSet = full
+                }
+            ];
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.True(
+                    texts.Any(t => t.Contains("2026-01-10 22:00:00", StringComparison.Ordinal)),
+                    "The restore point list did not render its rows.");
+                Assert.Contains(texts, t => t.Contains("Showing 1 of 4", StringComparison.Ordinal));
+
+                listener.AssertNone("RestoreView point list");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    /// <summary>
     /// The restore history view (#31). Populated, because its rows colour the outcome through a
     /// Style on a Run and the detail pane only exists once something is selected - none of which
     /// is built when the list is empty.

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -257,6 +257,37 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isVerifyingChain;
 
+    // ── restore point filters (#27) ─────────────────────────────────────────────
+
+    /// <summary>True when the container holds any restore points at all.</summary>
+    [ObservableProperty]
+    private bool _hasVisiblePoints;
+
+    [ObservableProperty]
+    private string _pointCountText = string.Empty;
+
+    [ObservableProperty]
+    private bool _showFullPoints = true;
+
+    [ObservableProperty]
+    private bool _showDiffPoints = true;
+
+    [ObservableProperty]
+    private bool _showLogPoints = true;
+
+    [ObservableProperty]
+    private string _pointsFromText = string.Empty;
+
+    [ObservableProperty]
+    private string _pointsToText = string.Empty;
+
+    /// <summary>Parsed from the text boxes; null means no bound on that end.</summary>
+    [ObservableProperty]
+    private DateTime? _pointsFrom;
+
+    [ObservableProperty]
+    private DateTime? _pointsTo;
+
     /// <summary>Per-set RESTORE VERIFYONLY results for the selected chain.</summary>
     public ObservableCollection<ChainVerifyResult> ChainVerifyResults { get; } = [];
 
@@ -526,7 +557,17 @@ public partial class RestoreViewModel : ViewModelBase
             SelectedDatabaseName = DiscoveredDatabases[0];
     }
 
-    partial void OnSelectedDatabaseNameChanged(string? value)
+    partial void OnSelectedDatabaseNameChanged(string? value) => RefreshSelectedDatabase(value);
+
+    /// <summary>
+    /// Rebuilds the working set and the restore points for the chosen database.
+    ///
+    /// Called on selection change AND at the end of every load. Relying on the change alone meant
+    /// a reload with the same server and database still selected - the natural thing to do after
+    /// taking a fresh backup - raised no property change at all, so the sets and the timeline kept
+    /// the PREVIOUS scan's contents and the new backup never appeared.
+    /// </summary>
+    private void RefreshSelectedDatabase(string? value)
     {
         if (value == null || _allSets.Count == 0) return;
 
@@ -665,6 +706,10 @@ public partial class RestoreViewModel : ViewModelBase
                 ComputeAndDisplayRestorePoints();
             }
 
+
+            // Unconditionally, not just when the selection changed - see RefreshSelectedDatabase.
+            RefreshSelectedDatabase(SelectedDatabaseName);
+
             // Only when nothing above went wrong. Selecting the first server or database runs the
             // whole filter-and-compute cascade, which can end in "no valid restore points found" -
             // and painting a success line over that left an empty timeline with the status bar
@@ -722,9 +767,15 @@ public partial class RestoreViewModel : ViewModelBase
         SetStatus("Cancelling...");
     }
 
+    /// <summary>
+    /// Every computed restore point, before the view's filters. The timeline and the list both
+    /// show a subset of this (#27).
+    /// </summary>
+    private List<RestorePoint> _allPoints = [];
+
     private void ComputeAndDisplayRestorePoints()
     {
-        var points = _chainBuilder.ComputeRestorePoints(_dbSets);
+        _allPoints = _chainBuilder.ComputeRestorePoints(_dbSets);
 
         // Inventory-level findings: backups that exist but can never be offered. These belong to
         // the discovered set rather than to any one chain, so they are held separately and survive
@@ -734,14 +785,93 @@ public partial class RestoreViewModel : ViewModelBase
         // orphaned logs and "no full backup at all" were being computed nowhere and shown nowhere.
         InventoryIssues = new ObservableCollection<ChainIssue>(
             _chainValidator.ValidateInventory(_dbSets)
-                .Concat(_chainValidator.ValidateReachability(_dbSets, points)));
+                .Concat(_chainValidator.ValidateReachability(_dbSets, _allPoints)));
         HasInventoryIssues = InventoryIssues.Count > 0;
 
-        // Compute timeline positions (0-1)
+        // A fresh load starts wide open. Carrying a previous database's date range over would
+        // silently hide points that have nothing to do with it.
+        _suppressPointFilterRefresh = true;
+        ShowFullPoints = ShowDiffPoints = ShowLogPoints = true;
+        PointsFromText = string.Empty;
+        PointsToText = string.Empty;
+        _suppressPointFilterRefresh = false;
+
+        HasRestorePoints = _allPoints.Count > 0;
+
+        if (_allPoints.Count == 0)
+        {
+            RestorePoints = [];
+            HasVisiblePoints = false;
+            RestoreWindowText = string.Empty;
+            PointCountText = string.Empty;
+            TimelineTicks.Clear();
+            TimelineHeight = 50;
+            SetError("No valid restore points found. Ensure there is at least one full backup.");
+            return;
+        }
+
+        ApplyPointFilters(selectLatest: true);
+        ClearStatus();
+    }
+
+    /// <summary>
+    /// Narrows the timeline and the list to the points the filters allow, then lays the timeline
+    /// out over just those.
+    ///
+    /// Laying out over the VISIBLE set rather than all of them is what makes the date range behave
+    /// like a zoom: narrow to a two-hour window and those points spread across the whole track
+    /// instead of staying bunched in the sliver they occupied before (#27).
+    /// </summary>
+    private void ApplyPointFilters(bool selectLatest = false)
+    {
+        var previous = SelectedRestorePoint;
+        var visible = _allPoints.Where(PointMatchesFilters).ToList();
+
+        LayOutTimeline(visible);
+
+        RestorePoints = new ObservableCollection<RestorePoint>(visible);
+        HasVisiblePoints = visible.Count > 0;
+
+        PointCountText = visible.Count == _allPoints.Count
+            ? $"{_allPoints.Count} restore point(s)"
+            : $"Showing {visible.Count} of {_allPoints.Count} restore point(s)";
+
+        if (visible.Count == 0)
+        {
+            RestoreWindowText = string.Empty;
+            return;
+        }
+
+        // Keep the selection when it survives the filter - changing a type toggle should not throw
+        // away the point someone had already chosen.
+        SelectedRestorePoint = !selectLatest && previous != null && visible.Contains(previous)
+            ? previous
+            : visible[^1];
+    }
+
+    private bool PointMatchesFilters(RestorePoint p)
+    {
+        var typeAllowed = p.Type switch
+        {
+            BackupType.Full => ShowFullPoints,
+            BackupType.Differential => ShowDiffPoints,
+            BackupType.TransactionLog => ShowLogPoints,
+            _ => true
+        };
+        if (!typeAllowed) return false;
+
+        if (PointsFrom.HasValue && p.Timestamp < PointsFrom.Value) return false;
+        if (PointsTo.HasValue && p.Timestamp > PointsTo.Value) return false;
+
+        return true;
+    }
+
+    private void LayOutTimeline(List<RestorePoint> points)
+    {
         if (points.Count > 1)
         {
-            var minTicks = points.First().Timestamp.Ticks;
-            var maxTicks = points.Last().Timestamp.Ticks;
+            var minTicks = points[0].Timestamp.Ticks;
+            var maxTicks = points[^1].Timestamp.Ticks;
             var range = (double)(maxTicks - minTicks);
             foreach (var p in points)
                 p.TimelinePosition = range > 0 ? (p.Timestamp.Ticks - minTicks) / range : 0.5;
@@ -751,36 +881,99 @@ public partial class RestoreViewModel : ViewModelBase
             points[0].TimelinePosition = 0.5;
         }
 
-        // Compute vertical stacking rows to avoid horizontal overlap
+        // Vertical stacking, so points too close together to draw side by side are not drawn on
+        // top of each other.
         ComputeRows(points);
 
-        RestorePoints = new ObservableCollection<RestorePoint>(points);
-        HasRestorePoints = points.Count > 0;
-
-        if (points.Count > 0)
+        if (points.Count == 0)
         {
-            var first = points.First().Timestamp;
-            var last = points.Last().Timestamp;
-            RestoreWindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
-            TimelineStartText = $"{first:yyyy-MM-dd HH:mm}";
-
-            // Compute time-interval tick marks
-            TimelineTicks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));
-
-            // Timeline height based on max row
-            int maxRow = points.Max(p => p.Row);
-            TimelineHeight = Math.Max(50, 30 + (maxRow + 1) * 18);
-
-            SelectedRestorePoint = points.Last();
-            ClearStatus();
-        }
-        else
-        {
-            RestoreWindowText = string.Empty;
             TimelineTicks.Clear();
             TimelineHeight = 50;
-            SetError("No valid restore points found. Ensure there is at least one full backup.");
+            return;
         }
+
+        var first = points[0].Timestamp;
+        var last = points[^1].Timestamp;
+        RestoreWindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
+        TimelineStartText = $"{first:yyyy-MM-dd HH:mm}";
+
+        TimelineTicks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));
+
+        int maxRow = points.Max(p => p.Row);
+        TimelineHeight = Math.Max(50, 30 + (maxRow + 1) * 18);
+    }
+
+    /// <summary>Set while the filters are being reset in bulk, so each one does not re-filter.</summary>
+    private bool _suppressPointFilterRefresh;
+
+    private void OnPointFilterChanged()
+    {
+        if (_suppressPointFilterRefresh || _allPoints.Count == 0) return;
+        ApplyPointFilters();
+    }
+
+    partial void OnShowFullPointsChanged(bool value) => OnPointFilterChanged();
+    partial void OnShowDiffPointsChanged(bool value) => OnPointFilterChanged();
+    partial void OnShowLogPointsChanged(bool value) => OnPointFilterChanged();
+
+    partial void OnPointsFromTextChanged(string value)
+    {
+        PointsFrom = ParseFilterDate(value);
+        OnPointFilterChanged();
+    }
+
+    partial void OnPointsToTextChanged(string value)
+    {
+        PointsTo = ParseFilterDate(value);
+        OnPointFilterChanged();
+    }
+
+    /// <summary>
+    /// Invariant, and forgiving about how much of a timestamp was typed - "2026-01-10" is a
+    /// perfectly reasonable thing to enter into a date box. Unparsable means no bound rather than
+    /// an error, so half-typed input does not blank the timeline mid-keystroke.
+    /// </summary>
+    private static DateTime? ParseFilterDate(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+
+        return DateTime.TryParse(
+            text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    /// <summary>Back to every point, without reloading anything from the container.</summary>
+    [RelayCommand]
+    private void ResetPointFilters()
+    {
+        _suppressPointFilterRefresh = true;
+        ShowFullPoints = ShowDiffPoints = ShowLogPoints = true;
+        PointsFromText = string.Empty;
+        PointsToText = string.Empty;
+        _suppressPointFilterRefresh = false;
+
+        if (_allPoints.Count > 0) ApplyPointFilters();
+    }
+
+    /// <summary>
+    /// Narrows the range to the day the selected point falls on. A week of 15-minute logs is
+    /// roughly 670 points; picking one precisely means getting to a day first, and doing that by
+    /// typing two timestamps is a chore when the answer is nearly always "the day it broke".
+    /// </summary>
+    [RelayCommand]
+    private void ZoomToSelectedDay()
+    {
+        if (SelectedRestorePoint == null) return;
+
+        var day = SelectedRestorePoint.Timestamp.Date;
+
+        _suppressPointFilterRefresh = true;
+        PointsFromText = day.ToString("yyyy-MM-dd HH:mm:ss");
+        PointsToText = day.AddDays(1).AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss");
+        _suppressPointFilterRefresh = false;
+
+        ApplyPointFilters();
     }
 
     private static void ComputeRows(List<RestorePoint> points)

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -158,9 +158,72 @@
                     <TextBlock Text="2. SELECT RESTORE POINT"
                                Style="{StaticResource SubHeaderText}"
                                Margin="0,0,0,4" />
-                    <TextBlock Text="Click a point on the timeline or select from the list below."
+                    <TextBlock Text="Click a point on the timeline, or pick one from the list below."
                                Style="{StaticResource SecondaryText}"
                                Margin="0,0,0,12" />
+
+                    <!-- Narrowing controls. A week of 15-minute logs is roughly 670 points, which
+                         no timeline can draw legibly - so the range and the type toggles are the
+                         way to get from "everything" down to something you can click (#27). -->
+                    <Border Background="{StaticResource InputBackgroundBrush}"
+                            CornerRadius="6" Padding="12,10" Margin="0,0,0,12">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                <CheckBox Content="Full" IsChecked="{Binding ShowFullPoints}"
+                                          Style="{StaticResource DarkCheckBox}" Margin="0,0,12,0" />
+                                <CheckBox Content="Diff" IsChecked="{Binding ShowDiffPoints}"
+                                          Style="{StaticResource DarkCheckBox}" Margin="0,0,12,0" />
+                                <CheckBox Content="Log" IsChecked="{Binding ShowLogPoints}"
+                                          Style="{StaticResource DarkCheckBox}" Margin="0,0,20,0" />
+
+                                <TextBlock Text="From" Style="{StaticResource SecondaryText}"
+                                           VerticalAlignment="Center" Margin="0,0,6,0" />
+                                <TextBox Text="{Binding PointsFromText, UpdateSourceTrigger=PropertyChanged}"
+                                         Style="{StaticResource DarkTextBox}"
+                                         Width="150" Margin="0,0,12,0"
+                                         ToolTip="yyyy-MM-dd or yyyy-MM-dd HH:mm:ss. Leave empty for no lower bound." />
+
+                                <TextBlock Text="To" Style="{StaticResource SecondaryText}"
+                                           VerticalAlignment="Center" Margin="0,0,6,0" />
+                                <TextBox Text="{Binding PointsToText, UpdateSourceTrigger=PropertyChanged}"
+                                         Style="{StaticResource DarkTextBox}"
+                                         Width="150"
+                                         ToolTip="yyyy-MM-dd or yyyy-MM-dd HH:mm:ss. Leave empty for no upper bound." />
+                            </StackPanel>
+
+                            <TextBlock Grid.Column="1" Text="{Binding PointCountText}"
+                                       Style="{StaticResource SecondaryText}"
+                                       VerticalAlignment="Center"
+                                       HorizontalAlignment="Right"
+                                       Margin="12,0,12,0" />
+
+                            <StackPanel Grid.Column="2" Orientation="Horizontal">
+                                <Button Content="Zoom to day"
+                                        Command="{Binding ZoomToSelectedDayCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,4" FontSize="11" Margin="0,0,8,0"
+                                        ToolTip="Narrows the range to the day the selected point falls on." />
+                                <Button Content="Reset"
+                                        Command="{Binding ResetPointFiltersCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,4" FontSize="11"
+                                        ToolTip="Show every restore point again." />
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <TextBlock Text="No restore point matches these filters. Widen the range or switch a type back on."
+                               Style="{StaticResource SecondaryText}"
+                               Foreground="{StaticResource WarningBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,12"
+                               Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
 
                     <!-- ========== VISUAL TIMELINE ========== -->
                     <Border Background="{StaticResource InputBackgroundBrush}"
@@ -313,6 +376,61 @@
                             </Grid>
                         </Grid>
                     </Border>
+
+                    <!-- The list the header has always promised. The timeline is good for seeing
+                         the shape of what is available; it is hopeless for picking one point out
+                         of hundreds, which is what someone doing a point-in-time restore is
+                         actually trying to do. Sortable, and its selection is the same selection
+                         as the timeline's (#27). -->
+                    <TextBlock Text="RESTORE POINTS" Style="{StaticResource LabelText}" Margin="0,4,0,4"
+                               Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}}" />
+                    <DataGrid ItemsSource="{Binding RestorePoints}"
+                              SelectedItem="{Binding SelectedRestorePoint}"
+                              Style="{StaticResource DarkDataGrid}"
+                              MaxHeight="240"
+                              Margin="0,0,0,12"
+                              CanUserSortColumns="True"
+                              ScrollViewer.CanContentScroll="True"
+                              EnableRowVirtualization="True"
+                              Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Point in time" Width="180"
+                                                SortMemberPath="Timestamp"
+                                                Binding="{Binding TimestampDisplay}">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="ToolTip" Value="{Binding TimestampNote}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsTimestampApproximate}" Value="True">
+                                                <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+
+                            <DataGridTemplateColumn Header="Type" Width="90" SortMemberPath="Type">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Border Background="{Binding Type, Converter={StaticResource TypeToColor}}"
+                                                CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Opacity="0.85">
+                                            <TextBlock Text="{Binding Type}" Foreground="White"
+                                                       FontSize="11" FontWeight="SemiBold" />
+                                        </Border>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+
+                            <DataGridTextColumn Header="Restores" Width="*"
+                                                Binding="{Binding TypeDisplay}" />
+                            <DataGridTextColumn Header="Files" Width="60"
+                                                SortMemberPath="TotalFiles"
+                                                Binding="{Binding TotalFiles}" />
+                            <DataGridTextColumn Header="Size" Width="90"
+                                                SortMemberPath="TotalSizeBytes"
+                                                Binding="{Binding SizeDisplay}" />
+                        </DataGrid.Columns>
+                    </DataGrid>
 
                     <!-- Restore Chain Backup Sets (for selected restore point) -->
                     <DataGrid ItemsSource="{Binding ChainSets}"


### PR DESCRIPTION
Closes #27.

The timeline was the only way to pick a restore point. At a realistic log cadence — 15-minute logs over a week is roughly 670 points — the dots overlap into a band and there is nothing else to click. The header has been telling people to "select from the list below" for a while; there was no list.

## A list, alongside the timeline

Sortable by time, type, file count or size, sharing one selection with the timeline. The timeline stays what it's good at — seeing the shape of what's available — and the list does the part it can't: picking one specific point out of hundreds.

Approximate timestamps carry the same `~` and amber they got in #47, so a blob-derived point doesn't look precise here either.

## Narrowing

Type toggles (Full / Diff / Log) and a **From**/**To** range above the timeline, with a count that reads `Showing 40 of 671 restore point(s)`.

The range is a **zoom, not just a filter**: the timeline is laid out over the visible points, so narrowing to a two-hour window spreads those points across the whole track instead of leaving them bunched in the sliver they occupied before. Filtering without that would make them no easier to click than they were — there's a test for it.

**Zoom to day** narrows to the day the selected point falls on, because the answer is nearly always "the day it broke" and typing two timestamps to get there is a chore.

Dates parse invariantly and forgivingly: `2026-01-10` is fine, and half-typed input means "no bound" rather than blanking the timeline mid-keystroke.

Filters reset on every load — a range typed for one database would otherwise silently hide points belonging to the next.

I did **not** do the third bullet (collapsing dense log runs into a band with a count at low zoom). The range control gets to the same place, and a collapsed band that then has to be expanded is another interaction to learn. Worth revisiting if it still feels needed after some use.

## A bug this turned up

**Reloading with the same database selected never recomputed the restore points.** They were rebuilt only when the *selection* changed, so pressing Load again — the natural thing to do after taking a fresh backup — left the timeline showing the previous scan. The new backups were read from the container, grouped into sets, and then went nowhere.

`RefreshSelectedDatabase` is now called at the end of every load rather than only from the property-changed hook. Two tests fail against the old code, checked by reverting.

## Tests

**12 new; 658 total**, build clean at `-warnaserror`. Includes a XAML test that the list renders and binds, since a silently failed binding there would leave the timeline as the only selector again — the exact problem being fixed.

Published build, smoke-launched:

```
C:\Users\jake\AppData\Local\Temp\NineLives-27\NineLives.exe
```

The layout of the filter row and the list is the part that needs eyeballing — tests prove it binds, not that it reads well.


