### PR TITLE
Lift the restore-point timeline out of RestoreViewModel (#115)

### DIFF
--- a/src/NineLives.Tests/BusyFeedbackTests.cs
+++ b/src/NineLives.Tests/BusyFeedbackTests.cs
@@ -150,7 +150,7 @@ public class ChainCheckStateTests
         Assert.True(vm.VerifyPassed);
 
         // The result belongs to the chain that was checked.
-        vm.SelectedRestorePoint = vm.RestorePoints.First();
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.First();
 
         Assert.False(vm.ChainCheckPassed);
         Assert.False(vm.VerifyPassed);

--- a/src/NineLives.Tests/RestoreTimelineViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreTimelineViewModelTests.cs
@@ -1,0 +1,439 @@
+using System.Globalization;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The timeline's layout, filters and selection, now that they are their own type rather than 300
+/// lines in the middle of RestoreViewModel (#115 seam 2).
+///
+/// Most of these tests moved here from RestoreViewModelTests, where each one stood up a ViewModel,
+/// a fake blob service and a fake credential store, and awaited a container listing - to assert
+/// where a dot sits on a track. None of that is needed: the timeline is handed restore points and
+/// decides how to show them.
+/// </summary>
+public class RestoreTimelineViewModelTests
+{
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private static BackupSet Set(BackupType type, DateTime timestamp) => new()
+    {
+        Type = type,
+        Timestamp = timestamp,
+        SetId = $"{type}-{timestamp:yyyyMMddHHmmss}",
+        DatabaseName = "MyDb",
+        Files = [new BackupFileInfo { BlobName = "backup.bak", SizeBytes = 1024, Type = type }]
+    };
+
+    private static RestorePoint Point(DateTime timestamp, BackupType type = BackupType.TransactionLog)
+    {
+        var own = Set(type, timestamp);
+        return new RestorePoint
+        {
+            Timestamp = timestamp,
+            Type = type,
+            PrimarySet = own,
+            RequiredFullSet = type == BackupType.Full ? own : Set(BackupType.Full, T0)
+        };
+    }
+
+    /// <summary>A full at T0 plus <paramref name="logCount"/> logs at hourly intervals after it.</summary>
+    private static List<RestorePoint> FullPlusLogs(int logCount)
+    {
+        var points = new List<RestorePoint> { Point(T0, BackupType.Full) };
+        for (int i = 1; i <= logCount; i++) points.Add(Point(T0.AddHours(i)));
+        return points;
+    }
+
+    private static RestoreTimelineViewModel Loaded(int logCount = 3)
+    {
+        var timeline = new RestoreTimelineViewModel();
+        timeline.Load(FullPlusLogs(logCount));
+        return timeline;
+    }
+
+    // ── loading ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoadingShowsEveryPointAndSelectsTheMostRecent()
+    {
+        var timeline = Loaded();
+
+        Assert.True(timeline.HasPoints);
+        Assert.True(timeline.HasVisiblePoints);
+        Assert.Equal(4, timeline.Points.Count);
+        Assert.Equal(T0.AddHours(3), timeline.SelectedPoint!.Timestamp);
+    }
+
+    [Fact]
+    public void LoadingNothingLeavesTheTimelineEmpty()
+    {
+        var timeline = new RestoreTimelineViewModel();
+
+        timeline.Load([]);
+
+        Assert.False(timeline.HasPoints);
+        Assert.False(timeline.HasVisiblePoints);
+        Assert.Empty(timeline.Points);
+        Assert.Empty(timeline.CountText);
+    }
+
+    /// <summary>
+    /// Loading a database with no restore points has to drop the selection, not just the points.
+    ///
+    /// Everything downstream hangs off the selected point - the chain, the generated script, the
+    /// verification results. Keeping one belonging to the previous database leaves a complete,
+    /// authoritative-looking RESTORE on screen underneath a timeline that has nothing on it.
+    /// </summary>
+    [Fact]
+    public void LoadingADatabaseWithNoPointsDropsThePreviousSelection()
+    {
+        var timeline = Loaded();
+        Assert.NotNull(timeline.SelectedPoint);
+
+        timeline.Load([]);
+
+        Assert.Null(timeline.SelectedPoint);
+    }
+
+    [Fact]
+    public void ClearingEmptiesEverything()
+    {
+        var timeline = Loaded();
+
+        timeline.Clear();
+
+        Assert.False(timeline.HasPoints);
+        Assert.False(timeline.HasVisiblePoints);
+        Assert.Empty(timeline.Points);
+        Assert.Empty(timeline.Ticks);
+        Assert.Empty(timeline.WindowText);
+        Assert.Empty(timeline.StartText);
+        Assert.Empty(timeline.EndText);
+        Assert.Null(timeline.SelectedPoint);
+    }
+
+    /// <summary>
+    /// A clear has to forget the points as well as hide them, otherwise a filter change afterwards
+    /// brings the previous container's points back.
+    /// </summary>
+    [Fact]
+    public void AFilterChangeAfterAClearBringsNothingBack()
+    {
+        var timeline = Loaded();
+
+        timeline.Clear();
+        timeline.ShowLog = false;
+        timeline.ShowLog = true;
+
+        Assert.Empty(timeline.Points);
+        Assert.Null(timeline.SelectedPoint);
+    }
+
+    // ── layout ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PositionsSpanTheWholeTrack()
+    {
+        var timeline = Loaded();
+
+        var ordered = timeline.Points.OrderBy(p => p.Timestamp).ToList();
+        Assert.Equal(0.0, ordered.First().TimelinePosition, 6);
+        Assert.Equal(1.0, ordered.Last().TimelinePosition, 6);
+
+        // Evenly spaced points must stay evenly spaced, and monotonic.
+        Assert.All(ordered, p => Assert.InRange(p.TimelinePosition, 0.0, 1.0));
+        for (int i = 1; i < ordered.Count; i++)
+            Assert.True(ordered[i].TimelinePosition >= ordered[i - 1].TimelinePosition);
+    }
+
+    [Fact]
+    public void ASinglePointSitsInTheMiddleRatherThanAtZero()
+    {
+        var timeline = Loaded(logCount: 0);
+
+        var only = Assert.Single(timeline.Points);
+        Assert.Equal(0.5, only.TimelinePosition, 6);
+    }
+
+    [Fact]
+    public void PointsTooCloseToDrawSideBySideAreStackedIntoRows()
+    {
+        // 60 hourly logs over a fixed track: the gap between neighbours falls below the separation
+        // the row packer allows, so they cannot all sit on one row.
+        var timeline = Loaded(logCount: 60);
+
+        Assert.True(timeline.Points.Max(p => p.Row) > 0,
+            "Every point was placed on row 0, so they would be drawn on top of each other.");
+
+        // The track grows to fit however many rows were needed, otherwise the upper rows are drawn
+        // outside the control.
+        Assert.True(timeline.TrackHeight > 50);
+    }
+
+    /// <summary>
+    /// The two labels sit at each END of the track, so each one names one end. The right-hand one
+    /// was bound to the whole range - "start to end" - which put the start time at both ends and
+    /// buried the end time in the middle of a label nobody read as a label.
+    /// </summary>
+    [Fact]
+    public void EachEndOfTheTrackIsLabelledWithItsOwnTime()
+    {
+        var timeline = Loaded();
+
+        Assert.Equal("2026-01-10 22:00", timeline.StartText);
+        Assert.Equal("2026-01-11 01:00", timeline.EndText);
+
+        // The whole range, for the header above the track.
+        Assert.Equal("2026-01-10 22:00 to 2026-01-11 01:00", timeline.WindowText);
+    }
+
+    /// <summary>
+    /// Tick marks sit strictly inside the track, so a label does not overprint the start and end
+    /// labels drawn at the ends.
+    /// </summary>
+    [Fact]
+    public void TicksAreLabelledAndSitInsideTheTrack()
+    {
+        var timeline = Loaded();
+
+        Assert.NotEmpty(timeline.Ticks);
+        Assert.All(timeline.Ticks, t =>
+        {
+            Assert.InRange(t.Position, 0.02, 0.98);
+            Assert.NotEmpty(t.Label);
+        });
+    }
+
+    /// <summary>
+    /// The interval suits the span - hours across an afternoon, dates across a month - otherwise a
+    /// year of backups gets an hourly tick every few pixels.
+    /// </summary>
+    [Theory]
+    [InlineData(3, "HH:mm")]      // three hourly logs: within the day
+    [InlineData(24 * 20, "MMM")]  // twenty days: dates
+    public void TheTickIntervalSuitsTheSpan(int logCount, string expectedFormatMarker)
+    {
+        var timeline = Loaded(logCount);
+
+        var label = timeline.Ticks.First().Label;
+        bool looksLikeATime = label.Contains(':');
+
+        Assert.Equal(expectedFormatMarker == "HH:mm", looksLikeATime);
+    }
+
+    [Fact]
+    public void ASinglePointHasNoTicksToDraw()
+    {
+        var timeline = Loaded(logCount: 0);
+
+        Assert.Empty(timeline.Ticks);
+    }
+
+    // ── narrowing the points (#27) ──────────────────────────────────────────────
+
+    [Fact]
+    public void TurningOffATypeRemovesThosePointsFromBothSelectors()
+    {
+        var timeline = Loaded();
+        Assert.Equal(4, timeline.Points.Count);
+
+        timeline.ShowLog = false;
+
+        // The list and the timeline are the same collection, so this is both.
+        var only = Assert.Single(timeline.Points);
+        Assert.Equal(BackupType.Full, only.Type);
+        Assert.Contains("Showing 1 of 4", timeline.CountText);
+    }
+
+    [Fact]
+    public void ADateRangeNarrowsToTheWindowAsked()
+    {
+        var timeline = Loaded(logCount: 5);
+
+        timeline.FromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
+        timeline.ToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Equal(3, timeline.Points.Count);
+        Assert.All(timeline.Points, p => Assert.InRange(p.Timestamp, T0.AddHours(2), T0.AddHours(4)));
+    }
+
+    /// <summary>
+    /// The point of the range: the surviving points spread across the whole track rather than
+    /// staying bunched in the sliver they occupied before. Without this it filters but does not
+    /// zoom, and picking one of them is no easier than it was.
+    /// </summary>
+    [Fact]
+    public void NarrowingTheRangeSpreadsTheRemainingPointsAcrossTheTrack()
+    {
+        var timeline = Loaded(logCount: 20);
+
+        var before = timeline.Points
+            .Where(p => p.Timestamp >= T0.AddHours(2) && p.Timestamp <= T0.AddHours(4))
+            .Select(p => p.TimelinePosition)
+            .ToList();
+
+        // Before narrowing, three of twenty-one points sit inside a tenth of the track.
+        Assert.True(before.Max() - before.Min() < 0.2);
+
+        timeline.FromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
+        timeline.ToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+
+        var after = timeline.Points.Select(p => p.TimelinePosition).ToList();
+        Assert.Equal(0.0, after.Min(), 6);
+        Assert.Equal(1.0, after.Max(), 6);
+    }
+
+    [Fact]
+    public void AHalfTypedDateDoesNotBlankTheTimeline()
+    {
+        var timeline = Loaded();
+
+        // Mid-keystroke. Unparsable means no bound rather than an error.
+        timeline.FromText = "2026-01-";
+
+        Assert.Equal(4, timeline.Points.Count);
+        Assert.Null(timeline.From);
+    }
+
+    [Fact]
+    public void ADateIsReadTheSameWayWhateverTheMachinesCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            // en-US would read 02/03 as February; en-GB as March. The box is documented as
+            // yyyy-MM-dd, which is unambiguous, and it is parsed invariantly so it stays that way.
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+
+            var timeline = Loaded();
+            timeline.FromText = "2026-01-10 23:30:00";
+
+            Assert.Equal(new DateTime(2026, 1, 10, 23, 30, 0), timeline.From);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void AFilterThatMatchesNothingSaysSoRatherThanLookingEmpty()
+    {
+        var timeline = Loaded();
+
+        timeline.ShowFull = false;
+        timeline.ShowLog = false;
+        timeline.ShowDiff = false;
+
+        Assert.Empty(timeline.Points);
+        Assert.False(timeline.HasVisiblePoints);
+
+        // Still true - the database HAS restore points, they are just all filtered out. The two are
+        // different states and the view shows different things for them.
+        Assert.True(timeline.HasPoints);
+    }
+
+    [Fact]
+    public void AnExistingSelectionSurvivesAFilterThatStillIncludesIt()
+    {
+        var timeline = Loaded(logCount: 5);
+
+        var chosen = timeline.Points.First(p => p.Timestamp == T0.AddHours(2));
+        timeline.SelectedPoint = chosen;
+
+        // Narrow to a window that still contains it.
+        timeline.FromText = T0.AddHours(1).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Same(chosen, timeline.SelectedPoint);
+    }
+
+    [Fact]
+    public void ZoomToDayNarrowsToTheSelectedPointsDay()
+    {
+        // Two days of hourly logs. T0 is 22:00, so they cross midnight - the day being zoomed to is
+        // the selected point's, not the first point's.
+        var timeline = Loaded(logCount: 30);
+
+        var chosen = timeline.Points.First(p => p.Timestamp == T0.AddHours(5));
+        timeline.SelectedPoint = chosen;
+        timeline.ZoomToSelectedDayCommand.Execute(null);
+
+        Assert.All(timeline.Points, p => Assert.Equal(chosen.Timestamp.Date, p.Timestamp.Date));
+        Assert.True(timeline.Points.Count < 31);
+        Assert.Contains(timeline.Points, p => p.Timestamp == chosen.Timestamp);
+    }
+
+    [Fact]
+    public void ZoomToDayWithNothingSelectedChangesNothing()
+    {
+        var timeline = Loaded();
+        timeline.SelectedPoint = null;
+
+        timeline.ZoomToSelectedDayCommand.Execute(null);
+
+        Assert.Equal(4, timeline.Points.Count);
+        Assert.Empty(timeline.FromText);
+    }
+
+    [Fact]
+    public void ResetPutsEveryPointBack()
+    {
+        var timeline = Loaded(logCount: 5);
+
+        // Logs off leaves only the full, which sits before the range - so nothing at all.
+        timeline.ShowLog = false;
+        timeline.FromText = T0.AddHours(3).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Empty(timeline.Points);
+
+        timeline.ResetFiltersCommand.Execute(null);
+
+        Assert.Equal(6, timeline.Points.Count);
+        Assert.Equal(string.Empty, timeline.FromText);
+        Assert.True(timeline.ShowLog);
+    }
+
+    [Fact]
+    public void LoadingAgainDoesNotInheritThePreviousFilters()
+    {
+        // A range typed for one database would silently hide points belonging to the next.
+        var timeline = Loaded(logCount: 5);
+        timeline.FromText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Equal(2, timeline.Points.Count);
+
+        timeline.Load(FullPlusLogs(5));
+
+        Assert.Equal(6, timeline.Points.Count);
+        Assert.Equal(string.Empty, timeline.FromText);
+    }
+
+    // ── selection ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ClickingADotSelectsIt()
+    {
+        var timeline = Loaded();
+        var chosen = timeline.Points.First();
+
+        timeline.SelectPointCommand.Execute(chosen);
+
+        Assert.Same(chosen, timeline.SelectedPoint);
+    }
+
+    /// <summary>
+    /// The dot command is bound to every item in an ItemsControl, so it is worth being sure a null
+    /// parameter cannot clear the selection out from under the chain that was built for it.
+    /// </summary>
+    [Fact]
+    public void SelectingNothingLeavesTheSelectionAlone()
+    {
+        var timeline = Loaded();
+        var before = timeline.SelectedPoint;
+
+        timeline.SelectPointCommand.Execute(null);
+
+        Assert.Same(before, timeline.SelectedPoint);
+    }
+}

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -28,14 +28,15 @@ public class RestoreViewModelTests
 
     private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
 
-    private static BackupFileInfo File(string blobName, BackupType type, DateTime lastModified)
+    private static BackupFileInfo File(
+        string blobName, BackupType type, DateTime lastModified, string database = "MyDb")
         => new()
         {
             BlobName = blobName,
             BlobUrl = $"https://mystorageaccount.blob.core.windows.net/backups/{blobName}",
             Type = type,
             InferredServerName = "SRV01",
-            InferredDatabaseName = "MyDb",
+            InferredDatabaseName = database,
             SizeBytes = 1000,
             LastModified = new DateTimeOffset(lastModified, TimeSpan.Zero)
         };
@@ -79,14 +80,14 @@ public class RestoreViewModelTests
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
         Assert.True(vm.BackupsLoaded);
-        Assert.True(vm.HasRestorePoints);
+        Assert.True(vm.Timeline.HasPoints);
 
         // A full plus three logs: the full itself, then one point per log.
-        Assert.Equal(4, vm.RestorePoints.Count);
+        Assert.Equal(4, vm.Timeline.Points.Count);
 
         // The default selection is the latest point, which is what someone restoring after an
         // incident almost always wants.
-        Assert.Equal(T0.AddHours(3), vm.SelectedRestorePoint!.Timestamp);
+        Assert.Equal(T0.AddHours(3), vm.Timeline.SelectedPoint!.Timestamp);
         Assert.True(vm.HasValidChain);
     }
 
@@ -99,7 +100,7 @@ public class RestoreViewModelTests
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
         // The second log: full + the logs up to and including it, and nothing after.
-        vm.SelectedRestorePoint = vm.RestorePoints.Single(
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Single(
             p => p.Timestamp == T0.AddHours(2) && p.Type == BackupType.TransactionLog);
 
         Assert.NotNull(vm.RestoreChain);
@@ -117,10 +118,10 @@ public class RestoreViewModelTests
         await vm.LoadBackupsCommand.ExecuteAsync(null);
         vm.TargetDatabaseName = "MyDb_Restored";
 
-        vm.SelectedRestorePoint = vm.RestorePoints.First(p => p.Type == BackupType.Full);
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.First(p => p.Type == BackupType.Full);
         var fullOnly = vm.GeneratedScript;
 
-        vm.SelectedRestorePoint = vm.RestorePoints.Last();
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Last();
         var withLogs = vm.GeneratedScript;
 
         Assert.DoesNotContain("RESTORE LOG", fullOnly);
@@ -139,7 +140,7 @@ public class RestoreViewModelTests
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        Assert.False(vm.HasRestorePoints);
+        Assert.False(vm.Timeline.HasPoints);
 
         // The explanation has to survive the rest of the load. It used to be overwritten by
         // "Loaded 1 files in 1 backup set(s)...", leaving an empty timeline and a status bar
@@ -149,60 +150,6 @@ public class RestoreViewModelTests
 
         // And the inventory panel says the same thing in the place that persists.
         Assert.True(vm.HasInventoryIssues);
-    }
-
-    // ── timeline maths ──────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task TimelinePositionsSpanTheWholeTrack()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(3);
-        vm.SelectedContainer = Container();
-
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        var ordered = vm.RestorePoints.OrderBy(p => p.Timestamp).ToList();
-        Assert.Equal(0.0, ordered.First().TimelinePosition, 6);
-        Assert.Equal(1.0, ordered.Last().TimelinePosition, 6);
-
-        // Evenly spaced points must stay evenly spaced, and monotonic.
-        Assert.All(ordered, p => Assert.InRange(p.TimelinePosition, 0.0, 1.0));
-        for (int i = 1; i < ordered.Count; i++)
-            Assert.True(ordered[i].TimelinePosition >= ordered[i - 1].TimelinePosition);
-    }
-
-    [Fact]
-    public async Task ASinglePointSitsInTheMiddleRatherThanAtZero()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(0);
-        vm.SelectedContainer = Container();
-
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        var only = Assert.Single(vm.RestorePoints);
-        Assert.Equal(0.5, only.TimelinePosition, 6);
-    }
-
-    [Fact]
-    public async Task PointsTooCloseToDrawSideBySideAreStackedIntoRows()
-    {
-        var vm = NewViewModel();
-
-        // 60 hourly logs over a fixed track: the gap between neighbours falls below the
-        // separation the row packer allows, so they cannot all sit on one row.
-        _blob.Files = FullPlusLogs(60);
-        vm.SelectedContainer = Container();
-
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        Assert.True(vm.RestorePoints.Max(p => p.Row) > 0,
-            "Every point was placed on row 0, so they would be drawn on top of each other.");
-
-        // The track grows to fit however many rows were needed, otherwise the upper rows are
-        // drawn outside the control.
-        Assert.True(vm.TimelineHeight > 50);
     }
 
     // ── changing container ──────────────────────────────────────────────────────
@@ -224,15 +171,15 @@ public class RestoreViewModelTests
         vm.TargetDatabaseName = "MyDb_Restored";
 
         Assert.True(vm.BackupsLoaded);
-        Assert.NotEmpty(vm.RestorePoints);
+        Assert.NotEmpty(vm.Timeline.Points);
         Assert.NotEmpty(vm.GeneratedScript);
 
         vm.SelectedContainer = Container();   // a different container
 
         Assert.False(vm.BackupsLoaded);
-        Assert.Empty(vm.RestorePoints);
-        Assert.False(vm.HasRestorePoints);
-        Assert.Null(vm.SelectedRestorePoint);
+        Assert.Empty(vm.Timeline.Points);
+        Assert.False(vm.Timeline.HasPoints);
+        Assert.Null(vm.Timeline.SelectedPoint);
         Assert.Null(vm.RestoreChain);
         Assert.Empty(vm.GeneratedScript);
         Assert.False(vm.HasScript);
@@ -263,187 +210,48 @@ public class RestoreViewModelTests
         Assert.False(vm.IsExecuteArmed);
     }
 
-    // ── narrowing the restore points (#27) ──────────────────────────────────────
-
-    [Fact]
-    public async Task TurningOffATypeRemovesThosePointsFromBothSelectors()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(3);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        Assert.Equal(4, vm.RestorePoints.Count);
-
-        vm.ShowLogPoints = false;
-
-        // The list and the timeline are the same collection, so this is both.
-        var only = Assert.Single(vm.RestorePoints);
-        Assert.Equal(BackupType.Full, only.Type);
-        Assert.Contains("Showing 1 of 4", vm.PointCountText);
-    }
-
-    [Fact]
-    public async Task ADateRangeNarrowsToTheWindowAsked()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(5);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        vm.PointsFromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
-        vm.PointsToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
-
-        Assert.Equal(3, vm.RestorePoints.Count);
-        Assert.All(vm.RestorePoints, p => Assert.InRange(p.Timestamp, T0.AddHours(2), T0.AddHours(4)));
-    }
+    // ── changing database ───────────────────────────────────────────────────────
 
     /// <summary>
-    /// The point of the range: the surviving points spread across the whole track rather than
-    /// staying bunched in the sliver they occupied before. Without this it filters but does not
-    /// zoom, and picking one of them is no easier than it was.
+    /// Switching to a database with no restore points has to take the chain and the script with it.
+    ///
+    /// It did not. The timeline emptied and the error appeared, but the selected point belonged to
+    /// the previous database and nothing cleared it - so a complete RESTORE stayed on screen,
+    /// naming the previous database's backups, underneath a timeline with nothing on it and a
+    /// message saying there was nothing to restore to. Found while splitting the timeline out
+    /// (#115 seam 2).
+    ///
+    /// A database with logs but no full is not a contrived setup: it is what a container looks like
+    /// when the fulls have aged out of the retention window.
     /// </summary>
     [Fact]
-    public async Task NarrowingTheRangeSpreadsTheRemainingPointsAcrossTheTrack()
+    public async Task SwitchingToADatabaseWithNoRestorePointsClearsTheChainAndTheScript()
     {
         var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(20);
+        _blob.Files =
+        [
+            .. FullPlusLogs(3),
+            File("LOG/SRV01/OtherDb/20260110_230000.trn", BackupType.TransactionLog, T0.AddHours(1), "OtherDb"),
+            File("LOG/SRV01/OtherDb/20260111_000000.trn", BackupType.TransactionLog, T0.AddHours(2), "OtherDb")
+        ];
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        var before = vm.RestorePoints
-            .Where(p => p.Timestamp >= T0.AddHours(2) && p.Timestamp <= T0.AddHours(4))
-            .Select(p => p.TimelinePosition)
-            .ToList();
+        Assert.NotNull(vm.Timeline.SelectedPoint);
+        Assert.NotEmpty(vm.GeneratedScript);
 
-        // Before narrowing, three of twenty-one points sit inside a tenth of the track.
-        Assert.True(before.Max() - before.Min() < 0.2);
+        // OtherDb has logs but no full, so there is nothing it can be restored to.
+        vm.SelectedDatabaseName = "OtherDb";
 
-        vm.PointsFromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
-        vm.PointsToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
-
-        var after = vm.RestorePoints.Select(p => p.TimelinePosition).ToList();
-        Assert.Equal(0.0, after.Min(), 6);
-        Assert.Equal(1.0, after.Max(), 6);
+        Assert.Empty(vm.Timeline.Points);
+        Assert.Null(vm.Timeline.SelectedPoint);
+        Assert.Null(vm.RestoreChain);
+        Assert.Empty(vm.GeneratedScript);
+        Assert.False(vm.HasScript);
+        Assert.True(vm.HasError);
     }
 
-    [Fact]
-    public async Task AHalfTypedDateDoesNotBlankTheTimeline()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(3);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        // Mid-keystroke. Unparsable means no bound rather than an error.
-        vm.PointsFromText = "2026-01-";
-
-        Assert.Equal(4, vm.RestorePoints.Count);
-        Assert.Null(vm.PointsFrom);
-    }
-
-    [Fact]
-    public async Task ADateIsReadTheSameWayWhateverTheMachinesCulture()
-    {
-        var original = System.Globalization.CultureInfo.CurrentCulture;
-        try
-        {
-            // en-US would read 02/03 as February; en-GB as March. The box is documented as
-            // yyyy-MM-dd, which is unambiguous, and it is parsed invariantly so it stays that way.
-            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("en-US");
-
-            var vm = NewViewModel();
-            _blob.Files = FullPlusLogs(3);
-            vm.SelectedContainer = Container();
-            await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-            vm.PointsFromText = "2026-01-10 23:30:00";
-
-            Assert.Equal(new DateTime(2026, 1, 10, 23, 30, 0), vm.PointsFrom);
-        }
-        finally
-        {
-            System.Globalization.CultureInfo.CurrentCulture = original;
-        }
-    }
-
-    [Fact]
-    public async Task AFilterThatMatchesNothingSaysSoRatherThanLookingEmpty()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(3);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        vm.ShowFullPoints = false;
-        vm.ShowLogPoints = false;
-        vm.ShowDiffPoints = false;
-
-        Assert.Empty(vm.RestorePoints);
-        Assert.False(vm.HasVisiblePoints);
-
-        // Still true - the container HAS restore points, they are just all filtered out. The two
-        // are different states and the view shows different things for them.
-        Assert.True(vm.HasRestorePoints);
-    }
-
-    [Fact]
-    public async Task AnExistingSelectionSurvivesAFilterThatStillIncludesIt()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(5);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        var chosen = vm.RestorePoints.First(p => p.Timestamp == T0.AddHours(2));
-        vm.SelectedRestorePoint = chosen;
-
-        // Narrow to a window that still contains it.
-        vm.PointsFromText = T0.AddHours(1).ToString("yyyy-MM-dd HH:mm:ss");
-
-        Assert.Same(chosen, vm.SelectedRestorePoint);
-    }
-
-    [Fact]
-    public async Task ZoomToDayNarrowsToTheSelectedPointsDay()
-    {
-        var vm = NewViewModel();
-
-        // Two days of hourly logs.
-        _blob.Files = FullPlusLogs(30);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        // T0 is 22:00, so hourly logs cross midnight - the day being zoomed to is the selected
-        // point's, not the first point's.
-        var chosen = vm.RestorePoints.First(p => p.Timestamp == T0.AddHours(5));
-        vm.SelectedRestorePoint = chosen;
-        vm.ZoomToSelectedDayCommand.Execute(null);
-
-        Assert.All(vm.RestorePoints, p => Assert.Equal(chosen.Timestamp.Date, p.Timestamp.Date));
-        Assert.True(vm.RestorePoints.Count < 31);
-        Assert.Contains(vm.RestorePoints, p => p.Timestamp == chosen.Timestamp);
-    }
-
-    [Fact]
-    public async Task ResetPutsEveryPointBack()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(5);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        // Logs off leaves only the full, which sits before the range - so nothing at all.
-        vm.ShowLogPoints = false;
-        vm.PointsFromText = T0.AddHours(3).ToString("yyyy-MM-dd HH:mm:ss");
-        Assert.Empty(vm.RestorePoints);
-
-        vm.ResetPointFiltersCommand.Execute(null);
-
-        Assert.Equal(6, vm.RestorePoints.Count);
-        Assert.Equal(string.Empty, vm.PointsFromText);
-        Assert.True(vm.ShowLogPoints);
-    }
+    // ── narrowing the restore points (#27) ──────────────────────────────────────
 
     [Fact]
     public async Task LoadingADifferentDatabaseDoesNotInheritThePreviousFilters()
@@ -453,14 +261,14 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        vm.PointsFromText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
-        Assert.Equal(2, vm.RestorePoints.Count);
+        vm.Timeline.FromText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Equal(2, vm.Timeline.Points.Count);
 
         // A range typed for one database would silently hide points belonging to the next.
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        Assert.Equal(6, vm.RestorePoints.Count);
-        Assert.Equal(string.Empty, vm.PointsFromText);
+        Assert.Equal(6, vm.Timeline.Points.Count);
+        Assert.Equal(string.Empty, vm.Timeline.FromText);
     }
 
     /// <summary>
@@ -479,15 +287,15 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        Assert.Equal(3, vm.RestorePoints.Count);
+        Assert.Equal(3, vm.Timeline.Points.Count);
 
         // A new log arrives in the container, and the user presses Load again.
         var fresh = T0.AddHours(3);
         _blob.Files = FullPlusLogs(3);
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        Assert.Equal(4, vm.RestorePoints.Count);
-        Assert.Contains(vm.RestorePoints, p => p.Timestamp == fresh);
+        Assert.Equal(4, vm.Timeline.Points.Count);
+        Assert.Contains(vm.Timeline.Points, p => p.Timestamp == fresh);
     }
 
     // ── filtering ───────────────────────────────────────────────────────────────

--- a/src/NineLives.Tests/VerifyWithMoveTests.cs
+++ b/src/NineLives.Tests/VerifyWithMoveTests.cs
@@ -272,7 +272,7 @@ public class VerifyWithMoveViewModelTests(WpfFixture wpf)
             await vm.VerifyChainCommand.ExecuteAsync(null);
 
             // The warning belongs to the chain that was verified.
-            vm.SelectedRestorePoint = null;
+            vm.Timeline.SelectedPoint = null;
             problem = vm.HasTargetPathProblem;
         });
 

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -544,10 +544,10 @@ public class XamlLoadTests(WpfFixture wpf)
             };
 
             var vm = NewRestoreViewModel();
-            vm.HasRestorePoints = true;
-            vm.HasVisiblePoints = true;
-            vm.PointCountText = "Showing 1 of 4 restore point(s)";
-            vm.RestorePoints =
+            vm.Timeline.HasPoints = true;
+            vm.Timeline.HasVisiblePoints = true;
+            vm.Timeline.CountText = "Showing 1 of 4 restore point(s)";
+            vm.Timeline.Points =
             [
                 new RestorePoint
                 {

--- a/src/NineLives/ViewModels/RestoreTimelineViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreTimelineViewModel.cs
@@ -1,0 +1,413 @@
+﻿using System.Collections.ObjectModel;
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The restore-point timeline: which of the computed points are visible, where each one sits on
+/// the track, the tick marks underneath it, and the selection.
+///
+/// Second seam out of RestoreViewModel (#115). This part is nearly pure - points in, positions and
+/// labels out - and none of it needs a container, a server or a chain to exercise, which is why it
+/// comes early in the split.
+///
+/// It does NOT compute the restore points. Working out which points exist is chain reasoning and
+/// belongs to <see cref="Services.BackupChainBuilder"/>; this type is handed the result and decides
+/// how to show it.
+/// </summary>
+public partial class RestoreTimelineViewModel : ObservableObject
+{
+    /// <summary>
+    /// The track's height with nothing on it. Only ever seen for the instant between a load
+    /// starting and the points arriving - the whole step is collapsed while there are no points.
+    /// </summary>
+    private const int EmptyTrackHeight = 50;
+
+    /// <summary>Every computed restore point, before the filters. What is shown is a subset (#27).</summary>
+    private List<RestorePoint> _all = [];
+
+    /// <summary>Set while the filters are being changed in bulk, so each one does not re-filter.</summary>
+    private bool _suppressRefresh;
+
+    // ── what the view shows ─────────────────────────────────────────────────────
+
+    /// <summary>The points that pass the filters, in time order.</summary>
+    [ObservableProperty]
+    private ObservableCollection<RestorePoint> _points = [];
+
+    [ObservableProperty]
+    private RestorePoint? _selectedPoint;
+
+    /// <summary>True when the database has any restore points at all, filters aside.</summary>
+    [ObservableProperty]
+    private bool _hasPoints;
+
+    /// <summary>True when the filters leave at least one of them on screen.</summary>
+    [ObservableProperty]
+    private bool _hasVisiblePoints;
+
+    [ObservableProperty]
+    private string _countText = string.Empty;
+
+    /// <summary>The span the visible points cover, as "from to to".</summary>
+    [ObservableProperty]
+    private string _windowText = string.Empty;
+
+    /// <summary>
+    /// The labels at each end of the track. Plain properties rather than the old
+    /// {Binding RestorePoints[0].Timestamp}, which threw an index error into WPF's binding trace on
+    /// every layout while the collection was empty.
+    /// </summary>
+    [ObservableProperty]
+    private string _startText = string.Empty;
+
+    [ObservableProperty]
+    private string _endText = string.Empty;
+
+    [ObservableProperty]
+    private ObservableCollection<TimelineTick> _ticks = [];
+
+    [ObservableProperty]
+    private int _trackHeight = EmptyTrackHeight;
+
+    // ── filters (#27) ───────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private bool _showFull = true;
+
+    [ObservableProperty]
+    private bool _showDiff = true;
+
+    [ObservableProperty]
+    private bool _showLog = true;
+
+    [ObservableProperty]
+    private string _fromText = string.Empty;
+
+    [ObservableProperty]
+    private string _toText = string.Empty;
+
+    /// <summary>Parsed from the text boxes; null means no bound on that end.</summary>
+    [ObservableProperty]
+    private DateTime? _from;
+
+    [ObservableProperty]
+    private DateTime? _to;
+
+    /// <summary>
+    /// Takes a fresh set of restore points and shows them, with the filters wide open.
+    ///
+    /// Wide open because carrying a previous database's date range over would silently hide points
+    /// that have nothing to do with it.
+    /// </summary>
+    public void Load(IEnumerable<RestorePoint> points)
+    {
+        _all = points.ToList();
+
+        _suppressRefresh = true;
+        ShowFull = ShowDiff = ShowLog = true;
+        FromText = string.Empty;
+        ToText = string.Empty;
+        _suppressRefresh = false;
+
+        if (_all.Count == 0)
+        {
+            Clear();
+            return;
+        }
+
+        HasPoints = true;
+        ApplyFilters(selectLatest: true);
+    }
+
+    /// <summary>
+    /// Empties the timeline, for a container change or an abandoned load.
+    ///
+    /// Clearing the selection is the point of it: everything downstream - the chain, the generated
+    /// script, the verification results - hangs off the selected point, and leaving one behind
+    /// leaves a complete, authoritative-looking RESTORE on screen for a database that is no longer
+    /// the one selected above it.
+    /// </summary>
+    public void Clear()
+    {
+        _all = [];
+        Points = [];
+        HasPoints = false;
+        HasVisiblePoints = false;
+        CountText = string.Empty;
+        WindowText = string.Empty;
+        StartText = string.Empty;
+        EndText = string.Empty;
+        Ticks.Clear();
+        TrackHeight = EmptyTrackHeight;
+        SelectedPoint = null;
+    }
+
+    /// <summary>
+    /// Narrows the track and the list to the points the filters allow, then lays the track out over
+    /// just those.
+    ///
+    /// Laying out over the VISIBLE set rather than all of them is what makes the date range behave
+    /// like a zoom: narrow to a two-hour window and those points spread across the whole track
+    /// instead of staying bunched in the sliver they occupied before (#27).
+    /// </summary>
+    private void ApplyFilters(bool selectLatest = false)
+    {
+        var previous = SelectedPoint;
+        var visible = _all.Where(Matches).ToList();
+
+        LayOut(visible);
+
+        Points = new ObservableCollection<RestorePoint>(visible);
+        HasVisiblePoints = visible.Count > 0;
+
+        CountText = visible.Count == _all.Count
+            ? $"{_all.Count} restore point(s)"
+            : $"Showing {visible.Count} of {_all.Count} restore point(s)";
+
+        if (visible.Count == 0)
+        {
+            WindowText = string.Empty;
+            return;
+        }
+
+        // Keep the selection when it survives the filter - changing a type toggle should not throw
+        // away the point someone had already chosen.
+        SelectedPoint = !selectLatest && previous != null && visible.Contains(previous)
+            ? previous
+            : visible[^1];
+    }
+
+    private bool Matches(RestorePoint p)
+    {
+        var typeAllowed = p.Type switch
+        {
+            BackupType.Full => ShowFull,
+            BackupType.Differential => ShowDiff,
+            BackupType.TransactionLog => ShowLog,
+            _ => true
+        };
+        if (!typeAllowed) return false;
+
+        if (From.HasValue && p.Timestamp < From.Value) return false;
+        if (To.HasValue && p.Timestamp > To.Value) return false;
+
+        return true;
+    }
+
+    private void LayOut(List<RestorePoint> points)
+    {
+        if (points.Count > 1)
+        {
+            var minTicks = points[0].Timestamp.Ticks;
+            var maxTicks = points[^1].Timestamp.Ticks;
+            var range = (double)(maxTicks - minTicks);
+            foreach (var p in points)
+                p.TimelinePosition = range > 0 ? (p.Timestamp.Ticks - minTicks) / range : 0.5;
+        }
+        else if (points.Count == 1)
+        {
+            points[0].TimelinePosition = 0.5;
+        }
+
+        // Vertical stacking, so points too close together to draw side by side are not drawn on
+        // top of each other.
+        ComputeRows(points);
+
+        if (points.Count == 0)
+        {
+            Ticks.Clear();
+            TrackHeight = EmptyTrackHeight;
+            return;
+        }
+
+        var first = points[0].Timestamp;
+        var last = points[^1].Timestamp;
+        WindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
+        StartText = $"{first:yyyy-MM-dd HH:mm}";
+        EndText = $"{last:yyyy-MM-dd HH:mm}";
+
+        Ticks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));
+
+        int maxRow = points.Max(p => p.Row);
+        TrackHeight = Math.Max(EmptyTrackHeight, 30 + (maxRow + 1) * 18);
+    }
+
+    private void OnFilterChanged()
+    {
+        if (_suppressRefresh || _all.Count == 0) return;
+        ApplyFilters();
+    }
+
+    partial void OnShowFullChanged(bool value) => OnFilterChanged();
+    partial void OnShowDiffChanged(bool value) => OnFilterChanged();
+    partial void OnShowLogChanged(bool value) => OnFilterChanged();
+
+    partial void OnFromTextChanged(string value)
+    {
+        From = ParseFilterDate(value);
+        OnFilterChanged();
+    }
+
+    partial void OnToTextChanged(string value)
+    {
+        To = ParseFilterDate(value);
+        OnFilterChanged();
+    }
+
+    /// <summary>
+    /// Invariant, and forgiving about how much of a timestamp was typed - "2026-01-10" is a
+    /// perfectly reasonable thing to enter into a date box. Unparsable means no bound rather than
+    /// an error, so half-typed input does not blank the timeline mid-keystroke.
+    /// </summary>
+    private static DateTime? ParseFilterDate(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+
+        return DateTime.TryParse(
+            text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    [RelayCommand]
+    private void SelectPoint(RestorePoint? point)
+    {
+        if (point != null) SelectedPoint = point;
+    }
+
+    /// <summary>Back to every point, without reloading anything from the container.</summary>
+    [RelayCommand]
+    private void ResetFilters()
+    {
+        _suppressRefresh = true;
+        ShowFull = ShowDiff = ShowLog = true;
+        FromText = string.Empty;
+        ToText = string.Empty;
+        _suppressRefresh = false;
+
+        if (_all.Count > 0) ApplyFilters();
+    }
+
+    /// <summary>
+    /// Narrows the range to the day the selected point falls on. A week of 15-minute logs is
+    /// roughly 670 points; picking one precisely means getting to a day first, and doing that by
+    /// typing two timestamps is a chore when the answer is nearly always "the day it broke".
+    /// </summary>
+    [RelayCommand]
+    private void ZoomToSelectedDay()
+    {
+        if (SelectedPoint == null) return;
+
+        var day = SelectedPoint.Timestamp.Date;
+
+        _suppressRefresh = true;
+        FromText = day.ToString("yyyy-MM-dd HH:mm:ss");
+        ToText = day.AddDays(1).AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss");
+        _suppressRefresh = false;
+
+        ApplyFilters();
+    }
+
+    /// <summary>
+    /// Packs points into as few rows as possible, so two backups minutes apart on a month-long
+    /// track are drawn one above the other instead of on top of each other.
+    /// </summary>
+    private static void ComputeRows(List<RestorePoint> points)
+    {
+        const double minSeparation = 0.025;
+        var rows = new List<List<double>>();
+
+        foreach (var p in points)
+        {
+            bool placed = false;
+            for (int row = 0; row < rows.Count; row++)
+            {
+                bool overlaps = rows[row].Any(pos => Math.Abs(pos - p.TimelinePosition) < minSeparation);
+                if (!overlaps)
+                {
+                    p.Row = row;
+                    rows[row].Add(p.TimelinePosition);
+                    placed = true;
+                    break;
+                }
+            }
+            if (!placed)
+            {
+                p.Row = rows.Count;
+                rows.Add([p.TimelinePosition]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Labelled marks under the track, at an interval chosen to suit the span - hours across an
+    /// afternoon, fortnights across a year.
+    /// </summary>
+    private static List<TimelineTick> ComputeTicks(DateTime first, DateTime last)
+    {
+        var ticks = new List<TimelineTick>();
+        var range = last - first;
+        var totalTicks = (double)(last.Ticks - first.Ticks);
+        if (totalTicks <= 0) return ticks;
+
+        // Choose interval based on range
+        TimeSpan interval;
+        string format;
+        if (range.TotalDays > 60)
+        {
+            interval = TimeSpan.FromDays(14);
+            format = "MMM dd";
+        }
+        else if (range.TotalDays > 14)
+        {
+            interval = TimeSpan.FromDays(7);
+            format = "MMM dd";
+        }
+        else if (range.TotalDays > 3)
+        {
+            interval = TimeSpan.FromDays(1);
+            format = "MMM dd";
+        }
+        else if (range.TotalHours > 12)
+        {
+            interval = TimeSpan.FromHours(6);
+            format = "HH:mm";
+        }
+        else
+        {
+            interval = TimeSpan.FromHours(1);
+            format = "HH:mm";
+        }
+
+        // Round start to the next clean interval boundary
+        var cursor = RoundUp(first, interval);
+
+        while (cursor < last)
+        {
+            double pos = (cursor.Ticks - first.Ticks) / totalTicks;
+            if (pos >= 0.02 && pos <= 0.98)
+            {
+                ticks.Add(new TimelineTick { Position = pos, Label = cursor.ToString(format) });
+            }
+            cursor += interval;
+        }
+
+        return ticks;
+    }
+
+    private static DateTime RoundUp(DateTime dt, TimeSpan interval)
+    {
+        if (interval.TotalDays >= 1)
+        {
+            var next = dt.Date.AddDays(1);
+            while (next <= dt) next = next.AddDays((int)interval.TotalDays);
+            return next;
+        }
+        var ticks = (dt.Ticks + interval.Ticks - 1) / interval.Ticks * interval.Ticks;
+        return new DateTime(ticks);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -74,32 +74,12 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _targetDatabaseName = string.Empty;
 
-    // Restore points (replaces continuous slider)
-    [ObservableProperty]
-    private ObservableCollection<RestorePoint> _restorePoints = [];
-
-    [ObservableProperty]
-    private RestorePoint? _selectedRestorePoint;
-
-    [ObservableProperty]
-    private bool _hasRestorePoints;
-
-    [ObservableProperty]
-    private string _restoreWindowText = string.Empty;
-
     /// <summary>
-    /// Left-hand label under the timeline. A plain property rather than the old
-    /// {Binding RestorePoints[0].Timestamp}, which threw an index error into WPF's binding trace
-    /// on every layout while the collection was empty.
+    /// The restore-point timeline: the points, the filters over them, the layout and the
+    /// selection (#115 seam 2). Its selection is the one everything downstream hangs off, so this
+    /// class watches it in the constructor.
     /// </summary>
-    [ObservableProperty]
-    private string _timelineStartText = string.Empty;
-
-    [ObservableProperty]
-    private ObservableCollection<TimelineTick> _timelineTicks = [];
-
-    [ObservableProperty]
-    private int _timelineHeight = 60;
+    public RestoreTimelineViewModel Timeline { get; } = new();
 
     // Restore chain
     [ObservableProperty]
@@ -312,37 +292,6 @@ public partial class RestoreViewModel : ViewModelBase
 
     public bool IsBusyWithAnything => BusyDescription.Length > 0;
 
-    // ── restore point filters (#27) ─────────────────────────────────────────────
-
-    /// <summary>True when the container holds any restore points at all.</summary>
-    [ObservableProperty]
-    private bool _hasVisiblePoints;
-
-    [ObservableProperty]
-    private string _pointCountText = string.Empty;
-
-    [ObservableProperty]
-    private bool _showFullPoints = true;
-
-    [ObservableProperty]
-    private bool _showDiffPoints = true;
-
-    [ObservableProperty]
-    private bool _showLogPoints = true;
-
-    [ObservableProperty]
-    private string _pointsFromText = string.Empty;
-
-    [ObservableProperty]
-    private string _pointsToText = string.Empty;
-
-    /// <summary>Parsed from the text boxes; null means no bound on that end.</summary>
-    [ObservableProperty]
-    private DateTime? _pointsFrom;
-
-    [ObservableProperty]
-    private DateTime? _pointsTo;
-
     /// <summary>Per-set RESTORE VERIFYONLY results for the selected chain.</summary>
     public ObservableCollection<ChainVerifyResult> ChainVerifyResults { get; } = [];
 
@@ -461,7 +410,6 @@ public partial class RestoreViewModel : ViewModelBase
         _allBackups = [];
         _allSets = [];
         _dbSets = [];
-        _allPoints = [];
 
         BackupsLoaded = false;
         DiscoveredServers = [];
@@ -469,17 +417,9 @@ public partial class RestoreViewModel : ViewModelBase
         SelectedServerName = null;
         SelectedDatabaseName = null;
 
-        RestorePoints = [];
-        HasRestorePoints = false;
-        HasVisiblePoints = false;
-        PointCountText = string.Empty;
-        RestoreWindowText = string.Empty;
-        TimelineTicks.Clear();
-        TimelineHeight = 50;
-
-        // Assigning null runs the selection handler, which clears the chain, the script, the
-        // verification results and the inventory findings.
-        SelectedRestorePoint = null;
+        // Clearing the timeline drops its selection, which runs the selection handler below and
+        // clears the chain, the script, the verification results and the inventory findings.
+        Timeline.Clear();
 
         // Disarm. An armed Execute that survives a container change is an armed Execute aimed at
         // something the user is no longer looking at.
@@ -661,6 +601,14 @@ public partial class RestoreViewModel : ViewModelBase
                 RefreshCheckState();
         };
 
+        // The selection now lives on the timeline (#115 seam 2), which is a different object, so
+        // this is a subscription rather than a generated partial hook.
+        Timeline.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(RestoreTimelineViewModel.SelectedPoint))
+                OnSelectedRestorePointChanged(Timeline.SelectedPoint);
+        };
+
         RefreshContainers();
     }
 
@@ -740,19 +688,21 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void SelectRestorePoint(RestorePoint? point)
-    {
-        if (point != null)
-            SelectedRestorePoint = point;
-    }
-
-    [RelayCommand]
     private void ToggleChainDetails()
     {
         ShowChainDetails = !ShowChainDetails;
     }
 
-    partial void OnSelectedRestorePointChanged(RestorePoint? value)
+    /// <summary>
+    /// Everything downstream of the timeline: the chain, the script, the point-in-time window and
+    /// the verification results all belong to the selected point, and are rebuilt or thrown away
+    /// when it moves.
+    ///
+    /// A plain PropertyChanged subscription rather than a partial hook - the property now lives on
+    /// <see cref="Timeline"/>, and a partial hook can only be written for a property the same class
+    /// declares.
+    /// </summary>
+    private void OnSelectedRestorePointChanged(RestorePoint? value)
     {
         ShowChainDetails = false;
 
@@ -935,14 +885,11 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Every computed restore point, before the view's filters. The timeline and the list both
-    /// show a subset of this (#27).
+    /// Works out which points this database can be restored to, and hands them to the timeline.
     /// </summary>
-    private List<RestorePoint> _allPoints = [];
-
     private void ComputeAndDisplayRestorePoints()
     {
-        _allPoints = _chainBuilder.ComputeRestorePoints(_dbSets);
+        var points = _chainBuilder.ComputeRestorePoints(_dbSets);
 
         // Inventory-level findings: backups that exist but can never be offered. These belong to
         // the discovered set rather than to any one chain, so they are held separately and survive
@@ -952,286 +899,18 @@ public partial class RestoreViewModel : ViewModelBase
         // orphaned logs and "no full backup at all" were being computed nowhere and shown nowhere.
         InventoryIssues = new ObservableCollection<ChainIssue>(
             _chainValidator.ValidateInventory(_dbSets)
-                .Concat(_chainValidator.ValidateReachability(_dbSets, _allPoints)));
+                .Concat(_chainValidator.ValidateReachability(_dbSets, points)));
         HasInventoryIssues = InventoryIssues.Count > 0;
 
-        // A fresh load starts wide open. Carrying a previous database's date range over would
-        // silently hide points that have nothing to do with it.
-        _suppressPointFilterRefresh = true;
-        ShowFullPoints = ShowDiffPoints = ShowLogPoints = true;
-        PointsFromText = string.Empty;
-        PointsToText = string.Empty;
-        _suppressPointFilterRefresh = false;
+        Timeline.Load(points);
 
-        HasRestorePoints = _allPoints.Count > 0;
-
-        if (_allPoints.Count == 0)
+        if (points.Count == 0)
         {
-            RestorePoints = [];
-            HasVisiblePoints = false;
-            RestoreWindowText = string.Empty;
-            PointCountText = string.Empty;
-            TimelineTicks.Clear();
-            TimelineHeight = 50;
             SetError("No valid restore points found. Ensure there is at least one full backup.");
             return;
         }
 
-        ApplyPointFilters(selectLatest: true);
         ClearStatus();
-    }
-
-    /// <summary>
-    /// Narrows the timeline and the list to the points the filters allow, then lays the timeline
-    /// out over just those.
-    ///
-    /// Laying out over the VISIBLE set rather than all of them is what makes the date range behave
-    /// like a zoom: narrow to a two-hour window and those points spread across the whole track
-    /// instead of staying bunched in the sliver they occupied before (#27).
-    /// </summary>
-    private void ApplyPointFilters(bool selectLatest = false)
-    {
-        var previous = SelectedRestorePoint;
-        var visible = _allPoints.Where(PointMatchesFilters).ToList();
-
-        LayOutTimeline(visible);
-
-        RestorePoints = new ObservableCollection<RestorePoint>(visible);
-        HasVisiblePoints = visible.Count > 0;
-
-        PointCountText = visible.Count == _allPoints.Count
-            ? $"{_allPoints.Count} restore point(s)"
-            : $"Showing {visible.Count} of {_allPoints.Count} restore point(s)";
-
-        if (visible.Count == 0)
-        {
-            RestoreWindowText = string.Empty;
-            return;
-        }
-
-        // Keep the selection when it survives the filter - changing a type toggle should not throw
-        // away the point someone had already chosen.
-        SelectedRestorePoint = !selectLatest && previous != null && visible.Contains(previous)
-            ? previous
-            : visible[^1];
-    }
-
-    private bool PointMatchesFilters(RestorePoint p)
-    {
-        var typeAllowed = p.Type switch
-        {
-            BackupType.Full => ShowFullPoints,
-            BackupType.Differential => ShowDiffPoints,
-            BackupType.TransactionLog => ShowLogPoints,
-            _ => true
-        };
-        if (!typeAllowed) return false;
-
-        if (PointsFrom.HasValue && p.Timestamp < PointsFrom.Value) return false;
-        if (PointsTo.HasValue && p.Timestamp > PointsTo.Value) return false;
-
-        return true;
-    }
-
-    private void LayOutTimeline(List<RestorePoint> points)
-    {
-        if (points.Count > 1)
-        {
-            var minTicks = points[0].Timestamp.Ticks;
-            var maxTicks = points[^1].Timestamp.Ticks;
-            var range = (double)(maxTicks - minTicks);
-            foreach (var p in points)
-                p.TimelinePosition = range > 0 ? (p.Timestamp.Ticks - minTicks) / range : 0.5;
-        }
-        else if (points.Count == 1)
-        {
-            points[0].TimelinePosition = 0.5;
-        }
-
-        // Vertical stacking, so points too close together to draw side by side are not drawn on
-        // top of each other.
-        ComputeRows(points);
-
-        if (points.Count == 0)
-        {
-            TimelineTicks.Clear();
-            TimelineHeight = 50;
-            return;
-        }
-
-        var first = points[0].Timestamp;
-        var last = points[^1].Timestamp;
-        RestoreWindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
-        TimelineStartText = $"{first:yyyy-MM-dd HH:mm}";
-
-        TimelineTicks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));
-
-        int maxRow = points.Max(p => p.Row);
-        TimelineHeight = Math.Max(50, 30 + (maxRow + 1) * 18);
-    }
-
-    /// <summary>Set while the filters are being reset in bulk, so each one does not re-filter.</summary>
-    private bool _suppressPointFilterRefresh;
-
-    private void OnPointFilterChanged()
-    {
-        if (_suppressPointFilterRefresh || _allPoints.Count == 0) return;
-        ApplyPointFilters();
-    }
-
-    partial void OnShowFullPointsChanged(bool value) => OnPointFilterChanged();
-    partial void OnShowDiffPointsChanged(bool value) => OnPointFilterChanged();
-    partial void OnShowLogPointsChanged(bool value) => OnPointFilterChanged();
-
-    partial void OnPointsFromTextChanged(string value)
-    {
-        PointsFrom = ParseFilterDate(value);
-        OnPointFilterChanged();
-    }
-
-    partial void OnPointsToTextChanged(string value)
-    {
-        PointsTo = ParseFilterDate(value);
-        OnPointFilterChanged();
-    }
-
-    /// <summary>
-    /// Invariant, and forgiving about how much of a timestamp was typed - "2026-01-10" is a
-    /// perfectly reasonable thing to enter into a date box. Unparsable means no bound rather than
-    /// an error, so half-typed input does not blank the timeline mid-keystroke.
-    /// </summary>
-    private static DateTime? ParseFilterDate(string? text)
-    {
-        if (string.IsNullOrWhiteSpace(text)) return null;
-
-        return DateTime.TryParse(
-            text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
-            ? parsed
-            : null;
-    }
-
-    /// <summary>Back to every point, without reloading anything from the container.</summary>
-    [RelayCommand]
-    private void ResetPointFilters()
-    {
-        _suppressPointFilterRefresh = true;
-        ShowFullPoints = ShowDiffPoints = ShowLogPoints = true;
-        PointsFromText = string.Empty;
-        PointsToText = string.Empty;
-        _suppressPointFilterRefresh = false;
-
-        if (_allPoints.Count > 0) ApplyPointFilters();
-    }
-
-    /// <summary>
-    /// Narrows the range to the day the selected point falls on. A week of 15-minute logs is
-    /// roughly 670 points; picking one precisely means getting to a day first, and doing that by
-    /// typing two timestamps is a chore when the answer is nearly always "the day it broke".
-    /// </summary>
-    [RelayCommand]
-    private void ZoomToSelectedDay()
-    {
-        if (SelectedRestorePoint == null) return;
-
-        var day = SelectedRestorePoint.Timestamp.Date;
-
-        _suppressPointFilterRefresh = true;
-        PointsFromText = day.ToString("yyyy-MM-dd HH:mm:ss");
-        PointsToText = day.AddDays(1).AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss");
-        _suppressPointFilterRefresh = false;
-
-        ApplyPointFilters();
-    }
-
-    private static void ComputeRows(List<RestorePoint> points)
-    {
-        const double minSeparation = 0.025;
-        var rows = new List<List<double>>();
-
-        foreach (var p in points)
-        {
-            bool placed = false;
-            for (int row = 0; row < rows.Count; row++)
-            {
-                bool overlaps = rows[row].Any(pos => Math.Abs(pos - p.TimelinePosition) < minSeparation);
-                if (!overlaps)
-                {
-                    p.Row = row;
-                    rows[row].Add(p.TimelinePosition);
-                    placed = true;
-                    break;
-                }
-            }
-            if (!placed)
-            {
-                p.Row = rows.Count;
-                rows.Add([p.TimelinePosition]);
-            }
-        }
-    }
-
-    private static List<TimelineTick> ComputeTicks(DateTime first, DateTime last)
-    {
-        var ticks = new List<TimelineTick>();
-        var range = last - first;
-        var totalTicks = (double)(last.Ticks - first.Ticks);
-        if (totalTicks <= 0) return ticks;
-
-        // Choose interval based on range
-        TimeSpan interval;
-        string format;
-        if (range.TotalDays > 60)
-        {
-            interval = TimeSpan.FromDays(14);
-            format = "MMM dd";
-        }
-        else if (range.TotalDays > 14)
-        {
-            interval = TimeSpan.FromDays(7);
-            format = "MMM dd";
-        }
-        else if (range.TotalDays > 3)
-        {
-            interval = TimeSpan.FromDays(1);
-            format = "MMM dd";
-        }
-        else if (range.TotalHours > 12)
-        {
-            interval = TimeSpan.FromHours(6);
-            format = "HH:mm";
-        }
-        else
-        {
-            interval = TimeSpan.FromHours(1);
-            format = "HH:mm";
-        }
-
-        // Round start to the next clean interval boundary
-        var cursor = RoundUp(first, interval);
-
-        while (cursor < last)
-        {
-            double pos = (cursor.Ticks - first.Ticks) / totalTicks;
-            if (pos >= 0.02 && pos <= 0.98)
-            {
-                ticks.Add(new TimelineTick { Position = pos, Label = cursor.ToString(format) });
-            }
-            cursor += interval;
-        }
-
-        return ticks;
-    }
-
-    private static DateTime RoundUp(DateTime dt, TimeSpan interval)
-    {
-        if (interval.TotalDays >= 1)
-        {
-            var next = dt.Date.AddDays(1);
-            while (next <= dt) next = next.AddDays((int)interval.TotalDays);
-            return next;
-        }
-        var ticks = (dt.Ticks + interval.Ticks - 1) / interval.Ticks * interval.Ticks;
-        return new DateTime(ticks);
     }
 
     private void AutoPopulateMoveDefaults()
@@ -1315,8 +994,8 @@ public partial class RestoreViewModel : ViewModelBase
 
         if (EffectiveStopAt is DateTime stopAt)
             parts.Add($"Stop at {stopAt:yyyy-MM-dd HH:mm:ss} (point-in-time recovery).");
-        else if (SelectedRestorePoint != null && SelectedRestorePoint.Type == BackupType.TransactionLog)
-            parts.Add($"Restore to end of log backup at {SelectedRestorePoint.Timestamp:yyyy-MM-dd HH:mm:ss}.");
+        else if (Timeline.SelectedPoint is { Type: BackupType.TransactionLog } logPoint)
+            parts.Add($"Restore to end of log backup at {logPoint.Timestamp:yyyy-MM-dd HH:mm:ss}.");
 
         var optionsList = new List<string>();
 
@@ -2346,7 +2025,7 @@ public partial class RestoreViewModel : ViewModelBase
             TargetDatabase = TargetDatabaseName,
             ContainerName = SelectedContainer?.Name,
             SourceDatabase = SelectedDatabaseName,
-            RestorePointTimestamp = SelectedRestorePoint?.Timestamp,
+            RestorePointTimestamp = Timeline.SelectedPoint?.Timestamp,
             ChainSummary = RestoreChain?.Summary ?? "no chain",
             Outcome = outcome,
             ErrorMessage = failure,
@@ -2537,8 +2216,8 @@ public partial class RestoreViewModel : ViewModelBase
         header.AppendLine($"Target:     {TargetDatabaseName}");
         if (SelectedContainer != null)
             header.AppendLine($"Container:  {SelectedContainer.Name}");
-        if (SelectedRestorePoint != null)
-            header.AppendLine($"Point:      {SelectedRestorePoint.TimestampDisplay}");
+        if (Timeline.SelectedPoint != null)
+            header.AppendLine($"Point:      {Timeline.SelectedPoint.TimestampDisplay}");
         header.AppendLine($"Chain:      {RestoreChain?.Summary ?? "none"}");
         header.AppendLine($"Outcome:    {(ExecutionComplete ? (ExecutionSuccess ? "Succeeded" : "Did not succeed") : "Still running")}");
         header.AppendLine(new string('-', 60));

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -108,7 +108,7 @@
                             <Run Text="{Binding SetCount, Mode=OneWay}" FontWeight="SemiBold" />
                             <Run Text=" total sets" />
                         </TextBlock>
-                        <TextBlock Grid.Column="4" Text="{Binding RestoreWindowText}"
+                        <TextBlock Grid.Column="4" Text="{Binding Timeline.WindowText}"
                                    Style="{StaticResource SecondaryText}"
                                    VerticalAlignment="Center" HorizontalAlignment="Right" />
                     </Grid>
@@ -153,7 +153,7 @@
 
             <!-- Step 2: Restore Point Selection -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
-                    Visibility="{Binding HasRestorePoints, Converter={StaticResource BoolToVis}}">
+                    Visibility="{Binding Timeline.HasPoints, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
                     <TextBlock Text="2. SELECT RESTORE POINT"
                                Style="{StaticResource SubHeaderText}"
@@ -175,29 +175,29 @@
                             </Grid.ColumnDefinitions>
 
                             <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
-                                <CheckBox Content="Full" IsChecked="{Binding ShowFullPoints}"
+                                <CheckBox Content="Full" IsChecked="{Binding Timeline.ShowFull}"
                                           Style="{StaticResource DarkCheckBox}" Margin="0,0,12,0" />
-                                <CheckBox Content="Diff" IsChecked="{Binding ShowDiffPoints}"
+                                <CheckBox Content="Diff" IsChecked="{Binding Timeline.ShowDiff}"
                                           Style="{StaticResource DarkCheckBox}" Margin="0,0,12,0" />
-                                <CheckBox Content="Log" IsChecked="{Binding ShowLogPoints}"
+                                <CheckBox Content="Log" IsChecked="{Binding Timeline.ShowLog}"
                                           Style="{StaticResource DarkCheckBox}" Margin="0,0,20,0" />
 
                                 <TextBlock Text="From" Style="{StaticResource SecondaryText}"
                                            VerticalAlignment="Center" Margin="0,0,6,0" />
-                                <TextBox Text="{Binding PointsFromText, UpdateSourceTrigger=PropertyChanged}"
+                                <TextBox Text="{Binding Timeline.FromText, UpdateSourceTrigger=PropertyChanged}"
                                          Style="{StaticResource DarkTextBox}"
                                          Width="150" Margin="0,0,12,0"
                                          ToolTip="yyyy-MM-dd or yyyy-MM-dd HH:mm:ss. Leave empty for no lower bound." />
 
                                 <TextBlock Text="To" Style="{StaticResource SecondaryText}"
                                            VerticalAlignment="Center" Margin="0,0,6,0" />
-                                <TextBox Text="{Binding PointsToText, UpdateSourceTrigger=PropertyChanged}"
+                                <TextBox Text="{Binding Timeline.ToText, UpdateSourceTrigger=PropertyChanged}"
                                          Style="{StaticResource DarkTextBox}"
                                          Width="150"
                                          ToolTip="yyyy-MM-dd or yyyy-MM-dd HH:mm:ss. Leave empty for no upper bound." />
                             </StackPanel>
 
-                            <TextBlock Grid.Column="1" Text="{Binding PointCountText}"
+                            <TextBlock Grid.Column="1" Text="{Binding Timeline.CountText}"
                                        Style="{StaticResource SecondaryText}"
                                        VerticalAlignment="Center"
                                        HorizontalAlignment="Right"
@@ -205,12 +205,12 @@
 
                             <StackPanel Grid.Column="2" Orientation="Horizontal">
                                 <Button Content="Zoom to day"
-                                        Command="{Binding ZoomToSelectedDayCommand}"
+                                        Command="{Binding Timeline.ZoomToSelectedDayCommand}"
                                         Style="{StaticResource SecondaryButton}"
                                         Padding="10,4" FontSize="11" Margin="0,0,8,0"
                                         ToolTip="Narrows the range to the day the selected point falls on." />
                                 <Button Content="Reset"
-                                        Command="{Binding ResetPointFiltersCommand}"
+                                        Command="{Binding Timeline.ResetFiltersCommand}"
                                         Style="{StaticResource SecondaryButton}"
                                         Padding="10,4" FontSize="11"
                                         ToolTip="Show every restore point again." />
@@ -223,7 +223,7 @@
                                Foreground="{DynamicResource WarningBrush}"
                                TextWrapping="Wrap"
                                Margin="0,0,0,12"
-                               Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+                               Visibility="{Binding Timeline.HasVisiblePoints, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
 
                     <!-- ========== VISUAL TIMELINE ========== -->
                     <Border Background="{DynamicResource InputBackgroundBrush}"
@@ -247,9 +247,9 @@
                             </StackPanel>
 
                             <!-- Dots area (stacked vertically) -->
-                            <Grid Grid.Row="1" Height="{Binding TimelineHeight}" Margin="7,0">
+                            <Grid Grid.Row="1" Height="{Binding Timeline.TrackHeight}" Margin="7,0">
                                 <!-- Vertical guide lines at tick positions -->
-                                <ItemsControl ItemsSource="{Binding TimelineTicks}" IsHitTestVisible="False">
+                                <ItemsControl ItemsSource="{Binding Timeline.Ticks}" IsHitTestVisible="False">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
                                             <Grid />
@@ -271,7 +271,7 @@
                                 </ItemsControl>
 
                                 <!-- Clickable restore point dots -->
-                                <ItemsControl ItemsSource="{Binding RestorePoints}"
+                                <ItemsControl ItemsSource="{Binding Timeline.Points}"
                                               x:Name="TimelineDots">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
@@ -282,7 +282,7 @@
                                         <DataTemplate>
                                             <Button HorizontalAlignment="Left" VerticalAlignment="Bottom"
                                                     Cursor="Hand"
-                                                    Command="{Binding DataContext.SelectRestorePointCommand,
+                                                    Command="{Binding DataContext.Timeline.SelectPointCommand,
                                                               RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                     CommandParameter="{Binding}">
                                                 <Button.Template>
@@ -334,7 +334,7 @@
                                         VerticalAlignment="Top" CornerRadius="1.5" />
 
                                 <!-- Tick marks with labels -->
-                                <ItemsControl ItemsSource="{Binding TimelineTicks}">
+                                <ItemsControl ItemsSource="{Binding Timeline.Ticks}">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
                                             <Grid />
@@ -363,12 +363,16 @@
                             <!-- Start/End date labels -->
                             <Grid Grid.Row="3" Margin="7,2,7,0">
                                 <TextBlock Style="{StaticResource SecondaryText}" HorizontalAlignment="Left"
-                                           Text="{Binding TimelineStartText}"
+                                           Text="{Binding Timeline.StartText}"
                                            FontSize="10" />
+                                <!-- The END of the range, not the whole range: this label sits at
+                                     the right-hand end of the track and was showing "start to end",
+                                     so the start time appeared twice and the end was buried in it.
+                                     The full range is in the header above (#115 seam 2). -->
                                 <TextBlock Style="{StaticResource SecondaryText}" HorizontalAlignment="Right"
                                            FontSize="10">
                                     <TextBlock.Text>
-                                        <Binding Path="RestoreWindowText"
+                                        <Binding Path="Timeline.EndText"
                                                  FallbackValue=""
                                                  TargetNullValue="" />
                                     </TextBlock.Text>
@@ -383,16 +387,16 @@
                          actually trying to do. Sortable, and its selection is the same selection
                          as the timeline's (#27). -->
                     <TextBlock Text="RESTORE POINTS" Style="{StaticResource LabelText}" Margin="0,4,0,4"
-                               Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}}" />
-                    <DataGrid ItemsSource="{Binding RestorePoints}"
-                              SelectedItem="{Binding SelectedRestorePoint}"
+                               Visibility="{Binding Timeline.HasVisiblePoints, Converter={StaticResource BoolToVis}}" />
+                    <DataGrid ItemsSource="{Binding Timeline.Points}"
+                              SelectedItem="{Binding Timeline.SelectedPoint}"
                               Style="{StaticResource DarkDataGrid}"
                               MaxHeight="240"
                               Margin="0,0,0,12"
                               CanUserSortColumns="True"
                               ScrollViewer.CanContentScroll="True"
                               EnableRowVirtualization="True"
-                              Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}}">
+                              Visibility="{Binding Timeline.HasVisiblePoints, Converter={StaticResource BoolToVis}}">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Point in time" Width="180"
                                                 SortMemberPath="Timestamp"
@@ -490,7 +494,7 @@
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
                             <Run Text="Selected: " Foreground="{DynamicResource SecondaryTextBrush}" />
-                            <Run Text="{Binding SelectedRestorePoint.TimestampDisplay, Mode=OneWay}"
+                            <Run Text="{Binding Timeline.SelectedPoint.TimestampDisplay, Mode=OneWay}"
                                  FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}" />
                             <Run Text="  |  " Foreground="{DynamicResource SecondaryTextBrush}" />
                             <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{DynamicResource SecondaryTextBrush}" />


### PR DESCRIPTION
Second seam of #115.

The timeline was ~320 lines in the middle of a 2,572-line class: positions, row packing, tick intervals, the type and date filters from #27, and the selection that everything downstream hangs off. `RestoreTimelineViewModel` owns all of it now — points in, positions and labels out.

It deliberately does *not* compute the restore points. Working out which points exist is chain reasoning and belongs to `BackupChainBuilder`; this type is handed the result and decides how to show it. `RestoreViewModel` drops to 2,251 lines and watches `Timeline.SelectedPoint` to build the chain.

## Two defects fell out of the split

**A database with no restore points kept the previous one's selection.** Switching database emptied the timeline and showed "No valid restore points found", but nothing cleared the selection — so a complete, authoritative-looking RESTORE stayed on screen naming the *previous* database's backups, underneath an empty timeline and a message saying there was nothing to restore to. A database with logs but no full is not contrived: it is what a container looks like once the fulls have aged out of retention. `Clear()` drops the selection, which cascades to the chain, the script and the verification results.

**The right-hand label under the track showed the whole range.** It was bound to "start to end", so the start time appeared at both ends of the track and the end time was buried in the middle of it. It shows the end time now; the full range is still in the header above.

Both were proved by reverting the fix and watching the new tests fail.

## Tests

Twelve moved out of `RestoreViewModelTests`, where each one stood up a ViewModel, a fake blob service and a fake credential store, and awaited a container listing — to assert where a dot sits on a track. They construct a timeline directly now.

Fourteen more for what that made reachable: tick intervals and labelling, a single point having no ticks to draw, the window labels, clearing, a filter change after a clear, the two fixes above, and the dot command with a null parameter.

766 tests pass, build clean at `-warnaserror`. The restore screen was rendered to a PNG and checked before and after — the ~20 binding renames all resolve, and `XamlLoadTests` fails the build on any that would not.

## Remaining seams

3 (point-in-time), 4 (container listing and discovery), 5 (server-side credentials), 6 (execution), 7 (options and script generation). 7 is the one with the live defect history — with the options on their own type raising a single `OptionsChanged`, the #110 class of bug becomes structurally impossible rather than something to remember for every new option.
