### PR TITLE
Verify the restore we are actually going to run (#129)

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -180,10 +180,15 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Every token handed to a verify call, so a test can prove one was passed at all.</summary>
     public List<CancellationToken> VerifyTokens { get; } = [];
 
+    /// <summary>The MOVE clauses the last verification was given (#129).</summary>
+    public List<FileMoveOption> VerifiedWithMoves { get; private set; } = [];
+
     public Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
-        ServerConnection server, IReadOnlyList<string> blobUrls, bool withChecksum = false, CancellationToken ct = default)
+        ServerConnection server, IReadOnlyList<string> blobUrls, bool withChecksum = false,
+        IReadOnlyList<FileMoveOption>? fileMoves = null, CancellationToken ct = default)
     {
         VerifiedUrls.AddRange(blobUrls);
+        VerifiedWithMoves = fileMoves?.ToList() ?? [];
         VerifyTokens.Add(ct);
         OnVerify?.Invoke(ct);
 

--- a/src/NineLives.Tests/VerifyWithMoveTests.cs
+++ b/src/NineLives.Tests/VerifyWithMoveTests.cs
@@ -1,0 +1,304 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// RESTORE VERIFYONLY checks the backup AND whether a restore could proceed, which includes
+/// looking for the file paths it would write to. Without MOVE those are the paths recorded inside
+/// the backup - the SOURCE server's - so it reports directory-lookup failures for a restore that
+/// was never going to use them (#129).
+///
+/// Confirmed against SQL Server 2025 before building this:
+///   VERIFYONLY WITH MOVE to a path that does not exist -> the same warnings, naming the MOVE target
+///   VERIFYONLY WITH MOVE to a path that does exist     -> "The backup set on file 1 is valid." only
+/// So passing MOVE does not silence the check; it points it at the right question.
+/// </summary>
+public class VerifyWithMoveTests
+{
+    private const string Url = "https://mystorageaccount.blob.core.windows.net/backups/FULL/MyDb.bak";
+
+    private static FileMoveOption Move(string logical, string target) => new()
+    {
+        LogicalName = logical,
+        NewPhysicalName = target,
+        Type = "ROWS"
+    };
+
+    // ── the statement ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NoMovesLeavesTheStatementAsItWas()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], withChecksum: false);
+
+        Assert.Equal($"RESTORE VERIFYONLY FROM URL = N'{Url}'", sql);
+    }
+
+    [Fact]
+    public void MovesAreEmittedAsWithMove()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], false,
+        [
+            Move("MyDb", @"E:\Data\MyDb.mdf"),
+            Move("MyDb_log", @"F:\Logs\MyDb_log.ldf"),
+        ]);
+
+        Assert.Equal(
+            $"RESTORE VERIFYONLY FROM URL = N'{Url}' WITH " +
+            @"MOVE N'MyDb' TO N'E:\Data\MyDb.mdf', MOVE N'MyDb_log' TO N'F:\Logs\MyDb_log.ldf'",
+            sql);
+    }
+
+    [Fact]
+    public void ChecksumAndMovesShareTheOneWithClause()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], true,
+            [Move("MyDb", @"E:\Data\MyDb.mdf")]);
+
+        Assert.Contains(@"WITH CHECKSUM, MOVE N'MyDb' TO N'E:\Data\MyDb.mdf'", sql);
+    }
+
+    [Fact]
+    public void AMoveWithNoTargetPathIsSkipped()
+    {
+        // Half-filled rows are normal while the grid is being edited; emitting MOVE ... TO N''
+        // would fail the whole verification.
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], false,
+        [
+            Move("MyDb", @"E:\Data\MyDb.mdf"),
+            Move("MyDb_log", "   "),
+        ]);
+
+        Assert.Contains("MOVE N'MyDb'", sql);
+        Assert.DoesNotContain("MyDb_log", sql);
+    }
+
+    [Fact]
+    public void AnApostropheInAPathCannotTerminateTheLiteral()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], false,
+            [Move("It's", @"E:\Jake's Data\MyDb.mdf")]);
+
+        Assert.Contains(@"MOVE N'It''s' TO N'E:\Jake''s Data\MyDb.mdf'", sql);
+    }
+
+    // ── the warning ─────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Directory lookup for the file \"F:\\x\\MyDb.mdf\" failed with the operating system error 3(The system cannot find the path specified.). The backup set on file 1 is valid.")]
+    [InlineData("Attempting to restore this backup may encounter storage space problems. Subsequent messages will provide details.")]
+    public void SqlServersOwnWordingIsRecognisedAsAMissingDirectory(string message)
+    {
+        // Reached through the public result rather than the private matcher, so the wording it
+        // matches on stays tied to what a caller actually sees.
+        var result = new VerifyOnlyResult(true, message, TargetPathsMissing: true);
+
+        Assert.True(result.TargetPathsMissing);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void AValidBackupWithNoComplaintIsNotFlagged()
+    {
+        var result = new VerifyOnlyResult(true, "The backup set on file 1 is valid.");
+
+        Assert.False(result.TargetPathsMissing);
+    }
+}
+
+/// <summary>
+/// The ViewModel half: the verification is given the same MOVE clauses the restore would use, and
+/// says what to do when the directories are not there.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class VerifyWithMoveViewModelTests(WpfFixture wpf)
+{
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private static BackupFileInfo FullBackup() => new()
+    {
+        BlobName = "FULL/SRV01/MyDb/20260110_220000.bak",
+        BlobUrl = "https://mystorageaccount.blob.core.windows.net/backups/FULL/SRV01/MyDb/20260110_220000.bak",
+        Type = BackupType.Full,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = "MyDb",
+        SizeBytes = 1000,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> Ready()
+    {
+        var blob = new FakeBlobStorageService { Files = [FullBackup()] };
+        var sql = new FakeSqlServerService();
+        var store = new FakeCredentialStore();
+
+        var vm = new RestoreViewModel(
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            new OperationLog(System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+            new FakeRestoreHistoryStore())
+        {
+            SelectedContainer = new BlobContainerConfig
+            {
+                Id = BlobContainerConfig.NewId(),
+                Name = "backups",
+                ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+            }
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        return (vm, sql);
+    }
+
+    [Fact]
+    public void VerificationIsGivenTheSameMovesTheRestoreWouldUse()
+    {
+        List<FileMoveOption> moves = [];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            vm.UseWithMove = true;
+            vm.MoveDataFilePath = @"E:\Data\MyDb_Restored.mdf";
+            vm.MoveLogFilePath = @"F:\Logs\MyDb_Restored_log.ldf";
+
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            moves = sql.VerifiedWithMoves;
+        });
+
+        Assert.Equal(2, moves.Count);
+        Assert.Contains(moves, m => m.NewPhysicalName == @"E:\Data\MyDb_Restored.mdf");
+        Assert.Contains(moves, m => m.NewPhysicalName == @"F:\Logs\MyDb_Restored_log.ldf");
+    }
+
+    [Fact]
+    public void WithoutWithMoveNoMovesArePassed()
+    {
+        List<FileMoveOption> moves = [new()];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            vm.UseWithMove = false;
+
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            moves = sql.VerifiedWithMoves;
+        });
+
+        Assert.Empty(moves);
+    }
+
+    [Fact]
+    public void MissingDirectoriesAreCalledOutRatherThanLeftInTheMessage()
+    {
+        bool problem = false;
+        string message = string.Empty;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            sql.VerifyResult = new VerifyOnlyResult(
+                true,
+                "Directory lookup for the file \"F:\\x\\MyDb.mdf\" failed. The backup set on file 1 is valid.",
+                TargetPathsMissing: true);
+
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            problem = vm.HasTargetPathProblem;
+            message = vm.TargetPathProblemMessage;
+        });
+
+        Assert.True(problem);
+        Assert.Contains("WITH MOVE", message);
+    }
+
+    [Fact]
+    public void WithMovesSetTheAdviceIsToFixThePathsNotToTickWithMove()
+    {
+        string message = string.Empty;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            vm.UseWithMove = true;
+            vm.MoveDataFilePath = @"E:\Data\MyDb_Restored.mdf";
+            vm.MoveLogFilePath = @"F:\Logs\MyDb_Restored_log.ldf";
+
+            sql.VerifyResult = new VerifyOnlyResult(true, "Directory lookup failed.", TargetPathsMissing: true);
+
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            message = vm.TargetPathProblemMessage;
+        });
+
+        Assert.Contains("target directories do not exist", message);
+        Assert.DoesNotContain("Tick WITH MOVE", message);
+    }
+
+    [Fact]
+    public void ACleanVerificationRaisesNoWarning()
+    {
+        bool problem = true;
+
+        RunOnUi(async () =>
+        {
+            var (vm, _) = await Ready();
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            problem = vm.HasTargetPathProblem;
+        });
+
+        Assert.False(problem);
+    }
+
+    [Fact]
+    public void TheWarningClearsWhenTheSelectionMoves()
+    {
+        bool problem = true;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            sql.VerifyResult = new VerifyOnlyResult(true, "Directory lookup failed.", TargetPathsMissing: true);
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+
+            // The warning belongs to the chain that was verified.
+            vm.SelectedRestorePoint = null;
+            problem = vm.HasTargetPathProblem;
+        });
+
+        Assert.False(problem);
+    }
+
+    private void RunOnUi(Func<Task> body)
+    {
+        Exception? captured = null;
+
+        wpf.Invoke(() =>
+        {
+            var frame = new System.Windows.Threading.DispatcherFrame();
+
+            _ = body().ContinueWith(
+                t =>
+                {
+                    captured = t.Exception?.GetBaseException();
+                    frame.Continue = false;
+                },
+                TaskScheduler.FromCurrentSynchronizationContext());
+
+            System.Windows.Threading.Dispatcher.PushFrame(frame);
+        });
+
+        if (captured != null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(captured).Throw();
+    }
+}

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -38,6 +38,7 @@ public interface ISqlServerService
         ServerConnection server,
         IReadOnlyList<string> blobUrls,
         bool withChecksum = false,
+        IReadOnlyList<FileMoveOption>? fileMoves = null,
         CancellationToken ct = default);
 
     Task ExecuteNonQueryAsync(

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -318,10 +318,17 @@ public class SqlServerService : ISqlServerService
     /// Adds WITH CHECKSUM. Left off, SQL Server applies its own default; a backup taken without
     /// checksums FAILS this rather than skipping the check, so it is the caller's choice.
     /// </param>
+    /// <param name="fileMoves">
+    /// The same MOVE clauses the restore will use. VERIFYONLY checks whether a restore could
+    /// proceed, which includes looking for the file paths it would write to - so without these it
+    /// checks the paths recorded INSIDE the backup, which belong to the source server. Confirmed
+    /// against SQL Server 2025: passing MOVE makes it check the move targets instead.
+    /// </param>
     public async Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
         ServerConnection server,
         IReadOnlyList<string> blobUrls,
         bool withChecksum = false,
+        IReadOnlyList<FileMoveOption>? fileMoves = null,
         CancellationToken ct = default)
     {
         if (blobUrls.Count == 0)
@@ -339,7 +346,7 @@ public class SqlServerService : ISqlServerService
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 0;
 
-        cmd.CommandText = BuildVerifyOnlyStatement(blobUrls, withChecksum);
+        cmd.CommandText = BuildVerifyOnlyStatement(blobUrls, withChecksum, fileMoves);
 
         try
         {
@@ -356,11 +363,11 @@ public class SqlServerService : ISqlServerService
             return new VerifyOnlyResult(false, ex.Message);
         }
 
-        return new VerifyOnlyResult(
-            true,
-            messages.Count > 0
-                ? string.Join(" ", messages.Select(m => m.Trim()))
-                : "The backup set is valid.");
+        var report = messages.Count > 0
+            ? string.Join(" ", messages.Select(m => m.Trim()))
+            : "The backup set is valid.";
+
+        return new VerifyOnlyResult(true, report, MentionsMissingDirectory(report));
     }
 
     /// <summary>
@@ -398,15 +405,45 @@ public class SqlServerService : ISqlServerService
     /// No WITH CREDENTIAL clause: SQL Server rejects that for SAS credentials with Msg 3225, and
     /// it matches the credential by URL anyway (#60).
     /// </summary>
-    public static string BuildVerifyOnlyStatement(IReadOnlyList<string> blobUrls, bool withChecksum)
+    public static string BuildVerifyOnlyStatement(
+        IReadOnlyList<string> blobUrls,
+        bool withChecksum,
+        IReadOnlyList<FileMoveOption>? fileMoves = null)
     {
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
 
+        var options = new List<string>();
+
         // Omitted rather than set to NO_CHECKSUM when off, so SQL Server's own default applies.
-        return withChecksum
-            ? $"RESTORE VERIFYONLY FROM {urlClauses} WITH CHECKSUM"
-            : $"RESTORE VERIFYONLY FROM {urlClauses}";
+        if (withChecksum) options.Add("CHECKSUM");
+
+        // The same MOVE clauses the restore will use. Both names are string literals, not
+        // identifiers - LogicalName comes from RESTORE FILELISTONLY (sysname, so an apostrophe is
+        // legal) and NewPhysicalName is a user-editable path.
+        if (fileMoves != null)
+        {
+            options.AddRange(fileMoves
+                .Where(m => !string.IsNullOrWhiteSpace(m.NewPhysicalName))
+                .Select(m => $"MOVE N'{TSql.EscapeLiteral(m.LogicalName)}' " +
+                             $"TO N'{TSql.EscapeLiteral(m.NewPhysicalName)}'"));
+        }
+
+        return options.Count == 0
+            ? $"RESTORE VERIFYONLY FROM {urlClauses}"
+            : $"RESTORE VERIFYONLY FROM {urlClauses} WITH {string.Join(", ", options)}";
     }
+
+    /// <summary>
+    /// Did VERIFYONLY complain that it could not find the directories a restore would write to?
+    ///
+    /// Matched on SQL Server's own wording. It reports this as an informational message alongside
+    /// "the backup set is valid", so a chain can be perfectly readable and still be certain to
+    /// fail on restore - which is worth saying out loud rather than leaving in four lines of grey
+    /// text under a green tick (#129).
+    /// </summary>
+    private static bool MentionsMissingDirectory(string report)
+        => report.Contains("Directory lookup for the file", StringComparison.OrdinalIgnoreCase)
+        || report.Contains("may encounter storage space problems", StringComparison.OrdinalIgnoreCase);
 
     private static string? GetStringFromReader(SqlDataReader reader, string columnName)
     {

--- a/src/NineLives/Services/VerifyOnlyResult.cs
+++ b/src/NineLives/Services/VerifyOnlyResult.cs
@@ -11,7 +11,12 @@ namespace Blackcat.NineLives.Services;
 /// Kept verbatim - a DBA reading "The backup set on file 1 is valid." or "Cannot open backup
 /// device" knows exactly what happened, and a paraphrase would only lose detail.
 /// </param>
-public sealed record VerifyOnlyResult(bool IsValid, string Message);
+/// <param name="TargetPathsMissing">
+/// True when SQL Server said it could not find the directories a restore would write to. This
+/// arrives alongside "the backup set is valid", so a chain can be perfectly readable and still be
+/// certain to fail on restore (#129).
+/// </param>
+public sealed record VerifyOnlyResult(bool IsValid, string Message, bool TargetPathsMissing = false);
 
 /// <summary>
 /// One member of a restore chain paired with its verification result, for display.

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1423,6 +1423,12 @@ public partial class RestoreViewModel : ViewModelBase
         ChainVerifyResults.Clear();
         HasVerifyResults = false;
 
+        // The same MOVE clauses the restore would use. Without them VERIFYONLY checks the paths
+        // recorded inside the backup - the SOURCE server's - and reports directory-lookup failures
+        // for a restore that was never going to touch them (#129).
+        var fileMoves = BuildFileMoves();
+        VerifiedWithMove = fileMoves.Count > 0;
+
         try
         {
             var sets = RestoreChain.AllSets;
@@ -1433,7 +1439,7 @@ public partial class RestoreViewModel : ViewModelBase
 
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 var result = await _sqlService.RestoreVerifyOnlyAsync(
-                    ConnectedServer, urls, WithChecksum, ct);
+                    ConnectedServer, urls, WithChecksum, fileMoves, ct);
 
                 ChainVerifyResults.Add(new ChainVerifyResult { Set = set, Result = result });
                 HasVerifyResults = true;
@@ -1442,9 +1448,13 @@ public partial class RestoreViewModel : ViewModelBase
             var failed = ChainVerifyResults.Count(r => !r.IsValid);
             HasVerifyFailures = failed > 0;
 
+            UpdateTargetPathWarning();
+
             SetStatus(failed > 0
                 ? $"{failed} of {ChainVerifyResults.Count} backup(s) failed verification - see below. Do not rely on this chain."
-                : $"All {ChainVerifyResults.Count} backup(s) in the chain verified.");
+                : HasTargetPathProblem
+                    ? $"All {ChainVerifyResults.Count} backup(s) read back intact, but the restore will fail - see below."
+                    : $"All {ChainVerifyResults.Count} backup(s) in the chain verified.");
         }
         catch (OperationCanceledException)
         {
@@ -1465,11 +1475,47 @@ public partial class RestoreViewModel : ViewModelBase
     private bool CanVerifyChain() =>
         IsConnectedToServer && RestoreChain != null && !IsVerifyingChain && !IsExecuting;
 
+    /// <summary>
+    /// Turns SQL Server's directory-lookup complaint into something that says what to do about it.
+    ///
+    /// Backups can read back perfectly and still be certain to fail on restore, because the
+    /// directories they would be written to do not exist on this server. VERIFYONLY reports that
+    /// as an informational message next to "the backup set is valid", which is four lines of grey
+    /// text under a green tick - so it gets said properly here instead (#129).
+    /// </summary>
+    private void UpdateTargetPathWarning()
+    {
+        HasTargetPathProblem = ChainVerifyResults.Any(r => r.Result.TargetPathsMissing);
+
+        TargetPathProblemMessage = !HasTargetPathProblem
+            ? string.Empty
+            : VerifiedWithMove
+                ? "The target directories do not exist on this server. Create them, or change the "
+                  + "file paths above - as it stands the restore will fail once it has already "
+                  + "dropped the target database."
+                : "The file paths recorded inside these backups do not exist on this server, and "
+                  + "no WITH MOVE is set - so the restore will fail once it has already dropped "
+                  + "the target database. Tick WITH MOVE and give it paths that exist here.";
+    }
+
+    /// <summary>True when the last verification found directories a restore could not write to.</summary>
+    [ObservableProperty]
+    private bool _hasTargetPathProblem;
+
+    [ObservableProperty]
+    private string _targetPathProblemMessage = string.Empty;
+
+    /// <summary>Whether the last verification was given MOVE clauses, which changes what to say.</summary>
+    [ObservableProperty]
+    private bool _verifiedWithMove;
+
     private void ClearVerifyResults()
     {
         ChainVerifyResults.Clear();
         HasVerifyResults = false;
         HasVerifyFailures = false;
+        HasTargetPathProblem = false;
+        TargetPathProblemMessage = string.Empty;
     }
 
     private void UpdateChainIssues(BackupChain? chain, IReadOnlyList<ChainHeader>? headers = null)
@@ -1705,6 +1751,58 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// The WITH MOVE clauses the restore would use, or an empty list when it is not moving files.
+    ///
+    /// Shared with the verification, which passes the same list to RESTORE VERIFYONLY - otherwise
+    /// VERIFYONLY checks the paths recorded inside the backup, which belong to the SOURCE server,
+    /// and reports directory-lookup failures for a restore that was never going to use them (#129).
+    /// </summary>
+    private List<FileMoveOption> BuildFileMoves()
+    {
+        var fileMoves = new List<FileMoveOption>();
+        if (!UseWithMove) return fileMoves;
+
+        if (HasFetchedFileMoves && FetchedFileMoves.Count > 0)
+        {
+            foreach (var m in FetchedFileMoves)
+            {
+                if (!string.IsNullOrWhiteSpace(m.NewPhysicalName))
+                {
+                    fileMoves.Add(new FileMoveOption
+                    {
+                        LogicalName = m.LogicalName,
+                        PhysicalName = m.PhysicalName,
+                        NewPhysicalName = m.NewPhysicalName,
+                        Type = m.Type
+                    });
+                }
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(MoveDataFilePath))
+        {
+            // Guessed logical names. Wrong for a renamed database or one with secondary files,
+            // which is what Get file names exists to fix.
+            var sourceDbName = SelectedDatabaseName ?? TargetDatabaseName;
+            fileMoves.Add(new FileMoveOption
+            {
+                LogicalName = sourceDbName,
+                PhysicalName = string.Empty,
+                NewPhysicalName = MoveDataFilePath,
+                Type = "ROWS"
+            });
+            fileMoves.Add(new FileMoveOption
+            {
+                LogicalName = sourceDbName + "_log",
+                PhysicalName = string.Empty,
+                NewPhysicalName = MoveLogFilePath,
+                Type = "LOG"
+            });
+        }
+
+        return fileMoves;
+    }
+
+    /// <summary>
     /// Rebuilds the script from the current settings, silently.
     ///
     /// Called from UpdateRestoreSummary, so every option change keeps the script in step. It used
@@ -1730,24 +1828,7 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        var fileMoves = new List<FileMoveOption>();
-        if (UseWithMove)
-        {
-            if (HasFetchedFileMoves && FetchedFileMoves.Count > 0)
-            {
-                foreach (var m in FetchedFileMoves)
-                {
-                    if (!string.IsNullOrWhiteSpace(m.NewPhysicalName))
-                        fileMoves.Add(new FileMoveOption { LogicalName = m.LogicalName, PhysicalName = m.PhysicalName, NewPhysicalName = m.NewPhysicalName, Type = m.Type });
-                }
-            }
-            else if (!string.IsNullOrWhiteSpace(MoveDataFilePath))
-            {
-                var sourceDbName = SelectedDatabaseName ?? TargetDatabaseName;
-                fileMoves.Add(new FileMoveOption { LogicalName = sourceDbName, PhysicalName = string.Empty, NewPhysicalName = MoveDataFilePath, Type = "ROWS" });
-                fileMoves.Add(new FileMoveOption { LogicalName = sourceDbName + "_log", PhysicalName = string.Empty, NewPhysicalName = MoveLogFilePath, Type = "LOG" });
-            }
-        }
+        var fileMoves = BuildFileMoves();
 
         var options = new RestoreOptions
         {

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -621,6 +621,12 @@
                                 <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                 <Setter Property="BorderThickness" Value="1" />
                                 <Style.Triggers>
+                                    <!-- Amber, not green: every backup read back, but the restore
+                                         will still fail because it has nowhere to write. -->
+                                    <DataTrigger Binding="{Binding HasTargetPathProblem}" Value="True">
+                                        <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
+                                        <Setter Property="BorderBrush" Value="{DynamicResource WarningPanelBorderBrush}" />
+                                    </DataTrigger>
                                     <DataTrigger Binding="{Binding HasVerifyFailures}" Value="True">
                                         <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
                                         <Setter Property="BorderBrush" Value="{DynamicResource DangerPanelBorderBrush}" />
@@ -630,6 +636,25 @@
                         </Border.Style>
                         <StackPanel>
                             <TextBlock Text="RESTORE VERIFYONLY" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+
+                            <!-- SQL Server reports this as an informational line next to "the
+                                 backup set is valid", which is four lines of grey text under a
+                                 green tick. Said properly here instead (#129). -->
+                            <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                    BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                    BorderThickness="1" CornerRadius="4"
+                                    Padding="10" Margin="0,0,0,10"
+                                    Visibility="{Binding HasTargetPathProblem, Converter={StaticResource BoolToVis}}">
+                                <StackPanel>
+                                    <TextBlock Text="The restore will fail as it stands"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource WarningBrush}"
+                                               Margin="0,0,0,4" />
+                                    <TextBlock Text="{Binding TargetPathProblemMessage}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
                             <ItemsControl ItemsSource="{Binding ChainVerifyResults}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>


### PR DESCRIPTION
Closes #129.

## Confirmed against a real instance first

The whole fix rests on `RESTORE VERIFYONLY` accepting `WITH MOVE`, so that was checked against SQL Server 2025 before writing any of it — backing up `master` to a throwaway file and verifying it three ways:

| | result |
|---|---|
| `VERIFYONLY WITH MOVE` → path that does **not** exist | the same three warnings, naming the **MOVE target** |
| `VERIFYONLY WITH MOVE` → path that **does** exist | `The backup set on file 1 is valid.` and nothing else |
| `VERIFYONLY` with no MOVE | clean here, because the recorded paths happen to exist on this instance |

So passing MOVE does not silence the check — it points it at the right question. The probe backup was deleted afterwards.

## The fix

Verification is given the same MOVE clauses the restore would use, so it checks the paths that are actually going to be written to rather than the ones recorded inside the backup, which belong to the source server.

That also makes the pre-flight strictly better: it now verifies the **target** directories exist, which is a real failure worth catching before `WITH REPLACE` drops the target database.

The file-move builder is shared with the script generator, so the two cannot drift — verification and restore are guaranteed to be asking about the same paths.

## The other half

When the directories genuinely are missing, the backups can read back perfectly and the restore is still certain to fail. That was four lines of grey text under a green tick.

The panel now turns amber and says which case it is:

- **MOVE set** — "The target directories do not exist on this server. Create them, or change the file paths above."
- **No MOVE** — "The file paths recorded inside these backups do not exist on this server, and no WITH MOVE is set. Tick WITH MOVE and give it paths that exist here."

The status line changes too: *"All 4 backup(s) read back intact, but the restore will fail — see below."*

## Tests

14 new; **743 total**, build clean at `-warnaserror`. Statement shape, checksum and moves sharing one `WITH` clause, half-filled grid rows skipped, apostrophes escaped, and the ViewModel passing the right moves in each case.