### PR TITLE
Let the server queries be stopped (#111)

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -173,10 +173,23 @@ public sealed class FakeSqlServerService : ISqlServerService
         ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
         => Task.FromResult<BackupFileInfo?>(null);
 
+    /// <summary>Called with the token the viewmodel supplied, so a test can see it was cancellable.</summary>
+    public Action<CancellationToken>? OnVerify { get; set; }
+
+    /// <summary>Every token handed to a verify call, so a test can prove one was passed at all.</summary>
+    public List<CancellationToken> VerifyTokens { get; } = [];
+
     public Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
         ServerConnection server, IReadOnlyList<string> blobUrls, bool withChecksum = false, CancellationToken ct = default)
     {
         VerifiedUrls.AddRange(blobUrls);
+        VerifyTokens.Add(ct);
+        OnVerify?.Invoke(ct);
+
+        // The real service translates a cancelled command into this; the fake has to as well, or a
+        // test would pass against a viewmodel that ignores the token entirely.
+        ct.ThrowIfCancellationRequested();
+
         return Task.FromResult(VerifyResult);
     }
 

--- a/src/NineLives.Tests/QueryCancellationTests.cs
+++ b/src/NineLives.Tests/QueryCancellationTests.cs
@@ -1,0 +1,144 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Stopping a server query that is already running (#111).
+///
+/// `RESTORE VERIFYONLY` reads every byte of every backup in the chain at `CommandTimeout = 0`.
+/// Before this there was no token, no Stop button and no timeout: on a large chain the app was
+/// unresponsive for hours and the only way out was killing the process, which left the reads
+/// running server-side.
+/// </summary>
+public class QueryCancellationTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+        new FakeRestoreHistoryStore());
+
+    private static BackupFileInfo File(string blobName, BackupType type, DateTime stamp)
+        => new()
+        {
+            BlobName = blobName,
+            BlobUrl = $"https://mystorageaccount.blob.core.windows.net/backups/{blobName}",
+            Type = type,
+            InferredServerName = "SRV01",
+            InferredDatabaseName = "MyDb",
+            SizeBytes = 1000,
+            LastModified = new DateTimeOffset(stamp, TimeSpan.Zero)
+        };
+
+    /// <summary>A full plus three logs, so the chain has four sets to verify one at a time.</summary>
+    private async Task<RestoreViewModel> Connected()
+    {
+        _blob.Files =
+        [
+            File("FULL/SRV01/MyDb/20260110_220000.bak", BackupType.Full, T0),
+            File("LOG/SRV01/MyDb/20260110_230000.trn", BackupType.TransactionLog, T0.AddHours(1)),
+            File("LOG/SRV01/MyDb/20260111_000000.trn", BackupType.TransactionLog, T0.AddHours(2)),
+            File("LOG/SRV01/MyDb/20260111_010000.trn", BackupType.TransactionLog, T0.AddHours(3)),
+        ];
+
+        var vm = NewViewModel();
+        vm.SelectedContainer = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        return vm;
+    }
+
+    [Fact]
+    public async Task VerifyIsGivenARealTokenRatherThanNone()
+    {
+        var vm = await Connected();
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.NotEmpty(_sql.VerifyTokens);
+        Assert.All(_sql.VerifyTokens, t => Assert.True(t.CanBeCanceled,
+            "The viewmodel passed CancellationToken.None, so there is nothing a Stop button could do."));
+    }
+
+    [Fact]
+    public async Task StoppingMidVerifyLeavesTheRestUnread()
+    {
+        var vm = await Connected();
+
+        // Stop as soon as the first backup is being read, the way pressing the button would.
+        _sql.OnVerify = _ => vm.CancelQueryCommand.Execute(null);
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        // Four sets in the chain; the first raises the cancel, so nothing after it runs.
+        Assert.Single(_sql.VerifyTokens);
+        Assert.Contains("cancel", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Cancelling is not a failure. Reporting it as one would tell the user their backups are bad
+    /// when all they did was press Stop - the same trap the restore path already guards against.
+    /// </summary>
+    [Fact]
+    public async Task StoppingIsNotReportedAsAVerificationFailure()
+    {
+        var vm = await Connected();
+        _sql.OnVerify = _ => vm.CancelQueryCommand.Execute(null);
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.False(vm.HasError);
+        Assert.False(vm.HasVerifyFailures);
+    }
+
+    [Fact]
+    public async Task TheStopButtonIsOfferedOnlyWhileSomethingIsRunning()
+    {
+        var vm = await Connected();
+
+        Assert.False(vm.CanCancelQuery);
+
+        bool offeredDuring = false;
+        _sql.OnVerify = _ => offeredDuring = vm.CanCancelQuery;
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.True(offeredDuring, "No Stop was offered while the verify was running.");
+        Assert.False(vm.CanCancelQuery);
+    }
+
+    [Fact]
+    public async Task AFinishedVerifyLeavesNothingToCancel()
+    {
+        var vm = await Connected();
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.False(vm.CanCancelQuery);
+        Assert.False(vm.IsCancelling);
+        Assert.Equal(4, _sql.VerifyTokens.Count);
+    }
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1,4 +1,4 @@
-using System.Data;
+﻿using System.Data;
 using System.Security;
 using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
@@ -191,7 +191,9 @@ public class SqlServerService : ISqlServerService
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 0;
         cmd.CommandText = sql;
-        await cmd.ExecuteNonQueryAsync(ct);
+
+        await CancellableAsync(
+            () => cmd.ExecuteNonQueryAsync(ct), ct, "The recovery action");
     }
 
     public async Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
@@ -243,19 +245,22 @@ public class SqlServerService : ISqlServerService
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         cmd.CommandText = $"RESTORE FILELISTONLY FROM {urlClauses}";
 
-        var files = new List<FileMoveOption>();
-        await using var reader = await cmd.ExecuteReaderAsync(ct);
-        while (await reader.ReadAsync(ct))
+        return await CancellableAsync(async () =>
         {
-            files.Add(new FileMoveOption
+            var files = new List<FileMoveOption>();
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
             {
-                LogicalName = reader.GetString(reader.GetOrdinal("LogicalName")),
-                PhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName")),
-                Type = reader.GetString(reader.GetOrdinal("Type")),
-                NewPhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName"))
-            });
-        }
-        return files;
+                files.Add(new FileMoveOption
+                {
+                    LogicalName = reader.GetString(reader.GetOrdinal("LogicalName")),
+                    PhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName")),
+                    Type = reader.GetString(reader.GetOrdinal("Type")),
+                    NewPhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName"))
+                });
+            }
+            return files;
+        }, ct, "Reading the file list");
     }
 
     /// <summary>RESTORE HEADERONLY across the files of one backup set, striped or not.</summary>
@@ -272,6 +277,8 @@ public class SqlServerService : ISqlServerService
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         cmd.CommandText = $"RESTORE HEADERONLY FROM {urlClauses}";
 
+        return await CancellableAsync<BackupFileInfo?>(async () =>
+        {
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         if (!await reader.ReadAsync(ct)) return null;
 
@@ -294,6 +301,7 @@ public class SqlServerService : ISqlServerService
             DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN"),
             CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN")
         };
+        }, ct, "Reading the backup header");
     }
 
     /// <summary>
@@ -354,6 +362,33 @@ public class SqlServerService : ISqlServerService
                 ? string.Join(" ", messages.Select(m => m.Trim()))
                 : "The backup set is valid.");
     }
+
+    /// <summary>
+    /// Runs something against SQL Server and translates a cancellation into the exception the
+    /// caller expects.
+    ///
+    /// SqlClient reports a command cancelled mid-flight as a SqlException - "A severe error
+    /// occurred on the current command" - not an OperationCanceledException. Every call site that
+    /// takes a token needs the same trap, and writing it out at each one is how three of them came
+    /// to be missing it. Only when the token was actually signalled, so a genuine severe error
+    /// still propagates as the failure it is.
+    /// </summary>
+    private static async Task<T> CancellableAsync<T>(
+        Func<Task<T>> work, CancellationToken ct, string what)
+    {
+        try
+        {
+            return await work();
+        }
+        catch (SqlException) when (ct.IsCancellationRequested)
+        {
+            throw new OperationCanceledException($"{what} was cancelled.", ct);
+        }
+    }
+
+    private static async Task CancellableAsync(
+        Func<Task> work, CancellationToken ct, string what)
+        => await CancellableAsync<bool>(async () => { await work(); return true; }, ct, what);
 
     /// <summary>
     /// The exact T-SQL a verification runs. Every file of a striped set goes into one statement -

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -30,6 +30,24 @@ public partial class RestoreViewModel : ViewModelBase
     private readonly OperationCancellation _loadCancellation = new();
     private readonly OperationCancellation _executeCancellation = new();
 
+    /// <summary>
+    /// The server queries a user starts and might want to abandon: verify, validate, the two
+    /// metadata reads, creating the credential, and the post-failure recovery actions (#111).
+    ///
+    /// They share one source because they are mutually exclusive buttons - starting one while
+    /// another runs should stop the first, which is exactly what Begin() does. RESTORE VERIFYONLY
+    /// reads every byte of every backup in the chain at CommandTimeout = 0, so on a large chain
+    /// this was hours with no Stop button and no timeout.
+    /// </summary>
+    private readonly OperationCancellation _queryCancellation = new();
+
+    /// <summary>
+    /// The background credential check. Separate because it is not user-initiated and has no
+    /// button - and because it races itself: two overlapping checks would leave the panel showing
+    /// the result for whichever finished last, which could be the container the user just left.
+    /// </summary>
+    private readonly OperationCancellation _credentialCheckCancellation = new();
+
     #region Observable Properties
 
     [ObservableProperty]
@@ -206,6 +224,10 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _canCancelExecute;
 
+    /// <summary>True while a server query is running and has not been asked to stop (#111).</summary>
+    [ObservableProperty]
+    private bool _canCancelQuery;
+
     /// <summary>True between asking to stop and the operation actually unwinding.</summary>
     [ObservableProperty]
     private bool _isCancelling;
@@ -244,7 +266,10 @@ public partial class RestoreViewModel : ViewModelBase
     {
         CanCancelLoad = _loadCancellation.CanCancel;
         CanCancelExecute = _executeCancellation.CanCancel;
-        IsCancelling = _loadCancellation.IsCancelling || _executeCancellation.IsCancelling;
+        CanCancelQuery = _queryCancellation.CanCancel;
+        IsCancelling = _loadCancellation.IsCancelling
+            || _executeCancellation.IsCancelling
+            || _queryCancellation.IsCancelling;
     }
 
     /// <summary>True once the chain has been checked against RESTORE HEADERONLY metadata.</summary>
@@ -445,17 +470,28 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
+        // Cancels any check already in flight. Two overlapping checks left the panel showing the
+        // result of whichever finished LAST, which could be the container the user had just left -
+        // and that panel is what someone reads before deciding whether to create a credential.
+        var ct = _credentialCheckCancellation.Begin();
+
         IsCheckingCredential = true;
         CredentialStatusMessage = "Checking...";
-        var server = ConnectedServer!;
+        var server = ConnectedServer;
         try
         {
-            var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
+            var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName, ct);
             CredentialExistsOnServer = exists;
             CredentialIsValidSas = exists && isSas;
             CredentialStatusMessage = exists
                 ? (isSas ? "Credential is present and valid (SHARED ACCESS SIGNATURE)." : "Credential exists but is not a SAS credential; restore may fail.")
                 : "Credential is not present on this server. Restore will fail unless you create it.";
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer check - which is about to write its own answer here. Saying
+            // anything would just be the older check having the last word again.
+            return;
         }
         catch (Exception ex)
         {
@@ -465,8 +501,15 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
-            IsCheckingCredential = false;
-            CreateCredentialOnServerCommand.NotifyCanExecuteChanged();
+            // Only when this check is still the current one. Ending the newer check's source, or
+            // clearing its "Checking..." state, is how the previous version left the panel
+            // reporting the container the user had already moved away from.
+            if (!ct.IsCancellationRequested)
+            {
+                _credentialCheckCancellation.End();
+                IsCheckingCredential = false;
+                CreateCredentialOnServerCommand.NotifyCanExecuteChanged();
+            }
         }
     }
 
@@ -825,6 +868,20 @@ public partial class RestoreViewModel : ViewModelBase
         return new BlobListingScope(pathServer, SelectedDatabaseName);
     }
 
+    /// <summary>
+    /// Stops whichever server query is running - verify, validate, a metadata read, or a recovery
+    /// action. They share one source because they are mutually exclusive buttons (#111).
+    /// </summary>
+    [RelayCommand]
+    private void CancelQuery()
+    {
+        if (!_queryCancellation.CanCancel) return;
+
+        _queryCancellation.Cancel();
+        RefreshCancelState();
+        SetStatus("Stopping...");
+    }
+
     /// <summary>Stops an in-progress backup listing.</summary>
     [RelayCommand]
     private void CancelLoad()
@@ -1165,7 +1222,8 @@ public partial class RestoreViewModel : ViewModelBase
         PathSourceText = $"Querying {ConnectedServer.ServerName} for default paths...";
         try
         {
-            var (dataPath, logPath) = await _sqlService.GetDefaultPathsAsync(ConnectedServer);
+            var (dataPath, logPath) = await _sqlService.GetDefaultPathsAsync(
+                ConnectedServer, _queryCancellation.Begin());
             var dbName = string.IsNullOrWhiteSpace(TargetDatabaseName) ? "DatabaseName" : TargetDatabaseName;
 
             if (!string.IsNullOrEmpty(dataPath))
@@ -1286,18 +1344,28 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || ConnectedServer == null) return;
 
+        var ct = _queryCancellation.Begin();
         IsValidatingChain = true;
+        RefreshCancelState();
         ClearStatus();
         try
         {
             var headers = new List<ChainHeader>();
             foreach (var set in RestoreChain.AllSets)
             {
+                ct.ThrowIfCancellationRequested();
+
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 try
                 {
-                    var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls);
+                    var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls, ct);
                     headers.Add(new ChainHeader(set, header));
+                }
+                catch (OperationCanceledException)
+                {
+                    // Asked for. Must not be swallowed by the per-member catch below, which exists
+                    // so ONE unreadable backup does not abort the rest.
+                    throw;
                 }
                 catch (Exception)
                 {
@@ -1314,13 +1382,19 @@ public partial class RestoreViewModel : ViewModelBase
                 ? $"Chain validation found problems - see the panel above."
                 : $"Chain validated: {headers.Count} backup(s) read, LSN chain is intact.");
         }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Chain validation cancelled.");
+        }
         catch (Exception ex)
         {
             SetError($"Chain validation failed: {ex.Message}");
         }
         finally
         {
+            _queryCancellation.End();
             IsValidatingChain = false;
+            RefreshCancelState();
         }
     }
 
@@ -1341,7 +1415,9 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || ConnectedServer == null) return;
 
+        var ct = _queryCancellation.Begin();
         IsVerifyingChain = true;
+        RefreshCancelState();
         ClearStatus();
         ChainVerifyResults.Clear();
         HasVerifyResults = false;
@@ -1356,7 +1432,7 @@ public partial class RestoreViewModel : ViewModelBase
 
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 var result = await _sqlService.RestoreVerifyOnlyAsync(
-                    ConnectedServer, urls, WithChecksum);
+                    ConnectedServer, urls, WithChecksum, ct);
 
                 ChainVerifyResults.Add(new ChainVerifyResult { Set = set, Result = result });
                 HasVerifyResults = true;
@@ -1379,7 +1455,9 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _queryCancellation.End();
             IsVerifyingChain = false;
+            RefreshCancelState();
         }
     }
 
@@ -1667,7 +1745,8 @@ public partial class RestoreViewModel : ViewModelBase
         try
         {
             var change = await _sqlService.EnsureCredentialExistsAsync(
-                ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
+                ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken,
+                _queryCancellation.Begin());
             await RefreshCredentialStatusAsync();
             SetStatus(change == CredentialChange.Created
                 ? "Credential created on server."
@@ -1712,13 +1791,15 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || ConnectedServer == null || SelectedContainer == null) return;
 
+        var ct = _queryCancellation.Begin();
         IsBusy = true;
+        RefreshCancelState();
         BackupMetadataSummary = null;
         try
         {
             // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
             var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls);
+            var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls, ct);
 
             var dataDir = Path.GetDirectoryName(MoveDataFilePath) ?? @"C:\SQL\Data";
             var logDir = Path.GetDirectoryName(MoveLogFilePath) ?? dataDir;
@@ -1749,7 +1830,9 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _queryCancellation.End();
             IsBusy = false;
+            RefreshCancelState();
         }
     }
 
@@ -1761,12 +1844,14 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || ConnectedServer == null || SelectedContainer == null) return;
 
+        var ct = _queryCancellation.Begin();
         IsBusy = true;
+        RefreshCancelState();
         try
         {
             // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
             var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls);
+            var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls, ct);
 
             if (header == null)
             {
@@ -1795,7 +1880,9 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _queryCancellation.End();
             IsBusy = false;
+            RefreshCancelState();
         }
     }
 
@@ -2148,20 +2235,39 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (action == null || ConnectedServer == null) return;
 
+        // Cancellable, and it needs it more than most: this runs when a restore has already
+        // failed, RESTORE ... WITH RECOVERY can take a long time on a large database, and it goes
+        // out at CommandTimeout = 0. Without a Stop the only way out was killing the process - at
+        // the exact moment the user is trying to get their database back.
+        var ct = _queryCancellation.Begin();
+        RefreshCancelState();
+
         try
         {
             AppendLog($"\nRunning: {action.Sql}");
-            await _sqlService.ExecuteRecoveryActionAsync(ConnectedServer, action.Sql);
+            await _sqlService.ExecuteRecoveryActionAsync(ConnectedServer, action.Sql, ct);
             AppendLog("Completed.");
             await ReportRecoveryStateAsync(ConnectedServer);
 
             if (!HasRecoveryActions)
                 SetStatus($"[{TargetDatabaseName}] is back to a usable state.");
         }
+        catch (OperationCanceledException)
+        {
+            // SQL Server rolls back the statement that was in flight, so the database is where it
+            // was before this step - which is still whatever the failed restore left behind.
+            AppendLog("\nCancelled. The database is in the same state as before this step.");
+            SetStatus("Recovery step cancelled.");
+        }
         catch (Exception ex)
         {
             AppendLog($"\nERROR: {ex.Message}");
             SetError($"Recovery step failed: {ex.Message}");
+        }
+        finally
+        {
+            _queryCancellation.End();
+            RefreshCancelState();
         }
     }
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -485,6 +485,7 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
@@ -557,7 +558,19 @@
                             </Button.Content>
                         </Button>
 
+                        <!-- Only while something is running. RESTORE VERIFYONLY reads every byte
+                             of every backup in the chain at CommandTimeout = 0, so on a large
+                             chain this is the difference between waiting and killing the app. -->
                         <Button Grid.Column="3"
+                                Content="Stop"
+                                Command="{Binding CancelQueryCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="12,6" Margin="0,0,8,0"
+                                Foreground="{DynamicResource WarningBrush}"
+                                Visibility="{Binding CanCancelQuery, Converter={StaticResource BoolToVis}}"
+                                ToolTip="Stop the server query that is running." />
+
+                        <Button Grid.Column="4"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding ToggleChainDetailsCommand}"
                                 Padding="12,6">


### PR DESCRIPTION
Closes #111.

`RESTORE VERIFYONLY` reads **every byte of every backup in the chain**, at `CommandTimeout = 0`. It was given no token, so there was no Stop button and no timeout - on a large chain the app sat unresponsive for hours and the only way out was killing the process, which left the reads running server-side.

The cancellation trap already written into `RestoreVerifyOnlyAsync` - translating the `SqlException` a cancelled command raises into `OperationCanceledException` - could never fire, and the `catch (OperationCanceledException)` in the viewmodel was dead code.

Validate Chain, both metadata reads, creating the credential, fetching the default paths and the post-failure recovery actions were all the same. **The recovery action is the worst of them**: `RESTORE ... WITH RECOVERY`, uncancellable, at `CommandTimeout = 0`, at exactly the moment the user is trying to get their database back after a failed restore.

## How

One `OperationCancellation` shared by all of them, with a **Stop** button that appears while something is running. They share a source because they are mutually exclusive buttons, and `Begin()` cancelling the previous run is the behaviour wanted when one is started while another is going.

The background credential check gets **its own** source. That also fixes it racing itself: two overlapping checks left the panel showing the result for whichever finished *last*, which could be the container the user had just left - and that panel is what someone reads before deciding whether to create a credential.

A shared `CancellableAsync` helper in the service replaces the per-call-site translation, which is how three of them came to be missing it in the first place.

## Tests

5 new; **697 total**, build clean at `-warnaserror`.

The fake now throws on a cancelled token the way the real service does - without that, a test would pass against a viewmodel that ignores the token entirely. One test asserts the token is actually cancellable rather than `CancellationToken.None`, which is the precise shape of the bug.
