### PR TITLE
Save the config before the secret, not after (#113)

### DIFF
--- a/src/NineLives.Tests/SaveOrderingTests.cs
+++ b/src/NineLives.Tests/SaveOrderingTests.cs
@@ -1,0 +1,157 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Config first, secret second (#113).
+///
+/// The other order wrote a durable secret to Windows Credential Manager and only then found the
+/// config could not be saved - so the vault held the new token or password while config.json still
+/// held the old name, url or username. Nothing on screen shows a stored secret, so the mismatch is
+/// invisible: connections just start failing.
+///
+/// config.json being briefly locked is the ordinary case here - antivirus, a backup agent, a sync
+/// client mid-upload. It is the same condition that caused #7.
+/// </summary>
+public class SaveOrderingTests
+{
+    private static InvalidOperationException Locked()
+        => new("config.json is in use by another process");
+
+    // ── containers ──────────────────────────────────────────────────────────────
+
+    private static (BlobConfigViewModel vm, FakeCredentialStore store) NewContainerVm()
+    {
+        var store = new FakeCredentialStore();
+        return (new BlobConfigViewModel(store, new FakeBlobStorageService()), store);
+    }
+
+    [Fact]
+    public void ARefusedSaveDoesNotStoreTheSasToken()
+    {
+        var (vm, store) = NewContainerVm();
+        store.SaveConfigThrows = Locked();
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2026-01-01&sig=never-persisted";
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Empty(store.ListCredentialKeys("NineLives:Blob:"));
+    }
+
+    [Fact]
+    public void ARefusedSaveLeavesTheContainerAsItWas()
+    {
+        var (vm, store) = NewContainerVm();
+
+        var existing = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+        existing.Tags.Add("prod");
+        store.Config.BlobContainers.Add(existing);
+
+        vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        store.SaveConfigThrows = Locked();
+
+        vm.EditName = "renamed";
+        vm.EditTags = "staging";
+        vm.SaveCommand.Execute(null);
+
+        // The in-memory container must not keep values that never reached the disk - the next save
+        // would write them without the user knowing they were pending.
+        var container = vm.Containers.Single();
+        Assert.Equal("backups", container.Name);
+        Assert.Equal(["prod"], container.Tags);
+    }
+
+    [Fact]
+    public void ASuccessfulSaveStillStoresTheToken()
+    {
+        var (vm, store) = NewContainerVm();
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2026-01-01&sig=persisted";
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+        var saved = Assert.Single(store.Config.BlobContainers);
+        Assert.Equal("sv=2026-01-01&sig=persisted", store.GetSasToken(saved));
+    }
+
+    // ── servers ─────────────────────────────────────────────────────────────────
+
+    private static (ServerManagerViewModel vm, FakeCredentialStore store) NewServerVm()
+    {
+        var store = new FakeCredentialStore();
+        return (new ServerManagerViewModel(store, new FakeSqlServerService()), store);
+    }
+
+    [Fact]
+    public void ARefusedSaveDoesNotStoreTheSqlPassword()
+    {
+        var (vm, store) = NewServerVm();
+        store.SaveConfigThrows = Locked();
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "SRV01";
+        vm.EditServerName = "SRV01";
+        vm.EditAuthMode = AuthMode.SqlAuth;
+        vm.EditUsername = "restoreadmin";
+        vm.EditPassword = "never-persisted";
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Empty(store.ListCredentialKeys("NineLives:SQL:"));
+    }
+
+    /// <summary>
+    /// The shape that actually bites: username and password changed together. With the old
+    /// ordering the vault took the new password and the file kept the old username, so every
+    /// connection failed authentication with nothing on screen to explain it.
+    /// </summary>
+    [Fact]
+    public void ARefusedSaveLeavesTheServerAsItWas()
+    {
+        var store = new FakeCredentialStore();
+        var existing = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "olduser"
+        };
+        store.Config.Servers.Add(existing);
+        store.SaveSqlPassword(existing, "oldpassword");
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+        vm.SelectedServer = vm.Servers.Single();
+        vm.EditCommand.Execute(null);
+
+        store.SaveConfigThrows = Locked();
+
+        vm.EditUsername = "newuser";
+        vm.EditPassword = "newpassword";
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+
+        var server = vm.Servers.Single();
+        Assert.Equal("olduser", server.Username);
+        Assert.Equal("oldpassword", store.GetSqlPassword(server));
+    }
+}

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -189,6 +189,30 @@ public partial class BlobConfigViewModel : ViewModelBase
             EditTags != _originalTags;
     }
 
+    /// <summary>
+    /// Captures a container's persisted fields and returns the action that puts them back. Used to
+    /// undo an in-place edit when the config write is refused.
+    /// </summary>
+    private static Action Snapshot(BlobContainerConfig container)
+    {
+        var name = container.Name;
+        var url = container.ContainerUrl;
+        var pattern = container.PathPattern;
+        var sourceType = container.BackupSourceType;
+        var agPattern = container.AgPathPattern;
+        var tags = container.Tags.ToList();
+
+        return () =>
+        {
+            container.Name = name;
+            container.ContainerUrl = url;
+            container.PathPattern = pattern;
+            container.BackupSourceType = sourceType;
+            container.AgPathPattern = agPattern;
+            ReplaceTags(container.Tags, tags);
+        };
+    }
+
     private void StoreOriginalValues()
     {
         _originalName = EditName;
@@ -420,6 +444,11 @@ public partial class BlobConfigViewModel : ViewModelBase
         }
 
         BlobContainerConfig container;
+
+        // Undoes the edit if the save is refused. Null for a new container, which is removed from
+        // the list instead.
+        Action? restore = null;
+
         if (IsNew)
         {
             if (Containers.Any(c => c.Name.Equals(EditName, StringComparison.OrdinalIgnoreCase)))
@@ -444,6 +473,12 @@ public partial class BlobConfigViewModel : ViewModelBase
         else
         {
             container = SelectedContainer!;
+
+            // Snapshot before mutating, so a refused save can put the model back. Without this an
+            // edit that failed to persist left the in-memory container showing values that are not
+            // on disk - and the next save writes them without the user knowing they were pending.
+            restore = Snapshot(container);
+
             container.Name = EditName;
             // Mutate in place - see ReplaceTags.
             ReplaceTags(container.Tags, TagPalette.ParseTags(EditTags));
@@ -454,16 +489,37 @@ public partial class BlobConfigViewModel : ViewModelBase
             container.AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim();
         }
 
-        if (haveTokenToSave)
-            _credentialStore.SaveSasToken(container, EditSasToken);
-        // When editing and leaving SAS field empty, existing token is kept (never re-read or shown)
+        // Config FIRST, secret second.
+        //
+        // The other order wrote a durable secret and then discovered the config could not be
+        // saved. Change a name and a token together, have config.json briefly locked, and the
+        // Credential Manager ends up holding the NEW token under a key the OLD config points at -
+        // or, for a rename, under a name nothing references. The form never shows a stored secret,
+        // so nothing on screen reveals the mismatch. Delete already follows this rule.
         if (!SaveContainers())
         {
             // Nothing reached the disk, so do not leave the list showing a container that is not
             // really there. Stay in the edit form so the save can be retried once whatever was
             // holding the file has let go.
             if (IsNew) Containers.Remove(container);
+            else restore?.Invoke();
             return;
+        }
+
+        // When editing and leaving SAS field empty, existing token is kept (never re-read or shown)
+        if (haveTokenToSave)
+        {
+            try
+            {
+                _credentialStore.SaveSasToken(container, EditSasToken);
+            }
+            catch (Exception ex)
+            {
+                // The config is saved and consistent; only the token is missing. Say exactly that,
+                // because "save failed" would send the user looking for the wrong problem.
+                SetError($"The container was saved, but the SAS token could not be stored: {ex.Message}");
+                return;
+            }
         }
 
         SelectedContainer = container;

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -87,6 +87,34 @@ public partial class ServerManagerViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Captures a server's persisted fields and returns the action that puts them back. Used to
+    /// undo an in-place edit when the config write is refused.
+    /// </summary>
+    private static Action Snapshot(ServerConnection server)
+    {
+        var name = server.Name;
+        var serverName = server.ServerName;
+        var authMode = server.AuthMode;
+        var username = server.Username;
+        var timeout = server.ConnectionTimeoutSeconds;
+        var trust = server.TrustServerCertificate;
+        var encrypt = server.Encrypt;
+        var tags = server.Tags.ToList();
+
+        return () =>
+        {
+            server.Name = name;
+            server.ServerName = serverName;
+            server.AuthMode = authMode;
+            server.Username = username;
+            server.ConnectionTimeoutSeconds = timeout;
+            server.TrustServerCertificate = trust;
+            server.Encrypt = encrypt;
+            ReplaceTags(server.Tags, tags);
+        };
+    }
+
+    /// <summary>
     /// Persists the server list. Returns false and sets the error when the write failed, so
     /// callers do not go on to report success - the config save used to swallow everything and
     /// the UI said "saved successfully" whether or not anything reached the disk.
@@ -204,6 +232,10 @@ public partial class ServerManagerViewModel : ViewModelBase
         }
 
         ServerConnection server;
+
+        // Undoes the edit if the save is refused. Null for a new server, which is removed instead.
+        Action? restore = null;
+
         if (IsNew)
         {
             if (Servers.Any(s => s.Name.Equals(EditName, StringComparison.OrdinalIgnoreCase)))
@@ -218,6 +250,10 @@ public partial class ServerManagerViewModel : ViewModelBase
         else
         {
             server = SelectedServer!;
+
+            // Snapshot before mutating, so a refused save can put the model back rather than
+            // leaving it showing values that were never persisted.
+            restore = Snapshot(server);
         }
 
         server.Name = EditName;
@@ -231,17 +267,33 @@ public partial class ServerManagerViewModel : ViewModelBase
         server.TrustServerCertificate = EditTrustServerCert;
         server.Encrypt = EditEncrypt;
 
-        if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
-        {
-            _credentialStore.SaveSqlPassword(server, EditPassword);
-        }
-
+        // Config FIRST, password second.
+        //
+        // The other order wrote the password to Credential Manager and then found the config could
+        // not be saved. Change a login's username and password together with config.json briefly
+        // locked, and the vault holds the NEW password while the file still has the OLD username -
+        // so every connection fails auth, and the form never shows a stored password, so nothing
+        // on screen says why. Delete already follows this rule.
         if (!SaveServers())
         {
             // Nothing reached the disk, so do not leave the list showing a server that is not
             // really there. Stay in the edit form so the save can be retried.
             if (IsNew) Servers.Remove(server);
+            else restore?.Invoke();
             return;
+        }
+
+        if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
+        {
+            try
+            {
+                _credentialStore.SaveSqlPassword(server, EditPassword);
+            }
+            catch (Exception ex)
+            {
+                SetError($"The server was saved, but the password could not be stored: {ex.Message}");
+                return;
+            }
         }
 
         SelectedServer = server;


### PR DESCRIPTION
Closes #113.

Both `Save` paths wrote the secret to Windows Credential Manager **before** the config write was known to have succeeded:

```csharp
if (haveTokenToSave)
    _credentialStore.SaveSasToken(container, EditSasToken);   // durable, immediate
if (!SaveContainers())                                        // may be refused
    return;
```

`config.json` being briefly locked is the ordinary case here - antivirus, a backup agent, a sync client mid-upload. The same conditions that caused #7.

Change a SQL login''s **username and password together** and save. The save is refused and reported. Credential Manager now holds the **new** password under that server''s key while config.json still holds the **old** username. Every subsequent connection fails authentication, and the form deliberately never displays a stored secret - so there is nothing on screen that shows why.

The edit path was worse: the model was mutated in place *before* the save with no rollback, so a refused save left it showing values that were never persisted, and the next save wrote them without the user knowing they were pending.

## Now

Config first, then the secret, with a snapshot that puts the model back when the save is refused.

A secret that fails to store *after* a successful config write reports exactly that - "the container was saved, but the SAS token could not be stored" - rather than "save failed", which would send the user looking for the wrong problem.

Both `Delete` methods already followed this rule and explained why. `Save` now matches.

## Tests

5 new; **four fail against the old ordering**, verified by reverting. **702 total**, build clean at `-warnaserror`.