### PR TITLE
Stop the Restore screen and the container editor keeping stale state

### DIFF
--- a/src/NineLives.Tests/ContainerEditingTests.cs
+++ b/src/NineLives.Tests/ContainerEditingTests.cs
@@ -1,0 +1,96 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Editing a saved container without losing anything that was already on it.
+/// </summary>
+public class ContainerEditingTests
+{
+    private readonly FakeCredentialStore _store = new();
+
+    private BlobConfigViewModel NewViewModel()
+        => new(_store, new FakeBlobStorageService());
+
+    private BlobContainerConfig Tagged()
+    {
+        var container = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups",
+            PathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}"
+        };
+        container.Tags.Add("prod");
+        container.Tags.Add("uk-south");
+
+        _store.Config.BlobContainers.Add(container);
+        return container;
+    }
+
+    /// <summary>
+    /// Refresh Token is a separate button from Edit, so replacing an expired SAS is the natural
+    /// way to reach it - and it repopulated every field of the edit form EXCEPT the tags, which
+    /// Save then wrote back as empty. Silent, persisted, no undo.
+    /// </summary>
+    [Fact]
+    public void RefreshingTheTokenKeepsTheTags()
+    {
+        var container = Tagged();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+
+        vm.RefreshTokenCommand.Execute(null);
+        vm.EditSasToken = "sv=2026-01-01&sig=replacement";
+        vm.SaveCommand.Execute(null);
+
+        var saved = Assert.Single(_store.Config.BlobContainers);
+        Assert.Equal(["prod", "uk-south"], saved.Tags.OrderBy(t => t));
+    }
+
+    [Fact]
+    public void RefreshingTheTokenShowsTheExistingTagsInTheBox()
+    {
+        Tagged();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+
+        vm.RefreshTokenCommand.Execute(null);
+
+        Assert.Contains("prod", vm.EditTags);
+        Assert.Contains("uk-south", vm.EditTags);
+    }
+
+    [Fact]
+    public void ChangingOnlyTheTagsCountsAsAnUnsavedChange()
+    {
+        Tagged();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        Assert.False(vm.HasUnsavedChanges);
+
+        vm.EditTags = "prod, uk-south, restored-here";
+
+        Assert.True(vm.HasUnsavedChanges);
+    }
+
+    [Fact]
+    public void EditingTheTagsSavesThem()
+    {
+        Tagged();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        vm.EditTags = "staging";
+        vm.SaveCommand.Execute(null);
+
+        var saved = Assert.Single(_store.Config.BlobContainers);
+        Assert.Equal(["staging"], saved.Tags);
+    }
+}

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -205,6 +205,64 @@ public class RestoreViewModelTests
         Assert.True(vm.TimelineHeight > 50);
     }
 
+    // ── changing container ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Everything on the Restore screen below the container dropdown came from that container.
+    /// Switching it left the timeline, the chain and the script belonging to the previous one,
+    /// while the credential panel and Create credential moved to the new one - so Execute stayed
+    /// armed, pointed at the old container's URLs, and failed with Msg 3201 after WITH REPLACE had
+    /// already dropped the target.
+    /// </summary>
+    [Fact]
+    public async Task ChangingContainerDropsWhatTheLastOneLoaded()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        Assert.True(vm.BackupsLoaded);
+        Assert.NotEmpty(vm.RestorePoints);
+        Assert.NotEmpty(vm.GeneratedScript);
+
+        vm.SelectedContainer = Container();   // a different container
+
+        Assert.False(vm.BackupsLoaded);
+        Assert.Empty(vm.RestorePoints);
+        Assert.False(vm.HasRestorePoints);
+        Assert.Null(vm.SelectedRestorePoint);
+        Assert.Null(vm.RestoreChain);
+        Assert.Empty(vm.GeneratedScript);
+        Assert.False(vm.HasScript);
+        Assert.Empty(vm.DiscoveredDatabases);
+    }
+
+    [Fact]
+    public async Task ChangingContainerDisarmsExecute()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(1);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        await vm.ExecuteScriptCommand.ExecuteAsync(null);
+        Assert.True(vm.IsExecuteArmed);
+
+        vm.SelectedContainer = Container();
+
+        Assert.False(vm.IsExecuteArmed);
+    }
+
     // ── narrowing the restore points (#27) ──────────────────────────────────────
 
     [Fact]

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -30,6 +30,8 @@ public partial class BlobConfigViewModel : ViewModelBase
     [ObservableProperty]
     private string _editTags = string.Empty;
 
+    private string _originalTags = string.Empty;
+
     [ObservableProperty]
     private string _editContainerUrl = string.Empty;
 
@@ -167,6 +169,10 @@ public partial class BlobConfigViewModel : ViewModelBase
     }
     partial void OnEditAgPathPatternChanged(string? value) => CheckForUnsavedChanges();
 
+    // Tags are saved like every other field, so editing only the tags has to count as an unsaved
+    // change - otherwise the guard that protects unsaved edits lets them be discarded silently.
+    partial void OnEditTagsChanged(string value) => CheckForUnsavedChanges();
+
     private void CheckForUnsavedChanges()
     {
         if (!IsEditing) return;
@@ -179,7 +185,8 @@ public partial class BlobConfigViewModel : ViewModelBase
             sasChanged ||
             EditPathPattern != _originalPattern ||
             EditBackupSourceType != _originalBackupSourceType ||
-            EditAgPathPattern != _originalAgPathPattern;
+            EditAgPathPattern != _originalAgPathPattern ||
+            EditTags != _originalTags;
     }
 
     private void StoreOriginalValues()
@@ -190,6 +197,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         _originalPattern = EditPathPattern;
         _originalBackupSourceType = EditBackupSourceType;
         _originalAgPathPattern = EditAgPathPattern;
+        _originalTags = EditTags;
         HasUnsavedChanges = false;
     }
 
@@ -510,6 +518,13 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditPathPattern = SelectedContainer.PathPattern;
         EditBackupSourceType = SelectedContainer.BackupSourceType;
         EditAgPathPattern = SelectedContainer.AgPathPattern;
+
+        // Tags too. Save writes whatever is in this box over the container's tags, so leaving it
+        // empty here deleted every tag on any container whose token was refreshed - silently, and
+        // with no undo. Refresh Token is a separate button from Edit, so replacing an expired
+        // token was the natural way to hit it.
+        EditTags = TagPalette.FormatTags(SelectedContainer.Tags);
+
         SyncPathElementsFromPattern();
         SyncAgPathElementsFromPattern();
         IsNew = false;

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -386,7 +386,51 @@ public partial class RestoreViewModel : ViewModelBase
         if (value != null)
             SqlCredentialName = value.ContainerUrl;
         CredentialSectionVisible = value != null;
+
+        // Everything on screen below this point came from the PREVIOUS container. Leaving it there
+        // meant the credential panel and Create credential targeted the new container while the
+        // script still restored from the old one's URLs - so Execute stayed armed and enabled, and
+        // failed with Msg 3201 after WITH REPLACE had already dropped the target.
+        ClearLoadedBackups();
+
         _ = RefreshCredentialStatusAsync();
+    }
+
+    /// <summary>
+    /// Drops everything derived from a container's contents. Called when the container changes and
+    /// when a load is abandoned, so what is on screen always belongs to the container named above
+    /// it.
+    /// </summary>
+    private void ClearLoadedBackups()
+    {
+        _allBackups = [];
+        _allSets = [];
+        _dbSets = [];
+        _allPoints = [];
+
+        BackupsLoaded = false;
+        DiscoveredServers = [];
+        DiscoveredDatabases = [];
+        SelectedServerName = null;
+        SelectedDatabaseName = null;
+
+        RestorePoints = [];
+        HasRestorePoints = false;
+        HasVisiblePoints = false;
+        PointCountText = string.Empty;
+        RestoreWindowText = string.Empty;
+        TimelineTicks.Clear();
+        TimelineHeight = 50;
+
+        // Assigning null runs the selection handler, which clears the chain, the script, the
+        // verification results and the inventory findings.
+        SelectedRestorePoint = null;
+
+        // Disarm. An armed Execute that survives a container change is an armed Execute aimed at
+        // something the user is no longer looking at.
+        IsExecuteArmed = false;
+        ExecuteButtonText = "Execute on Server";
+        _armTimeoutCts?.Cancel();
     }
 
     /// <summary>Call when ConnectedServer or SelectedContainer changes so credential status is updated.</summary>
@@ -647,6 +691,11 @@ public partial class RestoreViewModel : ViewModelBase
             InspectBackupMetadataCommand.NotifyCanExecuteChanged();
             CopyFileListOnlyCommandCommand.NotifyCanExecuteChanged();
             CopyHeaderOnlyCommandCommand.NotifyCanExecuteChanged();
+
+            // No selected point means no script. Clearing the chain and leaving the script behind
+            // left a complete, authoritative-looking RESTORE on screen with nothing selected above
+            // it - which is the stale-script problem in its purest form.
+            UpdateRestoreSummary();
             return;
         }
 


### PR DESCRIPTION
Two unambiguous defects from the code review, both "state not kept in step".

## Changing the container left everything else behind (#112)

The handler updated the credential panel and nothing else. `BlobBrowserViewModel` clears its state on the same event; this one did not.

Load container A, select a restore point, switch to B. The credential panel and **Create credential on server** now target B - pushing B''s SAS under a credential named for B''s URL - while the script still restores from **A''s** URLs. Execute stayed armed and enabled, and would fail with Msg 3201 after `WITH REPLACE` had already dropped the target.

Everything derived from a container is now dropped when it changes, and Execute is disarmed - an armed Execute that survives a container change is an armed Execute aimed at something the user is no longer looking at.

Clearing the selected restore point now clears the script too. It used to leave a complete, authoritative-looking RESTORE on screen with nothing selected above it.

## Refresh Token silently wiped a container''s tags (#114)

`RefreshToken` repopulates the edit form - name, URL, pattern, source type, AG pattern - but not the tags. `Save` then writes that empty box over `container.Tags`.

Refresh Token is a separate button from Edit, so replacing an expired SAS is the natural way to hit it. Every tag on that container was deleted and persisted, with no warning and no undo.

Tags are also part of the unsaved-changes check now, which they never were - editing only the tags left `HasUnsavedChanges` false, so the guard protecting unsaved edits did not fire.

## Tests

6 new; **692 total**, build clean at `-warnaserror`.