### PR TITLE
Remove the null! placeholders on the chain members (#116)

### DIFF
--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace Blackcat.NineLives.Models;
 
@@ -271,8 +271,12 @@ public class RestorePoint
 {
     public DateTime Timestamp { get; set; }
     public BackupType Type { get; set; }
-    public BackupSet PrimarySet { get; set; } = null!;
-    public BackupSet RequiredFullSet { get; set; } = null!;
+    // required, not null!. The old annotation claimed "never null" while the code disagreed with
+    // itself about it: IsTimestampApproximate defended with ?., TotalFiles dereferenced bare, and
+    // BackupChainValidator had a null check the compiler believed was always true. Both are only
+    // ever built fully populated, so the compiler can be told that and then enforce it.
+    public required BackupSet PrimarySet { get; set; }
+    public required BackupSet RequiredFullSet { get; set; }
     public List<BackupSet> RequiredDiffSets { get; set; } = [];
     public List<BackupSet> RequiredLogSets { get; set; } = [];
 
@@ -290,7 +294,7 @@ public class RestorePoint
     /// True when this point's own time is a blob-derived approximation, which is what decides
     /// where it lands on the timeline.
     /// </summary>
-    public bool IsTimestampApproximate => PrimarySet?.IsTimestampApproximate ?? false;
+    public bool IsTimestampApproximate => PrimarySet.IsTimestampApproximate;
 
     public string TimestampDisplay => BackupTime.Format(Timestamp, IsTimestampApproximate);
 
@@ -349,7 +353,7 @@ public class RestorePoint
 
 public class BackupChain
 {
-    public BackupSet FullSet { get; set; } = null!;
+    public required BackupSet FullSet { get; set; }
     public List<BackupSet> DiffSets { get; set; } = [];
     public List<BackupSet> LogSets { get; set; } = [];
     public DateTime? StopAt { get; set; }

--- a/src/NineLives/Services/BackupChainValidator.cs
+++ b/src/NineLives/Services/BackupChainValidator.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -171,7 +171,7 @@ public class BackupChainValidator
         var reachable = new HashSet<BackupSet>();
         foreach (var point in restorePoints)
         {
-            if (point.PrimarySet != null) reachable.Add(point.PrimarySet);
+            reachable.Add(point.PrimarySet);
             foreach (var log in point.RequiredLogSets) reachable.Add(log);
         }
 

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -222,12 +222,14 @@ public class BlobStorageService : IBlobStorageService
     {
         // Same formatter the filters match against, so the values offered in the dropdown and
         // the values compared against a set can never drift apart.
+        // OfType rather than Where(s => s != null) + a ! at the end: it drops the nulls AND tells
+        // the compiler so, instead of filtering in a way it cannot follow and then overruling it.
         return files
             .Select(f => f.ServerDisplay)
-            .Where(s => s != null)
+            .OfType<string>()
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
-            .ToList()!;
+            .ToList();
     }
 
     public ContainerSummary GetSetBasedSummary(List<BackupSet> sets)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1795,10 +1795,15 @@ public partial class RestoreViewModel : ViewModelBase
         IsBusy = true;
         RefreshCancelState();
         BackupMetadataSummary = null;
+        // Captured BEFORE the await. Selecting a different restore point sets RestoreChain to null
+        // on the UI thread, and it can do that while this call is in flight - in which case the
+        // catch below would itself throw, replacing the error explaining why FILELISTONLY failed
+        // with a bare "Nine Lives hit an unexpected error".
+        // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
+        var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+
         try
         {
-            // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
-            var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
             var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls, ct);
 
             var dataDir = Path.GetDirectoryName(MoveDataFilePath) ?? @"C:\SQL\Data";
@@ -1821,9 +1826,8 @@ public partial class RestoreViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            var urlList = RestoreChain!.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var urlPreview = urlList.Count > 0 ? urlList[0] : "(no URL)";
-            if (urlList.Count > 1) urlPreview += $" (+{urlList.Count - 1} more)";
+            var urlPreview = urls.Count > 0 ? urls[0] : "(no URL)";
+            if (urls.Count > 1) urlPreview += $" (+{urls.Count - 1} more)";
             SetError($"RESTORE FILELISTONLY failed: {ex.Message}. URL used: {urlPreview}. Run the same RESTORE FILELISTONLY in SSMS to confirm credential/network.");
             FetchedFileMoves = [];
             HasFetchedFileMoves = false;
@@ -1847,10 +1851,12 @@ public partial class RestoreViewModel : ViewModelBase
         var ct = _queryCancellation.Begin();
         IsBusy = true;
         RefreshCancelState();
+        // Captured before the await - see the note on FetchLogicalNamesAsync.
+        // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
+        var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+
         try
         {
-            // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
-            var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
             var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls, ct);
 
             if (header == null)
@@ -1872,9 +1878,8 @@ public partial class RestoreViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            var urlList = RestoreChain!.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var urlPreview = urlList.Count > 0 ? urlList[0] : "(no URL)";
-            if (urlList.Count > 1) urlPreview += $" (+{urlList.Count - 1} more)";
+            var urlPreview = urls.Count > 0 ? urls[0] : "(no URL)";
+            if (urls.Count > 1) urlPreview += $" (+{urls.Count - 1} more)";
             SetError($"RESTORE HEADERONLY failed: {ex.Message}. URL used: {urlPreview}. Run the same RESTORE HEADERONLY in SSMS to confirm credential/network.");
             BackupMetadataSummary = null;
         }


### PR DESCRIPTION
Closes #116.

`RestorePoint.PrimarySet`, `RestorePoint.RequiredFullSet` and `BackupChain.FullSet` were declared `null!`. The annotation said "never null"; the code did not believe it:

- `IsTimestampApproximate` defended with `PrimarySet?.` while `TotalFiles` and `TotalSizeBytes` - two members of the same class - dereferenced `RequiredFullSet` bare
- `BackupChainValidator` had `if (point.PrimarySet != null)`, a null check the compiler believed was always true
- `CanFetchLogicalNames` and `CanInspectMetadata` call `RestoreChain.FullSet.Files.Count` from **`CanExecute`**, where an NRE surfaces as a mystery crash rather than at the point of the bug

They are only ever built fully populated, so they are `required` now and the compiler enforces what the annotation was only asserting. Every existing construction site already used object initialisers, so nothing needed changing - which is itself the evidence the claim was true. The dead null check is gone.

## The catch blocks that could throw

`FetchLogicalNamesAsync` and `InspectBackupMetadataAsync` guard `RestoreChain == null` on entry, then used `RestoreChain!` in their **catch**. Selecting a different restore point sets `RestoreChain` to null on the UI thread and can do so while those calls are in flight - in which case the catch handler itself threw, and the message explaining why FILELISTONLY or HEADERONLY failed was replaced by a bare "Nine Lives hit an unexpected error".

The URL list is captured before the await now, so the catch has what it needs without re-reading state that may have moved.

## Also

`GetDiscoveredServers` used `.Where(s => s != null)` followed by `.ToList()!` - filtering in a way the compiler cannot follow, then overruling it. `OfType<string>()` says the same thing honestly.

**702 tests**, build clean at `-warnaserror`.