### PR TITLE
Theme the app on the splash screen, and add light and high contrast

### DIFF
--- a/src/NineLives.Tests/ThemeTests.cs
+++ b/src/NineLives.Tests/ThemeTests.cs
@@ -1,0 +1,321 @@
+using System.Windows;
+using System.Windows.Media;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The palettes and the theme switch.
+///
+/// The failure this guards against is silent: a brush referenced with DynamicResource that a
+/// palette does not define does NOT throw. WPF resolves it to nothing and the element renders
+/// with no brush at all - white text on white, or an invisible border. Nothing in the build or
+/// the XAML load tests catches it, which is why the key sets are compared directly.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class ThemeTests(WpfFixture wpf)
+{
+    private static HashSet<string> KeysOf(ResourceDictionary dictionary)
+        => dictionary.Keys.Cast<object>().Select(k => k.ToString()!).ToHashSet();
+
+    [Theory]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void EveryPaletteDefinesExactlyTheSameKeys(AppTheme theme)
+    {
+        HashSet<string> dark = [], other = [];
+        wpf.Invoke(() =>
+        {
+            dark = KeysOf(ThemeManager.Load(AppTheme.Dark));
+            other = KeysOf(ThemeManager.Load(theme));
+        });
+
+        var missing = dark.Except(other).OrderBy(k => k).ToList();
+        var extra = other.Except(dark).OrderBy(k => k).ToList();
+
+        Assert.True(missing.Count == 0,
+            $"{theme} is missing: {string.Join(", ", missing)}. Anything using these renders with " +
+            "no brush at all - white on white, or an invisible border.");
+        Assert.True(extra.Count == 0,
+            $"{theme} defines keys the dark palette does not: {string.Join(", ", extra)}. " +
+            "Switching back to Dark would leave them unresolved.");
+    }
+
+    [Fact]
+    public void APaletteDefinesEnoughToBeAPalette()
+    {
+        // Guards the comparison above: two empty dictionaries also have identical key sets.
+        wpf.Invoke(() => Assert.True(KeysOf(ThemeManager.Load(AppTheme.Dark)).Count > 50));
+    }
+
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void EveryThemeSuppliesTheBrushesTheAppAsksForByName(AppTheme theme)
+    {
+        // A spot check of the keys used in the most places, resolved as brushes rather than just
+        // present as keys - a Color where a Brush is expected would bind to nothing.
+        string[] required =
+        [
+            "WindowBackgroundBrush", "SidebarBackgroundBrush", "CardBackgroundBrush",
+            "CardBorderBrush", "InputBackgroundBrush", "AccentBrush", "AccentForegroundBrush",
+            "PrimaryTextBrush", "SecondaryTextBrush", "DisabledTextBrush",
+            "SuccessBrush", "ErrorBrush", "WarningBrush",
+            "SuccessPanelBackgroundBrush", "WarningPanelBorderBrush", "DangerPanelBorderBrush",
+            "ConsoleBackgroundBrush", "ConsoleTextBrush", "SqlKeywordBrush",
+            "OverlayBrush", "AlternatingRowBackgroundBrush", "UpdateBannerBrush"
+        ];
+
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+            foreach (var key in required)
+                Assert.True(palette[key] is Brush, $"{theme}: {key} is not a Brush.");
+        });
+    }
+
+    /// <summary>
+    /// High contrast has to actually be high contrast. Checked as a ratio rather than by eye,
+    /// because "looks contrasty" is exactly the judgement that lets a 3:1 pair through.
+    /// </summary>
+    [Fact]
+    public void HighContrastPutsTextAndBackgroundAtTheExtremes()
+    {
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(AppTheme.HighContrast);
+
+            var background = ((SolidColorBrush)palette["WindowBackgroundBrush"]).Color;
+            var text = ((SolidColorBrush)palette["PrimaryTextBrush"]).Color;
+
+            Assert.Equal(Colors.Black, background);
+            Assert.Equal(Colors.White, text);
+
+            // Secondary text is the one usually sacrificed - it is grey in the other themes. Here
+            // it has to stay readable, so it is held above 7:1 (WCAG AAA for body text).
+            var secondary = ((SolidColorBrush)palette["SecondaryTextBrush"]).Color;
+            Assert.True(Contrast(secondary, background) >= 7.0,
+                $"Secondary text against the background is only {Contrast(secondary, background):F1}:1.");
+        });
+    }
+
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void BodyTextIsReadableAgainstItsCard(AppTheme theme)
+    {
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+            var card = ((SolidColorBrush)palette["CardBackgroundBrush"]).Color;
+            var text = ((SolidColorBrush)palette["PrimaryTextBrush"]).Color;
+
+            Assert.True(Contrast(text, card) >= 4.5,
+                $"{theme}: primary text on a card is {Contrast(text, card):F1}:1, below the 4.5:1 minimum.");
+        });
+    }
+
+    /// <summary>
+    /// Selected rows keep their text readable.
+    ///
+    /// High contrast originally used the accent yellow as the selected fill, which put white text
+    /// on yellow - unreadable. Selection is now carried by an accent-coloured BORDER, so the fill
+    /// can stay dark. Found by rendering the view and looking at it; pinned here so it stays fixed.
+    /// </summary>
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void TextOnASelectedRowStaysReadable(AppTheme theme)
+    {
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+            var selected = ((SolidColorBrush)palette["SidebarItemActiveBrush"]).Color;
+            var text = ((SolidColorBrush)palette["PrimaryTextBrush"]).Color;
+
+            Assert.True(Contrast(text, selected) >= 4.5,
+                $"{theme}: text on a selected row is {Contrast(text, selected):F1}:1.");
+        });
+    }
+
+    /// <summary>WCAG relative luminance contrast ratio.</summary>
+    private static double Contrast(Color a, Color b)
+    {
+        var la = Luminance(a);
+        var lb = Luminance(b);
+        var (hi, lo) = la > lb ? (la, lb) : (lb, la);
+        return (hi + 0.05) / (lo + 0.05);
+    }
+
+    private static double Luminance(Color c)
+    {
+        static double Channel(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+
+        return 0.2126 * Channel(c.R) + 0.7152 * Channel(c.G) + 0.0722 * Channel(c.B);
+    }
+
+    // ── switching ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Applying a theme changes what a loaded window resolves, without rebuilding it. This is the
+    /// whole reason the views use DynamicResource - with StaticResource the switch would appear to
+    /// work for anything created afterwards and leave every open window in the old colours.
+    /// </summary>
+    [Fact]
+    public void SwitchingThemeRecoloursAWindowThatIsAlreadyBuilt()
+    {
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                ThemeManager.Apply(AppTheme.Dark);
+
+                var view = new AboutView { DataContext = new AboutViewModel() };
+                var dark = (SolidColorBrush)view.FindResource("CardBackgroundBrush");
+
+                ThemeManager.Apply(AppTheme.Light);
+                var light = (SolidColorBrush)view.FindResource("CardBackgroundBrush");
+
+                Assert.NotEqual(dark.Color, light.Color);
+                Assert.Equal(Colors.White, light.Color);
+            });
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+
+    [Fact]
+    public void TheAppliedThemeIsRemembered()
+    {
+        var store = new FakeCredentialStore();
+
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                var vm = new AboutViewModel(store) { SelectedTheme = AppTheme.HighContrast };
+                Assert.Equal(AppTheme.HighContrast, ThemeManager.Current);
+            });
+
+            Assert.Equal(AppTheme.HighContrast, store.Config.Theme);
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+
+    [Fact]
+    public void AConfigThatCannotBeSavedStillLeavesTheThemeApplied()
+    {
+        // The user can see the change on screen. Undoing it because a file would not write would
+        // be a worse answer than saying so.
+        var store = new FakeCredentialStore
+        {
+            SaveConfigThrows = new InvalidOperationException("config.json is locked")
+        };
+
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                var vm = new AboutViewModel(store) { SelectedTheme = AppTheme.Light };
+
+                Assert.Equal(AppTheme.Light, ThemeManager.Current);
+                Assert.True(vm.HasError);
+                Assert.Contains("could not be saved", vm.ErrorMessage);
+            });
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+
+    /// <summary>
+    /// Every view builds and binds under every theme.
+    ///
+    /// This is the pass that catches a {StaticResource} left pointing at a key that moved into the
+    /// palettes - those DO throw - and it proves each palette actually loads and merges. It does
+    /// not catch a missing DynamicResource key, which is silent; that is what the key-set
+    /// comparison above is for.
+    /// </summary>
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void EveryViewLoadsUnderEveryTheme(AppTheme theme)
+    {
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                Assert.True(ThemeManager.Apply(theme), $"{theme} would not apply.");
+
+                var store = new FakeCredentialStore();
+                FrameworkElement[] views =
+                [
+                    new AboutView { DataContext = new AboutViewModel(store) },
+                    new BlobConfigView { DataContext = new BlobConfigViewModel(store, new BlobStorageService(store)) },
+                    new ServerManagerView { DataContext = new ServerManagerViewModel(store, new SqlServerService(store)) },
+                    new BlobBrowserView { DataContext = new BlobBrowserViewModel(new BlobStorageService(store), store) },
+                    new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) },
+                ];
+
+                var listener = BindingErrorListener.Attach();
+                try
+                {
+                    foreach (var view in views)
+                    {
+                        view.ApplyTemplate();
+                        view.Measure(new Size(1600, 1200));
+                        view.Arrange(new Rect(0, 0, 1600, 1200));
+                        view.UpdateLayout();
+                    }
+
+                    listener.AssertNone($"views under {theme}");
+                }
+                finally
+                {
+                    listener.Detach();
+                }
+            });
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+
+    [Fact]
+    public void AStartupWithARememberedThemeAppliesIt()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Theme = AppTheme.Light;
+
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                _ = new MainViewModel(store);
+                Assert.Equal(AppTheme.Light, ThemeManager.Current);
+            });
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+}

--- a/src/NineLives.Tests/WpfFixture.cs
+++ b/src/NineLives.Tests/WpfFixture.cs
@@ -74,10 +74,22 @@ public sealed class WpfFixture : IDisposable
         if (captured != null) ExceptionDispatchInfo.Capture(captured).Throw();
     }
 
+    /// <summary>
+    /// Deliberately does NOT shut the dispatcher down.
+    ///
+    /// It used to call InvokeShutdown and join with a five-second timeout. When the join timed out
+    /// - which it started doing once there was enough WPF work queued - the thread was left
+    /// running managed code while the runtime tore down around it, and the test host died with
+    /// "Attempt to execute managed code after the .NET runtime thread state has been destroyed".
+    /// That aborted the whole run mid-way, after every test in it had passed.
+    ///
+    /// The thread is IsBackground, so it cannot keep the process alive; letting the process end it
+    /// removes the race entirely. There is exactly one of these per run and it owns the only
+    /// Application, so nothing is leaked that outlives the process.
+    /// </summary>
     public void Dispose()
     {
-        _dispatcher?.InvokeShutdown();
-        _thread.Join(TimeSpan.FromSeconds(5));
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/NineLives/App.xaml
+++ b/src/NineLives/App.xaml
@@ -5,7 +5,10 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Themes/DarkTheme.xaml" />
+                <!-- The palette MUST be first: ThemeManager swaps whatever is at index 0, and it
+                     identifies it by position rather than by guessing at the source Uri. -->
+                <ResourceDictionary Source="Themes/Palette.Dark.xaml" />
+                <ResourceDictionary Source="Themes/Controls.xaml" />
                 <ResourceDictionary Source="Themes/Logo.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -8,7 +8,7 @@
         Height="800" Width="1200"
         MinHeight="600" MinWidth="900"
         WindowStartupLocation="CenterScreen"
-        Background="{StaticResource WindowBackgroundBrush}">
+        Background="{DynamicResource WindowBackgroundBrush}">
 
     <!-- DataContext is set in the constructor, not here. Declaring it in XAML meant every
          construction of this window - including a test that only wanted to check the markup -
@@ -50,14 +50,14 @@
              because something is on fire, and a popup between the DBA and the restore button
              would be exactly wrong. -->
         <Border Grid.Row="0"
-                Background="{StaticResource UpdateBannerBrush}"
-                BorderBrush="{StaticResource UpdateBannerEdgeBrush}"
+                Background="{DynamicResource UpdateBannerBrush}"
+                BorderBrush="{DynamicResource UpdateBannerEdgeBrush}"
                 BorderThickness="0,0,0,1"
                 Padding="16,10"
                 Visibility="{Binding UpdateAvailable, Converter={StaticResource BoolToVis}}">
             <!-- Lifts the band off the window rather than letting it read as another dark stripe. -->
             <Border.Effect>
-                <DropShadowEffect Color="#000000" BlurRadius="12" ShadowDepth="2" Opacity="0.45" Direction="270" />
+                <DropShadowEffect Color="{DynamicResource ShadowColor}" BlurRadius="12" ShadowDepth="2" Opacity="0.45" Direction="270" />
             </Border.Effect>
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -70,9 +70,9 @@
                 <!-- Badge. Pulses slowly - enough to catch the eye on a screen someone is already
                      looking at, slow enough not to nag while they work. -->
                 <Grid Grid.Column="0" Width="24" Height="24" Margin="0,0,12,0" VerticalAlignment="Center">
-                    <Ellipse Fill="#1A1205" Opacity="0.92" />
+                    <Ellipse Fill="{DynamicResource UpdateBannerBadgeBrush}" Opacity="0.92" />
                     <TextBlock Text="&#x2191;"
-                               Foreground="#FFC24B"
+                               Foreground="{DynamicResource UpdateBannerBadgeGlyphBrush}"
                                FontSize="15"
                                FontWeight="Bold"
                                HorizontalAlignment="Center"
@@ -93,7 +93,7 @@
                 <TextBlock Grid.Column="1"
                            Text="{Binding UpdateMessage}"
                            VerticalAlignment="Center"
-                           Foreground="{StaticResource UpdateBannerTextBrush}"
+                           Foreground="{DynamicResource UpdateBannerTextBrush}"
                            FontFamily="Segoe UI"
                            FontSize="13.5"
                            FontWeight="SemiBold"
@@ -119,13 +119,13 @@
             </Grid.ColumnDefinitions>
 
             <!-- Sidebar -->
-            <Border Grid.Column="0" Background="{StaticResource SidebarBackgroundBrush}">
+            <Border Grid.Column="0" Background="{DynamicResource SidebarBackgroundBrush}">
                 <DockPanel>
                     <!-- App Title -->
                     <StackPanel DockPanel.Dock="Top" Margin="20,20,20,8">
                         <TextBlock FontSize="18" FontWeight="Bold"
                                    FontFamily="Segoe UI">
-                            <Run Text="Nine" Foreground="{StaticResource PrimaryTextBrush}" /><Run Text=" Lives" Foreground="{StaticResource AccentBrush}" />
+                            <Run Text="Nine" Foreground="{DynamicResource PrimaryTextBrush}" /><Run Text=" Lives" Foreground="{DynamicResource AccentBrush}" />
                         </TextBlock>
                         <TextBlock Text="SQL Restore from Azure Blob"
                                    Style="{StaticResource SecondaryText}"
@@ -134,7 +134,7 @@
 
                     <Border DockPanel.Dock="Top"
                             Height="1"
-                            Background="{StaticResource CardBorderBrush}"
+                            Background="{DynamicResource CardBorderBrush}"
                             Margin="16,8,16,8" />
 
                     <!-- About Button -->
@@ -151,18 +151,18 @@
 
                     <!-- Connection Status -->
                     <Border DockPanel.Dock="Bottom"
-                            Background="{StaticResource CardBackgroundBrush}"
+                            Background="{DynamicResource CardBackgroundBrush}"
                             CornerRadius="6"
                             Padding="12,8"
                             Margin="12,8,12,16">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal">
                                 <Ellipse Width="8" Height="8"
-                                         Fill="{StaticResource SuccessBrush}"
+                                         Fill="{DynamicResource SuccessBrush}"
                                          VerticalAlignment="Center"
                                          Visibility="{Binding IsConnectedToSql, Converter={StaticResource BoolToVis}}" />
                                 <Ellipse Width="8" Height="8"
-                                         Fill="{StaticResource SecondaryTextBrush}"
+                                         Fill="{DynamicResource SecondaryTextBrush}"
                                          VerticalAlignment="Center"
                                          Visibility="{Binding IsConnectedToSql, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
                                 <TextBlock Style="{StaticResource SecondaryText}"
@@ -179,7 +179,7 @@
                     <StackPanel DockPanel.Dock="Top" Margin="0,8,0,0">
                         <TextBlock Text="CONFIGURATION"
                                    FontSize="10" FontWeight="Bold"
-                                   Foreground="{StaticResource DisabledTextBrush}"
+                                   Foreground="{DynamicResource DisabledTextBrush}"
                                    Margin="20,8,0,4"
                                    FontFamily="Segoe UI" />
 
@@ -203,12 +203,12 @@
                         </RadioButton>
 
                         <Border Height="1"
-                                Background="{StaticResource CardBorderBrush}"
+                                Background="{DynamicResource CardBorderBrush}"
                                 Margin="16,12,16,4" />
 
                         <TextBlock Text="OPERATIONS"
                                    FontSize="10" FontWeight="Bold"
-                                   Foreground="{StaticResource DisabledTextBrush}"
+                                   Foreground="{DynamicResource DisabledTextBrush}"
                                    Margin="20,8,0,4"
                                    FontFamily="Segoe UI" />
 
@@ -248,7 +248,7 @@
                 <Border DockPanel.Dock="Top"
                         Padding="16,6"
                         Visibility="{Binding IsConnectedToSql, Converter={StaticResource BoolToVis}}">
-                    <Border Background="#1A27AE60" CornerRadius="4" Padding="10,5">
+                    <Border Background="{DynamicResource SuccessPanelBackgroundBrush}" CornerRadius="4" Padding="10,5">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
@@ -256,11 +256,11 @@
                             </Grid.ColumnDefinitions>
                             <StackPanel Grid.Column="0" Orientation="Horizontal">
                                 <Ellipse Width="8" Height="8"
-                                         Fill="{StaticResource SuccessBrush}"
+                                         Fill="{DynamicResource SuccessBrush}"
                                          VerticalAlignment="Center"
                                          Margin="0,0,8,0" />
                                 <TextBlock VerticalAlignment="Center"
-                                           Foreground="{StaticResource SuccessBrush}"
+                                           Foreground="{DynamicResource SuccessBrush}"
                                            FontSize="12">
                                     <Run Text="Connected to" />
                                     <Run Text="{Binding ConnectedServerName, Mode=OneWay}" FontWeight="SemiBold" />
@@ -273,8 +273,8 @@
                                     FontSize="11"
                                     Background="Transparent"
                                     BorderThickness="1"
-                                    BorderBrush="{StaticResource SuccessBrush}"
-                                    Foreground="{StaticResource SuccessBrush}"
+                                    BorderBrush="{DynamicResource SuccessBrush}"
+                                    Foreground="{DynamicResource SuccessBrush}"
                                     Cursor="Hand"
                                     VerticalAlignment="Center" />
                         </Grid>
@@ -286,7 +286,7 @@
 
         <!-- Status Bar -->
         <Border Grid.Row="2"
-                Background="{StaticResource StatusBarBackgroundBrush}"
+                Background="{DynamicResource StatusBarBackgroundBrush}"
                 Padding="16,6">
             <Grid>
                 <Grid.ColumnDefinitions>

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -305,6 +305,13 @@ public class AppConfig
     public string? LastNotifiedReleaseTag { get; set; }
 
     /// <summary>
+    /// Colour scheme. Stored by name so the file stays readable and an unknown value degrades to
+    /// Dark rather than throwing - someone hand-editing this should not be able to stop the app
+    /// starting.
+    /// </summary>
+    public AppTheme Theme { get; set; } = AppTheme.Dark;
+
+    /// <summary>
     /// Set when config.json existed but could not be read or parsed. Not persisted - it describes
     /// this load attempt, not the configuration. While it is set, this object holds empty defaults
     /// that do NOT reflect what is on disk, so <see cref="CredentialStore.SaveConfig"/> will

--- a/src/NineLives/Services/ThemeManager.cs
+++ b/src/NineLives/Services/ThemeManager.cs
@@ -1,0 +1,90 @@
+using System.Windows;
+
+namespace Blackcat.NineLives.Services;
+
+public enum AppTheme
+{
+    Dark,
+    Light,
+    HighContrast
+}
+
+/// <summary>
+/// Swaps the colour palette at runtime.
+///
+/// The application's merged dictionaries are [palette, controls, logo]. Only the palette changes;
+/// the control styles and the logo are the same in every theme. Replacing the dictionary at index
+/// 0 re-resolves every <c>DynamicResource</c> in every loaded window immediately, which is why
+/// the styles and views reference brushes dynamically - a StaticResource is resolved once when the
+/// element loads and would keep the old colour for the lifetime of the window.
+///
+/// Position, not Source Uri, identifies the palette: comparing pack Uris is fiddly, and the merge
+/// order is declared in one place (App.xaml) right next to a comment saying so.
+/// </summary>
+public static class ThemeManager
+{
+    public const int PaletteIndex = 0;
+
+    /// <summary>The theme currently applied. Dark until something says otherwise.</summary>
+    public static AppTheme Current { get; private set; } = AppTheme.Dark;
+
+    /// <summary>
+    /// An absolute pack Uri, not a relative path.
+    ///
+    /// A relative Uri resolves against the ENTRY assembly, which is this app when it runs and the
+    /// test host when the tests run - so the tests could not load a palette at all. Naming the
+    /// assembly works in both.
+    /// </summary>
+    public static string SourceFor(AppTheme theme) => theme switch
+    {
+        AppTheme.Light => Pack("Palette.Light"),
+        AppTheme.HighContrast => Pack("Palette.HighContrast"),
+        _ => Pack("Palette.Dark")
+    };
+
+    private static string Pack(string name)
+        => $"pack://application:,,,/NineLives;component/Themes/{name}.xaml";
+
+    /// <summary>Loads a palette without applying it. Used by the tests to compare key sets.</summary>
+    public static ResourceDictionary Load(AppTheme theme) => new()
+    {
+        Source = new Uri(SourceFor(theme), UriKind.Absolute)
+    };
+
+    /// <summary>
+    /// Applies a theme to the running application.
+    ///
+    /// Never throws. A theme that will not load is a cosmetic problem, and taking the app down -
+    /// or worse, failing mid-restore - over a colour scheme would not be a trade anyone would
+    /// make. The previous palette simply stays in place.
+    /// </summary>
+    public static bool Apply(AppTheme theme, Application? application = null)
+    {
+        var app = application ?? Application.Current;
+        if (app == null) return false;
+
+        try
+        {
+            var merged = app.Resources.MergedDictionaries;
+            if (merged.Count == 0) return false;
+
+            merged[PaletteIndex] = Load(theme);
+            Current = theme;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Human-readable name, for the picker and the config file.</summary>
+    public static string DisplayName(AppTheme theme) => theme switch
+    {
+        AppTheme.Light => "Light",
+        AppTheme.HighContrast => "High contrast",
+        _ => "Dark"
+    };
+
+    public static IReadOnlyList<AppTheme> All => [AppTheme.Dark, AppTheme.Light, AppTheme.HighContrast];
+}

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
 
@@ -11,15 +11,6 @@
 
     <!-- Terminal console. Darker than the cards on purpose, so the console reads as a separate
          surface the way a real terminal does rather than as another panel in the form. -->
-    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#0C0E14" />
-    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#2A3040" />
-    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#161A24" />
-    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#C9D1D9" />
-    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#6E7681" />
-    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#79C0FF" />
-    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#3FB950" />
-    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#D29922" />
-    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#F85149" />
 
     <FontFamily x:Key="ConsoleFont">Cascadia Code, Cascadia Mono, Consolas, Courier New</FontFamily>
 
@@ -28,14 +19,6 @@
          uses red for things that have actually gone wrong. Against a dark navy UI a bright amber
          band is unmissable without pretending to be a failure. Dark text on it, because pale text
          on amber is the one combination that would undo the contrast. -->
-    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
-        <GradientStop Color="#FFC24B" Offset="0" />
-        <GradientStop Color="#F59E0B" Offset="0.55" />
-        <GradientStop Color="#EA8C04" Offset="1" />
-    </LinearGradientBrush>
-
-    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#1A1205" />
-    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#B36F00" />
 
     <!-- Solid dark on amber: the one thing to click, and it inverts the banner's own contrast. -->
     <Style x:Key="UpdateBannerPrimaryButton" TargetType="Button">
@@ -119,7 +102,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Padding" Value="12,8,12,10" />
-        <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ConsoleTextBrush}" />
         <Setter Property="ItemContainerStyle" Value="{StaticResource ConsoleListBoxItem}" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
@@ -138,19 +121,19 @@
                                LineStackingStrategy="BlockLineHeight">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
+                                <Setter Property="Foreground" Value="{DynamicResource ConsoleTextBrush}" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding Kind}" Value="Step">
-                                        <Setter Property="Foreground" Value="{StaticResource ConsoleStepBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ConsoleStepBrush}" />
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding Kind}" Value="Success">
-                                        <Setter Property="Foreground" Value="{StaticResource ConsoleSuccessBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ConsoleSuccessBrush}" />
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding Kind}" Value="Warning">
-                                        <Setter Property="Foreground" Value="{StaticResource ConsoleWarningBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ConsoleWarningBrush}" />
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding Kind}" Value="Error">
-                                        <Setter Property="Foreground" Value="{StaticResource ConsoleErrorBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ConsoleErrorBrush}" />
                                         <Setter Property="FontWeight" Value="SemiBold" />
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -163,97 +146,105 @@
     </Style>
 
     <!-- T-SQL syntax colouring, same family as the console so the two panes belong together. -->
-    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#FF7B9EFF" />
-    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#A5D6A7" />
-    <SolidColorBrush x:Key="SqlCommentBrush" Color="#5C6773" />
-    <SolidColorBrush x:Key="SqlNumberBrush" Color="#F0B457" />
-    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#E2C08D" />
 
     <!-- Color Palette -->
-    <Color x:Key="WindowBackgroundColor">#1B1E2B</Color>
-    <Color x:Key="SidebarBackgroundColor">#141722</Color>
-    <Color x:Key="CardBackgroundColor">#232738</Color>
-    <Color x:Key="CardBorderColor">#2D3148</Color>
-    <Color x:Key="InputBackgroundColor">#1A1D2A</Color>
-    <Color x:Key="InputBorderColor">#363B52</Color>
-    <Color x:Key="InputFocusBorderColor">#4A90D9</Color>
-    <Color x:Key="AccentColor">#4A90D9</Color>
-    <Color x:Key="AccentHoverColor">#5BA0E9</Color>
-    <Color x:Key="AccentPressedColor">#3A80C9</Color>
-    <Color x:Key="SuccessColor">#27AE60</Color>
-    <Color x:Key="ErrorColor">#E74C3C</Color>
-    <Color x:Key="WarningColor">#F39C12</Color>
-    <Color x:Key="PrimaryTextColor">#E8E8E8</Color>
-    <Color x:Key="SecondaryTextColor">#8890A4</Color>
-    <Color x:Key="DisabledTextColor">#555B6E</Color>
-    <Color x:Key="SidebarItemHoverColor">#1E2233</Color>
-    <Color x:Key="SidebarItemActiveColor">#252A3E</Color>
-    <Color x:Key="ScrollBarColor">#363B52</Color>
-    <Color x:Key="StatusBarBackgroundColor">#111320</Color>
-    <Color x:Key="DangerBackgroundColor">#3D1F1F</Color>
 
     <!-- Brushes -->
-    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
-    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="{StaticResource SidebarBackgroundColor}" />
-    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" />
-    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}" />
-    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
-    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
-    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
-    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
-    <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
-    <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
-    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
-    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
-    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
-    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
-    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
-    <SolidColorBrush x:Key="DisabledTextBrush" Color="{StaticResource DisabledTextColor}" />
-    <SolidColorBrush x:Key="SidebarItemHoverBrush" Color="{StaticResource SidebarItemHoverColor}" />
-    <SolidColorBrush x:Key="SidebarItemActiveBrush" Color="{StaticResource SidebarItemActiveColor}" />
-    <SolidColorBrush x:Key="ScrollBarBrush" Color="{StaticResource ScrollBarColor}" />
-    <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="{StaticResource StatusBarBackgroundColor}" />
-    <SolidColorBrush x:Key="DangerBackgroundBrush" Color="{StaticResource DangerBackgroundColor}" />
+
+    <!--
+        Control styles only. Every colour lives in a Palette.*.xaml, which ThemeManager swaps at
+        runtime - which is why the brushes below are DynamicResource rather than StaticResource.
+        A StaticResource is resolved once when the element loads and would not follow a theme
+        change, so a switched theme would leave half the window in the old colours.
+    -->
 
     <!-- TextBlock Styles -->
     <Style x:Key="HeaderText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="20" />
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
     </Style>
 
     <Style x:Key="SubHeaderText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
     </Style>
 
     <Style x:Key="BodyText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
     </Style>
 
     <Style x:Key="SecondaryText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="12" />
-        <Setter Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
     </Style>
 
     <Style x:Key="LabelText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="12" />
         <Setter Property="FontWeight" Value="Medium" />
-        <Setter Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
         <Setter Property="Margin" Value="0,0,0,4" />
+    </Style>
+
+
+    <!--
+        A list sitting on a card. The default ListBoxItem takes its foreground from the system,
+        which is near-black - so on a dark card the item text rendered black on black and simply
+        was not there. Caught by rendering the view to a PNG and looking at it.
+
+        Selection is marked by a tinted fill AND an accent border, not by colour alone: in high
+        contrast the fill is nearly the same as the row behind it, and the border is what carries
+        the meaning.
+    -->
+    <Style x:Key="CardListBoxItem" TargetType="ListBoxItem">
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="Padding" Value="10,6" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListBoxItem">
+                    <Border x:Name="bd"
+                            Background="Transparent"
+                            BorderBrush="Transparent"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}"
+                            Margin="0,0,0,2">
+                        <ContentPresenter />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
+                            <Setter TargetName="bd" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="CardListBox" TargetType="ListBox">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource CardListBoxItem}" />
     </Style>
 
     <!-- Card Style -->
     <Style x:Key="CardBorder" TargetType="Border">
-        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="6" />
         <Setter Property="Padding" Value="16" />
@@ -261,7 +252,7 @@
 
     <!-- Button Styles -->
     <Style x:Key="PrimaryButton" TargetType="Button">
-        <Setter Property="Background" Value="{StaticResource AccentBrush}" />
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
         <Setter Property="Foreground" Value="White" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
@@ -281,10 +272,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource AccentHoverBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource AccentHoverBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource AccentPressedBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource AccentPressedBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -297,12 +288,12 @@
 
     <Style x:Key="SecondaryButton" TargetType="Button">
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="Padding" Value="16,8" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="Cursor" Value="Hand" />
         <Setter Property="Template">
             <Setter.Value>
@@ -318,8 +309,8 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource SidebarItemHoverBrush}" />
-                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -331,7 +322,7 @@
     </Style>
 
     <Style x:Key="DangerButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
-        <Setter Property="Background" Value="{StaticResource ErrorBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ErrorBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -344,10 +335,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="#D63031" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource ErrorHoverBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="#C0392B" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource ErrorPressedBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -359,7 +350,7 @@
     </Style>
 
     <Style x:Key="SuccessButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
-        <Setter Property="Background" Value="{StaticResource SuccessBrush}" />
+        <Setter Property="Background" Value="{DynamicResource SuccessBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -372,10 +363,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="#2ECC71" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SuccessHoverBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="#1E8449" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SuccessPressedBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -388,10 +379,10 @@
 
     <!-- TextBox Style -->
     <Style x:Key="DarkTextBox" TargetType="TextBox">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="CaretBrush" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource InputBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
@@ -409,7 +400,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource InputFocusBorderBrush}" />
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource InputFocusBorderBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -422,10 +413,10 @@
 
     <!-- PasswordBox Style -->
     <Style x:Key="DarkPasswordBox" TargetType="PasswordBox">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="CaretBrush" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource InputBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
@@ -443,7 +434,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource InputFocusBorderBrush}" />
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource InputFocusBorderBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -459,29 +450,29 @@
                 <ColumnDefinition Width="28" />
             </Grid.ColumnDefinitions>
             <Border x:Name="Border" Grid.ColumnSpan="2"
-                    Background="{StaticResource InputBackgroundBrush}"
-                    BorderBrush="{StaticResource InputBorderBrush}"
+                    Background="{DynamicResource InputBackgroundBrush}"
+                    BorderBrush="{DynamicResource InputBorderBrush}"
                     BorderThickness="1" CornerRadius="4" />
             <Path x:Name="Arrow" Grid.Column="1"
                   Data="M 0 0 L 4 4 L 8 0 Z"
-                  Fill="{StaticResource SecondaryTextBrush}"
+                  Fill="{DynamicResource SecondaryTextBrush}"
                   HorizontalAlignment="Center" VerticalAlignment="Center" />
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
             </Trigger>
             <Trigger Property="IsChecked" Value="True">
-                <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource InputFocusBorderBrush}" />
+                <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource InputFocusBorderBrush}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <!-- ComboBox Style -->
     <Style x:Key="DarkComboBox" TargetType="ComboBox">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource InputBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
@@ -493,7 +484,7 @@
             <Setter.Value>
                 <Style TargetType="ComboBoxItem">
                     <Setter Property="Background" Value="Transparent" />
-                    <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                    <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
                     <Setter Property="Padding" Value="10,6" />
                     <Setter Property="Cursor" Value="Hand" />
                     <Setter Property="Template">
@@ -505,10 +496,10 @@
                                 </Border>
                                 <ControlTemplate.Triggers>
                                     <Trigger Property="IsHighlighted" Value="True">
-                                        <Setter TargetName="Bd" Property="Background" Value="{StaticResource SidebarItemHoverBrush}" />
+                                        <Setter TargetName="Bd" Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
                                     </Trigger>
                                     <Trigger Property="IsSelected" Value="True">
-                                        <Setter TargetName="Bd" Property="Background" Value="{StaticResource SidebarItemActiveBrush}" />
+                                        <Setter TargetName="Bd" Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
                                     </Trigger>
                                 </ControlTemplate.Triggers>
                             </ControlTemplate>
@@ -536,7 +527,7 @@
                                           HorizontalAlignment="Left" />
                         <TextBlock x:Name="Placeholder"
                                    Text="Select..."
-                                   Foreground="{StaticResource DisabledTextBrush}"
+                                   Foreground="{DynamicResource DisabledTextBrush}"
                                    IsHitTestVisible="False"
                                    Margin="12,8,28,8"
                                    VerticalAlignment="Center"
@@ -552,8 +543,8 @@
                                   MinWidth="{TemplateBinding ActualWidth}"
                                   MaxHeight="{TemplateBinding MaxDropDownHeight}">
                                 <Border x:Name="DropDownBorder"
-                                        Background="{StaticResource CardBackgroundBrush}"
-                                        BorderBrush="{StaticResource CardBorderBrush}"
+                                        Background="{DynamicResource CardBackgroundBrush}"
+                                        BorderBrush="{DynamicResource CardBorderBrush}"
                                         BorderThickness="1" CornerRadius="4"
                                         Margin="0,2,0,0" />
                                 <ScrollViewer Margin="4,6" SnapsToDevicePixels="True">
@@ -574,7 +565,7 @@
 
     <!-- CheckBox Style -->
     <Style x:Key="DarkCheckBox" TargetType="CheckBox">
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="Cursor" Value="Hand" />
@@ -584,8 +575,8 @@
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <Border x:Name="checkBorder"
                                 Width="18" Height="18"
-                                Background="{StaticResource InputBackgroundBrush}"
-                                BorderBrush="{StaticResource InputBorderBrush}"
+                                Background="{DynamicResource InputBackgroundBrush}"
+                                BorderBrush="{DynamicResource InputBorderBrush}"
                                 BorderThickness="1"
                                 CornerRadius="3"
                                 VerticalAlignment="Center">
@@ -602,12 +593,12 @@
                     </StackPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="checkBorder" Property="Background" Value="{StaticResource AccentBrush}" />
-                            <Setter TargetName="checkBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="checkBorder" Property="Background" Value="{DynamicResource AccentBrush}" />
+                            <Setter TargetName="checkBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                             <Setter TargetName="checkMark" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="checkBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="checkBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -617,7 +608,7 @@
 
     <!-- RadioButton Style -->
     <Style x:Key="DarkRadioButton" TargetType="RadioButton">
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="Cursor" Value="Hand" />
@@ -627,8 +618,8 @@
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <Border x:Name="radioBorder"
                                 Width="18" Height="18"
-                                Background="{StaticResource InputBackgroundBrush}"
-                                BorderBrush="{StaticResource InputBorderBrush}"
+                                Background="{DynamicResource InputBackgroundBrush}"
+                                BorderBrush="{DynamicResource InputBorderBrush}"
                                 BorderThickness="1"
                                 CornerRadius="9"
                                 VerticalAlignment="Center">
@@ -643,12 +634,12 @@
                     </StackPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="radioBorder" Property="Background" Value="{StaticResource AccentBrush}" />
-                            <Setter TargetName="radioBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="radioBorder" Property="Background" Value="{DynamicResource AccentBrush}" />
+                            <Setter TargetName="radioBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                             <Setter TargetName="radioDot" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="radioBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="radioBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -659,7 +650,7 @@
     <!-- Sidebar Navigation Button -->
     <Style x:Key="SidebarButton" TargetType="RadioButton">
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="Cursor" Value="Hand" />
@@ -689,13 +680,13 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource SidebarItemHoverBrush}" />
-                            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource SidebarItemActiveBrush}" />
-                            <Setter TargetName="indicator" Property="Background" Value="{StaticResource AccentBrush}" />
-                            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
+                            <Setter TargetName="indicator" Property="Background" Value="{DynamicResource AccentBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -705,9 +696,9 @@
 
     <!-- ToolTip Style -->
     <Style TargetType="ToolTip">
-        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="10,6" />
         <Setter Property="FontFamily" Value="Segoe UI" />
@@ -723,12 +714,12 @@
     <!-- DataGrid Styles -->
     <Style x:Key="DarkDataGrid" TargetType="DataGrid">
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="RowBackground" Value="Transparent" />
-        <Setter Property="AlternatingRowBackground" Value="#1A1D2A" />
+        <Setter Property="AlternatingRowBackground" Value="{DynamicResource AlternatingRowBackgroundBrush}" />
         <Setter Property="GridLinesVisibility" Value="Horizontal" />
-        <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="HeadersVisibility" Value="Column" />
@@ -740,12 +731,12 @@
     </Style>
 
     <Style TargetType="DataGridColumnHeader">
-        <Setter Property="Background" Value="{StaticResource SidebarBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+        <Setter Property="Background" Value="{DynamicResource SidebarBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="FontSize" Value="12" />
         <Setter Property="Padding" Value="10,8" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="BorderThickness" Value="0,0,0,1" />
     </Style>
 
@@ -764,8 +755,8 @@
         </Setter>
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="{StaticResource SidebarItemActiveBrush}" />
-                <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                <Setter Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -774,24 +765,24 @@
         <Setter Property="BorderThickness" Value="0" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{StaticResource SidebarItemHoverBrush}" />
+                <Setter Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="{StaticResource SidebarItemActiveBrush}" />
+                <Setter Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
             </Trigger>
         </Style.Triggers>
     </Style>
 
     <!-- Slider Style -->
     <Style x:Key="TimelineSlider" TargetType="Slider">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource AccentBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
     </Style>
 
     <!-- Progress Bar -->
     <Style x:Key="DarkProgressBar" TargetType="ProgressBar">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource AccentBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Height" Value="4" />
         <Setter Property="Template">
@@ -812,7 +803,7 @@
 
     <!-- Expander Style -->
     <Style x:Key="DarkExpander" TargetType="Expander">
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
     </Style>
@@ -864,8 +855,8 @@
                  PROD pill or reads as something a human asserted. -->
             <DataTrigger Binding="{Binding IsAutomatic}" Value="True">
                 <Setter TargetName="chip" Property="Background" Value="Transparent" />
-                <Setter TargetName="chip" Property="BorderBrush" Value="{StaticResource InputBorderBrush}" />
-                <Setter TargetName="chipText" Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+                <Setter TargetName="chip" Property="BorderBrush" Value="{DynamicResource InputBorderBrush}" />
+                <Setter TargetName="chipText" Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
                 <Setter TargetName="chipText" Property="FontWeight" Value="Normal" />
             </DataTrigger>
         </DataTemplate.Triggers>
@@ -897,6 +888,5 @@
             </Setter.Value>
         </Setter>
     </Style>
-
 
 </ResourceDictionary>

--- a/src/NineLives/Themes/Palette.Dark.xaml
+++ b/src/NineLives/Themes/Palette.Dark.xaml
@@ -1,0 +1,149 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Dark palette - the app's default, and the one the splash screen already spoke for.
+
+        The splash was the piece Jake liked, so the rest of the app is tuned to it rather than the
+        other way round: its deep near-black card (#0B0E17 to #05070C), its border (#2D3148), its
+        bright near-white text (#F2F4F8), its blue (#3B83E9) and its muted greys (#8890A4, #4A5163).
+        The old palette was a lighter, greyer navy with a softer blue, which is why the app and its
+        own splash screen did not look like the same product.
+
+        EVERY palette file must define EVERY key in this one. Themes are swapped at runtime by
+        replacing this dictionary, and a key missing from another palette does not throw - the
+        brush simply resolves to nothing and the element renders blank. ThemePaletteTests compares
+        the key sets to make that impossible to ship.
+    -->
+
+    <!-- ── surfaces ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="WindowBackgroundColor">#0F131E</Color>
+    <Color x:Key="SidebarBackgroundColor">#0B0E17</Color>
+    <Color x:Key="CardBackgroundColor">#161B29</Color>
+    <Color x:Key="CardBorderColor">#2D3148</Color>
+    <Color x:Key="InputBackgroundColor">#0C1017</Color>
+    <Color x:Key="InputBorderColor">#2D3148</Color>
+    <Color x:Key="InputFocusBorderColor">#3B83E9</Color>
+    <Color x:Key="StatusBarBackgroundColor">#05070C</Color>
+    <Color x:Key="SidebarItemHoverColor">#151A28</Color>
+    <Color x:Key="SidebarItemActiveColor">#1C2233</Color>
+    <Color x:Key="ScrollBarColor">#2D3148</Color>
+
+    <!-- ── accent ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="AccentColor">#3B83E9</Color>
+    <Color x:Key="AccentHoverColor">#5195F5</Color>
+    <Color x:Key="AccentPressedColor">#2A6DCC</Color>
+
+    <!-- Text ON an accent-filled surface. Not always white: a light theme's accent fill still
+         wants white, but a high-contrast one may not. -->
+    <Color x:Key="AccentForegroundColor">#FFFFFF</Color>
+
+    <!-- ── status ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="SuccessColor">#27AE60</Color>
+    <Color x:Key="ErrorColor">#E74C3C</Color>
+    <Color x:Key="WarningColor">#F39C12</Color>
+
+    <!-- ── text ──────────────────────────────────────────────────────────────── -->
+    <Color x:Key="PrimaryTextColor">#F2F4F8</Color>
+    <Color x:Key="SecondaryTextColor">#8890A4</Color>
+    <Color x:Key="DisabledTextColor">#4A5163</Color>
+
+    <!-- ── panels: a tinted background plus a border, per severity ───────────── -->
+    <Color x:Key="SuccessPanelBackgroundColor">#12241A</Color>
+    <Color x:Key="SuccessPanelBorderColor">#27AE60</Color>
+    <Color x:Key="WarningPanelBackgroundColor">#2A2314</Color>
+    <Color x:Key="WarningPanelBorderColor">#8A6D2F</Color>
+    <Color x:Key="DangerPanelBackgroundColor">#2E1717</Color>
+    <Color x:Key="DangerPanelBorderColor">#A33F3F</Color>
+
+    <!-- Kept under its old name because the danger card style refers to it. -->
+    <Color x:Key="DangerBackgroundColor">#2E1717</Color>
+
+    <!-- ── overlays ──────────────────────────────────────────────────────────── -->
+    <!-- The scrim over the app while something is loading, and the shadow under raised surfaces. -->
+    <Color x:Key="OverlayColor">#B0000000</Color>
+    <Color x:Key="ShadowColor">#000000</Color>
+
+    <!-- ── brushes ───────────────────────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
+    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="{StaticResource SidebarBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}" />
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
+    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
+    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
+    <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
+    <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
+    <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
+    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
+    <SolidColorBrush x:Key="DisabledTextBrush" Color="{StaticResource DisabledTextColor}" />
+    <SolidColorBrush x:Key="SidebarItemHoverBrush" Color="{StaticResource SidebarItemHoverColor}" />
+    <SolidColorBrush x:Key="SidebarItemActiveBrush" Color="{StaticResource SidebarItemActiveColor}" />
+    <SolidColorBrush x:Key="ScrollBarBrush" Color="{StaticResource ScrollBarColor}" />
+    <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="{StaticResource StatusBarBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerBackgroundBrush" Color="{StaticResource DangerBackgroundColor}" />
+
+    <SolidColorBrush x:Key="SuccessPanelBackgroundBrush" Color="{StaticResource SuccessPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="SuccessPanelBorderBrush" Color="{StaticResource SuccessPanelBorderColor}" />
+    <SolidColorBrush x:Key="WarningPanelBackgroundBrush" Color="{StaticResource WarningPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="WarningPanelBorderBrush" Color="{StaticResource WarningPanelBorderColor}" />
+    <SolidColorBrush x:Key="DangerPanelBackgroundBrush" Color="{StaticResource DangerPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerPanelBorderBrush" Color="{StaticResource DangerPanelBorderColor}" />
+
+    <SolidColorBrush x:Key="OverlayBrush" Color="{StaticResource OverlayColor}" />
+
+    <!-- ── console ───────────────────────────────────────────────────────────── -->
+    <!-- Darker than the cards on purpose, so the console reads as a separate surface the way a
+         real terminal does rather than as another panel in the form. -->
+    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#05070C" />
+    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#2D3148" />
+    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#0F131E" />
+    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#C9D1D9" />
+    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#6E7681" />
+    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#79C0FF" />
+    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#3FB950" />
+    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#D29922" />
+    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#F85149" />
+
+    <!-- ── SQL syntax highlighting ───────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#7B9EFF" />
+    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#A5D6A7" />
+    <SolidColorBrush x:Key="SqlCommentBrush" Color="#5C6773" />
+    <SolidColorBrush x:Key="SqlNumberBrush" Color="#F0B457" />
+    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#E2C08D" />
+
+    <!-- ── update banner ─────────────────────────────────────────────────────── -->
+    <!-- Amber rather than red: a new release is worth noticing but is not an emergency, and red
+         already means something has gone wrong in this app. -->
+    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Offset="0" Color="#FFC24B" />
+        <GradientStop Offset="0.5" Color="#F59E0B" />
+        <GradientStop Offset="1" Color="#EA8C04" />
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#B36F00" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeGlyphBrush" Color="#FFC24B" />
+
+
+    <!-- Hover and pressed states for the status buttons, and the DataGrid's banded row. All were
+         literals in the control styles, which meant a light theme drew a dark stripe through every
+         grid and a success button that jumped several shades on hover. -->
+    <Color x:Key="SuccessHoverColor">#2ECC71</Color>
+    <Color x:Key="SuccessPressedColor">#1E8449</Color>
+    <Color x:Key="ErrorHoverColor">#F05B4B</Color>
+    <Color x:Key="ErrorPressedColor">#C0392B</Color>
+    <Color x:Key="AlternatingRowBackgroundColor">#12161F</Color>
+
+    <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />
+    <SolidColorBrush x:Key="SuccessPressedBrush" Color="{StaticResource SuccessPressedColor}" />
+    <SolidColorBrush x:Key="ErrorHoverBrush" Color="{StaticResource ErrorHoverColor}" />
+    <SolidColorBrush x:Key="ErrorPressedBrush" Color="{StaticResource ErrorPressedColor}" />
+    <SolidColorBrush x:Key="AlternatingRowBackgroundBrush" Color="{StaticResource AlternatingRowBackgroundColor}" />
+
+</ResourceDictionary>

--- a/src/NineLives/Themes/Palette.HighContrast.xaml
+++ b/src/NineLives/Themes/Palette.HighContrast.xaml
@@ -1,0 +1,155 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        High contrast.
+
+        Not "the dark theme with the brightness turned up". The point of a high-contrast theme is
+        that nothing carries meaning by subtlety: every surface is pure black, every piece of text
+        is pure white or a fully saturated colour, and every border is visible rather than implied.
+
+        Text against background is 21:1 (white on black) and no status colour drops below roughly
+        7:1, which clears WCAG AAA for body text. The muted greys the other themes use for
+        secondary text are gone - secondary text here is #E8E8E8, distinguished by size and weight
+        rather than by fading it out, because fading is exactly what this theme exists to avoid.
+
+        Borders are 1px in the other palettes and the same here, but drawn in a colour that is
+        actually visible against the fill rather than a shade away from it. Card and input borders
+        are white for that reason: a panel edge you cannot see is a panel that is not there.
+
+        Must define exactly the keys in Palette.Dark.xaml - see the note there.
+    -->
+
+    <!-- ── surfaces ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="WindowBackgroundColor">#000000</Color>
+    <Color x:Key="SidebarBackgroundColor">#000000</Color>
+    <Color x:Key="CardBackgroundColor">#000000</Color>
+    <Color x:Key="CardBorderColor">#FFFFFF</Color>
+    <Color x:Key="InputBackgroundColor">#000000</Color>
+    <Color x:Key="InputBorderColor">#FFFFFF</Color>
+    <Color x:Key="InputFocusBorderColor">#FFFF00</Color>
+    <Color x:Key="StatusBarBackgroundColor">#000000</Color>
+    <Color x:Key="SidebarItemHoverColor">#1F1F1F</Color>
+    <!-- Grey, not the accent yellow: white text on yellow is unreadable, and
+         selection is carried by the accent-coloured border instead. -->
+    <Color x:Key="SidebarItemActiveColor">#333333</Color>
+    <Color x:Key="ScrollBarColor">#FFFFFF</Color>
+
+    <!-- ── accent ────────────────────────────────────────────────────────────── -->
+    <!-- Yellow rather than blue. Blue on black is the worst-performing pair for anyone with
+         reduced contrast sensitivity, and yellow-on-black is the pairing high-contrast schemes on
+         Windows have used for decades - it is what people who need this theme expect to see. -->
+    <Color x:Key="AccentColor">#FFFF00</Color>
+    <Color x:Key="AccentHoverColor">#FFFF66</Color>
+    <Color x:Key="AccentPressedColor">#CCCC00</Color>
+
+    <!-- Black text on the yellow fill. White on yellow is unreadable. -->
+    <Color x:Key="AccentForegroundColor">#000000</Color>
+
+    <!-- ── status ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="SuccessColor">#00FF00</Color>
+    <Color x:Key="ErrorColor">#FF5555</Color>
+    <Color x:Key="WarningColor">#FFAA00</Color>
+
+    <!-- ── text ──────────────────────────────────────────────────────────────── -->
+    <Color x:Key="PrimaryTextColor">#FFFFFF</Color>
+    <Color x:Key="SecondaryTextColor">#E8E8E8</Color>
+    <Color x:Key="DisabledTextColor">#A0A0A0</Color>
+
+    <!-- ── panels ────────────────────────────────────────────────────────────── -->
+    <!-- Black fills with a saturated border. A tinted background would reduce the contrast of the
+         text sitting on it, which is the one thing this theme must not do. -->
+    <Color x:Key="SuccessPanelBackgroundColor">#000000</Color>
+    <Color x:Key="SuccessPanelBorderColor">#00FF00</Color>
+    <Color x:Key="WarningPanelBackgroundColor">#000000</Color>
+    <Color x:Key="WarningPanelBorderColor">#FFAA00</Color>
+    <Color x:Key="DangerPanelBackgroundColor">#000000</Color>
+    <Color x:Key="DangerPanelBorderColor">#FF5555</Color>
+    <Color x:Key="DangerBackgroundColor">#000000</Color>
+
+    <!-- ── overlays ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="OverlayColor">#D0000000</Color>
+    <Color x:Key="ShadowColor">#000000</Color>
+
+    <!-- ── brushes ───────────────────────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
+    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="{StaticResource SidebarBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}" />
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
+    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
+    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
+    <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
+    <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
+    <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
+    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
+    <SolidColorBrush x:Key="DisabledTextBrush" Color="{StaticResource DisabledTextColor}" />
+    <SolidColorBrush x:Key="SidebarItemHoverBrush" Color="{StaticResource SidebarItemHoverColor}" />
+    <SolidColorBrush x:Key="SidebarItemActiveBrush" Color="{StaticResource SidebarItemActiveColor}" />
+    <SolidColorBrush x:Key="ScrollBarBrush" Color="{StaticResource ScrollBarColor}" />
+    <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="{StaticResource StatusBarBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerBackgroundBrush" Color="{StaticResource DangerBackgroundColor}" />
+
+    <SolidColorBrush x:Key="SuccessPanelBackgroundBrush" Color="{StaticResource SuccessPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="SuccessPanelBorderBrush" Color="{StaticResource SuccessPanelBorderColor}" />
+    <SolidColorBrush x:Key="WarningPanelBackgroundBrush" Color="{StaticResource WarningPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="WarningPanelBorderBrush" Color="{StaticResource WarningPanelBorderColor}" />
+    <SolidColorBrush x:Key="DangerPanelBackgroundBrush" Color="{StaticResource DangerPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerPanelBorderBrush" Color="{StaticResource DangerPanelBorderColor}" />
+
+    <SolidColorBrush x:Key="OverlayBrush" Color="{StaticResource OverlayColor}" />
+
+    <!-- ── console ───────────────────────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#000000" />
+    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#000000" />
+    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#C0C0C0" />
+    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#00FFFF" />
+    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#00FF00" />
+    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#FFAA00" />
+    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#FF5555" />
+
+    <!-- ── SQL syntax highlighting ───────────────────────────────────────────── -->
+    <!-- Fully saturated and far apart in hue, so the categories are told apart by more than a
+         shade. Nothing here relies on a subtle difference in tone. -->
+    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#00FFFF" />
+    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#00FF00" />
+    <SolidColorBrush x:Key="SqlCommentBrush" Color="#A0A0A0" />
+    <SolidColorBrush x:Key="SqlNumberBrush" Color="#FFAA00" />
+    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#FF80FF" />
+
+    <!-- ── update banner ─────────────────────────────────────────────────────── -->
+    <!-- Flat yellow rather than a gradient: a gradient is a subtlety, and the point here is that
+         nothing is subtle. -->
+    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Offset="0" Color="#FFFF00" />
+        <GradientStop Offset="1" Color="#FFFF00" />
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#000000" />
+    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeBrush" Color="#000000" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeGlyphBrush" Color="#FFFF00" />
+
+
+    <!-- Hover and pressed states for the status buttons, and the DataGrid's banded row. All were
+         literals in the control styles, which meant a light theme drew a dark stripe through every
+         grid and a success button that jumped several shades on hover. -->
+    <Color x:Key="SuccessHoverColor">#66FF66</Color>
+    <Color x:Key="SuccessPressedColor">#00CC00</Color>
+    <Color x:Key="ErrorHoverColor">#FF8888</Color>
+    <Color x:Key="ErrorPressedColor">#CC0000</Color>
+    <Color x:Key="AlternatingRowBackgroundColor">#1A1A1A</Color>
+
+    <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />
+    <SolidColorBrush x:Key="SuccessPressedBrush" Color="{StaticResource SuccessPressedColor}" />
+    <SolidColorBrush x:Key="ErrorHoverBrush" Color="{StaticResource ErrorHoverColor}" />
+    <SolidColorBrush x:Key="ErrorPressedBrush" Color="{StaticResource ErrorPressedColor}" />
+    <SolidColorBrush x:Key="AlternatingRowBackgroundBrush" Color="{StaticResource AlternatingRowBackgroundColor}" />
+
+</ResourceDictionary>

--- a/src/NineLives/Themes/Palette.Light.xaml
+++ b/src/NineLives/Themes/Palette.Light.xaml
@@ -1,0 +1,146 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Light palette.
+
+        Not the dark one inverted. Inverting a dark theme gives you grey-on-grey with a blue that
+        glows, because a colour tuned to sit on near-black is far too light against white. So the
+        blue is darkened to #1F63C4 - the same hue as the splash's #3B83E9, taken down until it
+        holds its own on a white card - and the greys are chosen for contrast against white rather
+        than mirrored.
+
+        Surfaces run the other way too: the sidebar is DARKER than the page here, where in the dark
+        theme it is darker as well. Keeping that relationship means the layout reads the same in
+        both, which is the point of theming rather than recolouring.
+
+        Must define exactly the keys in Palette.Dark.xaml - see the note there.
+    -->
+
+    <!-- ── surfaces ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="WindowBackgroundColor">#F4F6FA</Color>
+    <Color x:Key="SidebarBackgroundColor">#E7EBF3</Color>
+    <Color x:Key="CardBackgroundColor">#FFFFFF</Color>
+    <Color x:Key="CardBorderColor">#D3DAE6</Color>
+    <Color x:Key="InputBackgroundColor">#FFFFFF</Color>
+    <Color x:Key="InputBorderColor">#C3CCDB</Color>
+    <Color x:Key="InputFocusBorderColor">#1F63C4</Color>
+    <Color x:Key="StatusBarBackgroundColor">#E0E5EF</Color>
+    <Color x:Key="SidebarItemHoverColor">#D8DFEC</Color>
+    <Color x:Key="SidebarItemActiveColor">#CBD6E8</Color>
+    <Color x:Key="ScrollBarColor">#BFC8D8</Color>
+
+    <!-- ── accent ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="AccentColor">#1F63C4</Color>
+    <Color x:Key="AccentHoverColor">#2E74D8</Color>
+    <Color x:Key="AccentPressedColor">#17509F</Color>
+    <Color x:Key="AccentForegroundColor">#FFFFFF</Color>
+
+    <!-- ── status ────────────────────────────────────────────────────────────── -->
+    <!-- Darkened from the dark theme's: #27AE60 on white is legible but weak, and #E74C3C reads
+         as pink at small sizes. -->
+    <Color x:Key="SuccessColor">#1B7F45</Color>
+    <Color x:Key="ErrorColor">#C0392B</Color>
+    <Color x:Key="WarningColor">#B26A00</Color>
+
+    <!-- ── text ──────────────────────────────────────────────────────────────── -->
+    <Color x:Key="PrimaryTextColor">#141824</Color>
+    <Color x:Key="SecondaryTextColor">#5A6478</Color>
+    <Color x:Key="DisabledTextColor">#98A1B3</Color>
+
+    <!-- ── panels ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="SuccessPanelBackgroundColor">#E6F5EC</Color>
+    <Color x:Key="SuccessPanelBorderColor">#1B7F45</Color>
+    <Color x:Key="WarningPanelBackgroundColor">#FCF3E2</Color>
+    <Color x:Key="WarningPanelBorderColor">#B26A00</Color>
+    <Color x:Key="DangerPanelBackgroundColor">#FBEAE7</Color>
+    <Color x:Key="DangerPanelBorderColor">#C0392B</Color>
+    <Color x:Key="DangerBackgroundColor">#FBEAE7</Color>
+
+    <!-- ── overlays ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="OverlayColor">#80FFFFFF</Color>
+    <Color x:Key="ShadowColor">#7A8296</Color>
+
+    <!-- ── brushes ───────────────────────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
+    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="{StaticResource SidebarBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}" />
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
+    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
+    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
+    <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
+    <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
+    <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
+    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
+    <SolidColorBrush x:Key="DisabledTextBrush" Color="{StaticResource DisabledTextColor}" />
+    <SolidColorBrush x:Key="SidebarItemHoverBrush" Color="{StaticResource SidebarItemHoverColor}" />
+    <SolidColorBrush x:Key="SidebarItemActiveBrush" Color="{StaticResource SidebarItemActiveColor}" />
+    <SolidColorBrush x:Key="ScrollBarBrush" Color="{StaticResource ScrollBarColor}" />
+    <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="{StaticResource StatusBarBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerBackgroundBrush" Color="{StaticResource DangerBackgroundColor}" />
+
+    <SolidColorBrush x:Key="SuccessPanelBackgroundBrush" Color="{StaticResource SuccessPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="SuccessPanelBorderBrush" Color="{StaticResource SuccessPanelBorderColor}" />
+    <SolidColorBrush x:Key="WarningPanelBackgroundBrush" Color="{StaticResource WarningPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="WarningPanelBorderBrush" Color="{StaticResource WarningPanelBorderColor}" />
+    <SolidColorBrush x:Key="DangerPanelBackgroundBrush" Color="{StaticResource DangerPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerPanelBorderBrush" Color="{StaticResource DangerPanelBorderColor}" />
+
+    <SolidColorBrush x:Key="OverlayBrush" Color="{StaticResource OverlayColor}" />
+
+    <!-- ── console ───────────────────────────────────────────────────────────── -->
+    <!-- Deliberately still dark. A terminal is a terminal: SQL Server's output is easier to read
+         light-on-dark, and every DBA has spent their career reading it that way. Making it white
+         to match the page would be consistency for its own sake. -->
+    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#12161F" />
+    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#C3CCDB" />
+    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#1C2230" />
+    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#D9E1EA" />
+    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#8B95A3" />
+    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#79C0FF" />
+    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#4FC463" />
+    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#E0A831" />
+    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#FF6A61" />
+
+    <!-- ── SQL syntax highlighting ───────────────────────────────────────────── -->
+    <!-- The script pane sits on a light input surface here, so these are the dark-on-light set. -->
+    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#1F4FBF" />
+    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#1B7F45" />
+    <SolidColorBrush x:Key="SqlCommentBrush" Color="#77808F" />
+    <SolidColorBrush x:Key="SqlNumberBrush" Color="#A65F00" />
+    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#8A5A1B" />
+
+    <!-- ── update banner ─────────────────────────────────────────────────────── -->
+    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Offset="0" Color="#FFC24B" />
+        <GradientStop Offset="0.5" Color="#F59E0B" />
+        <GradientStop Offset="1" Color="#EA8C04" />
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#B36F00" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeGlyphBrush" Color="#FFC24B" />
+
+
+    <!-- Hover and pressed states for the status buttons, and the DataGrid's banded row. All were
+         literals in the control styles, which meant a light theme drew a dark stripe through every
+         grid and a success button that jumped several shades on hover. -->
+    <Color x:Key="SuccessHoverColor">#239954</Color>
+    <Color x:Key="SuccessPressedColor">#146334</Color>
+    <Color x:Key="ErrorHoverColor">#D2483A</Color>
+    <Color x:Key="ErrorPressedColor">#9C2D21</Color>
+    <Color x:Key="AlternatingRowBackgroundColor">#F2F5FA</Color>
+
+    <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />
+    <SolidColorBrush x:Key="SuccessPressedBrush" Color="{StaticResource SuccessPressedColor}" />
+    <SolidColorBrush x:Key="ErrorHoverBrush" Color="{StaticResource ErrorHoverColor}" />
+    <SolidColorBrush x:Key="ErrorPressedBrush" Color="{StaticResource ErrorPressedColor}" />
+    <SolidColorBrush x:Key="AlternatingRowBackgroundBrush" Color="{StaticResource AlternatingRowBackgroundColor}" />
+
+</ResourceDictionary>

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -1,11 +1,40 @@
 using System.Diagnostics;
 using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.ViewModels;
 
+/// <summary>A theme and the name shown for it.</summary>
+/// <param name="Value">The theme itself.</param>
+/// <param name="Name">What the picker calls it.</param>
+public sealed record ThemeOption(AppTheme Value, string Name)
+{
+    /// <summary>
+    /// The combo box's own control template renders the selected item through a plain
+    /// ContentPresenter, which ignores DisplayMemberPath and falls back to ToString - so without
+    /// this the picker reads "ThemeOption { Value = Dark, Name = Dark }".
+    /// </summary>
+    public override string ToString() => Name;
+}
+
 public partial class AboutViewModel : ViewModelBase
 {
+    private readonly ICredentialStore? _credentialStore;
+
+    public AboutViewModel() : this(null) { }
+
+    /// <summary>
+    /// Takes the store so the theme choice can be remembered. Optional, because About is otherwise
+    /// a static page and a test that only wants to render it should not need a store.
+    /// </summary>
+    public AboutViewModel(ICredentialStore? credentialStore)
+    {
+        _credentialStore = credentialStore;
+        _selectedTheme = ThemeManager.Current;
+    }
+
     public string AppName => "Nine Lives";
     public string Version => Services.AppVersion.Display;
     public string Year => "2026";
@@ -16,6 +45,48 @@ public partial class AboutViewModel : ViewModelBase
 
     /// <summary>Shown so the path can be read even if opening the folder fails.</summary>
     public string LogFolder => App.Log.Directory;
+
+    // ── appearance ──────────────────────────────────────────────────────────────
+
+    /// <summary>One entry per theme, named for the picker.</summary>
+    public IReadOnlyList<ThemeOption> Themes { get; } =
+        ThemeManager.All.Select(t => new ThemeOption(t, ThemeManager.DisplayName(t))).ToList();
+
+    [ObservableProperty]
+    private AppTheme _selectedTheme;
+
+    /// <summary>
+    /// Applies the theme immediately and remembers it.
+    ///
+    /// Applying first: a theme that will not load is worth knowing about right away, and the
+    /// switch is instant because every colour is a DynamicResource. Saving is best-effort - a
+    /// config that refuses to write should not undo a change the user can already see.
+    /// </summary>
+    partial void OnSelectedThemeChanged(AppTheme value)
+    {
+        if (!ThemeManager.Apply(value))
+        {
+            SetError("The theme could not be applied.");
+            return;
+        }
+
+        ClearStatus();
+
+        if (_credentialStore == null) return;
+
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            config.Theme = value;
+            _credentialStore.SaveConfig(config);
+        }
+        catch (Exception ex)
+        {
+            SetError($"The theme was applied, but could not be saved for next time: {ex.Message}");
+        }
+    }
+
+    public static string ThemeName(AppTheme theme) => ThemeManager.DisplayName(theme);
 
     /// <summary>
     /// Opens the log folder in Explorer. The logs are what someone attaches to a bug report, so

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -68,6 +68,11 @@ public partial class MainViewModel : ViewModelBase
     {
         _credentialStore = credentialStore;
 
+        // Before the child viewmodels build any views: applying a palette afterwards works, since
+        // every colour is a DynamicResource, but doing it first means the first frame drawn is
+        // already the right colour rather than a flash of dark on the way to light.
+        ApplySavedTheme();
+
         // Before anything reads the config: move secrets from name-derived keys onto stable ids
         // (#8). Must happen ahead of the child viewmodels, which load containers and servers in
         // their constructors and would otherwise look up keys the migration is about to change.
@@ -89,7 +94,7 @@ public partial class MainViewModel : ViewModelBase
             _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
             log: null, history: _historyStore);
         History = new HistoryViewModel(_historyStore);
-        About = new AboutViewModel();
+        About = new AboutViewModel(_credentialStore);
 
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
 
@@ -97,6 +102,22 @@ public partial class MainViewModel : ViewModelBase
 
         // Fire and forget - startup must not wait on the network.
         _ = CheckForUpdatesAsync();
+    }
+
+    /// <summary>
+    /// Puts the remembered colour scheme back. Never fatal: a theme that will not load leaves the
+    /// default in place, which is a cosmetic problem rather than one worth refusing to start over.
+    /// </summary>
+    private void ApplySavedTheme()
+    {
+        try
+        {
+            ThemeManager.Apply(_credentialStore.LoadConfig().Theme);
+        }
+        catch
+        {
+            // Dark it is.
+        }
     }
 
     /// <summary>

--- a/src/NineLives/Views/AboutView.xaml
+++ b/src/NineLives/Views/AboutView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.AboutView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.AboutView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
@@ -14,18 +14,18 @@
                 <TextBlock Style="{StaticResource LogoWordmark}"
                            FontSize="26"
                            Margin="0,0,0,12">
-                    <Run Text="N I N E" Foreground="{StaticResource PrimaryTextBrush}" />
+                    <Run Text="N I N E" Foreground="{DynamicResource PrimaryTextBrush}" />
                     <Run Text="  " />
-                    <Run Text="L I V E S" Foreground="#3B83E9" />
+                    <Run Text="L I V E S" Foreground="{DynamicResource AccentBrush}" />
                 </TextBlock>
 
                 <TextBlock Text="{Binding Version}"
                            FontSize="14"
-                           Foreground="{StaticResource SecondaryTextBrush}"
+                           Foreground="{DynamicResource SecondaryTextBrush}"
                            HorizontalAlignment="Center"
                            Margin="0,0,0,20" />
 
-                <Border Height="1" Background="{StaticResource CardBorderBrush}" Margin="0,0,0,20" />
+                <Border Height="1" Background="{DynamicResource CardBorderBrush}" Margin="0,0,0,20" />
 
                 <TextBlock Text="{Binding Description}"
                            Style="{StaticResource BodyText}"
@@ -33,12 +33,12 @@
                            TextAlignment="Center"
                            Margin="0,0,0,24" />
 
-                <Border Height="1" Background="{StaticResource CardBorderBrush}" Margin="0,0,0,20" />
+                <Border Height="1" Background="{DynamicResource CardBorderBrush}" Margin="0,0,0,20" />
 
                 <TextBlock Text="AUTHOR" Style="{StaticResource LabelText}" HorizontalAlignment="Center" />
                 <TextBlock Text="{Binding Author}"
                            FontSize="15" FontWeight="SemiBold"
-                           Foreground="{StaticResource PrimaryTextBrush}"
+                           Foreground="{DynamicResource PrimaryTextBrush}"
                            HorizontalAlignment="Center"
                            Margin="0,0,0,4" />
                 <TextBlock Text="{Binding Company}"
@@ -48,11 +48,29 @@
                 <TextBlock HorizontalAlignment="Center" Margin="0,0,0,20">
                     <Hyperlink NavigateUri="{Binding Website}"
                                RequestNavigate="Hyperlink_RequestNavigate"
-                               Foreground="{StaticResource AccentBrush}"
+                               Foreground="{DynamicResource AccentBrush}"
                                TextDecorations="None">
                         <Run Text="{Binding Website, Mode=OneWay}" />
                     </Hyperlink>
                 </TextBlock>
+
+                <Border Height="1" Background="{DynamicResource CardBorderBrush}" Margin="0,0,0,20" />
+
+                <TextBlock Text="APPEARANCE" Style="{StaticResource LabelText}" HorizontalAlignment="Center" />
+                <ComboBox ItemsSource="{Binding Themes}"
+                          DisplayMemberPath="Name"
+                          SelectedValuePath="Value"
+                          SelectedValue="{Binding SelectedTheme}"
+                          Style="{StaticResource DarkComboBox}"
+                          Width="200"
+                          HorizontalAlignment="Center"
+                          Margin="0,0,0,6"
+                          ToolTip="Dark is the default. High contrast is pure black and white with saturated status colours, for anyone who needs it." />
+                <TextBlock Text="Applies straight away, and is remembered."
+                           Style="{StaticResource SecondaryText}"
+                           FontSize="11"
+                           HorizontalAlignment="Center"
+                           Margin="0,0,0,20" />
 
                 <!-- The logs are what someone attaches to a bug report, so there has to be a way
                      to find them that is not "know where LocalAppData lives" (#40). -->

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.BlobBrowserView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.BlobBrowserView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
@@ -111,7 +111,7 @@
                     <StackPanel Grid.Column="0" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.TotalSets}"
                                    FontSize="20" FontWeight="Bold"
-                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                   Foreground="{DynamicResource PrimaryTextBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Total Sets" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -119,7 +119,7 @@
                     <StackPanel Grid.Column="1" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.FullBackups}"
                                    FontSize="20" FontWeight="Bold"
-                                   Foreground="{StaticResource AccentBrush}"
+                                   Foreground="{DynamicResource AccentBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Full" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -127,7 +127,7 @@
                     <StackPanel Grid.Column="2" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.DiffBackups}"
                                    FontSize="20" FontWeight="Bold"
-                                   Foreground="{StaticResource WarningBrush}"
+                                   Foreground="{DynamicResource WarningBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Diff" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -135,7 +135,7 @@
                     <StackPanel Grid.Column="3" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.LogBackups}"
                                    FontSize="20" FontWeight="Bold"
-                                   Foreground="{StaticResource SuccessBrush}"
+                                   Foreground="{DynamicResource SuccessBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Log" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -143,7 +143,7 @@
                     <StackPanel Grid.Column="4" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.TotalSizeDisplay}"
                                    FontSize="14" FontWeight="Bold"
-                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                   Foreground="{DynamicResource PrimaryTextBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Size" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -184,7 +184,7 @@
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
                             Visibility="{Binding HasFiles, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                     <TextBlock Text="&#x1F4C2;" FontSize="48" HorizontalAlignment="Center"
-                               Foreground="{StaticResource SecondaryTextBrush}" Margin="0,0,0,12" />
+                               Foreground="{DynamicResource SecondaryTextBrush}" Margin="0,0,0,12" />
                     <TextBlock Text="No backup files loaded"
                                Style="{StaticResource BodyText}"
                                HorizontalAlignment="Center" />
@@ -236,7 +236,7 @@
                 </DataGrid>
 
                 <!-- Loading -->
-                <Border Background="#80000000"
+                <Border Background="{DynamicResource OverlayBrush}"
                         CornerRadius="6"
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}">
                     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.BlobConfigView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.BlobConfigView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
@@ -51,7 +51,7 @@
                              SelectedItem="{Binding SelectedContainer}"
                              Background="Transparent"
                              BorderThickness="0"
-                             Foreground="{StaticResource PrimaryTextBrush}"
+                             Foreground="{DynamicResource PrimaryTextBrush}"
                              HorizontalContentAlignment="Stretch"
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -61,12 +61,12 @@
                                 <StackPanel Margin="4,6">
                                     <StackPanel Orientation="Horizontal">
                                         <Ellipse Width="8" Height="8"
-                                                 Fill="{StaticResource SuccessBrush}"
+                                                 Fill="{DynamicResource SuccessBrush}"
                                                  VerticalAlignment="Center"
                                                  Margin="0,0,8,0" />
                                         <TextBlock Text="{Binding Name}"
                                                    FontWeight="SemiBold"
-                                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                                                   Foreground="{DynamicResource PrimaryTextBrush}" />
                                     </StackPanel>
                                     <TextBlock Text="{Binding ContainerUrl}"
                                                Style="{StaticResource SecondaryText}"
@@ -96,11 +96,11 @@
                                             <ControlTemplate.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
                                                     <Setter TargetName="border" Property="Background"
-                                                            Value="{StaticResource SidebarItemHoverBrush}" />
+                                                            Value="{DynamicResource SidebarItemHoverBrush}" />
                                                 </Trigger>
                                                 <Trigger Property="IsSelected" Value="True">
                                                     <Setter TargetName="border" Property="Background"
-                                                            Value="{StaticResource SidebarItemActiveBrush}" />
+                                                            Value="{DynamicResource SidebarItemActiveBrush}" />
                                                 </Trigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
@@ -116,18 +116,18 @@
             <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto">
                 <StackPanel>
                     <!-- SAS Expiry Warning -->
-                    <Border Background="{StaticResource DangerBackgroundBrush}"
+                    <Border Background="{DynamicResource DangerBackgroundBrush}"
                             CornerRadius="6"
                             Padding="16,12"
                             Margin="0,0,0,16"
                             Visibility="{Binding IsSasExpired, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="&#x26A0;" FontSize="16" Foreground="{StaticResource ErrorBrush}"
+                                <TextBlock Text="&#x26A0;" FontSize="16" Foreground="{DynamicResource ErrorBrush}"
                                            VerticalAlignment="Center" Margin="0,0,8,0" />
                                 <TextBlock Text="SAS Token Expired"
                                            FontWeight="SemiBold"
-                                           Foreground="{StaticResource ErrorBrush}" />
+                                           Foreground="{DynamicResource ErrorBrush}" />
                             </StackPanel>
                             <TextBlock Text="{Binding SasExpiryText}"
                                        Style="{StaticResource SecondaryText}"
@@ -217,7 +217,7 @@
                                 </StackPanel>
 
                                 <!-- Test Result -->
-                                <Border Background="{StaticResource InputBackgroundBrush}"
+                                <Border Background="{DynamicResource InputBackgroundBrush}"
                                         CornerRadius="4"
                                         Padding="12,8"
                                         Margin="0,16,0,0"
@@ -241,7 +241,7 @@
                                         <StackPanel Grid.Column="0" HorizontalAlignment="Center">
                                             <TextBlock Text="{Binding ContainerSummary.FullBackups}"
                                                        FontSize="24" FontWeight="Bold"
-                                                       Foreground="{StaticResource AccentBrush}"
+                                                       Foreground="{DynamicResource AccentBrush}"
                                                        HorizontalAlignment="Center" />
                                             <TextBlock Text="Full" Style="{StaticResource SecondaryText}"
                                                        HorizontalAlignment="Center" />
@@ -249,7 +249,7 @@
                                         <StackPanel Grid.Column="1" HorizontalAlignment="Center">
                                             <TextBlock Text="{Binding ContainerSummary.DiffBackups}"
                                                        FontSize="24" FontWeight="Bold"
-                                                       Foreground="{StaticResource WarningBrush}"
+                                                       Foreground="{DynamicResource WarningBrush}"
                                                        HorizontalAlignment="Center" />
                                             <TextBlock Text="Diff" Style="{StaticResource SecondaryText}"
                                                        HorizontalAlignment="Center" />
@@ -257,7 +257,7 @@
                                         <StackPanel Grid.Column="2" HorizontalAlignment="Center">
                                             <TextBlock Text="{Binding ContainerSummary.LogBackups}"
                                                        FontSize="24" FontWeight="Bold"
-                                                       Foreground="{StaticResource SuccessBrush}"
+                                                       Foreground="{DynamicResource SuccessBrush}"
                                                        HorizontalAlignment="Center" />
                                             <TextBlock Text="Log" Style="{StaticResource SecondaryText}"
                                                        HorizontalAlignment="Center" />
@@ -265,7 +265,7 @@
                                         <StackPanel Grid.Column="3" HorizontalAlignment="Center">
                                             <TextBlock Text="{Binding ContainerSummary.TotalSizeDisplay}"
                                                        FontSize="18" FontWeight="Bold"
-                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       Foreground="{DynamicResource PrimaryTextBrush}"
                                                        HorizontalAlignment="Center" />
                                             <TextBlock Text="Total" Style="{StaticResource SecondaryText}"
                                                        HorizontalAlignment="Center" />
@@ -338,13 +338,13 @@
                                              TextWrapping="Wrap" AcceptsReturn="False" MaxHeight="80"
                                              VerticalScrollBarVisibility="Auto"
                                              Visibility="{Binding ShowSasToken, Converter={StaticResource BoolToVis}}" />
-                                    <Border Background="{StaticResource InputBackgroundBrush}"
+                                    <Border Background="{DynamicResource InputBackgroundBrush}"
                                             CornerRadius="4" Padding="10,8"
-                                            BorderBrush="{StaticResource CardBorderBrush}"
+                                            BorderBrush="{DynamicResource CardBorderBrush}"
                                             BorderThickness="1" MinHeight="36"
                                             Visibility="{Binding ShowSasToken, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                                         <TextBlock Text="••••••••••••••••••••••••••••••••••••••••••••••••"
-                                                   Foreground="{StaticResource SecondaryTextBrush}"
+                                                   Foreground="{DynamicResource SecondaryTextBrush}"
                                                    VerticalAlignment="Center" FontSize="14" />
                                     </Border>
                                     <Button Content="{Binding ShowSasToken, Converter={StaticResource BoolToEyeIcon}}"
@@ -352,7 +352,7 @@
                                             HorizontalAlignment="Right" VerticalAlignment="Top"
                                             Margin="0,4,4,0" Padding="6,2" FontSize="14"
                                             Background="Transparent" BorderThickness="0"
-                                            Foreground="{StaticResource SecondaryTextBrush}"
+                                            Foreground="{DynamicResource SecondaryTextBrush}"
                                             Cursor="Hand" ToolTip="Show/hide SAS token" />
                                 </Grid>
                             </Grid>
@@ -389,7 +389,7 @@
                                        FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap" />
 
                             <!-- Draggable active path elements -->
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="8,6" Margin="0,0,0,6"
                                     MinHeight="40" AllowDrop="True"
                                     DragOver="PathDragOver" Drop="PathDrop">
@@ -427,7 +427,7 @@
                                                             <TextBlock Text="{Binding DisplayName}" Foreground="White"
                                                                        FontSize="12" FontWeight="SemiBold"
                                                                        VerticalAlignment="Center" />
-                                                            <Button Content="  x" Foreground="#CCFFFFFF" FontSize="11"
+                                                            <Button Content="  x" Foreground="{DynamicResource PrimaryTextBrush}" FontSize="11"
                                                                     FontWeight="Bold" Cursor="Hand"
                                                                     Background="Transparent" BorderThickness="0"
                                                                     VerticalAlignment="Center" Padding="0"
@@ -437,7 +437,7 @@
                                                                     ToolTip="Remove this element" />
                                                         </StackPanel>
                                                     </Border>
-                                                    <TextBlock Text="/" Foreground="{StaticResource SecondaryTextBrush}"
+                                                    <TextBlock Text="/" Foreground="{DynamicResource SecondaryTextBrush}"
                                                                FontSize="14" VerticalAlignment="Center" Margin="4,0,0,0" />
                                                 </StackPanel>
                                             </DataTemplate>
@@ -464,7 +464,7 @@
                                                 <ControlTemplate TargetType="Button">
                                                     <Border x:Name="bd" CornerRadius="4" Padding="10,5"
                                                             Opacity="0.5" BorderThickness="1"
-                                                            BorderBrush="{StaticResource CardBorderBrush}"
+                                                            BorderBrush="{DynamicResource CardBorderBrush}"
                                                             Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                         <StackPanel Orientation="Horizontal">
                                                             <TextBlock Text="+" Foreground="White" FontWeight="Bold"
@@ -492,14 +492,14 @@
 
                             <!-- AG path structure (when AG or Mixed) - drag/drop same as standalone -->
                             <Border Visibility="{Binding IsAgPathSectionVisible, Converter={StaticResource BoolToVis}}"
-                                    Background="{StaticResource InputBackgroundBrush}"
+                                    Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="12" Margin="0,0,0,16">
                                 <StackPanel>
                                     <TextBlock Text="AG PATH STRUCTURE" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
                                     <TextBlock Text="Drag the coloured elements to define how AG backup paths are structured (e.g. BackupType/ClusterName$AGName/DatabaseName/FileName). Leave default to also support Ola flat filenames."
                                                Style="{StaticResource SecondaryText}"
                                                FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap" />
-                                    <Border Background="{StaticResource CardBorderBrush}"
+                                    <Border Background="{DynamicResource CardBorderBrush}"
                                             CornerRadius="4" Padding="8,6" Margin="0,0,0,6"
                                             MinHeight="40" AllowDrop="True"
                                             BorderThickness="1"
@@ -538,7 +538,7 @@
                                                                     <TextBlock Text="{Binding DisplayName}" Foreground="White"
                                                                                FontSize="12" FontWeight="SemiBold"
                                                                                VerticalAlignment="Center" />
-                                                                    <Button Content="  x" Foreground="#CCFFFFFF" FontSize="11"
+                                                                    <Button Content="  x" Foreground="{DynamicResource PrimaryTextBrush}" FontSize="11"
                                                                             FontWeight="Bold" Cursor="Hand"
                                                                             Background="Transparent" BorderThickness="0"
                                                                             VerticalAlignment="Center" Padding="0"
@@ -548,7 +548,7 @@
                                                                             ToolTip="Remove this element" />
                                                                 </StackPanel>
                                                             </Border>
-                                                            <TextBlock Text="/" Foreground="{StaticResource SecondaryTextBrush}"
+                                                            <TextBlock Text="/" Foreground="{DynamicResource SecondaryTextBrush}"
                                                                        FontSize="14" VerticalAlignment="Center" Margin="4,0,0,0" />
                                                         </StackPanel>
                                                     </DataTemplate>
@@ -573,7 +573,7 @@
                                                         <ControlTemplate TargetType="Button">
                                                             <Border x:Name="bd" CornerRadius="4" Padding="10,5"
                                                                     Opacity="0.5" BorderThickness="1"
-                                                                    BorderBrush="{StaticResource CardBorderBrush}"
+                                                                    BorderBrush="{DynamicResource CardBorderBrush}"
                                                                     Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                                 <StackPanel Orientation="Horizontal">
                                                                     <TextBlock Text="+" Foreground="White" FontWeight="Bold"
@@ -600,7 +600,7 @@
 
                             <!-- Error display -->
                             <TextBlock Text="{Binding ErrorMessage}"
-                                       Foreground="{StaticResource ErrorBrush}"
+                                       Foreground="{DynamicResource ErrorBrush}"
                                        Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
                                        Margin="0,0,0,12"
                                        TextWrapping="Wrap" />
@@ -624,14 +624,14 @@
                                         Command="{Binding CancelEditCommand}"
                                         Margin="0,0,12,0" />
                                 <TextBlock Text="You have unsaved changes"
-                                           Foreground="{StaticResource WarningBrush}"
+                                           Foreground="{DynamicResource WarningBrush}"
                                            FontSize="12" FontStyle="Italic"
                                            VerticalAlignment="Center"
                                            Visibility="{Binding HasUnsavedChanges, Converter={StaticResource BoolToVis}}" />
                             </StackPanel>
 
                             <!-- Test Result in Edit Mode -->
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4"
                                     Padding="12,8"
                                     Margin="0,16,0,0"
@@ -644,7 +644,7 @@
                     </Border>
 
                     <!-- Loading Overlay -->
-                    <Border Background="#80000000"
+                    <Border Background="{DynamicResource OverlayBrush}"
                             CornerRadius="6"
                             Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"
                             Margin="0,16,0,0">

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="Blackcat.NineLives.Views.ExecutionWindow"
+﻿<Window x:Class="Blackcat.NineLives.Views.ExecutionWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
@@ -7,7 +7,7 @@
         MinWidth="640" MinHeight="380"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
-        Background="{StaticResource WindowBackgroundBrush}"
+        Background="{DynamicResource WindowBackgroundBrush}"
         Closing="OnClosing">
 
     <Window.Resources>
@@ -31,8 +31,8 @@
         </StackPanel>
 
         <Border Grid.Row="1" CornerRadius="6"
-                Background="{StaticResource ConsoleBackgroundBrush}"
-                BorderBrush="{StaticResource ConsoleBorderBrush}"
+                Background="{DynamicResource ConsoleBackgroundBrush}"
+                BorderBrush="{DynamicResource ConsoleBorderBrush}"
                 BorderThickness="1">
             <Grid>
                 <Grid.RowDefinitions>
@@ -41,9 +41,9 @@
                 </Grid.RowDefinitions>
 
                 <Border Grid.Row="0"
-                        Background="{StaticResource ConsoleChromeBrush}"
+                        Background="{DynamicResource ConsoleChromeBrush}"
                         CornerRadius="5,5,0,0"
-                        BorderBrush="{StaticResource ConsoleBorderBrush}"
+                        BorderBrush="{DynamicResource ConsoleBorderBrush}"
                         BorderThickness="0,0,0,1"
                         Padding="12,7">
                     <Grid>
@@ -51,23 +51,23 @@
                             <Ellipse Width="9" Height="9" Margin="0,0,7,0">
                                 <Ellipse.Style>
                                     <Style TargetType="Ellipse">
-                                        <Setter Property="Fill" Value="{StaticResource ConsoleMutedBrush}" />
+                                        <Setter Property="Fill" Value="{DynamicResource ConsoleMutedBrush}" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsExecuting}" Value="True">
-                                                <Setter Property="Fill" Value="{StaticResource ConsoleSuccessBrush}" />
+                                                <Setter Property="Fill" Value="{DynamicResource ConsoleSuccessBrush}" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
                                 </Ellipse.Style>
                             </Ellipse>
                             <TextBlock Text="restore console"
-                                       Foreground="{StaticResource ConsoleMutedBrush}"
+                                       Foreground="{DynamicResource ConsoleMutedBrush}"
                                        FontFamily="{StaticResource ConsoleFont}"
                                        FontSize="11" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                             <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
-                                       Foreground="{StaticResource ConsoleMutedBrush}"
+                                       Foreground="{DynamicResource ConsoleMutedBrush}"
                                        FontFamily="{StaticResource ConsoleFont}"
                                        FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0" />
                             <Button Content="Copy output"
@@ -94,7 +94,7 @@
 
         <!-- What a failed or cancelled restore left behind (#14). -->
         <Border Grid.Row="2" CornerRadius="4" Padding="12" Margin="0,12,0,0"
-                Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1"
+                Background="{DynamicResource DangerPanelBackgroundBrush}" BorderBrush="{DynamicResource DangerPanelBorderBrush}" BorderThickness="1"
                 Visibility="{Binding HasRecoveryActions, Converter={StaticResource BoolToVis}}">
             <StackPanel>
                 <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
@@ -105,11 +105,11 @@
                 <ItemsControl ItemsSource="{Binding RecoveryActions}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="10" Margin="0,0,0,8">
                                 <StackPanel>
                                     <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
-                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                               Foreground="{DynamicResource PrimaryTextBrush}"
                                                TextWrapping="Wrap" />
                                     <TextBox Text="{Binding Sql, Mode=OneWay}"
                                              Style="{StaticResource DarkTextBox}"

--- a/src/NineLives/Views/HistoryView.xaml
+++ b/src/NineLives/Views/HistoryView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.HistoryView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.HistoryView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
@@ -46,32 +46,30 @@
             <Border Grid.Column="0" Style="{StaticResource CardBorder}" Margin="0,0,12,0">
                 <ListBox ItemsSource="{Binding Entries}"
                          SelectedItem="{Binding SelectedEntry}"
-                         Background="Transparent"
-                         BorderThickness="0"
-                         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                         Style="{StaticResource CardListBox}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
-                            <StackPanel Margin="0,4,0,8">
+                            <StackPanel>
                                 <TextBlock Text="{Binding StartedDisplay}"
                                            Style="{StaticResource SecondaryText}"
                                            FontSize="11" />
                                 <TextBlock TextWrapping="Wrap" FontWeight="SemiBold" Margin="0,2,0,0">
                                     <Run Text="{Binding TargetDatabase, Mode=OneWay}" />
-                                    <Run Text=" on " Foreground="{StaticResource SecondaryTextBrush}" />
+                                    <Run Text=" on " Foreground="{DynamicResource SecondaryTextBrush}" />
                                     <Run Text="{Binding ServerName, Mode=OneWay}"
-                                         Foreground="{StaticResource SecondaryTextBrush}" />
+                                         Foreground="{DynamicResource SecondaryTextBrush}" />
                                 </TextBlock>
                                 <TextBlock Margin="0,2,0,0" FontSize="11">
                                     <Run Text="{Binding OutcomeDisplay, Mode=OneWay}">
                                         <Run.Style>
                                             <Style TargetType="Run">
-                                                <Setter Property="Foreground" Value="{StaticResource SuccessBrush}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
                                                 <Style.Triggers>
                                                     <DataTrigger Binding="{Binding Outcome}" Value="Failed">
-                                                        <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                                        <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding Outcome}" Value="Cancelled">
-                                                        <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                                        <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
@@ -79,7 +77,7 @@
                                     </Run>
                                     <Run Text="  " />
                                     <Run Text="{Binding DurationDisplay, Mode=OneWay}"
-                                         Foreground="{StaticResource SecondaryTextBrush}" />
+                                         Foreground="{DynamicResource SecondaryTextBrush}" />
                                 </TextBlock>
                             </StackPanel>
                         </DataTemplate>
@@ -105,7 +103,7 @@
                                        Margin="0,4,0,12" />
 
                             <TextBlock Text="{Binding SelectedEntry.ErrorMessage}"
-                                       Foreground="{StaticResource ErrorBrush}"
+                                       Foreground="{DynamicResource ErrorBrush}"
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,12"
                                        Visibility="{Binding SelectedEntry.ErrorMessage, Converter={StaticResource NullToVis}}" />
@@ -127,13 +125,13 @@
                             </StackPanel>
 
                             <TextBlock Text="SCRIPT" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="10" Margin="0,0,0,12">
                                 <TextBox Text="{Binding SelectedEntry.Script, Mode=OneWay}"
                                          IsReadOnly="True"
                                          Background="Transparent"
                                          BorderThickness="0"
-                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                         Foreground="{DynamicResource PrimaryTextBrush}"
                                          FontFamily="Cascadia Code, Consolas, Courier New"
                                          FontSize="11"
                                          MaxHeight="220"
@@ -142,13 +140,13 @@
                             </Border>
 
                             <TextBlock Text="EXECUTION LOG" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="10">
                                 <TextBox Text="{Binding SelectedEntry.Log, Mode=OneWay}"
                                          IsReadOnly="True"
                                          Background="Transparent"
                                          BorderThickness="0"
-                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                         Foreground="{DynamicResource PrimaryTextBrush}"
                                          FontFamily="Cascadia Code, Consolas, Courier New"
                                          FontSize="11"
                                          MaxHeight="260"
@@ -194,7 +192,7 @@
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsClearArmed}" Value="True">
                                         <Setter Property="Text" Value="Confirm clear" />
-                                        <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.RestoreView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.RestoreView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
@@ -86,19 +86,19 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Orientation="Horizontal">
-                            <Border Background="{StaticResource AccentBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
+                            <Border Background="{DynamicResource AccentBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
                                 <TextBlock Text="{Binding FullCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Full Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
-                            <Border Background="{StaticResource WarningBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
+                            <Border Background="{DynamicResource WarningBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
                                 <TextBlock Text="{Binding DiffCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Diff Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="2" Orientation="Horizontal">
-                            <Border Background="{StaticResource SuccessBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
+                            <Border Background="{DynamicResource SuccessBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
                                 <TextBlock Text="{Binding LogCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Log Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
@@ -123,12 +123,12 @@
                  the case where there are no restore points, so the user got an empty screen and no
                  explanation. A XAML load test caught that. -->
             <Border CornerRadius="4" Padding="12" Margin="0,0,0,16"
-                    Background="#332B1A" BorderBrush="#8A6D2F" BorderThickness="1"
+                    Background="{DynamicResource WarningPanelBackgroundBrush}" BorderBrush="{DynamicResource WarningPanelBorderBrush}" BorderThickness="1"
                     Visibility="{Binding HasInventoryIssues, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
                     <TextBlock Text="About the backups found in this container"
                                FontWeight="SemiBold"
-                               Foreground="{StaticResource PrimaryTextBrush}"
+                               Foreground="{DynamicResource PrimaryTextBrush}"
                                TextWrapping="Wrap"
                                Margin="0,0,0,8" />
                     <ItemsControl ItemsSource="{Binding InventoryIssues}">
@@ -165,7 +165,7 @@
                     <!-- Narrowing controls. A week of 15-minute logs is roughly 670 points, which
                          no timeline can draw legibly - so the range and the type toggles are the
                          way to get from "everything" down to something you can click (#27). -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="6" Padding="12,10" Margin="0,0,0,12">
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -220,13 +220,13 @@
 
                     <TextBlock Text="No restore point matches these filters. Widen the range or switch a type back on."
                                Style="{StaticResource SecondaryText}"
-                               Foreground="{StaticResource WarningBrush}"
+                               Foreground="{DynamicResource WarningBrush}"
                                TextWrapping="Wrap"
                                Margin="0,0,0,12"
                                Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
 
                     <!-- ========== VISUAL TIMELINE ========== -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="6" Padding="16,12" Margin="0,0,0,12">
                         <Grid>
                             <Grid.RowDefinitions>
@@ -238,11 +238,11 @@
 
                             <!-- Legend -->
                             <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
-                                <Ellipse Width="10" Height="10" Fill="{StaticResource AccentBrush}" Margin="0,0,4,0" />
+                                <Ellipse Width="10" Height="10" Fill="{DynamicResource AccentBrush}" Margin="0,0,4,0" />
                                 <TextBlock Text="Full" Style="{StaticResource SecondaryText}" Margin="0,0,16,0" VerticalAlignment="Center" />
-                                <Ellipse Width="10" Height="10" Fill="{StaticResource WarningBrush}" Margin="0,0,4,0" />
+                                <Ellipse Width="10" Height="10" Fill="{DynamicResource WarningBrush}" Margin="0,0,4,0" />
                                 <TextBlock Text="Diff" Style="{StaticResource SecondaryText}" Margin="0,0,16,0" VerticalAlignment="Center" />
-                                <Ellipse Width="10" Height="10" Fill="{StaticResource SuccessBrush}" Margin="0,0,4,0" />
+                                <Ellipse Width="10" Height="10" Fill="{DynamicResource SuccessBrush}" Margin="0,0,4,0" />
                                 <TextBlock Text="Log" Style="{StaticResource SecondaryText}" VerticalAlignment="Center" />
                             </StackPanel>
 
@@ -258,7 +258,7 @@
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
                                             <Border HorizontalAlignment="Left" VerticalAlignment="Stretch"
-                                                    Width="1" Background="{StaticResource CardBorderBrush}" Opacity="0.25">
+                                                    Width="1" Background="{DynamicResource CardBorderBrush}" Opacity="0.25">
                                                 <Border.Margin>
                                                     <MultiBinding Converter="{StaticResource TickPos}">
                                                         <Binding Path="Position" />
@@ -314,9 +314,9 @@
                                                             <Run Text="{Binding TimestampDisplay, Mode=OneWay}" />
                                                         </TextBlock>
                                                         <TextBlock Text="{Binding ChainDescription}"
-                                                                   Foreground="{StaticResource SecondaryTextBrush}" TextWrapping="Wrap" />
+                                                                   Foreground="{DynamicResource SecondaryTextBrush}" TextWrapping="Wrap" />
                                                         <TextBlock Text="{Binding TimestampNote}"
-                                                                   Foreground="{StaticResource WarningBrush}" TextWrapping="Wrap"
+                                                                   Foreground="{DynamicResource WarningBrush}" TextWrapping="Wrap"
                                                                    Margin="0,4,0,0"
                                                                    Visibility="{Binding IsTimestampApproximate, Converter={StaticResource BoolToVis}}" />
                                                     </StackPanel>
@@ -330,7 +330,7 @@
                             <!-- Track line + tick marks (time scale axis) -->
                             <Grid Grid.Row="2" Height="32" Margin="7,0">
                                 <!-- Track line -->
-                                <Border Height="3" Background="{StaticResource CardBorderBrush}"
+                                <Border Height="3" Background="{DynamicResource CardBorderBrush}"
                                         VerticalAlignment="Top" CornerRadius="1.5" />
 
                                 <!-- Tick marks with labels -->
@@ -350,9 +350,9 @@
                                                     </MultiBinding>
                                                 </StackPanel.Margin>
                                                 <Border Width="1" Height="12"
-                                                        Background="{StaticResource SecondaryTextBrush}" Opacity="0.6" />
+                                                        Background="{DynamicResource SecondaryTextBrush}" Opacity="0.6" />
                                                 <TextBlock Text="{Binding Label}" FontSize="10"
-                                                           Foreground="{StaticResource SecondaryTextBrush}"
+                                                           Foreground="{DynamicResource SecondaryTextBrush}"
                                                            Margin="-16,2,0,0" />
                                             </StackPanel>
                                         </DataTemplate>
@@ -402,7 +402,7 @@
                                         <Setter Property="ToolTip" Value="{Binding TimestampNote}" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsTimestampApproximate}" Value="True">
-                                                <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -462,7 +462,7 @@
                                         <Setter Property="ToolTip" Value="{Binding TimestampNote}" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsTimestampApproximate}" Value="True">
-                                                <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -488,11 +488,11 @@
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
-                            <Run Text="Selected: " Foreground="{StaticResource SecondaryTextBrush}" />
+                            <Run Text="Selected: " Foreground="{DynamicResource SecondaryTextBrush}" />
                             <Run Text="{Binding SelectedRestorePoint.TimestampDisplay, Mode=OneWay}"
-                                 FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}" />
-                            <Run Text="  |  " Foreground="{StaticResource SecondaryTextBrush}" />
-                            <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{StaticResource SecondaryTextBrush}" />
+                                 FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}" />
+                            <Run Text="  |  " Foreground="{DynamicResource SecondaryTextBrush}" />
+                            <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{DynamicResource SecondaryTextBrush}" />
                         </TextBlock>
 
                         <!-- On-demand LSN verification: one RESTORE HEADERONLY per chain member,
@@ -585,13 +585,13 @@
                             Visibility="{Binding HasVerifyResults, Converter={StaticResource BoolToVis}}">
                         <Border.Style>
                             <Style TargetType="Border">
-                                <Setter Property="Background" Value="#1A2A1E" />
-                                <Setter Property="BorderBrush" Value="{StaticResource SuccessBrush}" />
+                                <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                 <Setter Property="BorderThickness" Value="1" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasVerifyFailures}" Value="True">
-                                        <Setter Property="Background" Value="#3A1E1E" />
-                                        <Setter Property="BorderBrush" Value="#A33F3F" />
+                                        <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
+                                        <Setter Property="BorderBrush" Value="{DynamicResource DangerPanelBorderBrush}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -610,10 +610,10 @@
                                                 <Run Text="{Binding StatusDisplay, Mode=OneWay}">
                                                     <Run.Style>
                                                         <Style TargetType="Run">
-                                                            <Setter Property="Foreground" Value="{StaticResource SuccessBrush}" />
+                                                            <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
                                                             <Style.Triggers>
                                                                 <DataTrigger Binding="{Binding IsValid}" Value="False">
-                                                                    <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                                                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
                                                                 </DataTrigger>
                                                             </Style.Triggers>
                                                         </Style>
@@ -638,13 +638,13 @@
                             Visibility="{Binding HasChainIssues, Converter={StaticResource BoolToVis}}">
                         <Border.Style>
                             <Style TargetType="Border">
-                                <Setter Property="Background" Value="#332B1A" />
-                                <Setter Property="BorderBrush" Value="#8A6D2F" />
+                                <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource WarningPanelBorderBrush}" />
                                 <Setter Property="BorderThickness" Value="1" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasChainErrors}" Value="True">
-                                        <Setter Property="Background" Value="#3A1E1E" />
-                                        <Setter Property="BorderBrush" Value="#A33F3F" />
+                                        <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
+                                        <Setter Property="BorderBrush" Value="{DynamicResource DangerPanelBorderBrush}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -652,7 +652,7 @@
                         <StackPanel>
                             <TextBlock Text="{Binding ChainIssueSummary}"
                                        FontWeight="SemiBold"
-                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                       Foreground="{DynamicResource PrimaryTextBrush}"
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,8" />
                             <ItemsControl ItemsSource="{Binding ChainIssues}">
@@ -680,7 +680,7 @@
                          point. Shown whether or not a point is selected, because they explain why
                          the timeline has fewer entries than the browse list has files (#46). -->
                     <!-- Restore Chain Detail (togglable) -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="12" Margin="0,12,0,0"
                             Visibility="{Binding ShowChainDetails, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
@@ -796,7 +796,7 @@
 
                             <TextBlock Style="{StaticResource SecondaryText}"
                                        FontSize="10" TextWrapping="Wrap"
-                                       Foreground="{StaticResource WarningBrush}"
+                                       Foreground="{DynamicResource WarningBrush}"
                                        Margin="0,0,0,12"
                                        Visibility="{Binding ContinueAfterError, Converter={StaticResource BoolToVis}}"
                                        Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
@@ -814,10 +814,10 @@
                                 <Border CornerRadius="4" Padding="10,6" Margin="0,0,0,10">
                                     <Border.Style>
                                         <Style TargetType="Border">
-                                            <Setter Property="Background" Value="#30F39C12" />
+                                            <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding PathsFromServer}" Value="True">
-                                                    <Setter Property="Background" Value="#1A27AE60" />
+                                                    <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -831,10 +831,10 @@
                                         <Ellipse Grid.Column="0" Width="8" Height="8" VerticalAlignment="Center" Margin="0,0,8,0">
                                             <Ellipse.Style>
                                                 <Style TargetType="Ellipse">
-                                                    <Setter Property="Fill" Value="{StaticResource WarningBrush}" />
+                                                    <Setter Property="Fill" Value="{DynamicResource WarningBrush}" />
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding PathsFromServer}" Value="True">
-                                                            <Setter Property="Fill" Value="{StaticResource SuccessBrush}" />
+                                                            <Setter Property="Fill" Value="{DynamicResource SuccessBrush}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
@@ -900,7 +900,7 @@
                                 </StackPanel>
 
                                 <Border Visibility="{Binding HasFetchedFileMoves, Converter={StaticResource BoolToVis}}"
-                                        Background="{StaticResource InputBackgroundBrush}"
+                                        Background="{DynamicResource InputBackgroundBrush}"
                                         CornerRadius="4" Padding="8" Margin="0,0,0,8">
                                     <StackPanel>
                                         <TextBlock Text="Logical files (from RESTORE FILELISTONLY)" Style="{StaticResource LabelText}" Margin="0,0,0,6" />
@@ -920,7 +920,7 @@
                                 </Border>
 
                                 <Border Visibility="{Binding BackupMetadataSummary, Converter={StaticResource NullToVis}}"
-                                        Background="{StaticResource InputBackgroundBrush}"
+                                        Background="{DynamicResource InputBackgroundBrush}"
                                         CornerRadius="4" Padding="10" Margin="0,0,0,8">
                                     <StackPanel>
                                         <TextBlock Text="Backup metadata (RESTORE HEADERONLY)" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
@@ -995,7 +995,7 @@
                                      ToolTip="Defaults to the container URL. The credential on the server must match this name (container URL) for RESTORE FROM URL." />
 
                             <!-- Blob credential: when not connected, prompt to connect to verify; when connected, show status and optional Create -->
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="12,10" Margin="0,0,0,16"
                                     Visibility="{Binding CredentialSectionVisible, Converter={StaticResource BoolToVis}}">
                                 <StackPanel>
@@ -1012,19 +1012,19 @@
                                         <Border Padding="0,0,0,8">
                                             <Border.Style>
                                                 <Style TargetType="Border">
-                                                    <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
+                                                    <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
                                                     <Setter Property="BorderThickness" Value="0" />
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding CredentialIsValidSas}" Value="True">
-                                                            <Setter Property="Background" Value="#1A27AE60" />
-                                                            <Setter Property="BorderBrush" Value="{StaticResource SuccessBrush}" />
+                                                            <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
                                                             <Setter Property="CornerRadius" Value="4" />
                                                             <Setter Property="Padding" Value="8,6,8,6" />
                                                         </DataTrigger>
                                                         <DataTrigger Binding="{Binding CredentialExistsOnServer}" Value="False">
-                                                            <Setter Property="Background" Value="#30E74C3C" />
-                                                            <Setter Property="BorderBrush" Value="{StaticResource ErrorBrush}" />
+                                                            <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
                                                             <Setter Property="CornerRadius" Value="4" />
                                                             <Setter Property="Padding" Value="8,6,8,6" />
@@ -1034,8 +1034,8 @@
                                                                 <Condition Binding="{Binding CredentialExistsOnServer}" Value="True" />
                                                                 <Condition Binding="{Binding CredentialIsValidSas}" Value="False" />
                                                             </MultiDataTrigger.Conditions>
-                                                            <Setter Property="Background" Value="#30E67E22" />
-                                                            <Setter Property="BorderBrush" Value="{StaticResource WarningBrush}" />
+                                                            <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource WarningBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
                                                             <Setter Property="CornerRadius" Value="4" />
                                                             <Setter Property="Padding" Value="8,6,8,6" />
@@ -1089,7 +1089,7 @@
                     <TextBlock Text="RESTORE SUMMARY"
                                Style="{StaticResource SubHeaderText}"
                                Margin="0,0,0,8" />
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="12,10">
                         <TextBlock Text="{Binding RestoreSummaryText}"
                                    Style="{StaticResource BodyText}"
@@ -1144,7 +1144,7 @@
                          the last thing between the user and an irreversible overwrite, and a
                          hostname alone is a weak signal - blackcatsvr01 and blackcatsvr02 differ
                          by one character. A red PROD pill is read before the sentence is. -->
-                    <Border Background="#30E74C3C" CornerRadius="4" Padding="12,8" Margin="0,0,0,12"
+                    <Border Background="{DynamicResource DangerPanelBackgroundBrush}" CornerRadius="4" Padding="12,8" Margin="0,0,0,12"
                             Visibility="{Binding IsExecuteArmed, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
                             <ItemsControl ItemsSource="{Binding ConnectedServerTags}"
@@ -1152,37 +1152,37 @@
                                           Margin="0,0,0,6"
                                           Visibility="{Binding HasConnectedServerTags, Converter={StaticResource BoolToVis}}" />
                             <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap">
-                                <Run Text="&#x26A0;" Foreground="{StaticResource ErrorBrush}" FontSize="14" />
+                                <Run Text="&#x26A0;" Foreground="{DynamicResource ErrorBrush}" FontSize="14" />
                                 <Run Text=" Click again to execute restore against" />
-                                <Run Text="{Binding ConnectedServerName, Mode=OneWay}" FontWeight="SemiBold" Foreground="{StaticResource ErrorBrush}" />
+                                <Run Text="{Binding ConnectedServerName, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource ErrorBrush}" />
                                 <Run Text=". Target:" />
                                 <Run Text="{Binding TargetDatabaseName, Mode=OneWay}" FontWeight="SemiBold" />
                                 <Run Text="(" />
                                 <Run Text="{Binding ChainSummary, Mode=OneWay}" />
-                                <Run Text="). This operation cannot be undone." Foreground="{StaticResource ErrorBrush}" />
+                                <Run Text="). This operation cannot be undone." Foreground="{DynamicResource ErrorBrush}" />
                             </TextBlock>
                         </StackPanel>
                     </Border>
 
                     <!-- Not connected warning -->
-                    <Border Background="{StaticResource DangerBackgroundBrush}"
+                    <Border Background="{DynamicResource DangerBackgroundBrush}"
                             CornerRadius="4" Padding="12,8" Margin="0,0,0,12"
                             Visibility="{Binding IsConnectedToServer, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                         <TextBlock Style="{StaticResource SecondaryText}">
-                            <Run Text="&#x26A0;" Foreground="{StaticResource WarningBrush}" />
+                            <Run Text="&#x26A0;" Foreground="{DynamicResource WarningBrush}" />
                             <Run Text=" Connect to a SQL Server instance (SQL Servers tab) to enable script execution." />
                         </TextBlock>
                     </Border>
 
                     <TextBlock Text="{Binding ErrorMessage}"
-                               Foreground="{StaticResource ErrorBrush}"
+                               Foreground="{DynamicResource ErrorBrush}"
                                Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
                                Margin="0,0,0,12" TextWrapping="Wrap" />
 
                     <!-- The generated script. Stays visible during and after execution: it used to
                          be hidden the moment Execute was pressed, so the script and the console
                          shared one slot and you could not see what was running while it ran. -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="0"
                             Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
@@ -1201,7 +1201,7 @@
                                                     FontFamily="{StaticResource ConsoleFont}"
                                                     FontSize="12"
                                                     TextWrapping="NoWrap"
-                                                    Foreground="{StaticResource ConsoleTextBrush}" />
+                                                    Foreground="{DynamicResource ConsoleTextBrush}" />
                             </ScrollViewer>
                         </StackPanel>
                     </Border>
@@ -1212,8 +1212,8 @@
                          growing string: appending to a bound string re-rendered the whole control
                          on every message, which is why progress arrived in bursts. -->
                     <Border CornerRadius="6" Margin="0,12,0,0"
-                            Background="{StaticResource ConsoleBackgroundBrush}"
-                            BorderBrush="{StaticResource ConsoleBorderBrush}"
+                            Background="{DynamicResource ConsoleBackgroundBrush}"
+                            BorderBrush="{DynamicResource ConsoleBorderBrush}"
                             BorderThickness="1">
                         <!-- Shown only when the console is NOT in its own window - the two are
                              mutually exclusive, so the output is never rendered twice. -->
@@ -1245,9 +1245,9 @@
 
                             <!-- Chrome strip: title, live indicator, copy. -->
                             <Border Grid.Row="0"
-                                    Background="{StaticResource ConsoleChromeBrush}"
+                                    Background="{DynamicResource ConsoleChromeBrush}"
                                     CornerRadius="5,5,0,0"
-                                    BorderBrush="{StaticResource ConsoleBorderBrush}"
+                                    BorderBrush="{DynamicResource ConsoleBorderBrush}"
                                     BorderThickness="0,0,0,1"
                                     Padding="12,7">
                                 <Grid>
@@ -1255,17 +1255,17 @@
                                         <Ellipse Width="9" Height="9" Margin="0,0,7,0">
                                             <Ellipse.Style>
                                                 <Style TargetType="Ellipse">
-                                                    <Setter Property="Fill" Value="{StaticResource ConsoleMutedBrush}" />
+                                                    <Setter Property="Fill" Value="{DynamicResource ConsoleMutedBrush}" />
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding IsExecuting}" Value="True">
-                                                            <Setter Property="Fill" Value="{StaticResource ConsoleSuccessBrush}" />
+                                                            <Setter Property="Fill" Value="{DynamicResource ConsoleSuccessBrush}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
                                             </Ellipse.Style>
                                         </Ellipse>
                                         <TextBlock Text="restore console"
-                                                   Foreground="{StaticResource ConsoleMutedBrush}"
+                                                   Foreground="{DynamicResource ConsoleMutedBrush}"
                                                    FontFamily="{StaticResource ConsoleFont}"
                                                    FontSize="11"
                                                    VerticalAlignment="Center" />
@@ -1273,7 +1273,7 @@
 
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                                         <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
-                                                   Foreground="{StaticResource ConsoleMutedBrush}"
+                                                   Foreground="{DynamicResource ConsoleMutedBrush}"
                                                    FontFamily="{StaticResource ConsoleFont}"
                                                    FontSize="11"
                                                    VerticalAlignment="Center"
@@ -1308,7 +1308,7 @@
                          worst moment to be left working that out from a raw SQL error. Each action
                          shows the exact statement before it runs. -->
                     <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
-                            Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1">
+                            Background="{DynamicResource DangerPanelBackgroundBrush}" BorderBrush="{DynamicResource DangerPanelBorderBrush}" BorderThickness="1">
                         <!-- Same rule as the console: not while it is showing in its own window,
                              where the recovery actions already appear. -->
                         <Border.Style>
@@ -1334,12 +1334,12 @@
                             <ItemsControl ItemsSource="{Binding RecoveryActions}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Border Background="{StaticResource InputBackgroundBrush}"
+                                        <Border Background="{DynamicResource InputBackgroundBrush}"
                                                 CornerRadius="4" Padding="10" Margin="0,0,0,8">
                                             <StackPanel>
                                                 <TextBlock Text="{Binding Title}"
                                                            FontWeight="SemiBold"
-                                                           Foreground="{StaticResource PrimaryTextBrush}"
+                                                           Foreground="{DynamicResource PrimaryTextBrush}"
                                                            TextWrapping="Wrap" />
                                                 <TextBox Text="{Binding Sql, Mode=OneWay}"
                                                          Style="{StaticResource DarkTextBox}"
@@ -1374,7 +1374,7 @@
             </Border>
 
             <!-- Loading -->
-            <Border Background="#80000000" CornerRadius="6"
+            <Border Background="{DynamicResource OverlayBrush}" CornerRadius="6"
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}" Padding="20">
                 <StackPanel HorizontalAlignment="Center">
                     <TextBlock Text="Loading..." Style="{StaticResource BodyText}" HorizontalAlignment="Center" />

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.ServerManagerView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.ServerManagerView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
@@ -55,17 +55,17 @@
                              BorderThickness="0"
                              HorizontalContentAlignment="Stretch"
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                             Foreground="{StaticResource PrimaryTextBrush}">
+                             Foreground="{DynamicResource PrimaryTextBrush}">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="4,6">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="&#x26C1;" FontSize="14" Margin="0,0,8,0"
                                                    VerticalAlignment="Center"
-                                                   Foreground="{StaticResource SecondaryTextBrush}" />
+                                                   Foreground="{DynamicResource SecondaryTextBrush}" />
                                         <TextBlock Text="{Binding Name}"
                                                    FontWeight="SemiBold"
-                                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                                                   Foreground="{DynamicResource PrimaryTextBrush}" />
                                     </StackPanel>
                                     <!-- Now that the row is width-constrained (no horizontal
                                          scrolling), a long name would be cut mid-character
@@ -97,11 +97,11 @@
                                             <ControlTemplate.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
                                                     <Setter TargetName="border" Property="Background"
-                                                            Value="{StaticResource SidebarItemHoverBrush}" />
+                                                            Value="{DynamicResource SidebarItemHoverBrush}" />
                                                 </Trigger>
                                                 <Trigger Property="IsSelected" Value="True">
                                                     <Setter TargetName="border" Property="Background"
-                                                            Value="{StaticResource SidebarItemActiveBrush}" />
+                                                            Value="{DynamicResource SidebarItemActiveBrush}" />
                                                 </Trigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
@@ -117,17 +117,17 @@
             <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto">
                 <StackPanel>
                     <!-- Connected Banner -->
-                    <Border Background="#1A3D1F"
+                    <Border Background="{DynamicResource SuccessPanelBackgroundBrush}"
                             CornerRadius="6"
                             Padding="16,10"
                             Margin="0,0,0,16"
                             Visibility="{Binding IsConnected, Converter={StaticResource BoolToVis}}">
                         <StackPanel Orientation="Horizontal">
                             <Ellipse Width="10" Height="10"
-                                     Fill="{StaticResource SuccessBrush}"
+                                     Fill="{DynamicResource SuccessBrush}"
                                      VerticalAlignment="Center" Margin="0,0,10,0" />
                             <TextBlock Text="{Binding ConnectedServerDisplay, StringFormat='Connected to {0}'}"
-                                       Foreground="{StaticResource SuccessBrush}"
+                                       Foreground="{DynamicResource SuccessBrush}"
                                        FontWeight="SemiBold" VerticalAlignment="Center" />
                             <Button Content="Disconnect"
                                     Style="{StaticResource SecondaryButton}"
@@ -184,7 +184,7 @@
                                             Command="{Binding DeleteCommand}" />
                                 </StackPanel>
 
-                                <Border Background="{StaticResource InputBackgroundBrush}"
+                                <Border Background="{DynamicResource InputBackgroundBrush}"
                                         CornerRadius="4"
                                         Padding="12,8"
                                         Margin="0,16,0,0"
@@ -302,7 +302,7 @@
                                      Margin="0,0,0,16" />
 
                             <TextBlock Text="{Binding ErrorMessage}"
-                                       Foreground="{StaticResource ErrorBrush}"
+                                       Foreground="{DynamicResource ErrorBrush}"
                                        Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
                                        Margin="0,0,0,12"
                                        TextWrapping="Wrap" />
@@ -321,7 +321,7 @@
                                         Command="{Binding CancelEditCommand}" />
                             </StackPanel>
 
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4"
                                     Padding="12,8"
                                     Margin="0,16,0,0"
@@ -333,7 +333,7 @@
                         </StackPanel>
                     </Border>
 
-                    <Border Background="#80000000"
+                    <Border Background="{DynamicResource OverlayBrush}"
                             CornerRadius="6"
                             Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"
                             Margin="0,16,0,0">


### PR DESCRIPTION
The splash screen is the piece worth matching, so the rest of the app is now tuned to it rather than the other way round — plus a light theme and a high-contrast one, switchable from About and remembered.

## The dark theme now matches its own splash

The splash was already using a deeper, more confident palette than the app: near-black cards (`#0B0E17` → `#05070C`), `#2D3148` borders, bright `#F2F4F8` text and a more saturated blue (`#3B83E9`). The app was a lighter, greyer navy with a softer blue (`#4A90D9`) and dimmer text — which is why it and its own splash didn't look like the same product.

Backgrounds are deepened, the blue is the splash's blue, and primary text is the splash's near-white. Typography was already Segoe UI at the same sizes, so that stayed.

## Three themes

**Dark** — the default, as above.

**Light** — not the dark one inverted. A blue tuned to sit on near-black glows against white, so it's darkened to `#1F63C4` (same hue, taken down until it holds its own on a white card), and the greys are chosen for contrast against white rather than mirrored. Status colours are darkened too: `#27AE60` on white is weak and `#E74C3C` reads as pink at small sizes.

The console stays dark in light mode. A terminal is a terminal — SQL Server's output is easier to read light-on-dark, and every DBA has spent their career reading it that way. Making it white to match the page would be consistency for its own sake.

**High contrast** — not "dark with the brightness up". Pure black surfaces, pure white text, visible borders rather than implied ones, and yellow as the accent (blue-on-black is the worst pairing for reduced contrast sensitivity, and yellow-on-black is what Windows high-contrast schemes have used for decades). Secondary text stops being grey — it's `#E8E8E8`, distinguished by size and weight instead, because fading text is the thing this theme exists to avoid.

## How it's built

`Themes/DarkTheme.xaml` was doing two jobs. It's now `Themes/Controls.xaml` (styles only) plus `Palette.Dark/Light/HighContrast.xaml` (colours only), and `ThemeManager` swaps the palette at index 0 of the merged dictionaries.

Every brush reference became `DynamicResource` — 224 of them. That's the part that makes the switch instant rather than restart-only: a `StaticResource` resolves once when the element loads, so a switched theme would leave every open window in the old colours.

Hardcoded hexes scattered through the views (panel tints, overlay scrims, the DataGrid's banded row, button hover states) are palette keys now. A literal `#1A1D2A` row stripe is a dark band through every grid in light mode.

## The failure mode this had to guard against

A `DynamicResource` pointing at a key a palette doesn't define **does not throw**. WPF resolves it to nothing and the result is white text on white, or an invisible border. Nothing in the build or the existing XAML tests catches that.

So the palettes' key sets are compared directly — each must define exactly what the dark one does, in both directions. Plus every view is loaded under every theme, and contrast is checked as a **ratio**, not by eye: primary text on a card ≥ 4.5:1 in all three, and high contrast's secondary text ≥ 7:1 (WCAG AAA).

## Two bugs found by actually looking

I rendered each view under each theme to a PNG and read them, rather than trusting that it built.

**List item text was invisible.** The history list's `ListBoxItem` took its foreground from the system — near-black — so on a dark card the database names rendered black on black. That's a bug I shipped in #31 and couldn't see. There's now a `CardListBox` style that themes it properly.

**The theme picker read `ThemeOption { Value = Dark, Name = Dark }`.** The combo box's custom control template renders the selected item through a plain `ContentPresenter`, which ignores `DisplayMemberPath`.

Also caught: high contrast originally used the accent yellow as the selected-row fill, putting white text on yellow. Selection is now carried by an accent-coloured *border* so the fill can stay dark — pinned by a contrast test.

## Tests

**20 new; 679 total**, build clean at `-warnaserror`. Published and smoke-launched.

```
C:\Users\jake\AppData\Local\Temp\NineLives-theme\NineLives.exe
```

Switch themes from **About → Appearance**. The Restore screen in light mode is the one worth a close look — it's the densest view and the least checked.

