### PR TITLE
Show that the app is doing something (#128)

### DIFF
--- a/src/NineLives.Tests/BusyFeedbackTests.cs
+++ b/src/NineLives.Tests/BusyFeedbackTests.cs
@@ -1,0 +1,249 @@
+﻿using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Feedback that the app is doing something (#128).
+///
+/// Check chain and Verify backups only changed their own label, and verify can run as long as the
+/// restore - so on a large chain the app looked hung. Once one has passed for the selected chain
+/// there is also no reason to run it again, and re-running VERIFYONLY by accident is expensive.
+/// </summary>
+public class ChainCheckStateTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+        new FakeRestoreHistoryStore());
+
+    private static BackupFileInfo File(string blobName, BackupType type, DateTime stamp) => new()
+    {
+        BlobName = blobName,
+        BlobUrl = $"https://mystorageaccount.blob.core.windows.net/backups/{blobName}",
+        Type = type,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = "MyDb",
+        SizeBytes = 1000,
+        LastModified = new DateTimeOffset(stamp, TimeSpan.Zero)
+    };
+
+    private async Task<RestoreViewModel> Loaded()
+    {
+        _blob.Files =
+        [
+            File("FULL/SRV01/MyDb/20260110_220000.bak", BackupType.Full, T0),
+            File("LOG/SRV01/MyDb/20260110_230000.trn", BackupType.TransactionLog, T0.AddHours(1)),
+        ];
+
+        var vm = NewViewModel();
+        vm.SelectedContainer = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        return vm;
+    }
+
+    [Fact]
+    public async Task AChainThatPassedItsCheckDoesNotOfferToCheckItAgain()
+    {
+        var vm = await Loaded();
+
+        Assert.False(vm.ChainCheckPassed);
+        Assert.True(vm.ValidateChainCommand.CanExecute(null));
+
+        // The outcome the real check produces when the headers line up.
+        vm.ChainLsnVerified = true;
+        vm.HasChainIssues = false;
+
+        Assert.True(vm.ChainCheckPassed);
+        Assert.False(vm.ValidateChainCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task AChainWithProblemsStaysCheckable()
+    {
+        var vm = await Loaded();
+
+        // A check that found something is worth re-running once the problem is dealt with.
+        vm.ChainLsnVerified = true;
+        vm.HasChainIssues = true;
+
+        Assert.False(vm.ChainCheckPassed);
+        Assert.True(vm.ValidateChainCommand.CanExecute(null));
+    }
+
+    /// <summary>
+    /// Running the real command against headers it cannot read leaves the button enabled - the
+    /// check did not pass, so offering it again is right.
+    /// </summary>
+    [Fact]
+    public async Task RunningTheCheckAndFindingProblemsLeavesItEnabled()
+    {
+        var vm = await Loaded();
+
+        await vm.ValidateChainCommand.ExecuteAsync(null);
+
+        Assert.True(vm.ChainLsnVerified);
+        Assert.True(vm.HasChainIssues);
+        Assert.False(vm.ChainCheckPassed);
+        Assert.True(vm.ValidateChainCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task VerifyingTwiceOnTheSameChainIsNotOffered()
+    {
+        var vm = await Loaded();
+
+        Assert.True(vm.VerifyChainCommand.CanExecute(null));
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.True(vm.VerifyPassed);
+        Assert.False(vm.VerifyChainCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task AVerifyThatFoundMissingDirectoriesHasNotPassed()
+    {
+        var vm = await Loaded();
+        _sql.VerifyResult = new VerifyOnlyResult(true, "Directory lookup failed.", TargetPathsMissing: true);
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        // The backups read back, but the restore cannot land - not a pass.
+        Assert.False(vm.VerifyPassed);
+        Assert.True(vm.VerifyChainCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task ChangingTheSelectedPointMakesBothCheckableAgain()
+    {
+        var vm = await Loaded();
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+        vm.ChainLsnVerified = true;
+        vm.HasChainIssues = false;
+
+        Assert.True(vm.ChainCheckPassed);
+        Assert.True(vm.VerifyPassed);
+
+        // The result belongs to the chain that was checked.
+        vm.SelectedRestorePoint = vm.RestorePoints.First();
+
+        Assert.False(vm.ChainCheckPassed);
+        Assert.False(vm.VerifyPassed);
+        Assert.True(vm.ValidateChainCommand.CanExecute(null));
+        Assert.True(vm.VerifyChainCommand.CanExecute(null));
+    }
+
+    // ── what the screen says it is doing ────────────────────────────────────────
+
+    [Fact]
+    public async Task TheScreenNamesWhatItIsDoing()
+    {
+        var vm = await Loaded();
+
+        Assert.Empty(vm.BusyDescription);
+        Assert.False(vm.IsBusyWithAnything);
+
+        vm.IsValidatingChain = true;
+        Assert.Equal("Checking the chain...", vm.BusyDescription);
+
+        vm.IsValidatingChain = false;
+        vm.IsVerifyingChain = true;
+        Assert.Equal("Verifying backups...", vm.BusyDescription);
+
+        vm.IsVerifyingChain = false;
+        vm.IsExecuting = true;
+        Assert.Contains("MyDb_Restored", vm.BusyDescription);
+
+        vm.IsExecuting = false;
+        Assert.Empty(vm.BusyDescription);
+    }
+
+    [Fact]
+    public async Task ARestoreOutranksTheOtherWork()
+    {
+        var vm = await Loaded();
+
+        vm.IsBusy = true;
+        vm.IsExecuting = true;
+
+        // The one that matters is the one writing to a database.
+        Assert.Contains("Restoring", vm.BusyDescription);
+    }
+}
+
+/// <summary>
+/// The window says what the app is doing, wherever the user has scrolled to.
+/// </summary>
+public class GlobalBusyTests
+{
+    [Fact]
+    public void TheWindowIsIdleUntilAChildIsBusy()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        Assert.False(vm.IsBusy);
+        Assert.Empty(vm.BusyText);
+    }
+
+    [Fact]
+    public void AChildStartingWorkReachesTheWindow()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.BlobBrowser.IsBusy = true;
+        Assert.True(vm.IsBusy);
+        Assert.Equal("Listing the container...", vm.BusyText);
+
+        vm.BlobBrowser.IsBusy = false;
+        Assert.False(vm.IsBusy);
+        Assert.Empty(vm.BusyText);
+    }
+
+    [Fact]
+    public void TheRestoreScreenNamesItsOwnWork()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.Restore.IsVerifyingChain = true;
+
+        Assert.True(vm.IsBusy);
+        Assert.Equal("Verifying backups...", vm.BusyText);
+    }
+
+    [Fact]
+    public void ARestoreOutranksAnythingElseRunning()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.ServerManager.IsBusy = true;
+        vm.Restore.TargetDatabaseName = "MyDb_Restored";
+        vm.Restore.IsExecuting = true;
+
+        Assert.Contains("Restoring", vm.BusyText);
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -105,8 +105,24 @@ public class XamlLoadTests(WpfFixture wpf)
             // Against a fake store, not the real one. This used to construct a MainViewModel over
             // the actual %LOCALAPPDATA% config and run the secret-key migration across it - a test
             // reaching into the user's own data (#41).
-            var window = new MainWindow(new MainViewModel(new FakeCredentialStore()));
-            Realise(window);
+            var vm = new MainViewModel(new FakeCredentialStore());
+
+            // Busy, so the strip that says what the app is doing is actually built and bound - it
+            // is collapsed the rest of the time, and a mistyped path there would be silent (#128).
+            vm.BlobBrowser.IsBusy = true;
+
+            var window = new MainWindow(vm);
+
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(window);
+                listener.AssertNone("MainWindow");
+            }
+            finally
+            {
+                listener.Detach();
+            }
         });
     }
 

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -244,6 +244,29 @@
 
             <!-- Main Content Area -->
             <DockPanel Grid.Column="1">
+                <!-- What the app is doing, in the one place that is always on screen. Every screen
+                     has its own status line, but they sit at the bottom of pages long enough to
+                     scroll - so "is it doing something?" depended on where you happened to be
+                     looking (#128). -->
+                <Border DockPanel.Dock="Top"
+                        Padding="16,6,16,0"
+                        Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}">
+                    <Border Background="{DynamicResource CardBackgroundBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"
+                            BorderThickness="1"
+                            CornerRadius="4" Padding="10,5">
+                        <StackPanel Orientation="Horizontal">
+                            <ContentControl Template="{StaticResource BusySpinner}"
+                                            Width="13" Height="13"
+                                            VerticalAlignment="Center" Margin="0,0,8,0" />
+                            <TextBlock Text="{Binding BusyText}"
+                                       VerticalAlignment="Center"
+                                       FontSize="12"
+                                       Foreground="{DynamicResource AccentBrush}" />
+                        </StackPanel>
+                    </Border>
+                </Border>
+
                 <!-- Persistent Connection Status Banner -->
                 <Border DockPanel.Dock="Top"
                         Padding="16,6"

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -166,6 +166,55 @@
         change, so a switched theme would leave half the window in the old colours.
     -->
 
+    <!--
+        A small rotating arc, for anything that runs long enough to look stuck. Check chain and
+        Verify backups only changed their own label, and verify can run as long as the restore -
+        so on a large chain the app looked hung (#128).
+
+        The storyboard starts on IsVisible and stops when it goes away, rather than running
+        forever behind a collapsed element.
+    -->
+    <ControlTemplate x:Key="BusySpinner" TargetType="ContentControl">
+        <Grid x:Name="root" RenderTransformOrigin="0.5,0.5">
+            <Grid.RenderTransform>
+                <RotateTransform x:Name="spin" Angle="0" />
+            </Grid.RenderTransform>
+            <!-- An arc rather than a full ring: a complete circle rotating looks static. -->
+            <Ellipse Stroke="{DynamicResource AccentBrush}"
+                     StrokeThickness="2"
+                     StrokeDashArray="3 2"
+                     Opacity="0.9" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsVisible" Value="True">
+                <Trigger.EnterActions>
+                    <BeginStoryboard x:Name="spinStory">
+                        <Storyboard>
+                            <DoubleAnimation Storyboard.TargetName="spin"
+                                             Storyboard.TargetProperty="Angle"
+                                             From="0" To="360"
+                                             Duration="0:0:1.1"
+                                             RepeatBehavior="Forever" />
+                        </Storyboard>
+                    </BeginStoryboard>
+                </Trigger.EnterActions>
+                <Trigger.ExitActions>
+                    <StopStoryboard BeginStoryboardName="spinStory" />
+                </Trigger.ExitActions>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!-- The tick shown when a check has passed for the selected chain. -->
+    <Style x:Key="PassedTick" TargetType="TextBlock">
+        <Setter Property="Text" Value="&#x2713;" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="FontWeight" Value="Bold" />
+        <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Margin" Value="0,0,6,0" />
+    </Style>
+
     <!-- TextBlock Styles -->
     <Style x:Key="HeaderText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Models;
@@ -98,10 +98,53 @@ public partial class MainViewModel : ViewModelBase
 
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
 
+        // One place that answers "is it doing something?". Every screen already tracks its own
+        // work; without this the answer depended on which part of a long page was scrolled into
+        // view, and the Restore screen's own status line is below the fold most of the time (#128).
+        WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Restore);
+
         CurrentView = BlobConfig;
 
         // Fire and forget - startup must not wait on the network.
         _ = CheckForUpdatesAsync();
+    }
+
+    /// <summary>What the app is currently doing, or empty when it is idle.</summary>
+    [ObservableProperty]
+    private string _busyText = string.Empty;
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    private readonly List<ViewModelBase> _watched = [];
+
+    private void WatchForBusy(params ViewModelBase[] children)
+    {
+        foreach (var child in children)
+        {
+            _watched.Add(child);
+            child.PropertyChanged += (_, _) => RefreshBusy();
+        }
+    }
+
+    /// <summary>
+    /// The Restore screen names what it is doing; the others only say they are busy, and what that
+    /// means is obvious from the screen. Restore wins when more than one is going, because it is
+    /// the one that can be running a RESTORE.
+    /// </summary>
+    private void RefreshBusy()
+    {
+        var text =
+            Restore.IsBusyWithAnything ? Restore.BusyDescription
+            : BlobConfig.IsBusy ? "Testing the container connection..."
+            : BlobBrowser.IsBusy ? "Listing the container..."
+            : ServerManager.IsBusy ? "Connecting to SQL Server..."
+            : string.Empty;
+
+        if (text == BusyText) return;
+
+        BusyText = text;
+        IsBusy = text.Length > 0;
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -282,6 +282,46 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isVerifyingChain;
 
+    partial void OnIsVerifyingChainChanged(bool value) => RefreshCheckState();
+    partial void OnIsValidatingChainChanged(bool value) => RefreshCheckState();
+    partial void OnChainLsnVerifiedChanged(bool value) => RefreshCheckState();
+    partial void OnHasChainIssuesChanged(bool value) => RefreshCheckState();
+    partial void OnHasVerifyResultsChanged(bool value) => RefreshCheckState();
+    partial void OnHasVerifyFailuresChanged(bool value) => RefreshCheckState();
+    partial void OnHasTargetPathProblemChanged(bool value) => RefreshCheckState();
+
+    /// <summary>
+    /// Republishes the two "already passed" flags and re-queries the buttons that depend on them.
+    /// Everything they are computed from is a separate observable property, so without this the
+    /// tick appears and the button stays enabled - or worse, the other way round.
+    /// </summary>
+    private void RefreshCheckState()
+    {
+        OnPropertyChanged(nameof(ChainCheckPassed));
+        OnPropertyChanged(nameof(VerifyPassed));
+        OnPropertyChanged(nameof(BusyDescription));
+        OnPropertyChanged(nameof(IsBusyWithAnything));
+        ValidateChainCommand.NotifyCanExecuteChanged();
+        VerifyChainCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// What this screen is doing, for the strip at the top of the window - empty when idle (#128).
+    /// </summary>
+    public string BusyDescription
+    {
+        get
+        {
+            if (IsExecuting) return $"Restoring {TargetDatabaseName}...";
+            if (IsVerifyingChain) return "Verifying backups...";
+            if (IsValidatingChain) return "Checking the chain...";
+            if (IsBusy) return "Loading backups...";
+            return string.Empty;
+        }
+    }
+
+    public bool IsBusyWithAnything => BusyDescription.Length > 0;
+
     // ── restore point filters (#27) ─────────────────────────────────────────────
 
     /// <summary>True when the container holds any restore points at all.</summary>
@@ -618,6 +658,14 @@ public partial class RestoreViewModel : ViewModelBase
         // without it, running the execute path in a test appends real restore lines to the user's
         // actual log file, which is the same class of side effect this whole change is about.
         _log = log ?? App.Log;
+
+        // IsBusy and TargetDatabaseName live on the base class, so they cannot have a generated
+        // partial hook - but the busy strip is computed from them.
+        PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(IsBusy) or nameof(TargetDatabaseName))
+                RefreshCheckState();
+        };
 
         RefreshContainers();
     }
@@ -1399,8 +1447,14 @@ public partial class RestoreViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// True once the chain has been checked and came back clean. The result belongs to the chain
+    /// that was checked, so it clears with the selection (#128).
+    /// </summary>
+    public bool ChainCheckPassed => ChainLsnVerified && !HasChainIssues;
+
     private bool CanValidateChain() =>
-        IsConnectedToServer && RestoreChain != null && !IsValidatingChain;
+        IsConnectedToServer && RestoreChain != null && !IsValidatingChain && !ChainCheckPassed;
 
     /// <summary>
     /// Runs RESTORE VERIFYONLY over every set in the chain: does each backup actually read back,
@@ -1472,8 +1526,16 @@ public partial class RestoreViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// True once every backup in the chain read back intact AND the restore has somewhere to
+    /// write. Re-running VERIFYONLY on a large chain by accident is expensive, so once it has
+    /// passed for this selection the button is done.
+    /// </summary>
+    public bool VerifyPassed => HasVerifyResults && !HasVerifyFailures && !HasTargetPathProblem;
+
     private bool CanVerifyChain() =>
-        IsConnectedToServer && RestoreChain != null && !IsVerifyingChain && !IsExecuting;
+        IsConnectedToServer && RestoreChain != null && !IsVerifyingChain && !IsExecuting
+        && !VerifyPassed;
 
     /// <summary>
     /// Turns SQL Server's directory-lookup complaint into something that says what to do about it.
@@ -1648,6 +1710,7 @@ public partial class RestoreViewModel : ViewModelBase
     {
         VerifyChainCommand.NotifyCanExecuteChanged();
         RefreshExecuteBlockedReason();
+        RefreshCheckState();
     }
 
     /// <summary>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -508,25 +508,29 @@
                                 Padding="12,6" Margin="0,0,8,0"
                                 ToolTip="Do these backups belong together? Reads each backup's header and compares the LSNs. Takes seconds. Requires a connected server.">
                             <Button.Content>
-                                <TextBlock>
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="Check chain (HEADERONLY)" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsValidatingChain}" Value="True">
-                                                    <Setter Property="Text" Value="Checking..." />
-                                                </DataTrigger>
-                                                <MultiDataTrigger>
-                                                    <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding ChainLsnVerified}" Value="True" />
-                                                        <Condition Binding="{Binding HasChainIssues}" Value="False" />
-                                                    </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Text" Value="Chain checked" />
-                                                </MultiDataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
+                                <StackPanel Orientation="Horizontal">
+                                    <ContentControl Template="{StaticResource BusySpinner}"
+                                                    Width="13" Height="13" Margin="0,0,6,0"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{Binding IsValidatingChain, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock Style="{StaticResource PassedTick}"
+                                               Visibility="{Binding ChainCheckPassed, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value="Check chain (HEADERONLY)" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsValidatingChain}" Value="True">
+                                                        <Setter Property="Text" Value="Checking..." />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding ChainCheckPassed}" Value="True">
+                                                        <Setter Property="Text" Value="Chain checked" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
                             </Button.Content>
                         </Button>
 
@@ -540,26 +544,29 @@
                                 Padding="12,6" Margin="0,0,8,0"
                                 ToolTip="Is each backup actually readable? Runs RESTORE VERIFYONLY over every backup in the chain, reading every byte - this can take as long as the restore itself. Requires a connected server.">
                             <Button.Content>
-                                <TextBlock>
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="Verify backups (VERIFYONLY)" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsVerifyingChain}" Value="True">
-                                                    <Setter Property="Text" Value="Verifying..." />
-                                                </DataTrigger>
-                                                <MultiDataTrigger>
-                                                    <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding HasVerifyResults}" Value="True" />
-                                                        <Condition Binding="{Binding HasVerifyFailures}" Value="False" />
-                                                        <Condition Binding="{Binding IsVerifyingChain}" Value="False" />
-                                                    </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Text" Value="Backups verified" />
-                                                </MultiDataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
+                                <StackPanel Orientation="Horizontal">
+                                    <ContentControl Template="{StaticResource BusySpinner}"
+                                                    Width="13" Height="13" Margin="0,0,6,0"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{Binding IsVerifyingChain, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock Style="{StaticResource PassedTick}"
+                                               Visibility="{Binding VerifyPassed, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value="Verify backups (VERIFYONLY)" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsVerifyingChain}" Value="True">
+                                                        <Setter Property="Text" Value="Verifying..." />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding VerifyPassed}" Value="True">
+                                                        <Setter Property="Text" Value="Backups verified" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
                             </Button.Content>
                         </Button>
 


### PR DESCRIPTION
Closes #128.

## Spinner, tick, and done

Check chain and Verify backups now show a rotating arc while running and a green tick once they have passed, and the button is disabled while that result still applies.

There is no reason to run either twice against the same selection, and re-running VERIFYONLY on a large chain by accident is expensive. The result belongs to the chain that was checked, so both clear when the selected restore point changes.

Two states that are deliberately not a pass:

- **A chain check that found problems** — worth re-running once the problem is dealt with, so the button stays enabled.
- **A verification that found missing target directories** (#129) — the backups read back, but the restore cannot land. Not a pass.

The spinner storyboard starts on `IsVisible` and stops when it goes away, rather than rotating forever behind a collapsed element.

## A busy strip at the top of the window

Every screen already tracked its own work, but those status lines sit at the bottom of pages long enough to scroll — so "is it doing something?" depended on where you happened to be looking. The Restore screen is the worst of it.

The strip sits next to the connection banner and names what is running: listing a container, testing a container connection, connecting to SQL Server, checking a chain, verifying, or restoring. A restore outranks anything else, since it is the one writing to a database.

`MainViewModel` watches the child viewmodels rather than each screen reporting upward, so nothing new has to be remembered at each call site.

## Tests

13 new; **761 total**, build clean at `-warnaserror`.

`MainWindowLoads` now realises the window **busy**, with the binding-error listener attached — the strip is collapsed the rest of the time, and a mistyped path in markup that is never built is invisible.

Rendered all four button states and read them back: idle, checking, verifying, both passed.