### PR TITLE
Make the script on screen the script that runs

### DIFF
--- a/src/NineLives.Tests/ScriptStaysInStepTests.cs
+++ b/src/NineLives.Tests/ScriptStaysInStepTests.cs
@@ -1,0 +1,169 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The script on screen is the script that runs.
+///
+/// This is the invariant the whole Restore screen rests on: people read the generated T-SQL before
+/// executing it against production, and if an option can change without the script following, the
+/// thing they read is not the thing that runs. Four options - both WITH MOVE paths, the STANDBY
+/// undo file and STATS - had no change handler at all, so editing them changed the display and
+/// nothing else.
+///
+/// Every test here fails against the code before that was fixed.
+/// </summary>
+public class ScriptStaysInStepTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+        new FakeRestoreHistoryStore());
+
+    private static BackupFileInfo FullBackup() => new()
+    {
+        BlobName = "FULL/SRV01/MyDb/20260110_220000.bak",
+        BlobUrl = "https://mystorageaccount.blob.core.windows.net/backups/FULL/SRV01/MyDb/20260110_220000.bak",
+        Type = BackupType.Full,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = "MyDb",
+        SizeBytes = 1000,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    private async Task<RestoreViewModel> Loaded()
+    {
+        _blob.Files = [FullBackup()];
+
+        var vm = NewViewModel();
+        vm.SelectedContainer = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        return vm;
+    }
+
+    // ── WITH MOVE ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TypingADataFilePathPutsItInTheScript()
+    {
+        var vm = await Loaded();
+        vm.UseWithMove = true;
+
+        vm.MoveDataFilePath = @"E:\SQLData\MyDb_Restored.mdf";
+        vm.MoveLogFilePath = @"F:\SQLLogs\MyDb_Restored_log.ldf";
+
+        Assert.Contains(@"MOVE N'MyDb' TO N'E:\SQLData\MyDb_Restored.mdf'", vm.GeneratedScript);
+        Assert.Contains(@"MOVE N'MyDb_log' TO N'F:\SQLLogs\MyDb_Restored_log.ldf'", vm.GeneratedScript);
+    }
+
+    /// <summary>
+    /// The worst shape of the bug. WITH MOVE ticked and paths visibly filled in, but the script
+    /// carried no MOVE clause - so SQL Server would restore to the file paths baked into the
+    /// backup, which are the SOURCE database's own files.
+    /// </summary>
+    [Fact]
+    public async Task WithMoveTickedNeverProducesAScriptWithNoMoveClause()
+    {
+        var vm = await Loaded();
+
+        vm.UseWithMove = true;
+        vm.MoveDataFilePath = @"E:\SQLData\MyDb_Restored.mdf";
+        vm.MoveLogFilePath = @"F:\SQLLogs\MyDb_Restored_log.ldf";
+
+        Assert.Contains("MOVE N'", vm.GeneratedScript);
+    }
+
+    [Fact]
+    public async Task EditingAFetchedLogicalFilesTargetPathReachesTheScript()
+    {
+        var vm = await Loaded();
+        vm.UseWithMove = true;
+
+        // As RESTORE FILELISTONLY would have populated it.
+        vm.FetchedFileMoves =
+        [
+            new FileMoveOption
+            {
+                LogicalName = "MyDb",
+                PhysicalName = @"C:\Data\MyDb.mdf",
+                NewPhysicalName = @"C:\Data\MyDb.mdf",
+                Type = "ROWS"
+            }
+        ];
+        vm.HasFetchedFileMoves = true;
+
+        // The user retypes it in the grid because C: is full.
+        vm.FetchedFileMoves[0].NewPhysicalName = @"E:\Data\MyDb.mdf";
+
+        Assert.Contains(@"TO N'E:\Data\MyDb.mdf'", vm.GeneratedScript);
+        Assert.DoesNotContain(@"TO N'C:\Data\MyDb.mdf'", vm.GeneratedScript);
+    }
+
+    // ── STANDBY ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StandbyWithNoUndoFileProducesNoScriptRatherThanAnEmptyLiteral()
+    {
+        var vm = await Loaded();
+
+        vm.RecoveryMode = RecoveryMode.Standby;
+
+        // STANDBY = '' is the last statement of the chain, so it fails AFTER the target has been
+        // dropped and overwritten. Refusing to produce a script is the only safe answer.
+        Assert.False(vm.HasScript);
+        Assert.Empty(vm.GeneratedScript);
+    }
+
+    [Fact]
+    public async Task StandbyWithAnUndoFileProducesTheClause()
+    {
+        var vm = await Loaded();
+
+        vm.RecoveryMode = RecoveryMode.Standby;
+        vm.StandbyFilePath = @"E:\Standby\MyDb.undo";
+
+        Assert.Contains(@"STANDBY = 'E:\Standby\MyDb.undo'", vm.GeneratedScript);
+    }
+
+    [Fact]
+    public async Task GenerateSaysWhyWhenStandbyHasNoUndoFile()
+    {
+        var vm = await Loaded();
+        vm.RecoveryMode = RecoveryMode.Standby;
+
+        vm.GenerateScriptCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Contains("undo file", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── STATS ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChangingStatsPercentReachesTheScript()
+    {
+        var vm = await Loaded();
+
+        vm.StatsPercent = 25;
+
+        Assert.Contains("STATS = 25;", vm.GeneratedScript);
+        Assert.DoesNotContain("STATS = 10;", vm.GeneratedScript);
+    }
+}

--- a/src/NineLives/Models/RestoreOptions.cs
+++ b/src/NineLives/Models/RestoreOptions.cs
@@ -1,3 +1,5 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace Blackcat.NineLives.Models;
 
 public enum RecoveryMode
@@ -51,10 +53,19 @@ public class RestoreOptions
     // ViewModel, which is what talks to the server about it.
 }
 
-public class FileMoveOption
+/// <summary>
+/// One logical file and where it should land.
+///
+/// Observable because <see cref="NewPhysicalName"/> is edited directly in a grid. As a plain POCO
+/// nothing knew the target path had changed, so the generated script kept the path that was
+/// fetched from the server rather than the one on screen - and the script is what gets executed.
+/// </summary>
+public partial class FileMoveOption : ObservableObject
 {
     public string LogicalName { get; set; } = string.Empty;
     public string PhysicalName { get; set; } = string.Empty;
-    public string NewPhysicalName { get; set; } = string.Empty;
     public string Type { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    private string _newPhysicalName = string.Empty;
 }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -436,6 +436,24 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private ObservableCollection<FileMoveOption> _fetchedFileMoves = [];
 
+    /// <summary>
+    /// Each row is edited in place in the grid, so the script has to follow the ROW, not just the
+    /// collection. Without this, retyping a target path changed what was on screen and nothing
+    /// else - and the script is what gets executed.
+    /// </summary>
+    partial void OnFetchedFileMovesChanged(
+        ObservableCollection<FileMoveOption>? oldValue,
+        ObservableCollection<FileMoveOption> newValue)
+    {
+        if (oldValue != null)
+            foreach (var move in oldValue) move.PropertyChanged -= OnFileMoveChanged;
+
+        foreach (var move in newValue) move.PropertyChanged += OnFileMoveChanged;
+    }
+
+    private void OnFileMoveChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        => UpdateRestoreSummary();
+
     [ObservableProperty]
     private bool _hasFetchedFileMoves;
 
@@ -1440,6 +1458,16 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnWithChecksumChanged(bool value) => UpdateRestoreSummary();
     partial void OnContinueAfterErrorChanged(bool value) => UpdateRestoreSummary();
 
+    // These four are typed into text boxes rather than ticked, and every one of them was missing
+    // its handler - so the script on screen did not change when they did. That is the exact
+    // failure RegenerateScript exists to prevent: typing a new data-file path, watching the box
+    // update, and running a script that still had the old one - or, for WITH MOVE, no MOVE clause
+    // at all, sending the restore to the file paths baked into the backup.
+    partial void OnMoveDataFilePathChanged(string value) => UpdateRestoreSummary();
+    partial void OnMoveLogFilePathChanged(string value) => UpdateRestoreSummary();
+    partial void OnStandbyFilePathChanged(string value) => UpdateRestoreSummary();
+    partial void OnStatsPercentChanged(int value) => UpdateRestoreSummary();
+
     // Verification opens its own connection and reads whole backups. Letting it start while a
     // restore is running would put a second heavy reader on the same server at the worst moment.
     partial void OnIsExecutingChanged(bool value) => VerifyChainCommand.NotifyCanExecuteChanged();
@@ -1460,6 +1488,15 @@ public partial class RestoreViewModel : ViewModelBase
         CopyFileListOnlyCommandCommand.NotifyCanExecuteChanged();
         CopyHeaderOnlyCommandCommand.NotifyCanExecuteChanged();
     }
+
+    /// <summary>
+    /// STANDBY needs somewhere to put its undo file. Blank produced <c>STANDBY = ''</c>, which
+    /// SQL Server rejects - as the LAST statement of the chain, so it failed after SET SINGLE_USER
+    /// and WITH REPLACE had already dropped and overwritten the target, leaving it in RESTORING
+    /// and single-user with nothing to show for it.
+    /// </summary>
+    private bool HasStandbyFileIfNeeded =>
+        RecoveryMode != RecoveryMode.Standby || !string.IsNullOrWhiteSpace(StandbyFilePath);
 
     /// <summary>
     /// Explicit Generate. Same work as the live rebuild, but it says why nothing was produced -
@@ -1488,6 +1525,13 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
+        if (!HasStandbyFileIfNeeded)
+        {
+            SetError("STANDBY needs an undo file path. Without one the script would end in " +
+                     "STANDBY = '', which fails after the database has already been overwritten.");
+            return;
+        }
+
         RegenerateScript();
         if (HasScript) SetStatus("Script generated successfully.");
     }
@@ -1510,7 +1554,8 @@ public partial class RestoreViewModel : ViewModelBase
 
         if (RestoreChain == null
             || string.IsNullOrWhiteSpace(TargetDatabaseName)
-            || (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null))
+            || (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null)
+            || !HasStandbyFileIfNeeded)
         {
             GeneratedScript = string.Empty;
             HasScript = false;
@@ -1763,14 +1808,32 @@ public partial class RestoreViewModel : ViewModelBase
         if (string.IsNullOrEmpty(GeneratedScript) || !IsConnectedToServer)
             return;
 
-        // Refuse to arm when the chain cannot possibly restore. This is the last safe moment:
+        // Rebuild before arming, so what runs is what the options currently say - not whatever the
+        // last change handler happened to leave behind. Every option is supposed to keep the script
+        // in step on its own; this is the backstop that makes forgetting one a stale display rather
+        // than a restore that does something different from what it shows.
+        RegenerateScript();
+        if (string.IsNullOrEmpty(GeneratedScript))
+        {
+            SetError("The current options do not produce a script. Check the settings above.");
+            IsExecuteArmed = false;
+            ExecuteButtonText = "Execute on Server";
+            return;
+        }
+
+        // Refuse to run when the chain cannot possibly restore. This is the last safe moment:
         // once execution starts, WITH REPLACE drops the target database, and a chain that fails
         // partway leaves nothing usable behind. Failing here costs the user a few seconds;
         // failing mid-restore costs them the database they were restoring over.
-        if (HasChainErrors && !IsExecuteArmed)
+        //
+        // Checked on the confirm press as well as when arming: validation can finish during the
+        // five-second countdown and find an error that was not known when the button was armed.
+        if (HasChainErrors)
         {
             var first = ChainIssues.First(i => i.IsError);
             SetError($"Cannot execute: {first.Title}. {first.Detail}");
+            IsExecuteArmed = false;
+            ExecuteButtonText = "Execute on Server";
             return;
         }
 
@@ -1801,6 +1864,10 @@ public partial class RestoreViewModel : ViewModelBase
 
         var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
+        // Reset alongside ExecutionComplete. Left over from a previous run it could combine with an
+        // early bail-out to show the success banner - and write "Outcome: Succeeded" into a saved
+        // log - for a restore that never ran.
+        ExecutionSuccess = false;
         ExecutionComplete = false;
         ConsoleLines.Clear();
         HasConsoleOutput = false;


### PR DESCRIPTION
From the full code review. These are the findings serious enough to fix immediately rather than file — all of them break the one invariant the Restore screen rests on: **the script on screen is the script that runs.**

People read the generated T-SQL before executing it against production. If an option can change without the script following, the thing they read is not the thing that runs.

## Four options never reached the script

`MoveDataFilePath`, `MoveLogFilePath`, `StandbyFilePath` and `StatsPercent` are typed into text boxes rather than ticked, and **none of them had a change handler**. Fifteen options did; these four didn't. Editing them updated the box and nothing else.

The worst shape of it: tick **Restore to different file locations** while connected. The fetch of the server's default paths is fire-and-forget, so `UpdateRestoreSummary` ran while both paths were still empty — and the fallback branch needs a non-empty `MoveDataFilePath`. The paths then visibly filled in a moment later and regenerated nothing.

So: WITH MOVE ticked, paths on screen, and a script with **no MOVE clause at all** — meaning SQL Server restores to the file paths baked into the backup, which are the *source* database's own `.mdf`/`.ldf`. Against a server already hosting that database, that overwrites the live files, after `SET SINGLE_USER` and `WITH REPLACE` have run.

Same for retyping a target path in the fetched-logical-files grid: `FileMoveOption` was a plain POCO, so nothing knew the row had changed. It's observable now and the viewmodel subscribes per row.

## STANDBY with no undo file wrote `STANDBY = ''`

Pick STANDBY, leave the path empty. That's the **last statement of the chain**, so it fails after the target has already been dropped and overwritten — leaving it in RESTORING *and* SINGLE_USER, since the `SET MULTI_USER` only fires for `RecoveryMode.Recovery`.

No script is produced without an undo file now, and **Generate Script** says why.

## Two smaller ones from the same review

**The script is regenerated before arming.** Belt and braces: every option is still supposed to keep the script in step on its own, but forgetting a handler is now a stale display rather than a restore that does something different from what it shows.

**Chain errors are re-checked on the confirm press**, not only when arming. `ValidateChain` can finish during the five-second countdown and find an error that wasn't known when the button was armed.

**`ExecutionSuccess` is reset at the start of a run.** Left over from a previous run it could combine with an early bail-out to show the success banner — and write `Outcome: Succeeded` into a saved log — for a restore that never ran. Narrow to reach, but it's the one flag that says the restore worked.

## Tests

7 new; **five of them fail against the code before this change**, verified by reverting. **686 total**, build clean at `-warnaserror`.

## Not in this PR

The review found plenty more, filed separately rather than bundled here: no cancellation on Verify/Validate/recovery actions (`CommandTimeout = 0` with no Stop button), changing container on the Restore screen leaving the chain and script stale, secrets written to Credential Manager before the config write is known to have succeeded, `Refresh Token` silently wiping a container's tags, and the `null!` placeholders on the chain members.

