### PR TITLE
Saved servers list: edges, no repeated auth line, and a connected marker (#127)

### DIFF
--- a/src/NineLives.Tests/ServerListTests.cs
+++ b/src/NineLives.Tests/ServerListTests.cs
@@ -1,0 +1,195 @@
+using System.Windows;
+using System.Windows.Controls;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The saved servers list marks the one that is connected (#127). Connecting used to change the
+/// banner at the top of the window and nothing in the list, so with more than a screenful of
+/// servers there was no way to tell which one was live.
+/// </summary>
+public class ServerConnectedMarkerTests
+{
+    private readonly FakeCredentialStore _store = new();
+    private readonly FakeSqlServerService _sql = new();
+
+    private ServerManagerViewModel NewViewModel() => new(_store, _sql);
+
+    private ServerConnection Add(string name)
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = name,
+            ServerName = name,
+            AuthMode = AuthMode.WindowsAuth
+        };
+        _store.Config.Servers.Add(server);
+        return server;
+    }
+
+    [Fact]
+    public async Task ConnectingMarksThatServerAndOnlyThatServer()
+    {
+        Add("SRV01");
+        Add("SRV02");
+
+        var vm = NewViewModel();
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV02");
+
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        Assert.False(vm.Servers.Single(s => s.Name == "SRV01").IsConnectedServer);
+        Assert.True(vm.Servers.Single(s => s.Name == "SRV02").IsConnectedServer);
+    }
+
+    [Fact]
+    public async Task ConnectingToADifferentServerMovesTheMarker()
+    {
+        Add("SRV01");
+        Add("SRV02");
+
+        var vm = NewViewModel();
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV01");
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV02");
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        // Two servers marked connected at once would be worse than none.
+        Assert.Single(vm.Servers, s => s.IsConnectedServer);
+        Assert.True(vm.Servers.Single(s => s.Name == "SRV02").IsConnectedServer);
+    }
+
+    [Fact]
+    public async Task DisconnectingClearsTheMarker()
+    {
+        Add("SRV01");
+
+        var vm = NewViewModel();
+        vm.SelectedServer = vm.Servers.Single();
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        vm.DisconnectCommand.Execute(null);
+
+        Assert.DoesNotContain(vm.Servers, s => s.IsConnectedServer);
+    }
+
+    [Fact]
+    public void TheMarkerIsNotPersisted()
+    {
+        // It describes this session. Writing it to config.json would have the app claim a
+        // connection it does not have on the next launch.
+        var server = Add("SRV01");
+        server.IsConnectedServer = true;
+
+        var json = System.Text.Json.JsonSerializer.Serialize(server);
+
+        Assert.DoesNotContain("IsConnectedServer", json);
+    }
+}
+
+/// <summary>
+/// The list renders the marker, and no longer repeats the server name and auth mode underneath it.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class ServerListViewTests(WpfFixture wpf)
+{
+    [Fact]
+    public void TheConnectedServerIsMarkedInTheList()
+    {
+        wpf.Invoke(() =>
+        {
+            var store = new FakeCredentialStore();
+            store.Config.Servers.Add(new ServerConnection
+            {
+                Id = ServerConnection.NewId(),
+                Name = "SRV01",
+                ServerName = "SRV01"
+            });
+
+            var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+            vm.Servers.Single().IsConnectedServer = true;
+
+            var view = new ServerManagerView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.Contains("connected", texts);
+
+                listener.AssertNone("ServerManagerView connected marker");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    [Fact]
+    public void TheListDoesNotRepeatTheAuthenticationLine()
+    {
+        wpf.Invoke(() =>
+        {
+            var store = new FakeCredentialStore();
+            store.Config.Servers.Add(new ServerConnection
+            {
+                Id = ServerConnection.NewId(),
+                Name = "SRV01",
+                ServerName = "SRV01",
+                AuthMode = AuthMode.WindowsAuth
+            });
+
+            var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+            var view = new ServerManagerView { DataContext = vm };
+            Realise(view);
+
+            // DisplayText - "SRV01 (Windows Auth)" - was shown on every card. It repeats the
+            // server name and adds a detail that only matters when editing or when a connection
+            // fails, both of which belong to the detail pane.
+            var texts = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+            Assert.DoesNotContain(texts, t => t == "SRV01 (Windows Auth)");
+
+            // The name itself is still there.
+            Assert.Contains("SRV01", texts);
+        });
+    }
+
+    private static void Realise(FrameworkElement element)
+    {
+        element.ApplyTemplate();
+        element.Measure(new Size(1400, 900));
+        element.Arrange(new Rect(0, 0, 1400, 900));
+        element.UpdateLayout();
+    }
+
+    private static bool IsShown(FrameworkElement element)
+    {
+        for (DependencyObject? node = element; node != null;
+             node = System.Windows.Media.VisualTreeHelper.GetParent(node))
+        {
+            if (node is Window) break;
+            if (node is UIElement { Visibility: not Visibility.Visible }) return false;
+        }
+        return true;
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is T match) yield return match;
+            foreach (var descendant in FindAll<T>(child)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
@@ -165,4 +165,25 @@ public class ServerConnection : INotifyPropertyChanged
     public string DisplayText => AuthMode == AuthMode.WindowsAuth
         ? $"{ServerName} (Windows Auth)"
         : $"{ServerName} ({Username})";
+
+    private bool _isConnectedServer;
+
+    /// <summary>
+    /// True for the one server currently connected. Not persisted - it describes this session.
+    ///
+    /// Connecting used to change the banner at the top of the window and nothing in the list, so
+    /// with more than a screenful of servers there was no way to tell which one was live (#127).
+    /// Kept on the model rather than compared in the view so the row can simply bind to it.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsConnectedServer
+    {
+        get => _isConnectedServer;
+        set
+        {
+            if (_isConnectedServer == value) return;
+            _isConnectedServer = value;
+            OnPropertyChanged(nameof(IsConnectedServer));
+        }
+    }
 }

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -338,6 +338,7 @@ public partial class ServerManagerViewModel : ViewModelBase
         if (IsConnected && ConnectedServerDisplay == removed.DisplayText)
         {
             IsConnected = false;
+            MarkConnected(null);
             ConnectedServerDisplay = string.Empty;
             ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs
             {
@@ -427,6 +428,7 @@ public partial class ServerManagerViewModel : ViewModelBase
 
             IsConnected = true;
             ConnectedServerDisplay = SelectedServer.DisplayText;
+            MarkConnected(SelectedServer);
             ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs
             {
                 IsConnected = true,
@@ -445,11 +447,21 @@ public partial class ServerManagerViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Exactly one server carries the connected marker, so the list can never show two.
+    /// </summary>
+    private void MarkConnected(ServerConnection? connected)
+    {
+        foreach (var server in Servers)
+            server.IsConnectedServer = ReferenceEquals(server, connected);
+    }
+
     [RelayCommand]
     private void Disconnect()
     {
         IsConnected = false;
         ConnectedServerDisplay = string.Empty;
+        MarkConnected(null);
         ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs
         {
             IsConnected = false,

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -60,23 +60,53 @@
                             <DataTemplate>
                                 <StackPanel Margin="4,6">
                                     <StackPanel Orientation="Horizontal">
+                                        <!-- Green while this is the connected server, so the list
+                                             says which one is live rather than only the banner at
+                                             the top of the window (#127). -->
                                         <TextBlock Text="&#x26C1;" FontSize="14" Margin="0,0,8,0"
-                                                   VerticalAlignment="Center"
-                                                   Foreground="{DynamicResource SecondaryTextBrush}" />
+                                                   VerticalAlignment="Center">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsConnectedServer}" Value="True">
+                                                            <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+
+                                        <!-- Now that the row is width-constrained (no horizontal
+                                             scrolling), a long name would be cut mid-character
+                                             rather than scrolled - so trim it explicitly. -->
                                         <TextBlock Text="{Binding Name}"
                                                    FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource PrimaryTextBrush}" />
+                                                   TextTrimming="CharacterEllipsis"
+                                                   Foreground="{DynamicResource PrimaryTextBrush}"
+                                                   VerticalAlignment="Center" />
+
+                                        <Border Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                                                BorderBrush="{DynamicResource SuccessBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="8"
+                                                Padding="6,0" Margin="8,0,0,0"
+                                                VerticalAlignment="Center"
+                                                Visibility="{Binding IsConnectedServer, Converter={StaticResource BoolToVis}}">
+                                            <TextBlock Text="connected"
+                                                       FontSize="10" FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource SuccessBrush}" />
+                                        </Border>
                                     </StackPanel>
-                                    <!-- Now that the row is width-constrained (no horizontal
-                                         scrolling), a long name would be cut mid-character
-                                         rather than scrolled - so trim it explicitly. -->
-                                    <TextBlock Text="{Binding DisplayText}"
-                                               Style="{StaticResource SecondaryText}"
-                                               TextTrimming="CharacterEllipsis"
-                                               Margin="22,2,0,0" />
+
+                                    <!-- The server name and auth mode used to be repeated here.
+                                         Neither is what gets scanned for in a list whose job is
+                                         "which server do I want", and the auth mode only matters
+                                         when editing or when a connection fails - both of which
+                                         are the detail pane's job (#127). -->
                                     <ItemsControl ItemsSource="{Binding TagChips}"
                                                   Style="{StaticResource TagChipList}"
-                                                  Margin="22,2,0,0" />
+                                                  Margin="22,4,0,0" />
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
@@ -88,9 +118,15 @@
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="ListBoxItem">
+                                            <!-- A border at rest, not only when selected. Without
+                                                 one the list reads as a single undifferentiated
+                                                 column of text (#127). -->
                                             <Border x:Name="border"
                                                     Background="{TemplateBinding Background}"
+                                                    BorderBrush="{DynamicResource CardBorderBrush}"
+                                                    BorderThickness="1"
                                                     CornerRadius="4"
+                                                    Margin="0,0,0,6"
                                                     Padding="{TemplateBinding Padding}">
                                                 <ContentPresenter />
                                             </Border>
@@ -103,6 +139,13 @@
                                                     <Setter TargetName="border" Property="Background"
                                                             Value="{DynamicResource SidebarItemActiveBrush}" />
                                                 </Trigger>
+                                                <!-- Last, so it wins over selection: selecting a
+                                                     different server must not take the marker off
+                                                     the one that is actually live. -->
+                                                <DataTrigger Binding="{Binding IsConnectedServer}" Value="True">
+                                                    <Setter TargetName="border" Property="BorderBrush"
+                                                            Value="{DynamicResource SuccessBrush}" />
+                                                </DataTrigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
                                     </Setter.Value>


### PR DESCRIPTION
Closes #127. All three items.

## The auth line is gone from the card

Each card carried:

```
SERVER
SRV01\SQLEXPRESS

AUTHENTICATION
SRV01\SQLEXPRESS (Windows Auth)
```

The second block repeats the server name and adds the auth mode. In a list whose job is "which server do I want", neither is what gets scanned for, and the auth mode only matters when editing or when a connection fails — both of which the detail pane already shows. Removed from the card, unchanged on the right.

## Cards look like cards

No border unless selected meant a list of servers read as one undifferentiated column of text. They have a border and spacing at rest now, matching the container cards.

## The connected server is marked

Connecting changed the banner at the top of the window and nothing in the list. Scroll down a list of eight and there was no way to tell which one was live.

The connected server gets a green icon, a green border and a small **connected** pill.

Two details that matter:

- **The connected trigger is declared last**, so it wins over selection. Selecting a different server must not take the marker off the one that is actually live — they are different states and the list previously showed neither distinctly.
- **The flag is `[JsonIgnore]`.** It describes this session; persisting it would have the app claim a connection it does not have on the next launch. There is a test for that.

## Tests

6 new; **749 total**, build clean at `-warnaserror`. Covers the marker moving when connecting elsewhere, only ever one server marked, clearing on disconnect and on deleting the connected server, that it is not serialised, and that the list renders the marker and no longer repeats the auth line.

Rendered in dark and high contrast and read back before committing.