### PR TITLE
Reconcile the two clocks with a backup server time zone (#102)

### DIFF
--- a/src/NineLives.Tests/BackupServerTimeZoneTests.cs
+++ b/src/NineLives.Tests/BackupServerTimeZoneTests.cs
@@ -1,0 +1,233 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Putting both clocks on one clock (#102).
+///
+/// #47 made the app honest about the fact that a filename timestamp reads the backup server's
+/// local clock while a blob's LastModified reads UTC - it labelled the second as approximate and
+/// left it there. That is all it could do: nothing in a container says what zone the server is in.
+///
+/// Told the zone, the UTC reading converts and the two become comparable rather than merely
+/// labelled. What no zone can fix is that LastModified is when the UPLOAD finished, not when the
+/// backup was taken, so it stays marked approximate.
+/// </summary>
+public class BackupServerTimeZoneTests
+{
+    private readonly BlobStorageService _service = new(new FakeCredentialStore());
+
+    /// <summary>UTC+10 in winter, UTC+11 in summer - so DST is actually exercised.</summary>
+    private const string Sydney = "AUS Eastern Standard Time";
+
+    private static BackupFileInfo File(string blobName, DateTimeOffset lastModified)
+        => new()
+        {
+            BlobName = blobName,
+            Type = BackupType.Full,
+            InferredServerName = "SRV01",
+            InferredDatabaseName = "MyDb",
+            SizeBytes = 100,
+            LastModified = lastModified
+        };
+
+    [Fact]
+    public void WithoutAZoneTheReadingStaysOnTheBlobsClock()
+    {
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/adhoc.bak", new DateTimeOffset(2026, 6, 15, 22, 30, 0, TimeSpan.Zero))]);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.BlobLastModified, set.TimestampSource);
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 30, 0), set.Timestamp);
+        Assert.True(set.IsTimestampOnAnotherClock);
+    }
+
+    [Fact]
+    public void WithAZoneTheReadingMovesOntoTheBackupServersClock()
+    {
+        // 22:30 UTC on 15 June is 08:30 the next morning in Sydney (UTC+10, no DST in June).
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/adhoc.bak", new DateTimeOffset(2026, 6, 15, 22, 30, 0, TimeSpan.Zero))],
+            Sydney);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.BlobLastModifiedConverted, set.TimestampSource);
+        Assert.Equal(new DateTime(2026, 6, 16, 8, 30, 0), set.Timestamp);
+
+        // On the right clock now, so it sorts correctly - but still the upload time.
+        Assert.False(set.IsTimestampOnAnotherClock);
+        Assert.True(set.IsTimestampApproximate);
+    }
+
+    /// <summary>
+    /// The reason a zone is stored rather than a fixed offset. A container spanning a DST
+    /// transition needs the rule, not one number.
+    /// </summary>
+    [Fact]
+    public void TheOffsetFollowsDaylightSaving()
+    {
+        var winter = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/winter.bak", new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero))],
+            Sydney).Single();
+
+        var summer = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/summer.bak", new DateTimeOffset(2026, 12, 15, 12, 0, 0, TimeSpan.Zero))],
+            Sydney).Single();
+
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 0, 0), winter.Timestamp);   // UTC+10
+        Assert.Equal(new DateTime(2026, 12, 15, 23, 0, 0), summer.Timestamp);  // UTC+11
+    }
+
+    /// <summary>
+    /// The whole point: a database with both kinds of naming sorts in the right order once the
+    /// zone is known. Unconverted, the ad-hoc backup lands ten hours out of position.
+    /// </summary>
+    [Fact]
+    public void AMixedDatabaseSortsCorrectlyOnceTheZoneIsKnown()
+    {
+        // The scheduled backup ran at 09:00 Sydney time; the ad-hoc one an hour later, which is
+        // 00:00 UTC.
+        List<BackupFileInfo> files =
+        [
+            File("FULL/SRV01/MyDb/20260616_090000.bak", new DateTimeOffset(2026, 6, 15, 23, 0, 0, TimeSpan.Zero)),
+            File("FULL/SRV01/MyDb/adhoc.bak", new DateTimeOffset(2026, 6, 16, 0, 0, 0, TimeSpan.Zero)),
+        ];
+
+        var unconverted = _service.GroupIntoBackupSets(files);
+        var adhocUnconverted = unconverted.Single(s => s.SetId == "adhoc");
+        var scheduled = unconverted.Single(s => s.SetId == "20260616_090000");
+
+        // 00:00 against 09:00 - the ad-hoc one looks nine hours EARLIER than the backup it
+        // actually followed.
+        Assert.True(adhocUnconverted.Timestamp < scheduled.Timestamp);
+
+        var converted = _service.GroupIntoBackupSets(files, Sydney);
+        var adhocConverted = converted.Single(s => s.SetId == "adhoc");
+
+        Assert.Equal(new DateTime(2026, 6, 16, 10, 0, 0), adhocConverted.Timestamp);
+        Assert.True(adhocConverted.Timestamp > scheduled.Timestamp);
+        Assert.Equal("adhoc", converted[^1].SetId);
+    }
+
+    [Fact]
+    public void AFileNameTimestampIsNeverConverted()
+    {
+        // It is already on the backup server's clock. Converting it would move it by the offset
+        // for no reason - the exact bug in reverse.
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/20260615_220000.bak", new DateTimeOffset(2026, 6, 15, 22, 0, 0, TimeSpan.Zero))],
+            Sydney);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.FileName, set.TimestampSource);
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 0, 0), set.Timestamp);
+    }
+
+    [Theory]
+    [InlineData("Not A Real Zone")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AZoneThisMachineDoesNotKnowFallsBackRatherThanThrowing(string id)
+    {
+        // A config carried from another machine, or hand-edited. Browsing a container must not be
+        // stopped by a setting that only affects how a few timestamps are displayed.
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/adhoc.bak", new DateTimeOffset(2026, 6, 15, 22, 30, 0, TimeSpan.Zero))],
+            id);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.BlobLastModified, set.TimestampSource);
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 30, 0), set.Timestamp);
+    }
+
+    [Fact]
+    public void AConvertedReadingExplainsItselfDifferently()
+    {
+        var converted = new BackupSet { TimestampSource = BackupTimestampSource.BlobLastModifiedConverted };
+        var unconverted = new BackupSet { TimestampSource = BackupTimestampSource.BlobLastModified };
+
+        Assert.Contains("time zone", converted.TimestampNote);
+        Assert.DoesNotContain("time zone", unconverted.TimestampNote);
+        Assert.Contains("hours away", unconverted.TimestampNote);
+    }
+
+    // ── the setting itself ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheZoneIsSavedAndReadBack()
+    {
+        var store = new FakeCredentialStore();
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2026-01-01&sig=x";
+        vm.EditBackupServerTimeZone = BlobConfigViewModel.TimeZones.First(z => z.Id == Sydney);
+        vm.SaveCommand.Execute(null);
+
+        var saved = Assert.Single(store.Config.BlobContainers);
+        Assert.Equal(Sydney, saved.BackupServerTimeZoneId);
+
+        // And it comes back into the form when the container is edited again.
+        var reopened = new BlobConfigViewModel(store, new FakeBlobStorageService())
+        {
+            SelectedContainer = null
+        };
+        reopened.SelectedContainer = reopened.Containers.Single();
+        reopened.EditCommand.Execute(null);
+
+        Assert.Equal(Sydney, reopened.EditBackupServerTimeZone?.Id);
+    }
+
+    [Fact]
+    public void NotKnownIsTheDefaultAndStoresNothing()
+    {
+        var store = new FakeCredentialStore();
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2026-01-01&sig=x";
+        vm.SaveCommand.Execute(null);
+
+        Assert.Null(Assert.Single(store.Config.BlobContainers).BackupServerTimeZoneId);
+    }
+
+    [Fact]
+    public void AStoredZoneThisMachineDoesNotKnowShowsAsNotKnown()
+    {
+        // Otherwise the picker claims a setting the app is not actually applying.
+        var option = TimeZoneOption.For("Mars Standard Time", BlobConfigViewModel.TimeZones);
+
+        Assert.Null(option.Id);
+        Assert.Same(TimeZoneOption.Unknown, option);
+    }
+
+    [Fact]
+    public void ChangingOnlyTheZoneCountsAsAnUnsavedChange()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        });
+
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        Assert.False(vm.HasUnsavedChanges);
+
+        vm.EditBackupServerTimeZone = BlobConfigViewModel.TimeZones.First(z => z.Id == Sydney);
+
+        Assert.True(vm.HasUnsavedChanges);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.Tests;
@@ -101,7 +101,8 @@ public sealed class FakeBlobStorageService : IBlobStorageService
 
     public ContainerSummary GetContainerSummary(List<BackupFileInfo> files) => _real.GetContainerSummary(files);
     public ContainerSummary GetSetBasedSummary(List<BackupSet> sets) => _real.GetSetBasedSummary(sets);
-    public List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files) => _real.GroupIntoBackupSets(files);
+    public List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files, string? backupServerTimeZoneId = null)
+        => _real.GroupIntoBackupSets(files, backupServerTimeZoneId);
     public List<string> GetDiscoveredDatabases(List<BackupFileInfo> files) => _real.GetDiscoveredDatabases(files);
     public List<string> GetDiscoveredServers(List<BackupFileInfo> files) => _real.GetDiscoveredServers(files);
 }

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -30,7 +30,18 @@ public enum BackupTimestampSource
     /// Fallback: the blob's LastModified, which is UTC, and additionally records when the file
     /// finished uploading rather than when the backup was taken.
     /// </summary>
-    BlobLastModified
+    BlobLastModified,
+
+    /// <summary>
+    /// The blob's LastModified, converted into the backup server's own time zone because the
+    /// container says which one that is (#102).
+    ///
+    /// This is on the SAME clock as a filename or header reading, so it sorts correctly against
+    /// them - the skew is gone. What remains is that LastModified records when the upload
+    /// FINISHED rather than when the backup was taken, which no time zone can fix, so it is still
+    /// shown as approximate.
+    /// </summary>
+    BlobLastModifiedConverted
 }
 
 /// <summary>
@@ -50,11 +61,52 @@ public static class BackupTime
     public static DateTime WallClock(DateTimeOffset value)
         => DateTime.SpecifyKind(value.UtcDateTime, DateTimeKind.Unspecified);
 
+    /// <summary>
+    /// Converts a blob's LastModified into the backup server's own local time.
+    ///
+    /// This is the only thing that genuinely reconciles the two clocks: a filename says what the
+    /// backup server's clock read, and the blob says UTC. Given the server's zone the second can
+    /// be expressed as the first, and the two become comparable rather than merely labelled.
+    ///
+    /// A zone the machine does not know - a config edited by hand, an IANA id on an older Windows
+    /// build - returns null rather than throwing, and the caller falls back to the unconverted
+    /// reading. A wrong time is worse than an honest one, but refusing to open the container over
+    /// it would be worse still.
+    /// </summary>
+    public static DateTime? ToBackupServerTime(DateTimeOffset value, string? timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId)) return null;
+
+        try
+        {
+            var zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+
+            // From the instant, not from the wall clock: this is what makes DST correct. A backup
+            // taken in July and one taken in December convert with different offsets, which a
+            // fixed number could never do.
+            return DateTime.SpecifyKind(
+                TimeZoneInfo.ConvertTime(value, zone).DateTime, DateTimeKind.Unspecified);
+        }
+        catch (Exception e) when (e is TimeZoneNotFoundException or InvalidTimeZoneException)
+        {
+            return null;
+        }
+    }
+
     /// <summary>Explains an approximate reading. Shown as a tooltip wherever one is displayed.</summary>
     public const string ApproximateNote =
         "Approximate. This file's name carries no timestamp, so the time shown is when the blob "
         + "was last modified (UTC), not when the backup was taken on the server. It may sit hours "
         + "away from the other entries.";
+
+    /// <summary>
+    /// Explains a converted reading: on the right clock now, but still the upload time.
+    /// </summary>
+    public const string ConvertedNote =
+        "Approximate. This file's name carries no timestamp, so the time shown is when the blob "
+        + "was last modified - converted into the backup server's time zone, so it sorts correctly "
+        + "against the others. It is still when the upload finished rather than when the backup "
+        + "was taken.";
 
     /// <summary>Prefix marking a displayed time as approximate.</summary>
     public const string ApproximateMarker = "~";
@@ -176,11 +228,27 @@ public class BackupSet
     /// True when the time had to be taken from the blob rather than the filename, which puts it
     /// on a different clock (UTC) from its neighbours and can sort it hours out of position.
     /// </summary>
-    public bool IsTimestampApproximate => TimestampSource == BackupTimestampSource.BlobLastModified;
+    public bool IsTimestampApproximate =>
+        TimestampSource is BackupTimestampSource.BlobLastModified
+                        or BackupTimestampSource.BlobLastModifiedConverted;
+
+    /// <summary>
+    /// True when the reading is not only approximate but on a DIFFERENT clock from its
+    /// neighbours - which is what makes it sort out of position rather than merely be imprecise.
+    /// Converting it into the backup server's zone (#102) removes this while leaving the
+    /// approximation.
+    /// </summary>
+    public bool IsTimestampOnAnotherClock =>
+        TimestampSource == BackupTimestampSource.BlobLastModified;
 
     public string TimestampDisplay => BackupTime.Format(Timestamp, IsTimestampApproximate);
 
-    public string? TimestampNote => IsTimestampApproximate ? BackupTime.ApproximateNote : null;
+    public string? TimestampNote => TimestampSource switch
+    {
+        BackupTimestampSource.BlobLastModified => BackupTime.ApproximateNote,
+        BackupTimestampSource.BlobLastModifiedConverted => BackupTime.ConvertedNote,
+        _ => null
+    };
 
     public string? DatabaseName { get; set; }
     public string? ServerName { get; set; }

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -64,6 +64,21 @@ public class BlobContainerConfig : INotifyPropertyChanged
     /// </summary>
     public string? AgPathPattern { get; set; }
 
+    /// <summary>
+    /// The time zone the backup SERVER runs in, if known (#102).
+    ///
+    /// A backup's time comes from either its filename - which the backup job wrote in the server's
+    /// local time - or the blob's LastModified, which is UTC. Without this they cannot be put on
+    /// one clock, only labelled; with it, the UTC readings convert and sort correctly against the
+    /// rest.
+    ///
+    /// Stored as a system id (Windows or IANA - .NET accepts both since 6.0). Null means unknown,
+    /// which is the default and behaves exactly as before. An id this machine does not recognise
+    /// is treated as unknown rather than as an error: someone browsing a container should not be
+    /// stopped by a setting that only affects how a few timestamps are displayed.
+    /// </summary>
+    public string? BackupServerTimeZoneId { get; set; }
+
     private ObservableCollection<string> _tags = [];
 
     /// <summary>

--- a/src/NineLives/Models/TimeZoneOption.cs
+++ b/src/NineLives/Models/TimeZoneOption.cs
@@ -1,0 +1,28 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// A time zone as the container editor offers it (#102).
+/// </summary>
+/// <param name="Id">The system id stored in config, or null for "not known".</param>
+/// <param name="Name">What the picker shows.</param>
+public sealed record TimeZoneOption(string? Id, string Name)
+{
+    /// <summary>
+    /// The default. Backup times stay on whichever clock they came from and are labelled rather
+    /// than reconciled - which is honest, and exactly what the app did before this setting existed.
+    /// </summary>
+    public static readonly TimeZoneOption Unknown = new(null, "Not known - leave times as they are");
+
+    /// <summary>
+    /// Matches a stored id back to an offered option, falling back to "not known" for an id this
+    /// machine does not recognise. A config carried to another machine, or hand-edited, must not
+    /// leave the picker showing something the app is not actually using.
+    /// </summary>
+    public static TimeZoneOption For(string? id, IEnumerable<TimeZoneOption> options)
+        => string.IsNullOrWhiteSpace(id)
+            ? Unknown
+            : options.FirstOrDefault(o => o.Id == id) ?? Unknown;
+
+    /// <summary>The picker renders the selected item through a plain ContentPresenter.</summary>
+    public override string ToString() => Name;
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Blackcat.NineLives.Models;
@@ -257,7 +257,8 @@ public class BlobStorageService : IBlobStorageService
     /// <summary>
     /// Groups individual backup files into logical BackupSets, handling striped backups.
     /// </summary>
-    public List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files)
+    public List<BackupSet> GroupIntoBackupSets(
+        List<BackupFileInfo> files, string? backupServerTimeZoneId = null)
     {
         var groups = new Dictionary<string, List<BackupFileInfo>>();
 
@@ -304,18 +305,24 @@ public class BlobStorageService : IBlobStorageService
             var (setId, _) = BackupSet.ParseFileName(first.FileName);
 
             // The filename is the backup server's local clock; the blob's LastModified is UTC.
-            // Nothing here can reconcile them, so record WHICH one this set got and let the UI
-            // mark the fallback as approximate rather than presenting both as one timeline.
+            //
+            // With the container's backup server time zone configured they can be put on ONE clock
+            // (#102). Without it they can only be labelled - so record which one this set got, and
+            // let the UI say so rather than presenting both as a single exact timeline (#47).
             var parsed = BackupSet.ParseTimestamp(setId);
+            var converted = parsed == null
+                ? BackupTime.ToBackupServerTime(first.LastModified, backupServerTimeZoneId)
+                : null;
 
             sets.Add(new BackupSet
             {
                 SetId = setId,
                 Type = first.Type,
                 Files = groupFiles.OrderBy(f => f.FileName).ToList(),
-                Timestamp = parsed ?? BackupTime.WallClock(first.LastModified),
-                TimestampSource = parsed != null
-                    ? BackupTimestampSource.FileName
+                Timestamp = parsed ?? converted ?? BackupTime.WallClock(first.LastModified),
+                TimestampSource =
+                    parsed != null ? BackupTimestampSource.FileName
+                    : converted != null ? BackupTimestampSource.BlobLastModifiedConverted
                     : BackupTimestampSource.BlobLastModified,
                 DatabaseName = first.InferredDatabaseName,
                 ServerName = first.InferredServerName,

--- a/src/NineLives/Services/IBlobStorageService.cs
+++ b/src/NineLives/Services/IBlobStorageService.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -24,7 +24,12 @@ public interface IBlobStorageService
 
     ContainerSummary GetContainerSummary(List<BackupFileInfo> files);
     ContainerSummary GetSetBasedSummary(List<BackupSet> sets);
-    List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files);
+    /// <param name="backupServerTimeZoneId">
+    /// The backup server's time zone, when the container says which one it is. Lets a blob's UTC
+    /// LastModified be put on the same clock as a filename timestamp (#102). Null leaves them
+    /// labelled but unreconciled.
+    /// </param>
+    List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files, string? backupServerTimeZoneId = null);
     List<string> GetDiscoveredDatabases(List<BackupFileInfo> files);
     List<string> GetDiscoveredServers(List<BackupFileInfo> files);
 }

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -147,7 +147,8 @@ public partial class BlobBrowserViewModel : ViewModelBase
         try
         {
             _allFiles = await _blobService.ListBackupFilesAsync(SelectedContainer, ct);
-            _allSets = _blobService.GroupIntoBackupSets(_allFiles);
+            _allSets = _blobService.GroupIntoBackupSets(
+                _allFiles, SelectedContainer?.BackupServerTimeZoneId);
             HasFiles = _allFiles.Count > 0;
 
             var servers = _blobService.GetDiscoveredServers(_allFiles);

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -49,6 +49,37 @@ public partial class BlobConfigViewModel : ViewModelBase
     [ObservableProperty]
     private string? _editAgPathPattern;
 
+    /// <summary>
+    /// The backup server's time zone, or null for "not known" (#102). Selected from
+    /// <see cref="TimeZones"/>.
+    /// </summary>
+    [ObservableProperty]
+    private TimeZoneOption? _editBackupServerTimeZone;
+
+    private string? _originalTimeZoneId;
+
+    /// <summary>
+    /// Every zone this machine knows, with an explicit "not known" first. Read once - the list
+    /// does not change while the app is running, and enumerating it is not free.
+    /// </summary>
+    public static IReadOnlyList<TimeZoneOption> TimeZones { get; } = BuildTimeZones();
+
+    private static IReadOnlyList<TimeZoneOption> BuildTimeZones()
+    {
+        var options = new List<TimeZoneOption> { TimeZoneOption.Unknown };
+        try
+        {
+            options.AddRange(TimeZoneInfo.GetSystemTimeZones()
+                .Select(z => new TimeZoneOption(z.Id, z.DisplayName)));
+        }
+        catch
+        {
+            // A machine with an unreadable zone database still gets "not known", which is the
+            // behaviour the app had before this existed.
+        }
+        return options;
+    }
+
     [ObservableProperty]
     private ObservableCollection<PathElement> _activePathElements = [];
 
@@ -168,6 +199,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         CheckForUnsavedChanges();
     }
     partial void OnEditAgPathPatternChanged(string? value) => CheckForUnsavedChanges();
+    partial void OnEditBackupServerTimeZoneChanged(TimeZoneOption? value) => CheckForUnsavedChanges();
 
     // Tags are saved like every other field, so editing only the tags has to count as an unsaved
     // change - otherwise the guard that protects unsaved edits lets them be discarded silently.
@@ -186,7 +218,8 @@ public partial class BlobConfigViewModel : ViewModelBase
             EditPathPattern != _originalPattern ||
             EditBackupSourceType != _originalBackupSourceType ||
             EditAgPathPattern != _originalAgPathPattern ||
-            EditTags != _originalTags;
+            EditTags != _originalTags ||
+            EditBackupServerTimeZone?.Id != _originalTimeZoneId;
     }
 
     /// <summary>
@@ -200,6 +233,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         var pattern = container.PathPattern;
         var sourceType = container.BackupSourceType;
         var agPattern = container.AgPathPattern;
+        var timeZoneId = container.BackupServerTimeZoneId;
         var tags = container.Tags.ToList();
 
         return () =>
@@ -209,6 +243,7 @@ public partial class BlobConfigViewModel : ViewModelBase
             container.PathPattern = pattern;
             container.BackupSourceType = sourceType;
             container.AgPathPattern = agPattern;
+            container.BackupServerTimeZoneId = timeZoneId;
             ReplaceTags(container.Tags, tags);
         };
     }
@@ -222,6 +257,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         _originalBackupSourceType = EditBackupSourceType;
         _originalAgPathPattern = EditAgPathPattern;
         _originalTags = EditTags;
+        _originalTimeZoneId = EditBackupServerTimeZone?.Id;
         HasUnsavedChanges = false;
     }
 
@@ -386,6 +422,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditPathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
         EditBackupSourceType = BackupSourceType.Standalone;
         EditAgPathPattern = null;
+        EditBackupServerTimeZone = TimeZoneOption.Unknown;
         SyncPathElementsFromPattern();
         SyncAgPathElementsFromPattern();
         HasStoredSasToken = false;
@@ -409,6 +446,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditSasToken = string.Empty; // Never show stored token; user can only replace it
         EditPathPattern = SelectedContainer.PathPattern;
         EditBackupSourceType = SelectedContainer.BackupSourceType;
+        EditBackupServerTimeZone = TimeZoneOption.For(SelectedContainer.BackupServerTimeZoneId, TimeZones);
         EditAgPathPattern = SelectedContainer.AgPathPattern;
         SyncPathElementsFromPattern();
         SyncAgPathElementsFromPattern();
@@ -466,6 +504,7 @@ public partial class BlobConfigViewModel : ViewModelBase
                 PathPattern = EditPathPattern,
                 BackupSourceType = EditBackupSourceType,
                 AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim(),
+                BackupServerTimeZoneId = EditBackupServerTimeZone?.Id,
                 Tags = [.. TagPalette.ParseTags(EditTags)]
             };
             Containers.Add(container);
@@ -485,6 +524,7 @@ public partial class BlobConfigViewModel : ViewModelBase
             container.ContainerUrl = EditContainerUrl.TrimEnd('/');
             container.PathPattern = EditPathPattern;
             container.BackupSourceType = EditBackupSourceType;
+            container.BackupServerTimeZoneId = EditBackupServerTimeZone?.Id;
             var agPattern = IsAgPathSectionVisible ? PathElement.BuildPattern(AgActivePathElements) : null;
             container.AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim();
         }
@@ -572,6 +612,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         HasStoredSasToken = true; // Still have a token; user will replace it
         EditSasToken = string.Empty;
         EditPathPattern = SelectedContainer.PathPattern;
+        EditBackupServerTimeZone = TimeZoneOption.For(SelectedContainer.BackupServerTimeZoneId, TimeZones);
         EditBackupSourceType = SelectedContainer.BackupSourceType;
         EditAgPathPattern = SelectedContainer.AgPathPattern;
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -789,7 +789,8 @@ public partial class RestoreViewModel : ViewModelBase
             var progress = new Progress<int>(n => LoadProgressText = $"Scanned {n:N0} blobs...");
 
             _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer, scope, progress, ct);
-            _allSets = _blobService.GroupIntoBackupSets(_allBackups);
+            _allSets = _blobService.GroupIntoBackupSets(
+                _allBackups, SelectedContainer?.BackupServerTimeZoneId);
 
             var servers = _blobService.GetDiscoveredServers(_allBackups);
             DiscoveredServers = new ObservableCollection<string>(servers);

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -372,6 +372,20 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
 
+                            <!-- The only thing that genuinely reconciles the two clocks a backup
+                                 time can come from: a filename is the backup server's local time,
+                                 a blob's LastModified is UTC. Optional, and "not known" behaves
+                                 exactly as the app did before it existed (#102). -->
+                            <TextBlock Text="BACKUP SERVER TIME ZONE" Style="{StaticResource LabelText}" />
+                            <TextBlock Text="Only needed when some backups here have no timestamp in their filename. Setting it lets those be sorted correctly against the rest instead of being marked approximate."
+                                       Style="{StaticResource SecondaryText}"
+                                       FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap" />
+                            <ComboBox ItemsSource="{Binding TimeZones}"
+                                      SelectedItem="{Binding EditBackupServerTimeZone}"
+                                      DisplayMemberPath="Name"
+                                      Style="{StaticResource DarkComboBox}"
+                                      Margin="0,0,0,16" />
+
                             <TextBlock>
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock" BasedOn="{StaticResource LabelText}">


### PR DESCRIPTION
Closes #102. Finishes what #47 could only label.

A backup''s time comes from one of two places that are not on the same clock: the filename, which the backup job wrote in the **backup server''s local time**, or the blob''s `LastModified`, which is **UTC**. #47 recorded which, and marked the UTC ones approximate. That was as far as it could go - nothing in a container says what zone the server is in.

Containers can now say. Told the zone, the UTC reading converts and the two become **comparable rather than merely labelled**.

## What it fixes

A database with mixed naming - an ad-hoc `MyDb_preupgrade.bak` dropped alongside the scheduled ones - sorted the ad-hoc backup hours out of position. There is a test for exactly that: an ad-hoc backup taken an hour *after* a scheduled one appeared **nine hours earlier** unconverted, and lands in the right place once the zone is known.

Conversion is from the **instant**, not the wall clock, so daylight saving is handled. That is the reason a zone is stored rather than a fixed offset - a container spanning a transition needs the rule, not one number. Tested against Sydney, which is UTC+10 in June and UTC+11 in December.

## What it does not fix

`LastModified` is when the **upload finished**, not when the backup was taken. No time zone touches that, so a converted reading is still marked approximate - with a note saying which of the two problems is left rather than repeating the old one.

`IsTimestampOnAnotherClock` is the new distinction: approximate *and* on a different clock is what makes a set sort out of position; approximate alone just means imprecise.

## Defaults and failure

Optional, defaulting to **"Not known - leave times as they are"**, which behaves exactly as the app did before this existed. A filename timestamp is never converted - it is already on the server''s clock, and converting it would move it by the offset for no reason.

An id this machine does not recognise - a config carried from another machine, or hand-edited - falls back to "not known" rather than throwing, in both the conversion and the picker. Browsing a container should not be stopped by a setting that only affects how a few timestamps are displayed, and the picker must not claim a setting the app is not applying.

## Tests

13 new; **721 total**, build clean at `-warnaserror`.