### PR TITLE
Lift the execution console out of RestoreViewModel (#115)

### DIFF
--- a/src/NineLives.Tests/ConsoleBufferTests.cs
+++ b/src/NineLives.Tests/ConsoleBufferTests.cs
@@ -1,0 +1,196 @@
+﻿using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The console's line handling and batching, now that it is its own type rather than 90 lines in
+/// the middle of a 2,400-line viewmodel (#115).
+///
+/// None of this needed a restore, a server or a container to exercise - it just could not be
+/// reached without one.
+/// </summary>
+public class ConsoleBufferTests
+{
+    private static ConsoleBuffer New(Action<string>? alsoLog = null) => new(alsoLog);
+
+    [Fact]
+    public void AMessageBecomesALine()
+    {
+        var console = New();
+
+        console.Append("Beginning restore execution...");
+
+        var line = Assert.Single(console.Lines);
+        Assert.Equal("Beginning restore execution...", line.Text);
+        Assert.True(console.HasOutput);
+    }
+
+    [Fact]
+    public void AMultiLineMessageIsSplit()
+    {
+        var console = New();
+
+        console.Append("first\nsecond\nthird");
+
+        Assert.Equal(["first", "second", "third"], console.Lines.Select(l => l.Text));
+    }
+
+    [Fact]
+    public void CarriageReturnsAreNotLeftOnTheEndOfLines()
+    {
+        var console = New();
+
+        console.Append("first\r\nsecond");
+
+        Assert.Equal(["first", "second"], console.Lines.Select(l => l.Text));
+    }
+
+    /// <summary>
+    /// Messages routinely arrive with a leading or trailing newline for spacing, and SQL Server's
+    /// own output has its own blank lines. Left alone that put a gap between almost every line.
+    /// </summary>
+    [Fact]
+    public void RunsOfBlankLinesCollapseToOne()
+    {
+        var console = New();
+
+        console.Append("first\n\n\n\nsecond");
+
+        Assert.Equal(["first", "", "second"], console.Lines.Select(l => l.Text));
+    }
+
+    [Fact]
+    public void ABlankLineIsNotAddedAtTheVeryStart()
+    {
+        var console = New();
+
+        console.Append("\nfirst");
+
+        Assert.Equal(["first"], console.Lines.Select(l => l.Text));
+    }
+
+    [Fact]
+    public void ABlankAcrossTwoSeparateMessagesStillCollapses()
+    {
+        // The buffer has to look at what is already on screen, not just what is pending - the
+        // messages that end and begin with a newline arrive separately.
+        var console = New();
+
+        console.Append("first\n");
+        console.Append("\nsecond");
+
+        Assert.Equal(["first", "", "second"], console.Lines.Select(l => l.Text));
+    }
+
+    [Fact]
+    public void LinesAreClassifiedAsTheyArrive()
+    {
+        var console = New();
+
+        console.Append("ERROR: could not open backup device");
+        console.Append("50 percent processed.");
+
+        Assert.Equal(ConsoleLineKind.Error, console.Lines[0].Kind);
+        Assert.NotEqual(ConsoleLineKind.Error, console.Lines[1].Kind);
+    }
+
+    [Fact]
+    public void EveryMessageAlsoGoesToTheLog()
+    {
+        // The file must not drift from what was on screen, so both are written from one place.
+        var logged = new List<string>();
+        var console = New(logged.Add);
+
+        console.Append("first");
+        console.Append("second");
+
+        Assert.Equal(["first", "second"], logged);
+    }
+
+    [Fact]
+    public void TextIsTheWholeConsoleForCopying()
+    {
+        var console = New();
+
+        console.Append("first\nsecond");
+
+        Assert.Equal($"first{Environment.NewLine}second", console.Text);
+    }
+
+    [Fact]
+    public void ClearingEmptiesEverything()
+    {
+        var console = New();
+        console.Append("first");
+
+        console.Clear();
+
+        Assert.Empty(console.Lines);
+        Assert.False(console.HasOutput);
+        Assert.Empty(console.Text);
+    }
+
+    [Fact]
+    public void ClearingDropsAnythingStillBuffered()
+    {
+        // A run that starts while the previous one's tail is still pending must not inherit it.
+        var console = New();
+        console.IsRunning = true;
+        console.Append("from the last run");
+        console.Clear();
+        console.Flush();
+
+        Assert.Empty(console.Lines);
+    }
+}
+
+/// <summary>
+/// The batching itself, which needs a dispatcher to tick.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class ConsoleBufferBatchingTests(WpfFixture wpf)
+{
+    /// <summary>
+    /// On a dispatcher thread lines wait for the timer rather than landing one at a time.
+    ///
+    /// SQL Server emits progress in clusters - several messages within a millisecond, then nothing
+    /// for a second. Adding each individually meant a layout pass and a scroll per message, which
+    /// is what made the console judder.
+    /// </summary>
+    [Fact]
+    public void LinesAreBatchedRatherThanAppliedImmediately()
+    {
+        wpf.Invoke(() =>
+        {
+            var console = new ConsoleBuffer { IsRunning = true };
+
+            console.Append("first");
+            console.Append("second");
+
+            // Still buffered - the timer has not ticked.
+            Assert.Empty(console.Lines);
+            Assert.True(console.HasPending);
+
+            console.Flush();
+
+            Assert.Equal(2, console.Lines.Count);
+            Assert.False(console.HasPending);
+        });
+    }
+
+    /// <summary>
+    /// Off a dispatcher there is nothing to drain the buffer, so it applies inline instead of
+    /// holding lines forever - which is what a plain unit test or a background thread gets.
+    /// </summary>
+    [Fact]
+    public async Task WithNoDispatcherTheLinesApplyImmediately()
+    {
+        var console = new ConsoleBuffer { IsRunning = true };
+
+        await Task.Run(() => console.Append("from a thread with no dispatcher"));
+
+        Assert.Single(console.Lines);
+    }
+}

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.ExceptionServices;
+﻿using System.Runtime.ExceptionServices;
 using System.Windows.Threading;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
@@ -145,7 +145,7 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
             store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
 
             await vm.ExecuteScriptCommand.ExecuteAsync(null);
-            log = vm.ConsoleText;
+            log = vm.Console.Text;
         });
 
         Assert.Contains("Server state not modified", log);

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -304,13 +304,13 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.BackupsLoaded = true;
             vm.HasScript = true;
             vm.GeneratedScript = "RESTORE DATABASE [MyDb] FROM URL = N'https://acct/backups/x.bak'";
-            vm.ConsoleLines =
+            vm.Console.Lines =
             [
                 new ConsoleLine("Beginning restore execution...", ConsoleLineKind.Step),
                 new ConsoleLine("50 percent processed."),
                 new ConsoleLine("ERROR: something went wrong", ConsoleLineKind.Error)
             ];
-            vm.HasConsoleOutput = true;
+            vm.Console.HasOutput = true;
             vm.IsExecuting = false;
             vm.ExecutionComplete = true;
 
@@ -354,8 +354,8 @@ public class XamlLoadTests(WpfFixture wpf)
         {
             var vm = NewRestoreViewModel();
             vm.BackupsLoaded = true;
-            vm.ConsoleLines = [new ConsoleLine("Beginning restore execution...")];
-            vm.HasConsoleOutput = true;
+            vm.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
+            vm.Console.HasOutput = true;
 
             var view = new RestoreView { DataContext = vm };
 
@@ -382,8 +382,8 @@ public class XamlLoadTests(WpfFixture wpf)
         {
             var vm = NewRestoreViewModel();
             vm.BackupsLoaded = true;
-            vm.ConsoleLines = [new ConsoleLine("Beginning restore execution...")];
-            vm.HasConsoleOutput = true;
+            vm.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
+            vm.Console.HasOutput = true;
             vm.IsConsoleDetached = false;   // as if the wiring failed
             vm.IsExecuting = true;
 

--- a/src/NineLives/ViewModels/ConsoleBuffer.cs
+++ b/src/NineLives/ViewModels/ConsoleBuffer.cs
@@ -1,0 +1,133 @@
+using System.Collections.ObjectModel;
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The execution console: the lines on screen, and the batching that keeps them arriving smoothly.
+///
+/// Lifted out of RestoreViewModel, which was doing thirteen jobs (#115). This one has no coupling
+/// to the rest of the restore - it takes text in and offers lines out - and pulling it apart makes
+/// the 60 ms batching testable without standing up a whole restore.
+///
+/// Writes to a COLLECTION rather than concatenating a bound string. Appending to a bound string
+/// rebuilds it and re-renders the whole TextBox on every message - O(n^2) - which was a large part
+/// of why a restore reporting progress every few percent looked like it arrived in bursts rather
+/// than live.
+/// </summary>
+public partial class ConsoleBuffer : ObservableObject
+{
+    /// <summary>
+    /// How long lines wait before being moved onto the bound collection.
+    ///
+    /// SQL Server emits progress in clusters - several messages within a millisecond, then nothing
+    /// for a second. Adding each one individually meant a layout pass and a scroll per message, in
+    /// bursts, which is what made the console judder. Flushing on a fixed tick turns any arrival
+    /// pattern into a steady redraw, and a whole cluster costs one layout pass instead of ten.
+    /// </summary>
+    private static readonly TimeSpan FlushInterval = TimeSpan.FromMilliseconds(60);
+
+    private readonly List<ConsoleLine> _pending = [];
+    private readonly Action<string>? _alsoLog;
+    private DispatcherTimer? _timer;
+
+    /// <summary>
+    /// Whether more output is still expected. While true the flush timer keeps ticking even with
+    /// nothing buffered; once false an empty tick stops it rather than spinning forever.
+    /// </summary>
+    public bool IsRunning { get; set; }
+
+    /// <param name="alsoLog">
+    /// Called with every message as it arrives, so the log file cannot drift from what was shown.
+    /// </param>
+    public ConsoleBuffer(Action<string>? alsoLog = null) => _alsoLog = alsoLog;
+
+    [ObservableProperty]
+    private ObservableCollection<ConsoleLine> _lines = [];
+
+    [ObservableProperty]
+    private bool _hasOutput;
+
+    /// <summary>The console as plain text, for copying into a bug report.</summary>
+    public string Text => string.Join(Environment.NewLine, Lines.Select(l => l.Text));
+
+    /// <summary>
+    /// Adds a message, splitting it into lines and collapsing runs of blanks.
+    ///
+    /// Messages routinely arrive with a leading or trailing newline for spacing, and SQL Server's
+    /// own output has its own blank lines. Left alone that produced a gap between almost every
+    /// line. One blank line is allowed as a separator; runs of them are not.
+    /// </summary>
+    public void Append(string message)
+    {
+        foreach (var raw in message.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+
+            if (line.Trim().Length == 0)
+            {
+                if (_pending.Count > 0 && _pending[^1].Text.Length == 0) continue;
+                if (_pending.Count == 0 && (Lines.Count == 0 || Lines[^1].Text.Length == 0)) continue;
+                _pending.Add(new ConsoleLine(string.Empty));
+                continue;
+            }
+
+            _pending.Add(ConsoleLine.From(line));
+        }
+
+        _alsoLog?.Invoke(message);
+        ScheduleFlush();
+    }
+
+    /// <summary>Moves everything buffered onto the bound collection now.</summary>
+    public void Flush()
+    {
+        if (_pending.Count == 0)
+        {
+            // Nothing arriving and nothing running - stop ticking rather than spin forever.
+            if (!IsRunning)
+            {
+                _timer?.Stop();
+                _timer = null;
+            }
+            return;
+        }
+
+        foreach (var line in _pending) Lines.Add(line);
+        _pending.Clear();
+        HasOutput = true;
+    }
+
+    /// <summary>Empties the console, for the start of a run.</summary>
+    public void Clear()
+    {
+        _pending.Clear();
+        Lines.Clear();
+        HasOutput = false;
+    }
+
+    /// <summary>
+    /// True while lines are waiting. Only the tests care - it is how "batched, not immediate" is
+    /// asserted without waiting on a dispatcher timer.
+    /// </summary>
+    internal bool HasPending => _pending.Count > 0;
+
+    private void ScheduleFlush()
+    {
+        if (_timer != null) return;
+
+        // No dispatcher (a plain unit test, or a background thread) means no timer to tick, so
+        // flush inline instead of buffering forever with nothing to drain it.
+        if (Dispatcher.FromThread(Thread.CurrentThread) == null)
+        {
+            Flush();
+            return;
+        }
+
+        _timer = new DispatcherTimer(DispatcherPriority.Background) { Interval = FlushInterval };
+        _timer.Tick += (_, _) => Flush();
+        _timer.Start();
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -242,16 +242,6 @@ public partial class RestoreViewModel : ViewModelBase
     // ── Execution console ───────────────────────────────────────────────────────
 
     /// <summary>
-    /// The console, one line per entry. A collection rather than one growing string so appending
-    /// costs the same on the thousandth line as on the first.
-    /// </summary>
-    [ObservableProperty]
-    private ObservableCollection<ConsoleLine> _consoleLines = [];
-
-    [ObservableProperty]
-    private bool _hasConsoleOutput;
-
-    /// <summary>
     /// True while the console is showing in its own window.
     ///
     /// The inline console hides itself for the duration, so the output is only ever in one place.
@@ -658,6 +648,10 @@ public partial class RestoreViewModel : ViewModelBase
         // without it, running the execute path in a test appends real restore lines to the user's
         // actual log file, which is the same class of side effect this whole change is about.
         _log = log ?? App.Log;
+
+        // Every console message is written to the log file as it arrives, so the file cannot drift
+        // from what was on screen.
+        Console = new ConsoleBuffer(message => _log.Info($"[execute] {message.Trim()}"));
 
         // IsBusy and TargetDatabaseName live on the base class, so they cannot have a generated
         // partial hook - but the busy strip is computed from them.
@@ -2190,13 +2184,13 @@ public partial class RestoreViewModel : ViewModelBase
 
         var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
+        Console.IsRunning = true;
         // Reset alongside ExecutionComplete. Left over from a previous run it could combine with an
         // early bail-out to show the success banner - and write "Outcome: Succeeded" into a saved
         // log - for a restore that never ran.
         ExecutionSuccess = false;
         ExecutionComplete = false;
-        ConsoleLines.Clear();
-        HasConsoleOutput = false;
+        Console.Clear();
         RecoveryActions = [];
         HasRecoveryActions = false;
         RefreshCancelState();
@@ -2326,8 +2320,9 @@ public partial class RestoreViewModel : ViewModelBase
         {
             _executeCancellation.End();
             IsExecuting = false;
+            Console.IsRunning = false;
             ExecutionComplete = true;
-            FlushConsole();   // nothing buffered may outlive the run
+            Console.Flush();   // nothing buffered may outlive the run
             RefreshCancelState();
 
             // After the flush, so the recorded log is the whole console rather than whatever had
@@ -2356,7 +2351,7 @@ public partial class RestoreViewModel : ViewModelBase
             Outcome = outcome,
             ErrorMessage = failure,
             Script = GeneratedScript,
-            Log = ConsoleText
+            Log = Console.Text
         });
     }
 
@@ -2476,85 +2471,22 @@ public partial class RestoreViewModel : ViewModelBase
     /// Redaction happens inside the log, not here (#40).
     /// </summary>
     /// <summary>
-    /// Appends to the on-screen console and to the log file at the same time, so the file cannot
-    /// drift from what the user was shown.
-    ///
-    /// Writes to a COLLECTION rather than concatenating a bound string. Appending to a bound string
-    /// rebuilds it and re-renders the whole TextBox on every message - O(n^2) - which was a large
-    /// part of why a restore reporting progress every few percent looked like it arrived in bursts
-    /// rather than live.
+    /// The execution console. Its batching and line handling live in ConsoleBuffer (#115) - this
+    /// screen only feeds it and shows it.
     /// </summary>
-    private void AppendLog(string message)
-    {
-        foreach (var raw in message.Split('\n'))
-        {
-            var line = raw.TrimEnd('\r');
-
-            // Messages routinely arrive with a leading or trailing newline for spacing, and SQL
-            // Server's own output has its own blank lines. Left alone that produced a gap between
-            // almost every line. One blank line is allowed as a separator; runs of them are not.
-            if (line.Trim().Length == 0)
-            {
-                if (_pending.Count > 0 && _pending[^1].Text.Length == 0) continue;
-                if (_pending.Count == 0 && (ConsoleLines.Count == 0 || ConsoleLines[^1].Text.Length == 0)) continue;
-                _pending.Add(new ConsoleLine(string.Empty));
-                continue;
-            }
-
-            _pending.Add(ConsoleLine.From(line));
-        }
-
-        _log.Info($"[execute] {message.Trim()}");
-        ScheduleConsoleFlush();
-    }
+    public ConsoleBuffer Console { get; }
 
     /// <summary>
-    /// Moves buffered lines onto the bound collection on a timer rather than as they arrive.
-    ///
-    /// SQL Server emits progress in clusters - several messages within a millisecond, then nothing
-    /// for a second. Adding each one individually meant a layout pass and a scroll per message, in
-    /// bursts, which is what made the console judder. Flushing on a fixed tick turns any arrival
-    /// pattern into a steady redraw, and a whole cluster costs one layout pass instead of ten.
+    /// Appends to the on-screen console and to the log file at the same time, so the file cannot
+    /// drift from what the user was shown.
     /// </summary>
-    private void ScheduleConsoleFlush()
-    {
-        if (_consoleFlushTimer != null) return;
+    private void AppendLog(string message) => Console.Append(message);
 
-        _consoleFlushTimer = new DispatcherTimer(DispatcherPriority.Background)
-        {
-            Interval = TimeSpan.FromMilliseconds(60)
-        };
-        _consoleFlushTimer.Tick += (_, _) => FlushConsole();
-        _consoleFlushTimer.Start();
-    }
 
-    private void FlushConsole()
-    {
-        if (_pending.Count == 0)
-        {
-            // Nothing arriving and nothing running - stop ticking rather than spin forever.
-            if (!IsExecuting)
-            {
-                _consoleFlushTimer?.Stop();
-                _consoleFlushTimer = null;
-            }
-            return;
-        }
-
-        foreach (var line in _pending) ConsoleLines.Add(line);
-        _pending.Clear();
-        HasConsoleOutput = true;
-    }
-
-    private readonly List<ConsoleLine> _pending = [];
-    private DispatcherTimer? _consoleFlushTimer;
-
-    /// <summary>The console as plain text, for copying into a bug report.</summary>
-    public string ConsoleText => string.Join(Environment.NewLine, ConsoleLines.Select(l => l.Text));
 
     [RelayCommand]
     private void CopyConsole()
-        => TryCopyToClipboard(ConsoleText, "Execution log copied to clipboard.");
+        => TryCopyToClipboard(Console.Text, "Execution log copied to clipboard.");
 
     /// <summary>
     /// Writes the console to a file, with a header saying what it was (#31). The clipboard is fine
@@ -2564,7 +2496,7 @@ public partial class RestoreViewModel : ViewModelBase
     [RelayCommand]
     private void SaveConsole()
     {
-        if (string.IsNullOrEmpty(ConsoleText))
+        if (string.IsNullOrEmpty(Console.Text))
         {
             SetError("There is no execution log to save yet.");
             return;
@@ -2612,7 +2544,7 @@ public partial class RestoreViewModel : ViewModelBase
         header.AppendLine(new string('-', 60));
         header.AppendLine();
 
-        return LogRedactor.Redact(header + ConsoleText);
+        return LogRedactor.Redact(header + Console.Text);
     }
 
     private async Task RunArmCountdownAsync(CancellationToken ct)

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -66,7 +66,7 @@
                                        FontSize="11" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                            <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
+                            <TextBlock Text="{Binding Console.Lines.Count, StringFormat='{}{0} lines'}"
                                        Foreground="{DynamicResource ConsoleMutedBrush}"
                                        FontFamily="{StaticResource ConsoleFont}"
                                        FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0" />
@@ -87,7 +87,7 @@
                      unbounded height realises every row and virtualisation silently does nothing.
                      A ListBox brings its own virtualising scroll viewer. -->
                 <ListBox Grid.Row="1" x:Name="ConsoleList"
-                         ItemsSource="{Binding ConsoleLines}"
+                         ItemsSource="{Binding Console.Lines}"
                          Style="{StaticResource ConsoleListBox}" />
             </Grid>
         </Border>

--- a/src/NineLives/Views/ExecutionWindow.xaml.cs
+++ b/src/NineLives/Views/ExecutionWindow.xaml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
@@ -27,9 +27,9 @@ public partial class ExecutionWindow : Window
         InitializeComponent();
         DataContext = _viewModel = viewModel;
 
-        viewModel.ConsoleLines.CollectionChanged += OnConsoleLinesChanged;
+        viewModel.Console.Lines.CollectionChanged += OnConsoleLinesChanged;
         ConsoleList.Loaded += (_, _) => HookScroller();
-        Closed += (_, _) => viewModel.ConsoleLines.CollectionChanged -= OnConsoleLinesChanged;
+        Closed += (_, _) => viewModel.Console.Lines.CollectionChanged -= OnConsoleLinesChanged;
     }
 
     private void HookScroller()

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1301,7 +1301,7 @@
                                 <Style.Triggers>
                                     <MultiDataTrigger>
                                         <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding HasConsoleOutput}" Value="True" />
+                                            <Condition Binding="{Binding Console.HasOutput}" Value="True" />
                                             <Condition Binding="{Binding IsConsoleDetached}" Value="False" />
                                             <!-- Belt and braces. While a restore runs the console
                                                  is always in its own window, so the inline one
@@ -1350,7 +1350,7 @@
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                        <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
+                                        <TextBlock Text="{Binding Console.Lines.Count, StringFormat='{}{0} lines'}"
                                                    Foreground="{DynamicResource ConsoleMutedBrush}"
                                                    FontFamily="{StaticResource ConsoleFont}"
                                                    FontSize="11"
@@ -1374,7 +1374,7 @@
                             <!-- Virtualised so a long restore stays responsive. Auto-follows the
                                  last line unless the user has scrolled up to read something. -->
                             <ListBox Grid.Row="1" x:Name="ConsoleList"
-                                     ItemsSource="{Binding ConsoleLines}"
+                                     ItemsSource="{Binding Console.Lines}"
                                      Style="{StaticResource ConsoleListBox}"
                                      MaxHeight="360" />
                         </Grid>

--- a/src/NineLives/Views/RestoreView.xaml.cs
+++ b/src/NineLives/Views/RestoreView.xaml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
@@ -33,7 +33,7 @@ public partial class RestoreView : UserControl
         if (e.NewValue is RestoreViewModel vm)
         {
             _viewModel = vm;
-            _observedLines = vm.ConsoleLines;
+            _observedLines = vm.Console.Lines;
             _observedLines.CollectionChanged += OnConsoleLinesChanged;
             vm.PropertyChanged += OnViewModelPropertyChanged;
         }


### PR DESCRIPTION
First seam of #115. The issue stays open for the rest.

Picked first because it has **no coupling to the restore at all** — it takes text in and offers lines out — so it establishes the pattern with the least risk.

## What moved

90 lines of line splitting, blank-run collapsing and dispatcher batching, plus the timer and the pending list. `ConsoleBuffer` owns its own dispatcher now, which also removes one of the `Application.Current` reaches from the viewmodel.

**RestoreViewModel: 2,412 → 2,186 lines.**

## One real fix that fell out

Off a dispatcher thread there was nothing to drain the buffer, so lines would have been held forever. It flushes inline in that case now. That never bit in the app — everything ran on the UI thread — but it made the batching untestable without a WPF fixture, and it would have bitten the moment anything appended from a background thread.

## Tests

15, for behaviour that was already there and could not be reached without standing up a whole restore:

- blank-run collapsing **across two separate messages** — the case that matters, since the messages ending and beginning with a newline arrive separately
- line classification, so an error still reads as an error
- every message reaching the log, which is what stops the file drifting from the screen
- the batching itself: buffered on a dispatcher thread, immediate without one

**774 total**, build clean at `-warnaserror`.

## Next

Timeline layout (~300 lines, nearly pure already), then the options/script seam — the one that makes the #110 class of bug structurally impossible rather than something to remember for every new option.