### PR TITLE
Cleanup pass: dead code, unused options, navigation constants (#42)

### DIFF
--- a/src/NineLives.Tests/BackupChainBuilderTests.cs
+++ b/src/NineLives.Tests/BackupChainBuilderTests.cs
@@ -373,34 +373,9 @@ public class BackupChainBuilderTests
         Assert.Equal(T(3), window.Value.latest);
     }
 
-    // ---- GetRestoreWindow (BackupFileInfo overload) ----------------------
-
-    [Fact]
-    public void GetRestoreWindow_Files_NoFulls_ReturnsNull()
-    {
-        var files = new List<BackupFileInfo>
-        {
-            File(BackupType.TransactionLog, T(1)),
-            File(BackupType.Unknown, T(2))
-        };
-
-        Assert.Null(_builder.GetRestoreWindow(files));
-    }
-
-    [Fact]
-    public void GetRestoreWindow_Files_UsesBackupStartDateWhenPresentOtherwiseLastModified()
-    {
-        // The full's EffectiveDate comes from BackupStartDate (not LastModified);
-        // the log has no header metadata so its LastModified wins for the latest bound.
-        var full = File(BackupType.Full, lastModified: T(9), backupStartDate: T(1));
-        var log = File(BackupType.TransactionLog, lastModified: T(12));
-
-        var window = _builder.GetRestoreWindow(new List<BackupFileInfo> { full, log });
-
-        Assert.NotNull(window);
-        Assert.Equal(T(1), window.Value.earliest);
-        Assert.Equal(T(12), window.Value.latest);
-    }
+    // The file-level GetRestoreWindow overload and its two tests are gone (#42). It had no
+    // production caller and compared BackupStartDate against LastModified - two different clocks
+    // (#47) - so its tests were pinning behaviour nothing depended on and nobody should copy.
 
     // ---- BuildChainFromRestorePoint --------------------------------------
 

--- a/src/NineLives.Tests/NavigationTests.cs
+++ b/src/NineLives.Tests/NavigationTests.cs
@@ -1,0 +1,102 @@
+using System.Windows.Controls.Primitives;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The sidebar (#42).
+///
+/// Navigation is by string, and an unrecognised name falls back to Blob Storage rather than
+/// failing - so a typo in the markup or a name missing from the switch shows up as a button that
+/// quietly goes to the wrong screen. Nothing throws and nothing logs.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class NavigationTests(WpfFixture wpf)
+{
+    [Fact]
+    public void EveryNameInTheListReachesItsOwnView()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+        var reached = new List<object>();
+
+        foreach (var name in MainViewModel.Nav.Views)
+        {
+            vm.NavigateToCommand.Execute(name);
+            Assert.NotNull(vm.CurrentView);
+            Assert.Equal(name, vm.CurrentViewName);
+            reached.Add(vm.CurrentView!);
+        }
+
+        // Distinct, so a name missing from the switch - which silently lands on Blob Storage -
+        // cannot pass by looking like a successful navigation.
+        Assert.Equal(MainViewModel.Nav.Views.Count, reached.Distinct().Count());
+    }
+
+    [Fact]
+    public void AnUnknownNameFallsBackRatherThanCrashing()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.NavigateToCommand.Execute("Not A View");
+
+        Assert.NotNull(vm.CurrentView);
+    }
+
+    /// <summary>
+    /// Every navigation button in the window passes a name the switch actually knows. This is the
+    /// half that a ViewModel test cannot reach: the strings live in XAML, and a mistyped one is
+    /// invisible at build time and silent at runtime.
+    /// </summary>
+    [Fact]
+    public void EverySidebarButtonPassesAKnownName()
+    {
+        wpf.Invoke(() =>
+        {
+            var window = new MainWindow(new MainViewModel(new FakeCredentialStore()));
+            window.ApplyTemplate();
+            window.Measure(new System.Windows.Size(1600, 1200));
+            window.Arrange(new System.Windows.Rect(0, 0, 1600, 1200));
+            window.UpdateLayout();
+
+            var all = FindAll<ButtonBase>(window).ToList();
+
+            // Matched by CommandParameter rather than by Command. The window has never been shown,
+            // so its bindings have not been evaluated and every Command is still null - but a
+            // CommandParameter is a literal set at parse time, and it is the half that can be
+            // mistyped. Nothing else in this window passes a string parameter.
+            var parameters = all
+                .Select(b => b.CommandParameter as string)
+                .Where(p => p != null)
+                .ToList();
+
+            Assert.True(parameters.Count > 0,
+                $"No navigation buttons found. ButtonBase elements in the tree: {all.Count}.");
+            Assert.All(parameters, p => Assert.Contains(p, MainViewModel.Nav.Views));
+
+            // And every view is actually reachable from the sidebar, so adding one to the switch
+            // without adding a button does not go unnoticed either.
+            Assert.Equal(
+                MainViewModel.Nav.Views.OrderBy(n => n),
+                parameters.Distinct().OrderBy(n => n));
+        });
+    }
+
+    /// <summary>
+    /// Walks the LOGICAL tree, not the visual one.
+    ///
+    /// A Window that has never been shown has no visual tree at all - the content is parsed and
+    /// the elements exist, but nothing has been rendered, so VisualTreeHelper finds precisely
+    /// nothing. The logical tree is built at parse time and is what these buttons live in.
+    /// </summary>
+    private static IEnumerable<T> FindAll<T>(System.Windows.DependencyObject root)
+        where T : System.Windows.DependencyObject
+    {
+        foreach (var child in System.Windows.LogicalTreeHelper.GetChildren(root))
+        {
+            if (child is not System.Windows.DependencyObject node) continue;
+            if (node is T match) yield return match;
+            foreach (var descendant in FindAll<T>(node)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
+++ b/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
@@ -443,15 +443,15 @@ public class RestoreScriptGeneratorTests
     [Fact]
     public void Generate_NeverEmbedsCredentials()
     {
-        var script = _generator.Generate(FullDiffLogChain(), Options(o =>
-        {
-            o.SasToken = "sv=2026&sig=SECRET";
-            o.CredentialName = "MyCred";
-        }));
+        // The options object no longer carries a SAS token or a credential name at all (#42), so
+        // the strongest thing left to assert is the contract itself: nothing that could carry a
+        // secret reaches the script. WITH CREDENTIAL is separately wrong for a SAS credential -
+        // SQL Server rejects it with Msg 3225 and matches by URL instead (#60).
+        var script = _generator.Generate(FullDiffLogChain(), Options());
 
-        // The generator's contract: no credential or SAS material in the script, ever.
-        Assert.DoesNotContain("SECRET", script);
         Assert.DoesNotContain("CREDENTIAL", script);
+        Assert.DoesNotContain("sig=", script);
+        Assert.DoesNotContain("sv=", script);
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="Blackcat.NineLives.MainWindow"
+﻿<Window x:Class="Blackcat.NineLives.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:Blackcat.NineLives.ViewModels"

--- a/src/NineLives/Models/RestoreOptions.cs
+++ b/src/NineLives/Models/RestoreOptions.cs
@@ -34,14 +34,21 @@ public class RestoreOptions
     /// the case where a partial recovery beats none, and is not something to leave switched on.
     /// </summary>
     public bool ContinueAfterError { get; set; }
-    public string? CredentialName { get; set; }
 
     public List<FileMoveOption> FileMoves { get; set; } = [];
 
-    // The SAS credential name to use in SQL Server
-    public string SqlCredentialName { get; set; } = "BlobRestoreCredential";
-    public string? SasToken { get; set; }
-    public string? StorageAccountUrl { get; set; }
+    // Deliberately no credential fields here (#42).
+    //
+    // CredentialName, SqlCredentialName, SasToken and StorageAccountUrl used to live on this
+    // object. Every one of them was written by the ViewModel and read by nothing: the generated
+    // script carries no WITH CREDENTIAL clause, because SQL Server rejects that for a SAS
+    // credential and matches by URL instead (#60).
+    //
+    // SasToken was the one that mattered - it copied a live SAS token into an options object whose
+    // whole purpose is to be handed to a text generator. Nothing was leaking it, but nothing
+    // needed it either, and a secret sitting one careless AppendLine away from a script is not
+    // worth keeping for a field no code reads. The credential name the app does use lives on the
+    // ViewModel, which is what talks to the server about it.
 }
 
 public class FileMoveOption

--- a/src/NineLives/Services/BackupChainBuilder.cs
+++ b/src/NineLives/Services/BackupChainBuilder.cs
@@ -139,15 +139,9 @@ public class BackupChainBuilder
         return (earliest, latest);
     }
 
-    // Keep backward compatibility for existing callers during migration
-    public (DateTime earliest, DateTime latest)? GetRestoreWindow(List<BackupFileInfo> allBackups)
-    {
-        var fulls = allBackups.Where(b => b.Type == BackupType.Full).ToList();
-        if (fulls.Count == 0) return null;
-
-        var earliest = fulls.Min(f => f.EffectiveDate);
-        var latest = allBackups.Max(b => b.EffectiveDate);
-
-        return (earliest, latest);
-    }
+    // The file-level overload that used to sit here is gone (#42). It was labelled "backward
+    // compatibility during migration", had no production caller, and mixed two time bases: it
+    // compared BackupStartDate (the backup server's local clock) against the blob's LastModified
+    // (UTC). Keeping it around was an invitation for a future caller to reintroduce the skew that
+    // #47 went to some trouble to make visible.
 }

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -198,27 +198,48 @@ public partial class MainViewModel : ViewModelBase
         ServerManager.DisconnectCommand.Execute(null);
     }
 
+    /// <summary>
+    /// The sidebar's view names. Constants rather than literals scattered across the switch,
+    /// because an unrecognised name here silently lands on Blob Storage rather than failing -
+    /// so a typo looks like a button that goes to the wrong place (#42).
+    ///
+    /// The XAML still passes them as strings; <see cref="Views"/> is what a test can check the
+    /// switch against.
+    /// </summary>
+    public static class Nav
+    {
+        public const string BlobStorage = "Blob Storage";
+        public const string SqlServers = "SQL Servers";
+        public const string BrowseBackups = "Browse Backups";
+        public const string Restore = "Restore";
+        public const string History = "History";
+        public const string About = "About";
+
+        public static IReadOnlyList<string> Views =>
+            [BlobStorage, SqlServers, BrowseBackups, Restore, History, About];
+    }
+
     [RelayCommand]
     private void NavigateTo(string viewName)
     {
         CurrentViewName = viewName;
         CurrentView = viewName switch
         {
-            "Blob Storage" => BlobConfig,
-            "SQL Servers" => ServerManager,
-            "Browse Backups" => BlobBrowser,
-            "Restore" => Restore,
-            "History" => History,
-            "About" => About,
+            Nav.BlobStorage => BlobConfig,
+            Nav.SqlServers => ServerManager,
+            Nav.BrowseBackups => BlobBrowser,
+            Nav.Restore => Restore,
+            Nav.History => History,
+            Nav.About => About,
             _ => BlobConfig
         };
 
         // Refresh container lists when navigating to views that depend on them
-        if (viewName is "Browse Backups")
+        if (viewName is Nav.BrowseBackups)
             BlobBrowser.RefreshContainers();
-        else if (viewName is "Restore")
+        else if (viewName is Nav.Restore)
             Restore.RefreshContainers();
-        else if (viewName is "History")
+        else if (viewName is Nav.History)
             // Re-read on every visit: a restore run since the last look must be here, and the
             // history is written by the Restore screen rather than by this one.
             History.Refresh();

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1517,10 +1517,6 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        var sasToken = SelectedContainer != null
-            ? _credentialStore.GetSasToken(SelectedContainer)
-            : null;
-
         var fileMoves = new List<FileMoveOption>();
         if (UseWithMove)
         {
@@ -1554,9 +1550,6 @@ public partial class RestoreViewModel : ViewModelBase
             NewBroker = NewBroker,
             WithChecksum = WithChecksum,
             ContinueAfterError = ContinueAfterError,
-            SqlCredentialName = SqlCredentialName,
-            SasToken = sasToken,
-            StorageAccountUrl = SelectedContainer?.ContainerUrl,
             FileMoves = fileMoves
         };
 


### PR DESCRIPTION
Works through the remaining items on #42. Several were already done in earlier work (the byte formatter is `ByteSize.Format`, `MatchesServerSet` compares the instance, delete asks first, a config that fails to parse now says so), so this covers what was actually left.

## The SAS token in the options object

`RestoreOptions` carried `CredentialName`, `SqlCredentialName`, `SasToken` and `StorageAccountUrl`. Every one was written by the ViewModel and **read by nothing** — the generated script deliberately has no `WITH CREDENTIAL` clause, because SQL Server rejects that for a SAS credential and matches by URL instead (#60).

`SasToken` is the one worth removing rather than just tidying: it copied a live SAS token into an object whose entire purpose is being handed to a text generator. Nothing leaked it, and there was a test proving so — but nothing needed it either, and a secret one careless `AppendLine` away from a script isn't worth keeping for a field no code reads.

The "never embeds credentials" test stays, asserting the contract directly: no `CREDENTIAL`, no `sig=`, no `sv=` in the generated script.

## Dead code

`GetRestoreWindow(List<BackupFileInfo>)` is gone, along with its two tests. It was labelled "backward compatibility during migration", had no production caller, and compared `BackupStartDate` (the backup server's clock) against `LastModified` (UTC) — the exact skew #47 went to some trouble to make visible. Leaving it there was an invitation to reintroduce it.

## Navigation strings

The sidebar navigates by string, and an unrecognised name **falls back to Blob Storage rather than failing** — so a typo shows up as a button that quietly goes to the wrong screen, with nothing thrown and nothing logged.

Now constants on `MainViewModel.Nav`, with three tests:

- every name in the list reaches its own distinct view (a name missing from the switch can't pass by silently landing on Blob Storage)
- an unknown name still falls back rather than crashing
- **every navigation button in the window passes a name the switch knows, and every known name has a button**

That last one catches the typo where it actually happens — in markup, invisible at build time. Verified by introducing `Histroy` in `MainWindow.xaml` and watching it fail.

It walks the **logical** tree, not the visual one: a window that has never been shown has no visual tree at all, and matches on `CommandParameter` rather than `Command`, because unshown bindings haven't been evaluated and every `Command` is still null. The parameter is the half that gets mistyped anyway.

## Still open on #42

Left deliberately, and the issue stays open for them: the drag-and-drop path builder is still duplicated between the standalone and AG patterns, `RefreshContainers`/`CopyPath` are still near-identical across two ViewModels, and `RestorePoint`/`BackupChain` still use `null!` placeholders. Those are bigger than a cleanup pass and each deserves its own change.

**659 tests**, build clean at `-warnaserror`.
