### PR TITLE
Make text on filled controls readable in every theme (#126)

### DIFF
--- a/src/NineLives.Tests/ThemeTests.cs
+++ b/src/NineLives.Tests/ThemeTests.cs
@@ -144,6 +144,141 @@ public class ThemeTests(WpfFixture wpf)
         });
     }
 
+    /// <summary>
+    /// Text on a FILLED control - a button, a checked box, a selected radio - is readable (#126).
+    ///
+    /// This is the pair that was wrong: the palettes carried an on-fill foreground and the control
+    /// styles hardcoded `Foreground="White"` instead, which in high contrast put white on yellow at
+    /// 1.07:1. Every fill is checked, in every theme, so a fourth button style cannot reintroduce
+    /// it quietly.
+    /// </summary>
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void TextOnAFilledControlIsReadable(AppTheme theme)
+    {
+        (string fill, string text)[] pairs =
+        [
+            ("AccentBrush", "AccentForegroundBrush"),
+            ("SuccessBrush", "SuccessForegroundBrush"),
+            ("ErrorBrush", "ErrorForegroundBrush"),
+            ("WarningBrush", "WarningForegroundBrush"),
+        ];
+
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+
+            foreach (var (fill, text) in pairs)
+            {
+                var background = ((SolidColorBrush)palette[fill]).Color;
+                var foreground = ((SolidColorBrush)palette[text]).Color;
+                var contrast = Contrast(foreground, background);
+
+                Assert.True(contrast >= 4.5,
+                    $"{theme}: {text} on {fill} is {contrast:F2}:1, below the 4.5:1 minimum.");
+            }
+        });
+    }
+
+    /// <summary>
+    /// The hover and pressed states of a filled button keep the same text readable - a button that
+    /// becomes illegible under the cursor is no better than one that starts that way.
+    /// </summary>
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void TextStaysReadableWhileAButtonIsHovered(AppTheme theme)
+    {
+        (string fill, string text)[] pairs =
+        [
+            ("AccentHoverBrush", "AccentForegroundBrush"),
+            ("AccentPressedBrush", "AccentForegroundBrush"),
+            ("SuccessHoverBrush", "SuccessForegroundBrush"),
+            ("SuccessPressedBrush", "SuccessForegroundBrush"),
+            ("ErrorHoverBrush", "ErrorForegroundBrush"),
+            ("ErrorPressedBrush", "ErrorForegroundBrush"),
+        ];
+
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+
+            foreach (var (fill, text) in pairs)
+            {
+                var background = ((SolidColorBrush)palette[fill]).Color;
+                var foreground = ((SolidColorBrush)palette[text]).Color;
+                var contrast = Contrast(foreground, background);
+
+                Assert.True(contrast >= 4.5,
+                    $"{theme}: {text} on {fill} is {contrast:F2}:1, below the 4.5:1 minimum.");
+            }
+        });
+    }
+
+    /// <summary>
+    /// The backup-type badges. Their fills come from a converter rather than the palette, so they
+    /// are the same in every theme and one foreground has to work against all of them.
+    /// </summary>
+    [Fact]
+    public void TextOnTheBackupTypeBadgesIsReadable()
+    {
+        Color[] fills =
+        [
+            Color.FromRgb(0x4A, 0x90, 0xD9),   // Full
+            Color.FromRgb(0xF3, 0x9C, 0x12),   // Differential
+            Color.FromRgb(0x27, 0xAE, 0x60),   // Transaction log
+            Color.FromRgb(0x88, 0x90, 0xA4),   // Unknown
+        ];
+
+        wpf.Invoke(() =>
+        {
+            var badgeText = ((SolidColorBrush)Application.Current.FindResource("BadgeTextBrush")).Color;
+
+            foreach (var fill in fills)
+            {
+                var contrast = Contrast(badgeText, fill);
+                Assert.True(contrast >= 4.5,
+                    $"Badge text on {fill} is {contrast:F2}:1, below the 4.5:1 minimum.");
+            }
+        });
+    }
+
+    /// <summary>
+    /// The converter that picks text for a data-driven fill always picks the better of black and
+    /// white - checked against every tag swatch and every path-element colour, which is where the
+    /// unreadable pairs actually were.
+    /// </summary>
+    [Fact]
+    public void TheContrastingTextConverterAlwaysPicksTheReadableOne()
+    {
+        string[] fills =
+        [
+            // GitHub's label swatches, used for tags.
+            "#B60205", "#D93F0B", "#FBCA04", "#0E8A16", "#006B75", "#1D76DB", "#0052CC", "#5319E7",
+            // Path element pills.
+            "#4A90D9", "#F39C12", "#9B59B6", "#27AE60",
+        ];
+
+        var converter = new Blackcat.NineLives.Converters.ContrastingTextConverter();
+
+        wpf.Invoke(() =>
+        {
+            foreach (var hex in fills)
+            {
+                var fill = (Color)ColorConverter.ConvertFromString(hex)!;
+                var chosen = ((SolidColorBrush)converter.Convert(
+                    hex, typeof(Brush), null!, System.Globalization.CultureInfo.InvariantCulture)).Color;
+
+                var contrast = Contrast(chosen, fill);
+                Assert.True(contrast >= 4.5,
+                    $"{hex} got text at {contrast:F2}:1, below the 4.5:1 minimum.");
+            }
+        });
+    }
+
     /// <summary>WCAG relative luminance contrast ratio.</summary>
     private static double Contrast(Color a, Color b)
     {

--- a/src/NineLives/Converters/ValueConverters.cs
+++ b/src/NineLives/Converters/ValueConverters.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
@@ -139,6 +139,73 @@ public class BackupTypeToColorConverter : IValueConverter
             "TransactionLog" => new SolidColorBrush(Color.FromRgb(0x27, 0xAE, 0x60)),
             _ => new SolidColorBrush(Color.FromRgb(0x88, 0x90, 0xA4))
         };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Picks black or white text for whatever colour it is given, by measured contrast (#126).
+///
+/// Used where the fill is DATA rather than theme - the path-element pills take their colour from
+/// the element, so no single hardcoded foreground can be right for all of them. White on the
+/// orange one scored 2.19:1 and on the green one 2.87:1, both well under the 4.5:1 minimum, while
+/// the blue and purple ones were fine. This asks the colour rather than assuming.
+/// </summary>
+public class ContrastingTextConverter : IValueConverter
+{
+    private static readonly SolidColorBrush Dark = new(Color.FromRgb(0x0F, 0x13, 0x1E));
+    private static readonly SolidColorBrush Light = new(Colors.White);
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var colour = value switch
+        {
+            Color c => c,
+            SolidColorBrush b => b.Color,
+            string hex when TryParse(hex, out var parsed) => parsed,
+            _ => Colors.Gray
+        };
+
+        // Compare both candidates and take the better, rather than thresholding on luminance. The
+        // usual 0.179 crossover assumes PURE black and white; this app's dark is #0F131E, which
+        // moves the crossover - and picking by the textbook threshold chose dark text at 4.12:1
+        // for an orange where white would have given 4.50:1.
+        return Contrast(Dark.Color, colour) >= Contrast(Light.Color, colour) ? Dark : Light;
+    }
+
+    private static bool TryParse(string hex, out Color colour)
+    {
+        try
+        {
+            colour = (Color)ColorConverter.ConvertFromString(hex);
+            return true;
+        }
+        catch
+        {
+            colour = Colors.Gray;
+            return false;
+        }
+    }
+
+    private static double Contrast(Color a, Color b)
+    {
+        var la = Luminance(a);
+        var lb = Luminance(b);
+        var (hi, lo) = la > lb ? (la, lb) : (lb, la);
+        return (hi + 0.05) / (lo + 0.05);
+    }
+
+    private static double Luminance(Color c)
+    {
+        static double Channel(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+
+        return 0.2126 * Channel(c.R) + 0.7152 * Channel(c.G) + 0.0722 * Channel(c.B);
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -8,9 +8,17 @@
          instance, so both work. -->
     <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
     <converters:NullToVisibilityConverter x:Key="NullToVis" />
+    <converters:ContrastingTextConverter x:Key="ContrastingText" />
 
     <!-- Terminal console. Darker than the cards on purpose, so the console reads as a separate
          surface the way a real terminal does rather than as another panel in the form. -->
+
+    <!--
+        Text on the backup-type badges and count chips. Those fills come from a converter rather
+        than the palette, so they are the same in every theme - and near-black clears 4.5:1 against
+        all four of them where white managed 2.19-3.34:1.
+    -->
+    <SolidColorBrush x:Key="BadgeTextBrush" Color="#0F131E" />
 
     <FontFamily x:Key="ConsoleFont">Cascadia Code, Cascadia Mono, Consolas, Courier New</FontFamily>
 
@@ -253,7 +261,9 @@
     <!-- Button Styles -->
     <Style x:Key="PrimaryButton" TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-        <Setter Property="Foreground" Value="White" />
+        <!-- From the palette, not hardcoded. White here is what made every primary button in high
+             contrast white-on-yellow at 1.07:1 (#126). -->
+        <Setter Property="Foreground" Value="{DynamicResource AccentForegroundBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="FontWeight" Value="SemiBold" />
@@ -323,6 +333,7 @@
 
     <Style x:Key="DangerButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
         <Setter Property="Background" Value="{DynamicResource ErrorBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ErrorForegroundBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -351,6 +362,7 @@
 
     <Style x:Key="SuccessButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
         <Setter Property="Background" Value="{DynamicResource SuccessBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SuccessForegroundBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -584,7 +596,7 @@
                                        Text="&#x2713;"
                                        FontSize="12"
                                        FontWeight="Bold"
-                                       Foreground="White"
+                                       Foreground="{DynamicResource AccentForegroundBrush}"
                                        HorizontalAlignment="Center"
                                        VerticalAlignment="Center"
                                        Visibility="Collapsed" />

--- a/src/NineLives/Themes/Palette.Dark.xaml
+++ b/src/NineLives/Themes/Palette.Dark.xaml
@@ -32,11 +32,18 @@
     <!-- ── accent ────────────────────────────────────────────────────────────── -->
     <Color x:Key="AccentColor">#3B83E9</Color>
     <Color x:Key="AccentHoverColor">#5195F5</Color>
-    <Color x:Key="AccentPressedColor">#2A6DCC</Color>
+    <Color x:Key="AccentPressedColor">#3A80E4</Color>
 
-    <!-- Text ON an accent-filled surface. Not always white: a light theme's accent fill still
-         wants white, but a high-contrast one may not. -->
-    <Color x:Key="AccentForegroundColor">#FFFFFF</Color>
+    <!--
+      Text ON a filled surface. Measured, not assumed: white on this theme's fills scores 2.19-3.82:1,
+      all of which fail WCAG AA for normal text, while near-black scores 4.85-8.46:1. The buttons had
+      Foreground="White" hardcoded in the control styles, which is what made the Connect button hard
+      to read (#126).
+    -->
+    <Color x:Key="AccentForegroundColor">#0F131E</Color>
+    <Color x:Key="SuccessForegroundColor">#0F131E</Color>
+    <Color x:Key="ErrorForegroundColor">#0F131E</Color>
+    <Color x:Key="WarningForegroundColor">#0F131E</Color>
 
     <!-- ── status ────────────────────────────────────────────────────────────── -->
     <Color x:Key="SuccessColor">#27AE60</Color>
@@ -76,6 +83,9 @@
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
     <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessForegroundBrush" Color="{StaticResource SuccessForegroundColor}" />
+    <SolidColorBrush x:Key="ErrorForegroundBrush" Color="{StaticResource ErrorForegroundColor}" />
+    <SolidColorBrush x:Key="WarningForegroundBrush" Color="{StaticResource WarningForegroundColor}" />
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
@@ -135,9 +145,9 @@
          literals in the control styles, which meant a light theme drew a dark stripe through every
          grid and a success button that jumped several shades on hover. -->
     <Color x:Key="SuccessHoverColor">#2ECC71</Color>
-    <Color x:Key="SuccessPressedColor">#1E8449</Color>
+    <Color x:Key="SuccessPressedColor">#22A05A</Color>
     <Color x:Key="ErrorHoverColor">#F05B4B</Color>
-    <Color x:Key="ErrorPressedColor">#C0392B</Color>
+    <Color x:Key="ErrorPressedColor">#E14E40</Color>
     <Color x:Key="AlternatingRowBackgroundColor">#12161F</Color>
 
     <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />

--- a/src/NineLives/Themes/Palette.HighContrast.xaml
+++ b/src/NineLives/Themes/Palette.HighContrast.xaml
@@ -44,7 +44,14 @@
     <Color x:Key="AccentPressedColor">#CCCC00</Color>
 
     <!-- Black text on the yellow fill. White on yellow is unreadable. -->
+    <!--
+      Text ON a filled surface. White on this theme's yellow is 1.07:1 - not "hard to read",
+      unreadable. Black scores 6.68-19.56:1 across the four fills.
+    -->
     <Color x:Key="AccentForegroundColor">#000000</Color>
+    <Color x:Key="SuccessForegroundColor">#000000</Color>
+    <Color x:Key="ErrorForegroundColor">#000000</Color>
+    <Color x:Key="WarningForegroundColor">#000000</Color>
 
     <!-- ── status ────────────────────────────────────────────────────────────── -->
     <Color x:Key="SuccessColor">#00FF00</Color>
@@ -83,6 +90,9 @@
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
     <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessForegroundBrush" Color="{StaticResource SuccessForegroundColor}" />
+    <SolidColorBrush x:Key="ErrorForegroundBrush" Color="{StaticResource ErrorForegroundColor}" />
+    <SolidColorBrush x:Key="WarningForegroundBrush" Color="{StaticResource WarningForegroundColor}" />
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
@@ -143,7 +153,7 @@
     <Color x:Key="SuccessHoverColor">#66FF66</Color>
     <Color x:Key="SuccessPressedColor">#00CC00</Color>
     <Color x:Key="ErrorHoverColor">#FF8888</Color>
-    <Color x:Key="ErrorPressedColor">#CC0000</Color>
+    <Color x:Key="ErrorPressedColor">#FF8080</Color>
     <Color x:Key="AlternatingRowBackgroundColor">#1A1A1A</Color>
 
     <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />

--- a/src/NineLives/Themes/Palette.Light.xaml
+++ b/src/NineLives/Themes/Palette.Light.xaml
@@ -32,16 +32,24 @@
 
     <!-- ── accent ────────────────────────────────────────────────────────────── -->
     <Color x:Key="AccentColor">#1F63C4</Color>
-    <Color x:Key="AccentHoverColor">#2E74D8</Color>
+    <Color x:Key="AccentHoverColor">#2A6ECD</Color>
     <Color x:Key="AccentPressedColor">#17509F</Color>
+    <!--
+      Text ON a filled surface. White wins on every fill here (4.24-5.77:1) because the fills are
+      already darkened for a white page - the opposite of the dark theme's answer.
+    -->
     <Color x:Key="AccentForegroundColor">#FFFFFF</Color>
+    <Color x:Key="SuccessForegroundColor">#FFFFFF</Color>
+    <Color x:Key="ErrorForegroundColor">#FFFFFF</Color>
+    <Color x:Key="WarningForegroundColor">#FFFFFF</Color>
 
     <!-- ── status ────────────────────────────────────────────────────────────── -->
     <!-- Darkened from the dark theme's: #27AE60 on white is legible but weak, and #E74C3C reads
          as pink at small sizes. -->
     <Color x:Key="SuccessColor">#1B7F45</Color>
     <Color x:Key="ErrorColor">#C0392B</Color>
-    <Color x:Key="WarningColor">#B26A00</Color>
+    <!-- #B26A00 measured 4.24:1 against white, just under AA. -->
+    <Color x:Key="WarningColor">#A35F00</Color>
 
     <!-- ── text ──────────────────────────────────────────────────────────────── -->
     <Color x:Key="PrimaryTextColor">#141824</Color>
@@ -73,6 +81,9 @@
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
     <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessForegroundBrush" Color="{StaticResource SuccessForegroundColor}" />
+    <SolidColorBrush x:Key="ErrorForegroundBrush" Color="{StaticResource ErrorForegroundColor}" />
+    <SolidColorBrush x:Key="WarningForegroundBrush" Color="{StaticResource WarningForegroundColor}" />
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
@@ -131,9 +142,9 @@
     <!-- Hover and pressed states for the status buttons, and the DataGrid's banded row. All were
          literals in the control styles, which meant a light theme drew a dark stripe through every
          grid and a success button that jumped several shades on hover. -->
-    <Color x:Key="SuccessHoverColor">#239954</Color>
+    <Color x:Key="SuccessHoverColor">#177040</Color>
     <Color x:Key="SuccessPressedColor">#146334</Color>
-    <Color x:Key="ErrorHoverColor">#D2483A</Color>
+    <Color x:Key="ErrorHoverColor">#C93D2F</Color>
     <Color x:Key="ErrorPressedColor">#9C2D21</Color>
     <Color x:Key="AlternatingRowBackgroundColor">#F2F5FA</Color>
 

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -219,7 +219,7 @@
                                             HorizontalAlignment="Left"
                                             Opacity="0.85">
                                         <TextBlock Text="{Binding TypeDisplay}"
-                                                   Foreground="White"
+                                                   Foreground="{StaticResource BadgeTextBrush}"
                                                    FontSize="11"
                                                    FontWeight="SemiBold" />
                                     </Border>

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -438,7 +438,7 @@
                                                     <Border CornerRadius="4" Padding="10,5" Cursor="Hand"
                                                             Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                         <StackPanel Orientation="Horizontal">
-                                                            <TextBlock Text="{Binding DisplayName}" Foreground="White"
+                                                            <TextBlock Text="{Binding DisplayName}" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}"
                                                                        FontSize="12" FontWeight="SemiBold"
                                                                        VerticalAlignment="Center" />
                                                             <Button Content="  x" Foreground="{DynamicResource PrimaryTextBrush}" FontSize="11"
@@ -481,9 +481,9 @@
                                                             BorderBrush="{DynamicResource CardBorderBrush}"
                                                             Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                         <StackPanel Orientation="Horizontal">
-                                                            <TextBlock Text="+" Foreground="White" FontWeight="Bold"
+                                                            <TextBlock Text="+" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}" FontWeight="Bold"
                                                                        FontSize="12" Margin="0,0,4,0" />
-                                                            <TextBlock Text="{Binding DisplayName}" Foreground="White"
+                                                            <TextBlock Text="{Binding DisplayName}" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}"
                                                                        FontSize="12" />
                                                         </StackPanel>
                                                     </Border>
@@ -549,7 +549,7 @@
                                                             <Border CornerRadius="4" Padding="10,5" Cursor="Hand"
                                                                     Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                                 <StackPanel Orientation="Horizontal">
-                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="White"
+                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}"
                                                                                FontSize="12" FontWeight="SemiBold"
                                                                                VerticalAlignment="Center" />
                                                                     <Button Content="  x" Foreground="{DynamicResource PrimaryTextBrush}" FontSize="11"
@@ -590,9 +590,9 @@
                                                                     BorderBrush="{DynamicResource CardBorderBrush}"
                                                                     Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                                 <StackPanel Orientation="Horizontal">
-                                                                    <TextBlock Text="+" Foreground="White" FontWeight="Bold"
+                                                                    <TextBlock Text="+" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}" FontWeight="Bold"
                                                                                FontSize="12" Margin="0,0,4,0" />
-                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="White"
+                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}"
                                                                                FontSize="12" />
                                                                 </StackPanel>
                                                             </Border>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -87,19 +87,19 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Orientation="Horizontal">
                             <Border Background="{DynamicResource AccentBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
-                                <TextBlock Text="{Binding FullCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
+                                <TextBlock Text="{Binding FullCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Full Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
                             <Border Background="{DynamicResource WarningBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
-                                <TextBlock Text="{Binding DiffCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
+                                <TextBlock Text="{Binding DiffCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Diff Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="2" Orientation="Horizontal">
                             <Border Background="{DynamicResource SuccessBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
-                                <TextBlock Text="{Binding LogCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
+                                <TextBlock Text="{Binding LogCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Log Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
@@ -414,7 +414,7 @@
                                     <DataTemplate>
                                         <Border Background="{Binding Type, Converter={StaticResource TypeToColor}}"
                                                 CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Opacity="0.85">
-                                            <TextBlock Text="{Binding Type}" Foreground="White"
+                                            <TextBlock Text="{Binding Type}" Foreground="{StaticResource BadgeTextBrush}"
                                                        FontSize="11" FontWeight="SemiBold" />
                                         </Border>
                                     </DataTemplate>
@@ -443,7 +443,7 @@
                                     <DataTemplate>
                                         <Border Background="{Binding Type, Converter={StaticResource TypeToColor}}"
                                                 CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Opacity="0.85">
-                                            <TextBlock Text="{Binding TypeDisplay}" Foreground="White"
+                                            <TextBlock Text="{Binding TypeDisplay}" Foreground="{StaticResource BadgeTextBrush}"
                                                        FontSize="11" FontWeight="SemiBold" />
                                         </Border>
                                     </DataTemplate>
@@ -740,7 +740,7 @@
                                             </Grid.ColumnDefinitions>
                                             <Border Background="{Binding Type, Converter={StaticResource TypeToColor}}"
                                                     CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Opacity="0.85">
-                                                <TextBlock Text="{Binding TypeDisplay}" Foreground="White"
+                                                <TextBlock Text="{Binding TypeDisplay}" Foreground="{StaticResource BadgeTextBrush}"
                                                            FontSize="11" FontWeight="SemiBold" HorizontalAlignment="Center" />
                                             </Border>
                                             <TextBlock Grid.Column="1" Text="{Binding BlobName}"


### PR DESCRIPTION
Closes #126.

The report was white text on the high-contrast yellow. It is worse than that.

## Cause

The palettes have carried an `AccentForegroundBrush` since the theming change — black in high contrast, white elsewhere — and **nothing ever used it**. `PrimaryButton` hardcodes `Foreground="White"`, and Danger and Success inherit from it. The palette was right; the control styles overruled it.

## Measured, and broader than reported

| fill | white | near-black |
|---|---|---|
| dark accent `#3B83E9` | 3.74:1 | **4.95:1** |
| dark success `#27AE60` | 2.87:1 | **6.46:1** |
| dark error `#E74C3C` | 3.82:1 | **4.85:1** |
| dark warning `#F39C12` | 2.19:1 | **8.46:1** |
| HC accent `#FFFF00` | 1.07:1 | **19.56:1** |
| light accent `#1F63C4` | **5.77:1** | 3.07:1 |

**White fails on every fill in the dark theme too**, not just high contrast — the green Connect button was the visible one, but it applies to all of them. Light is the opposite: white wins on all four, because those fills are already darkened for a white page.

## Visible change

**The dark theme now has dark button labels.** That is a change to the established look, and the one thing here worth eyeballing. It is one line per palette to put white back; the numbers are in the comment next to the setting.

## Found by writing the test

Four more failures that would not have been caught by eye:

- **Every pressed state was a darker shade of its base** — fine under white text, eats the contrast under dark text. Dark accent-pressed came out at 3.67:1. Pressed and hover shades are measured now.
- **Light's warning `#B26A00`** was 4.24:1 against white, just under. Darkened to `#A35F00`.
- **The backup-type badges** took white on mid-tone fills: 2.19:1 for Diff, 2.87:1 for Log. Those fills come from a converter and are the same in every theme, so they get one near-black `BadgeTextBrush` that clears all four.
- **The tag and path-element pills** take their colour from data, so no fixed foreground can be right — they use a converter that measures. It compares both candidates rather than thresholding on luminance: the textbook 0.179 crossover assumes *pure* black and white, and this app uses `#0F131E`, which moved it enough to pick dark text at 4.12:1 for an orange where white gives 4.50:1.

## Tests

Every fill, every hover, every pressed state, in all three themes, at 4.5:1 — plus the badges and every tag swatch. A fourth button style cannot reintroduce this quietly.

**729 tests**, build clean at `-warnaserror`. All three themes rendered to PNGs and checked.
