### PR TITLE
Say why Execute is disabled (#117)

### DIFF
--- a/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
+++ b/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
@@ -1,0 +1,128 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Saying why Execute cannot be pressed (#117).
+///
+/// It was disabled identically whether the user was not connected, had no script, or had a chain
+/// the app already knew would not restore. Three different problems, one greyed-out button, and
+/// the answer sitting in properties nobody displayed.
+/// </summary>
+public class ExecuteBlockedReasonTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+        new FakeRestoreHistoryStore());
+
+    private async Task<RestoreViewModel> Loaded()
+    {
+        _blob.Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = "FULL/SRV01/MyDb/20260110_220000.bak",
+                BlobUrl = "https://mystorageaccount.blob.core.windows.net/backups/FULL/SRV01/MyDb/20260110_220000.bak",
+                Type = BackupType.Full,
+                InferredServerName = "SRV01",
+                InferredDatabaseName = "MyDb",
+                SizeBytes = 1000,
+                LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+            }
+        ];
+
+        var vm = NewViewModel();
+        vm.SelectedContainer = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        return vm;
+    }
+
+    [Fact]
+    public async Task NotConnectedSaysSo()
+    {
+        var vm = await Loaded();
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        Assert.False(vm.CanPressExecute);
+        Assert.Contains("Connect", vm.ExecuteBlockedReason);
+    }
+
+    [Fact]
+    public async Task ConnectedButWithNoScriptSaysThatInstead()
+    {
+        var vm = await Loaded();
+        vm.IsConnectedToServer = true;
+        vm.TargetDatabaseName = string.Empty;   // no target, so no script
+
+        Assert.False(vm.CanPressExecute);
+        Assert.Contains("No script", vm.ExecuteBlockedReason);
+    }
+
+    [Fact]
+    public async Task AChainThatCannotRestoreSaysThatInstead()
+    {
+        var vm = await Loaded();
+        vm.IsConnectedToServer = true;
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.HasChainErrors = true;
+
+        Assert.False(vm.CanPressExecute);
+        Assert.Contains("cannot restore", vm.ExecuteBlockedReason);
+    }
+
+    [Fact]
+    public async Task NothingIsSaidWhenExecuteIsAvailable()
+    {
+        var vm = await Loaded();
+        vm.IsConnectedToServer = true;
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        Assert.True(vm.CanPressExecute);
+        Assert.False(vm.IsExecuteBlocked);
+        Assert.Empty(vm.ExecuteBlockedReason);
+    }
+
+    /// <summary>The reason has to keep up, or it explains a state the button is no longer in.</summary>
+    [Fact]
+    public async Task TheReasonFollowsTheStateThatCausedIt()
+    {
+        var vm = await Loaded();
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        Assert.Contains("Connect", vm.ExecuteBlockedReason);
+
+        vm.IsConnectedToServer = true;
+        Assert.Empty(vm.ExecuteBlockedReason);
+
+        vm.HasChainErrors = true;
+        Assert.Contains("cannot restore", vm.ExecuteBlockedReason);
+    }
+
+    [Fact]
+    public async Task NothingIsSaidWhileTheRestoreIsRunning()
+    {
+        var vm = await Loaded();
+        vm.IsConnectedToServer = true;
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsExecuting = true;
+
+        // The button is doing its other job here; a "why not" line would be noise.
+        Assert.Empty(vm.ExecuteBlockedReason);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1597,11 +1597,51 @@ public partial class RestoreViewModel : ViewModelBase
 
     // Verification opens its own connection and reads whole backups. Letting it start while a
     // restore is running would put a second heavy reader on the same server at the worst moment.
-    partial void OnIsExecutingChanged(bool value) => VerifyChainCommand.NotifyCanExecuteChanged();
+    partial void OnIsExecutingChanged(bool value)
+    {
+        VerifyChainCommand.NotifyCanExecuteChanged();
+        RefreshExecuteBlockedReason();
+    }
+
+    /// <summary>
+    /// Why Execute cannot be pressed, or empty when it can.
+    ///
+    /// The button was disabled identically whether the user was not connected, had no script, or
+    /// had a chain the app already knows will not restore. Three different problems, one greyed-out
+    /// button, and the information was all sitting in properties nobody showed.
+    /// </summary>
+    public string ExecuteBlockedReason
+    {
+        get
+        {
+            if (IsExecuting) return string.Empty;
+            if (!IsConnectedToServer) return "Connect to a SQL Server to execute this restore.";
+            if (!HasScript) return "No script yet - pick a restore point and a target database name.";
+            if (HasChainErrors) return "This chain cannot restore. See the problems listed above.";
+            return string.Empty;
+        }
+    }
+
+    public bool IsExecuteBlocked => ExecuteBlockedReason.Length > 0;
+
+    /// <summary>The button's own IsEnabled, so the reason and the enabled state cannot disagree.</summary>
+    public bool CanPressExecute => !IsExecuteBlocked;
+
+    private void RefreshExecuteBlockedReason()
+    {
+        OnPropertyChanged(nameof(ExecuteBlockedReason));
+        OnPropertyChanged(nameof(IsExecuteBlocked));
+        OnPropertyChanged(nameof(CanPressExecute));
+    }
+
+    partial void OnHasScriptChanged(bool value) => RefreshExecuteBlockedReason();
+
+    partial void OnHasChainErrorsChanged(bool value) => RefreshExecuteBlockedReason();
     partial void OnTargetDatabaseNameChanged(string value) => UpdateRestoreSummary();
 
     partial void OnIsConnectedToServerChanged(bool value)
     {
+        RefreshExecuteBlockedReason();
         var chips = value && ConnectedServer != null
             ? ConnectedServer.TagChips
             : [];

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1138,7 +1138,7 @@
                         <Button Content="{Binding ExecuteButtonText}"
                                 Style="{StaticResource DangerButton}"
                                 Command="{Binding ExecuteScriptCommand}"
-                                IsEnabled="{Binding IsConnectedToServer}"
+                                IsEnabled="{Binding CanPressExecute}"
                                 MinWidth="140" />
 
                         <!-- Only while a restore is actually running. Until now the only way to
@@ -1152,6 +1152,15 @@
                                 MinWidth="110"
                                 ToolTip="Asks SQL Server to abort the statement in flight. It rolls that statement back, but the target database is left mid-restore and will need recovering - the app will tell you how." />
                     </StackPanel>
+
+                    <!-- Why Execute is greyed out. Not connected, no script and a chain that cannot
+                         restore all looked identical - one disabled button, three different
+                         problems, and the answer already sitting in the viewmodel unshown. -->
+                    <TextBlock Text="{Binding ExecuteBlockedReason}"
+                               Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,8"
+                               Visibility="{Binding IsExecuteBlocked, Converter={StaticResource BoolToVis}}" />
 
                     <!-- Execute armed warning. The server's tags appear here deliberately: this is
                          the last thing between the user and an irreversible overwrite, and a


### PR DESCRIPTION
Item 4 from the UX list in #117. The issue stays open for the rest.

Execute was disabled identically whether the user was **not connected**, had **no script**, or had a **chain the app already knows will not restore**. Three different problems, one greyed-out button, and the answer was already sitting in `IsConnectedToServer` / `HasScript` / `HasChainErrors` - just never shown.

A line under the button now says which one applies:

- `Connect to a SQL Server to execute this restore.`
- `No script yet - pick a restore point and a target database name.`
- `This chain cannot restore. See the problems listed above.`

The button''s `IsEnabled` binds to the same property the reason is computed from, so the two cannot disagree - a disabled button with no explanation, or an explanation next to an enabled button, are both now impossible rather than merely unlikely.

Nothing is said while a restore is running; the button is doing its other job there.

## Tests

6 new; **708 total**, build clean at `-warnaserror`. One of them walks the state forward - not connected, then connected, then a broken chain - because a reason that does not keep up explains a state the button is no longer in.