### PR TITLE
Project infrastructure: changelog, issue templates, one publish definition (#39)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Something Nine Lives did wrong
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this.
+
+        **Before you paste anything:** Nine Lives talks to real servers and real storage
+        accounts. Please replace server names, database names, storage account names and
+        container names with placeholders (`SRV01`, `MyDb`, `mystorageaccount`) — and never
+        paste a SAS token, a connection string or a password. The app strips secrets from its
+        own log, but it cannot strip them from a screenshot.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did the app do, and what did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Select container ...
+        2. Load backups
+        3. Pick the restore point at ...
+        4. Press Execute
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Nine Lives version
+      description: Shown at the bottom right of the window, and on the About screen.
+      placeholder: v1.2.0
+    validations:
+      required: true
+
+  - type: input
+    id: windows
+    attributes:
+      label: Windows version
+      placeholder: Windows 11 Pro 23H2
+    validations:
+      required: true
+
+  - type: input
+    id: sql
+    attributes:
+      label: SQL Server version
+      description: Only if the problem involves a server. The app shows this once connected.
+      placeholder: SQL Server 2022
+
+  - type: dropdown
+    id: layout
+    attributes:
+      label: Backup layout
+      description: How the backups are arranged in the container.
+      options:
+        - Standalone (BackupType/Server/Database/File)
+        - Availability Group (flat Ola Hallengren naming)
+        - Mixed
+        - Something else / not sure
+
+  - type: textarea
+    id: script
+    attributes:
+      label: Generated script
+      description: >
+        If the problem is with the restore itself, the generated T-SQL is the most useful thing
+        you can attach. It contains no credentials — but it does contain URLs, so sanitise the
+        storage account and database names first.
+      render: sql
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Log
+      description: >
+        **Open log folder** on the About screen. Secrets are already stripped, but names are not,
+        so have a read before pasting.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/jakemorgangit/NineLives/security/advisories/new
+    about: >
+      Please report privately rather than opening an issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Something Nine Lives should be able to do
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please keep real server, database and storage account names out of the description -
+        `SRV01`, `MyDb` and `mystorageaccount` make the point just as well.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: >
+        The situation, rather than the feature. "I need to refresh a test database from
+        production every Monday" says more than "add a scheduler".
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: How do you do it today?
+      description: Including "I do it by hand in SSMS" - that is useful to know.
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like the app to do?
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Does this involve
+      options:
+        - label: Writing to a SQL Server (rather than reading from one)
+        - label: A storage provider other than Azure Blob
+        - label: Running without a user present (scheduled, scripted, CI)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,11 @@ jobs:
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
           Write-Host "Version: $version"
 
+      # Through the publish PROFILE, not a hand-repeated flag list. The two had drifted - the
+      # profile asked for ReadyToRun and this line did not - and nothing compares them, so the
+      # difference went unnoticed through three releases (#39).
       - name: Publish single-file exe
-        run: dotnet publish src/NineLives/NineLives.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o publish
+        run: dotnet publish src/NineLives/NineLives.csproj -p:PublishProfile=SingleFileExe -o publish
 
       - name: Package release assets
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,117 @@
+# Changelog
+
+All notable changes to Nine Lives are recorded here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
+more detail on the user-facing changes; this file is the short history.
+
+## [Unreleased]
+
+### Added
+
+- **Light and high-contrast themes**, switchable from About and remembered between runs. The dark
+  theme is retuned to match the splash screen it always sat next to (#109)
+- **Verify Backups** — `RESTORE VERIFYONLY` over every backup in the chain, so an unreadable blob
+  is found in seconds rather than an hour into a restore (#26)
+- **`CHECKSUM` and `CONTINUE_AFTER_ERROR`** restore options, both off by default (#26)
+- **Restore history** — every execution recorded with its script, console log and outcome, plus a
+  **Save output** action for the console (#31)
+- **A sortable list of restore points** beside the timeline, with type filters and a date range
+  that zooms rather than just filters (#27)
+- Backup times now record which clock they came from; blob-derived ones are marked approximate (#47)
+- A **Stop** button for the server queries — verify, validate, the metadata reads and the
+  post-failure recovery actions (#111)
+- Execute now says *why* it is disabled instead of just being greyed out (#117)
+
+### Fixed
+
+- **The script on screen is the script that runs.** Four options — both WITH MOVE paths, the
+  STANDBY undo file and STATS — never regenerated it. Ticking WITH MOVE while connected could
+  produce a script with no `MOVE` clause at all, sending the restore to the file paths baked into
+  the backup (#110)
+- STANDBY with a blank undo path emitted `STANDBY = ''`, which fails as the last statement of the
+  chain — after the target has already been overwritten (#110)
+- Changing the container on the Restore screen left the previous container's chain and script
+  armed and executable (#112)
+- **Refresh Token silently deleted a container's tags** (#114)
+- Reloading with the same database selected never rebuilt the restore points, so a backup taken
+  since the last scan never appeared (#27)
+- A container with no full backup had its explanation overwritten by the load summary (#41)
+- Saving now writes the config *before* the secret, so a refused save cannot leave Credential
+  Manager holding a password the config file does not match (#113)
+- The credential check no longer races itself and reports the container you just left (#111)
+
+### Changed
+
+- The I/O services are behind interfaces, so the ViewModels can be tested. The first ViewModel
+  tests came with it (#41)
+- `null!` placeholders on the chain members replaced with `required` (#116)
+- `RestoreOptions` no longer carries a SAS token it never used (#42)
+- One publish definition instead of three. The release workflow was missing `PublishReadyToRun`
+  because it repeated the profile's flags rather than using it (#39)
+
+## [1.2.0] - 2026-08-05
+
+The biggest release so far, and mostly about correctness. Runs on **.NET 10**. **587 tests**, up
+from 345.
+
+### Fixed
+
+- The restore could run against a different server than the one you connected with (#11)
+- Every Execute dropped and recreated the blob credential, whether or not anything needed
+  changing — removing it out from under anything else using it (#10)
+- A database whose name contained "diff" had its full backups classified as differentials, and
+  could end up with no restore points at all (#45)
+- A transaction log written as `.bak` became the root of a chain and truncated earlier log chains (#44)
+- A briefly locked `config.json` wiped every saved server and container (#7)
+- Renaming a container stranded its SAS token (#8)
+- Test Connection saved secrets before you did (#12)
+- An unexpected error no longer closes the app and takes the execution log with it (#13)
+
+### Added
+
+- Cancellation for a running restore and a long container listing (#25)
+- Post-failure recovery guidance, with the statements that put the database right (#14)
+- A proper terminal for the execution console — its own window, live progress, SQL syntax
+  highlighting, and a script that updates as options change
+- An operation log at `%LOCALAPPDATA%\NineLives\logs`, with secrets stripped on the way in (#40)
+- Unreachable log backups are reported rather than quietly disappearing (#46)
+
+### Security
+
+- SQL passwords are passed out-of-band and never appear in a connection string (#20)
+- Test Connection reports whether certificate validation would actually succeed (#17)
+- A SAS expiry that cannot be read counts as expired rather than valid (#21)
+- Copied blob URLs no longer carry the SAS token (#18)
+- Every dependency pinned and locked, verified on every build (#16)
+- Releases carry a Sigstore build provenance attestation (#33)
+
+## [1.1.0] - 2026-08-05
+
+345 tests.
+
+### Fixed
+
+- Every log backup reachable from a chain is now offered (#24)
+- Backup sets are identified per server and per instance, so two instances no longer merge (#43, #48)
+- Copy-only fulls are no longer used as differential bases (#49)
+
+### Added
+
+- Structural and LSN chain validation (#62, #23)
+- Tags on servers and containers (#67)
+- An update check against the releases page (#65)
+- The paw logo and the splash screen
+
+## [1.0.0] - 2026-08-05
+
+First release. Restore SQL Server databases from Azure Blob Storage with full, differential and
+transaction log chains.
+
+[Unreleased]: https://github.com/jakemorgangit/NineLives/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/jakemorgangit/NineLives/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/jakemorgangit/NineLives/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/jakemorgangit/NineLives/releases/tag/v1.0.0

--- a/build_standalone.cmd
+++ b/build_standalone.cmd
@@ -6,8 +6,11 @@ set "PUBLISH_OUT=%SCRIPT_DIR%publish"
 echo Close Nine Lives (NineLives.exe) if it is running, then press any key to publish...
 pause >nul
 
+REM Through the publish profile, so this produces the same binary the release workflow does.
+REM The flags used to be repeated here and in release.yml, and they had already drifted apart
+REM from the profile - see the note in Properties\PublishProfiles\SingleFileExe.pubxml (#39).
 cd /d "%SCRIPT_DIR%src\NineLives"
-dotnet publish -c Release -o "%PUBLISH_OUT%" -r win-x64 --self-contained -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish -p:PublishProfile=SingleFileExe -o "%PUBLISH_OUT%"
 
 set "EXIT_CODE=%ERRORLEVEL%"
 if %EXIT_CODE% equ 0 (

--- a/src/NineLives/Properties/PublishProfiles/SingleFileExe.pubxml
+++ b/src/NineLives/Properties/PublishProfiles/SingleFileExe.pubxml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  The single source of truth for how Nine Lives is published.
+
+  build_standalone.cmd and .github/workflows/release.yml both invoke this profile rather than
+  repeating its flags. They used to repeat them, and they had already drifted: neither passed
+  PublishReadyToRun, so every released binary was missing something this file claimed (#39).
+  See the note on that property for which way the difference was resolved, and why.
+
+  RuntimeIdentifier is overridable from the command line, which is how a second architecture
+  would be published without a second copy of everything else here.
+-->
 <Project>
   <PropertyGroup>
     <Configuration>Release</Configuration>
@@ -9,7 +20,26 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <PublishTrimmed>false</PublishTrimmed>
-    <PublishReadyToRun>true</PublishReadyToRun>
+
+    <!--
+      Off, deliberately, and measured rather than assumed.
+
+      This file used to say true while release.yml and build_standalone.cmd published without it,
+      so no released binary has ever had ReadyToRun. Unifying the three meant choosing which
+      behaviour to keep, so both were built and timed on the same machine:
+
+        no ReadyToRun   146.0 MB   warm start 3.35s
+        ReadyToRun      175.5 MB   warm start 3.27s
+
+      30 MB - a fifth of the download - for 80ms that nobody can perceive, and even that is inside
+      the noise. Startup here is dominated by the deliberate 2.5s splash dwell in App.OnStartup,
+      which no amount of precompilation touches.
+
+      This is a portable exe people fetch over the internet, and it is already unsigned enough of a
+      hurdle (#33) without being 20% bigger. Turn it on if the splash dwell ever goes and startup
+      starts to matter.
+    -->
+    <PublishReadyToRun>false</PublishReadyToRun>
     <!-- Same reasoning as Directory.Build.props: a single-file publish restore drags in an
          SDK-versioned tool pack, so it must not rewrite the committed lock file. Repeated
          here because a publish profile is imported after Directory.Build.props, too late


### PR DESCRIPTION
Three of the five items on #39. CONTRIBUTING.md and SECURITY.md already landed earlier.

## One publish definition, and a drift worth knowing about

The publish was defined three times - `SingleFileExe.pubxml`, `build_standalone.cmd` and `release.yml` - each with its own flag list. They had already drifted: the profile asked for `PublishReadyToRun` and the other two did not, so **no released binary has ever had it**, and nothing in the build compares them.

Unifying meant choosing which behaviour to keep, so I built both and timed them on the same machine rather than guessing:

| | size | warm start |
|---|---|---|
| no ReadyToRun | **146.0 MB** | 3.35s |
| ReadyToRun | 175.5 MB | 3.27s |

30 MB - a fifth of the download - for 80ms nobody can perceive, and even that is inside the run-to-run noise. Startup here is dominated by the deliberate **2.5 second splash dwell** in `App.OnStartup`, which no amount of precompilation touches.

So the profile says `false` now, the other two invoke the profile, and released binaries stay exactly the size they have always been. Verified: publishing through the profile produces 146.0 MB, and the result starts and closes cleanly.

If the splash dwell ever goes and startup starts to matter, it is a one-line change with the numbers written down next to it.

## CHANGELOG.md

Keep a Changelog format, covering 1.0.0 through 1.2.0 and everything merged into `dev` since. The release notes were the only history, and they live on a page that has to be sought out.

## Issue templates

Bug report and feature request, asking for app version, Windows version, SQL Server version and backup layout - and telling people to sanitise server, database and storage account names before pasting, with a reminder that the app can strip secrets from its own log but not from a screenshot. Security reports are routed to the private advisory form rather than into a public issue.

## Left on the issue

**The win-arm64 release leg.** It changes what users download and cannot be proven without cutting a real release, so it wants a deliberate decision.
