### PR TITLE
Name the four verification actions for what they do (#117)

### DIFF
--- a/src/NineLives/Services/BackupChainValidator.cs
+++ b/src/NineLives/Services/BackupChainValidator.cs
@@ -323,7 +323,7 @@ public class BackupChainValidator
             $"{chainBase.Timestamp:yyyy-MM-dd HH:mm}, against a typical log interval of {FormatGap(median.Value)}. " +
             "Log backups covering that period appear to be missing - commonly because logs are kept for a " +
             "shorter retention than fulls and differentials. The restore would fail with error 4305. " +
-            "Validate Chain will confirm against the backup headers."));
+            "Check chain will confirm against the backup headers."));
     }
 
     private static TimeSpan? MedianLogInterval(IReadOnlyList<BackupSet> logs)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1380,16 +1380,16 @@ public partial class RestoreViewModel : ViewModelBase
             ChainLsnVerified = true;
 
             SetStatus(HasChainIssues
-                ? $"Chain validation found problems - see the panel above."
-                : $"Chain validated: {headers.Count} backup(s) read, LSN chain is intact.");
+                ? $"Chain check found problems - see the panel above."
+                : $"Chain checked: {headers.Count} header(s) read, the LSN chain is unbroken.");
         }
         catch (OperationCanceledException)
         {
-            SetStatus("Chain validation cancelled.");
+            SetStatus("Chain check cancelled.");
         }
         catch (Exception ex)
         {
-            SetError($"Chain validation failed: {ex.Message}");
+            SetError($"Chain check failed: {ex.Message}");
         }
         finally
         {
@@ -1863,7 +1863,7 @@ public partial class RestoreViewModel : ViewModelBase
 
             FetchedFileMoves = new ObservableCollection<FileMoveOption>(list);
             HasFetchedFileMoves = FetchedFileMoves.Count > 0;
-            SetStatus($"RESTORE FILELISTONLY: {FetchedFileMoves.Count} logical file(s). Edit paths above and use WITH MOVE for correct restore.");
+            SetStatus($"Read {FetchedFileMoves.Count} logical file name(s) from the backup. Edit the target paths above, and tick WITH MOVE to use them.");
         }
         catch (Exception ex)
         {
@@ -1915,7 +1915,7 @@ public partial class RestoreViewModel : ViewModelBase
             sb.AppendLine($"Last LSN: {header.LastLsn?.ToString() ?? "(null)"}");
             sb.AppendLine($"Database backup LSN: {header.DatabaseBackupLsn?.ToString() ?? "(null)"}");
             BackupMetadataSummary = sb.ToString();
-            SetStatus("RESTORE HEADERONLY completed. See metadata summary below.");
+            SetStatus("Header read. See the metadata below.");
         }
         catch (Exception ex)
         {

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -496,28 +496,32 @@
                             <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{DynamicResource SecondaryTextBrush}" />
                         </TextBlock>
 
-                        <!-- On-demand LSN verification: one RESTORE HEADERONLY per chain member,
-                             so it is a deliberate action rather than automatic on selection. -->
+                        <!-- On-demand: one RESTORE HEADERONLY per chain member, so it is a
+                             deliberate action rather than automatic on selection.
+
+                             Named for the question it answers rather than for the word "validate".
+                             Two of the buttons on this screen used to say "verify" and mean
+                             different things, and a third said it while verifying nothing. -->
                         <Button Grid.Column="1"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding ValidateChainCommand}"
                                 Padding="12,6" Margin="0,0,8,0"
-                                ToolTip="Read each backup's header and verify the LSN chain is unbroken. Requires a connected server.">
+                                ToolTip="Do these backups belong together? Reads each backup's header and compares the LSNs. Takes seconds. Requires a connected server.">
                             <Button.Content>
                                 <TextBlock>
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="Validate Chain" />
+                                            <Setter Property="Text" Value="Check chain (HEADERONLY)" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsValidatingChain}" Value="True">
-                                                    <Setter Property="Text" Value="Validating..." />
+                                                    <Setter Property="Text" Value="Checking..." />
                                                 </DataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding ChainLsnVerified}" Value="True" />
                                                         <Condition Binding="{Binding HasChainIssues}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Text" Value="Chain Verified" />
+                                                    <Setter Property="Text" Value="Chain checked" />
                                                 </MultiDataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -526,19 +530,20 @@
                             </Button.Content>
                         </Button>
 
-                        <!-- A different question from Validate Chain: that one reads headers and
+                        <!-- A different question from Check chain: that one reads headers and
                              checks the LSNs line up, this one reads each backup end to end and
-                             checks it is intact. A truncated blob passes the first and fails this. -->
+                             checks it is intact. A truncated blob passes the first and fails this.
+                             It is also the only one here that costs real time. -->
                         <Button Grid.Column="2"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding VerifyChainCommand}"
                                 Padding="12,6" Margin="0,0,8,0"
-                                ToolTip="Run RESTORE VERIFYONLY over every backup in the chain to check each one reads back intact, before committing to the restore. Requires a connected server.">
+                                ToolTip="Is each backup actually readable? Runs RESTORE VERIFYONLY over every backup in the chain, reading every byte - this can take as long as the restore itself. Requires a connected server.">
                             <Button.Content>
                                 <TextBlock>
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="Verify Backups" />
+                                            <Setter Property="Text" Value="Verify backups (VERIFYONLY)" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsVerifyingChain}" Value="True">
                                                     <Setter Property="Text" Value="Verifying..." />
@@ -549,7 +554,7 @@
                                                         <Condition Binding="{Binding HasVerifyFailures}" Value="False" />
                                                         <Condition Binding="{Binding IsVerifyingChain}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Text" Value="Backups Verified" />
+                                                    <Setter Property="Text" Value="Backups verified" />
                                                 </MultiDataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -590,6 +595,20 @@
                             </Button.Content>
                         </Button>
                     </Grid>
+
+                    <!-- The pair above are the genuinely subtle one: both act on the whole chain
+                         and both sound like the same thing. The difference that matters when you
+                         are deciding whether to press one is how long it takes. -->
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               FontSize="11" TextWrapping="Wrap"
+                               Margin="0,6,0,0"
+                               Visibility="{Binding HasValidChain, Converter={StaticResource BoolToVis}}">
+                        <Run Text="Check chain" FontWeight="SemiBold" />
+                        <Run Text="reads each header and compares the LSNs - do these backups belong together? Seconds." />
+                        <LineBreak />
+                        <Run Text="Verify backups" FontWeight="SemiBold" />
+                        <Run Text="reads every byte of every backup - is each one actually readable? Can take as long as the restore." />
+                    </TextBlock>
 
                     <!-- Per-set VERIFYONLY results. Green while everything reads back, red the
                          moment one does not - a failed member here means the chain cannot restore,
@@ -883,34 +902,39 @@
                                 <TextBlock Style="{StaticResource SecondaryText}"
                                            FontSize="10" TextWrapping="Wrap"
                                            Margin="0,0,0,4"
-                                           Text="Logical file names are inferred by default. Use Verify backup to get actual names from the backup (RESTORE FILELISTONLY) for correct WITH MOVE." />
+                                           Text="Logical file names are guessed from the database name by default, which is wrong for a database that has been renamed or has secondary files. Get file names reads the real ones out of the backup." />
 
-                                <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
-                                    <Button Content="Verify backup (FILELISTONLY)"
+                                <!-- Wraps rather than clips. Four buttons on one line runs off the
+                                     edge of the panel at anything less than a wide window, and a
+                                     StackPanel does not wrap - it just hides the last one. -->
+                                <WrapPanel Orientation="Horizontal" Margin="0,8,0,8">
+                                    <!-- Was "Verify backup (FILELISTONLY)", which verified nothing:
+                                         it reads the logical file names so WITH MOVE can name them
+                                         correctly instead of guessing. Opening the backup to list
+                                         them does incidentally prove the credential works, which is
+                                         probably where the old name came from. -->
+                                    <Button Content="Get file names (FILELISTONLY)"
                                             Style="{StaticResource SecondaryButton}"
                                             Command="{Binding FetchLogicalNamesCommand}"
-                                            Padding="8,4" FontSize="11"
-                                            ToolTip="Run RESTORE FILELISTONLY on the full backup to get logical file names for WITH MOVE."
-                                            Margin="0,0,8,0" />
+                                            Padding="8,4" FontSize="11" Margin="0,0,8,6"
+                                            ToolTip="Reads the logical file names out of the full backup, so WITH MOVE can name them correctly rather than guessing from the database name. Reads this one backup, not the chain." />
                                     <Button Content="Copy FILELISTONLY command"
                                             Style="{StaticResource SecondaryButton}"
                                             Command="{Binding CopyFileListOnlyCommandCommand}"
-                                            Padding="8,4" FontSize="11"
-                                            ToolTip="Copy the RESTORE FILELISTONLY T-SQL to clipboard to run in SSMS (e.g. when you get error 13)."
-                                            Margin="0,0,8,0" />
-                                    <Button Content="View metadata (HEADERONLY)"
+                                            Padding="8,4" FontSize="11" Margin="0,0,8,6"
+                                            ToolTip="Copy the RESTORE FILELISTONLY T-SQL to clipboard to run in SSMS (e.g. when you get error 13)." />
+                                    <Button Content="Read header (HEADERONLY)"
                                             Style="{StaticResource SecondaryButton}"
                                             Command="{Binding InspectBackupMetadataCommand}"
-                                            Padding="8,4" FontSize="11"
-                                            ToolTip="Run RESTORE HEADERONLY to inspect backup set metadata."
-                                            Margin="0,0,8,0" />
+                                            Padding="8,4" FontSize="11" Margin="0,0,8,6"
+                                            ToolTip="Shows what the full backup says about itself - database, type, when it was taken, LSNs. Reads this one backup, not the chain." />
                                     <Button Content="Copy HEADERONLY command"
                                             Style="{StaticResource SecondaryButton}"
                                             Command="{Binding CopyHeaderOnlyCommandCommand}"
-                                            Padding="8,4" FontSize="11"
+                                            Padding="8,4" FontSize="11" Margin="0,0,8,6"
                                             ToolTip="Copy the RESTORE HEADERONLY T-SQL to clipboard to run in SSMS (e.g. when you get error 13)."
-                                            Margin="0,0,8,0" />
-                                </StackPanel>
+                                            />
+                                </WrapPanel>
 
                                 <Border Visibility="{Binding HasFetchedFileMoves, Converter={StaticResource BoolToVis}}"
                                         Background="{DynamicResource InputBackgroundBrush}"


### PR DESCRIPTION
Item 1 from #117. The issue stays open for the rest of the list.

| Was | Now |
|---|---|
| Verify backup (FILELISTONLY) | **Get file names** (FILELISTONLY) |
| View metadata (HEADERONLY) | **Read header** (HEADERONLY) |
| Validate Chain | **Check chain** (HEADERONLY) |
| Verify Backups | **Verify backups** (VERIFYONLY) |

Two of them said *verify* and meant different things, and one of those verified nothing: it runs `RESTORE FILELISTONLY` to read the **logical file names** out of the backup, so WITH MOVE can write `MOVE N''MyDb'' TO ...` correctly instead of the app guessing that the logical names match the database name - a guess that is silently wrong for any database that has been renamed or has secondary files.

It does open the backup on the URL to list them, which incidentally proves the credential and the network work. That is probably where the name came from, but it is a side effect, not the point.

Only one button keeps the word *verify* now, and it is the one that verifies. The T-SQL stays in the label - this audience knows what `VERIFYONLY` means, those words were just doing none of the work of saying what the button is **for**.

## The pair that actually needed explaining

`Check chain` and `Verify backups` both act on the whole chain and both sound like the same thing. There is now a line under them:

> **Check chain** reads each header and compares the LSNs - do these backups belong together? Seconds.
> **Verify backups** reads every byte of every backup - is each one actually readable? Can take as long as the restore.

The tooltips on the other two say "Reads this one backup, not the chain", because scope is the other distinction the UI never showed.

## Also

- Status messages use the same words as the button that produced them - "Chain checked", not "Chain validated"
- The WITH MOVE hint said "Use Verify backup to get actual names", which would have been nonsense; it now explains why the guess is wrong rather than naming a button
- The chain-gap warning in `BackupChainValidator` pointed at "Validate Chain"
- The four metadata buttons are in a `WrapPanel` - four on one line ran off the edge at anything less than a wide window, and a `StackPanel` does not wrap, it just hides the last one

Rendered the screen to a PNG and read it back to check it holds together rather than trusting it built.

**721 tests**, build clean at `-warnaserror`.