### PR TITLE
Lift the point-in-time target out of RestoreViewModel (#115)

### DIFF
--- a/src/NineLives.Tests/PointInTimeViewModelTests.cs
+++ b/src/NineLives.Tests/PointInTimeViewModelTests.cs
@@ -1,0 +1,289 @@
+using System.Globalization;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The point-in-time (STOPAT) target, extracted from RestoreViewModel in #115 seam 3.
+///
+/// None of this had a test. It was ~130 lines in the middle of a 2,500-line class and reaching it
+/// meant a container, a listing, a chain and a selected log restore point - so the rules that decide
+/// whether a restore stops at 14:23:41 or discards the afternoon were only ever checked by hand.
+///
+/// The bounds matter: the target is constrained to the LAST log's window because every earlier log
+/// then applies in full. A target inside an earlier log would need the chain truncated to that log,
+/// or the later logs restore across a gap and fail with error 4305.
+/// </summary>
+public class PointInTimeViewModelTests
+{
+    private static readonly DateTime Earliest = new(2026, 1, 10, 22, 0, 0);
+    private static readonly DateTime Latest = new(2026, 1, 10, 22, 15, 0);
+
+    private static PointInTimeViewModel WithWindow()
+    {
+        var vm = new PointInTimeViewModel();
+        vm.SetWindow((Earliest, Latest));
+        return vm;
+    }
+
+    // ── the window ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AWindowOffersTheTargetPrefilledWithTheLatestUsableTime()
+    {
+        var vm = WithWindow();
+
+        Assert.True(vm.CanUse);
+        Assert.Equal(Earliest, vm.Earliest);
+        Assert.Equal(Latest, vm.Latest);
+        Assert.Equal("2026-01-10 22:15:00", vm.StopAtText);
+
+        // Prefilled but not ticked - showing the bounds is not the same as committing to them.
+        Assert.False(vm.Use);
+        Assert.Contains("Valid range", vm.Message);
+    }
+
+    [Fact]
+    public void NoWindowTurnsTheWholeThingOff()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        // A full or differential restore point: stopping partway through means nothing.
+        vm.SetWindow(null);
+
+        Assert.False(vm.CanUse);
+        Assert.False(vm.Use);
+        Assert.Null(vm.Earliest);
+        Assert.Null(vm.Latest);
+        Assert.Empty(vm.StopAtText);
+        Assert.Null(vm.StopAt);
+        Assert.Empty(vm.Message);
+        Assert.False(vm.HasError);
+        Assert.Null(vm.Effective);
+    }
+
+    /// <summary>
+    /// Moving to a different log has to drop the previous one's tick as well as its bounds. A
+    /// target carried across would be validated against the new window and, if it happened to fall
+    /// inside it, would silently discard transactions nobody asked to discard.
+    /// </summary>
+    [Fact]
+    public void ANewWindowStartsUnticked()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.SetWindow((Earliest.AddHours(1), Latest.AddHours(1)));
+
+        Assert.False(vm.Use);
+        Assert.Null(vm.Effective);
+        Assert.Equal("2026-01-10 23:15:00", vm.StopAtText);
+    }
+
+    // ── bounds ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Exclusive: at exactly the previous set's time nothing from this log has been applied yet,
+    /// which is the EARLIER restore point, not this one.
+    /// </summary>
+    [Fact]
+    public void TheLowerBoundIsExclusive()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:00:00";
+
+        Assert.Null(vm.StopAt);
+        Assert.True(vm.HasError);
+        Assert.Contains("Must be after", vm.Message);
+        Assert.Contains("select an earlier restore point", vm.Message);
+    }
+
+    [Fact]
+    public void OneSecondIntoTheLogIsAccepted()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:00:01";
+
+        Assert.Equal(new DateTime(2026, 1, 10, 22, 0, 1), vm.StopAt);
+        Assert.False(vm.HasError);
+    }
+
+    /// <summary>Inclusive: the end of the log is exactly what restoring the whole log gives.</summary>
+    [Fact]
+    public void TheUpperBoundIsInclusive()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:15:00";
+
+        Assert.Equal(Latest, vm.StopAt);
+        Assert.False(vm.HasError);
+    }
+
+    [Fact]
+    public void OneSecondPastTheEndOfTheLogIsRejected()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:15:01";
+
+        Assert.Null(vm.StopAt);
+        Assert.True(vm.HasError);
+        Assert.Contains("Must be at or before", vm.Message);
+        Assert.Contains("select a later restore point", vm.Message);
+    }
+
+    // ── what was typed ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("2026-01-10 22:10:30")]
+    [InlineData("2026-01-10T22:10:30")]
+    [InlineData("2026-01-10 22:10")]
+    [InlineData("2026-01-10T22:10")]
+    [InlineData("  2026-01-10 22:10:30  ")]
+    public void TheAcceptedShapesAllParse(string text)
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = text;
+
+        Assert.NotNull(vm.StopAt);
+        Assert.False(vm.HasError);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("2026-01-")]
+    [InlineData("10/01/2026 22:10")]
+    [InlineData("yesterday")]
+    public void AnythingElseIsRejectedWithTheShapeItWants(string text)
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = text;
+
+        Assert.Null(vm.StopAt);
+        Assert.True(vm.HasError);
+        Assert.Contains("yyyy-MM-dd HH:mm:ss", vm.Message);
+    }
+
+    /// <summary>
+    /// Parsed invariantly and exactly. A target read as 3 February when the user meant 3 March is a
+    /// month of transactions silently discarded - and 10/01/2026 is a different day in en-US and
+    /// en-GB, so an ambiguous shape is refused outright rather than guessed at.
+    /// </summary>
+    [Fact]
+    public void ADateIsReadTheSameWayWhateverTheMachinesCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+
+            var vm = WithWindow();
+            vm.Use = true;
+            vm.StopAtText = "2026-01-10 22:10:30";
+
+            Assert.Equal(new DateTime(2026, 1, 10, 22, 10, 30), vm.StopAt);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    // ── when it counts as an error ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Half-typed input in a box nobody has ticked is not a reason to block the restore - the box
+    /// is prefilled and editable whether or not STOPAT is being used.
+    /// </summary>
+    [Fact]
+    public void ABadValueIsNotAnErrorUntilItIsBeingUsed()
+    {
+        var vm = WithWindow();
+
+        vm.StopAtText = "2026-01-";
+
+        Assert.Null(vm.StopAt);
+        Assert.False(vm.HasError);
+        Assert.Null(vm.Effective);
+    }
+
+    [Fact]
+    public void TickingTheBoxOverABadValueRaisesTheError()
+    {
+        var vm = WithWindow();
+        vm.StopAtText = "2026-01-";
+        Assert.False(vm.HasError);
+
+        vm.Use = true;
+
+        Assert.True(vm.HasError);
+    }
+
+    [Fact]
+    public void TheMessageSaysWhatWillHappenOnceItIsBeingUsed()
+    {
+        var vm = WithWindow();
+        vm.StopAtText = "2026-01-10 22:10:30";
+        Assert.Contains("Valid range", vm.Message);
+
+        vm.Use = true;
+
+        Assert.Contains("Recovery will stop at 2026-01-10 22:10:30", vm.Message);
+        Assert.Contains("discarded", vm.Message);
+    }
+
+    // ── what reaches the script ─────────────────────────────────────────────────
+
+    [Fact]
+    public void NothingIsGeneratedUntilTheBoxIsTicked()
+    {
+        var vm = WithWindow();
+
+        // A perfectly valid target, sitting in an unticked box.
+        vm.StopAtText = "2026-01-10 22:10:30";
+
+        Assert.NotNull(vm.StopAt);
+        Assert.Null(vm.Effective);
+    }
+
+    [Fact]
+    public void ATickedValidTargetIsWhatGetsGenerated()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:10:30";
+
+        Assert.Equal(new DateTime(2026, 1, 10, 22, 10, 30), vm.Effective);
+    }
+
+    /// <summary>
+    /// A ticked box over a rejected target must generate nothing rather than fall back to the whole
+    /// log: the user asked to stop somewhere and silently restoring past it is the failure that
+    /// matters here.
+    /// </summary>
+    [Fact]
+    public void ATickedInvalidTargetGeneratesNothing()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 23:59:59";
+
+        Assert.True(vm.HasError);
+        Assert.Null(vm.Effective);
+    }
+}

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -210,6 +210,80 @@ public class RestoreViewModelTests
         Assert.False(vm.IsExecuteArmed);
     }
 
+    // ── point in time (#115 seam 3) ─────────────────────────────────────────────
+
+    /// <summary>
+    /// The wiring between the STOPAT box and the script. The rules themselves are pinned in
+    /// PointInTimeViewModelTests; this is the part that has to reach the RESTORE that runs.
+    /// </summary>
+    [Fact]
+    public async Task ATickedPointInTimeTargetReachesTheGeneratedScript()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        // The latest point is a log, so stopping partway through it is meaningful.
+        Assert.True(vm.PointInTime.CanUse);
+        Assert.DoesNotContain("STOPAT", vm.GeneratedScript);
+
+        vm.PointInTime.Use = true;
+        vm.PointInTime.StopAtText = T0.AddHours(2).AddMinutes(30).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Contains("STOPAT = '2026-01-11T00:30:00'", vm.GeneratedScript);
+    }
+
+    /// <summary>
+    /// A ticked box over a rejected target leaves no script at all. Falling back to the whole log
+    /// would restore past the moment someone explicitly asked to stop at, which is the failure that
+    /// matters - and a script that quietly ignores the box above it is exactly the stale-script
+    /// problem.
+    /// </summary>
+    [Fact]
+    public async Task ATickedButInvalidPointInTimeTargetLeavesNoScript()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        Assert.NotEmpty(vm.GeneratedScript);
+
+        vm.PointInTime.Use = true;
+        vm.PointInTime.StopAtText = "well after the end of the log";
+
+        Assert.Empty(vm.GeneratedScript);
+        Assert.False(vm.HasScript);
+    }
+
+    /// <summary>
+    /// Selecting a full or differential point takes the STOPAT box away with it - there is no log
+    /// to stop partway through - and the script must lose the STOPAT too.
+    /// </summary>
+    [Fact]
+    public async Task MovingToANonLogPointDropsThePointInTimeTarget()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        vm.PointInTime.Use = true;
+        vm.PointInTime.StopAtText = T0.AddHours(2).AddMinutes(30).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Contains("STOPAT", vm.GeneratedScript);
+
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.First(p => p.Type == BackupType.Full);
+
+        Assert.False(vm.PointInTime.CanUse);
+        Assert.False(vm.PointInTime.Use);
+        Assert.Null(vm.PointInTime.Effective);
+        Assert.NotEmpty(vm.GeneratedScript);
+        Assert.DoesNotContain("STOPAT", vm.GeneratedScript);
+    }
+
     // ── changing database ───────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -395,6 +395,49 @@ public class XamlLoadTests(WpfFixture wpf)
         });
     }
 
+    /// <summary>
+    /// The point-in-time panel, and the fact that a rejected target reads as a rejection.
+    ///
+    /// "Must be after 22:00" was drawn in the same muted grey as "Valid range: ...". Execute is
+    /// already blocked at that point, so that message is the only thing on screen saying why
+    /// (#115 seam 3).
+    /// </summary>
+    [Fact]
+    public void ARejectedPointInTimeTargetIsShownAsAnError()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.PointInTime.SetWindow((new DateTime(2026, 1, 10, 22, 0, 0), new DateTime(2026, 1, 10, 22, 15, 0)));
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var message = FindAll<TextBlock>(view)
+                    .Single(t => t.Text.StartsWith("Valid range", StringComparison.Ordinal));
+                var informational = message.Foreground;
+
+                // Ticked, over a target past the end of the log.
+                vm.PointInTime.Use = true;
+                vm.PointInTime.StopAtText = "2026-01-10 23:59:59";
+                Realise(view);
+
+                Assert.True(vm.PointInTime.HasError);
+                Assert.StartsWith("Must be at or before", message.Text);
+                Assert.NotEqual(informational.ToString(), message.Foreground.ToString());
+
+                listener.AssertNone("RestoreView point-in-time panel");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
     /// <summary>The inventory warnings panel added with #46 - separate from the chain issues one.</summary>
     [Fact]
     public void TheInventoryPanelShowsItsFindings()

--- a/src/NineLives/ViewModels/PointInTimeViewModel.cs
+++ b/src/NineLives/ViewModels/PointInTimeViewModel.cs
@@ -1,0 +1,171 @@
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The point-in-time (STOPAT) target: the window it has to fall inside, what the user typed, and
+/// whether that is usable.
+///
+/// Third seam out of RestoreViewModel (#115). Only meaningful for a transaction-log restore point.
+/// Without STOPAT the granularity of a "point in time" restore is the end of whichever log backup
+/// was selected - so with 15-minute logs, recovering from a bad DELETE at 14:23:41 could only land
+/// on 14:15 or 14:30.
+///
+/// It does NOT work out the window. That is chain reasoning and belongs to
+/// <see cref="Models.BackupChain.StopAtWindow"/>; this type is handed the window and validates
+/// against it. Constraining the target to the LAST log's window is what keeps the generated chain
+/// valid - a target inside an earlier log would need the chain truncated to that log, or the later
+/// logs restore across a gap and fail with error 4305.
+/// </summary>
+public partial class PointInTimeViewModel : ObservableObject
+{
+    private const string StopAtFormat = "yyyy-MM-dd HH:mm:ss";
+
+    /// <summary>
+    /// Parsed exactly, and invariantly: a target read as 3 February when the user meant 3 March is
+    /// a month of transactions silently discarded. Seconds are optional because the box is often
+    /// filled from a timestamp that has none.
+    /// </summary>
+    private static readonly string[] AcceptedFormats =
+    [
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy-MM-ddTHH:mm:ss",
+        "yyyy-MM-dd HH:mm",
+        "yyyy-MM-ddTHH:mm"
+    ];
+
+    /// <summary>
+    /// True while <see cref="SetWindow"/> is rewriting several properties at once, so a listener
+    /// can skip the intermediate states and act on the finished one.
+    /// </summary>
+    internal bool IsUpdating { get; private set; }
+
+    /// <summary>True when the selected restore point is a log, so STOPAT applies at all.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Effective))]
+    private bool _canUse;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Effective))]
+    private bool _use;
+
+    /// <summary>What the user typed, parsed into <see cref="StopAt"/>.</summary>
+    [ObservableProperty]
+    private string _stopAtText = string.Empty;
+
+    /// <summary>The parsed and validated target, or null when unusable.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Effective))]
+    private DateTime? _stopAt;
+
+    /// <summary>Exclusive lower bound: the end of the previous set in the chain.</summary>
+    [ObservableProperty]
+    private DateTime? _earliest;
+
+    /// <summary>Inclusive upper bound: the end of the selected log backup.</summary>
+    [ObservableProperty]
+    private DateTime? _latest;
+
+    [ObservableProperty]
+    private string _message = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Effective))]
+    private bool _hasError;
+
+    /// <summary>The STOPAT value to generate, or null to restore the whole log chain.</summary>
+    public DateTime? Effective => CanUse && Use && !HasError ? StopAt : null;
+
+    /// <summary>
+    /// Points this at a new restore point's window, or turns it off when the point is not a log.
+    ///
+    /// Starts unticked with the box pre-filled with the latest usable time, so the box shows what
+    /// the bounds are before anyone commits to using it.
+    /// </summary>
+    public void SetWindow((DateTime Earliest, DateTime Latest)? window)
+    {
+        IsUpdating = true;
+        try
+        {
+            if (window == null)
+            {
+                CanUse = false;
+                Use = false;
+                Earliest = null;
+                Latest = null;
+                StopAtText = string.Empty;
+                StopAt = null;
+                Message = string.Empty;
+                HasError = false;
+                return;
+            }
+
+            CanUse = true;
+            Earliest = window.Value.Earliest;
+            Latest = window.Value.Latest;
+            Use = false;
+            StopAtText = window.Value.Latest.ToString(StopAtFormat);
+            Validate();
+        }
+        finally
+        {
+            IsUpdating = false;
+        }
+    }
+
+    private void Validate()
+    {
+        if (!CanUse)
+        {
+            StopAt = null;
+            Message = string.Empty;
+            HasError = false;
+            return;
+        }
+
+        if (!DateTime.TryParseExact(
+                StopAtText?.Trim(), AcceptedFormats,
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            StopAt = null;
+            // Only an error once it is actually being used - half-typed input in a box nobody has
+            // ticked is not a reason to block the restore.
+            HasError = Use;
+            Message = $"Enter a time as {StopAtFormat}.";
+            return;
+        }
+
+        // Exclusive lower bound: at exactly the previous set's time nothing from this log has been
+        // applied yet, which is the earlier restore point, not this one.
+        if (parsed <= Earliest)
+        {
+            StopAt = null;
+            HasError = Use;
+            Message =
+                $"Must be after {Earliest:yyyy-MM-dd HH:mm:ss} — to stop earlier, " +
+                "select an earlier restore point on the timeline.";
+            return;
+        }
+
+        if (parsed > Latest)
+        {
+            StopAt = null;
+            HasError = Use;
+            Message =
+                $"Must be at or before {Latest:yyyy-MM-dd HH:mm:ss} — to stop later, " +
+                "select a later restore point on the timeline.";
+            return;
+        }
+
+        StopAt = parsed;
+        HasError = false;
+        Message = Use
+            ? $"Recovery will stop at {parsed:yyyy-MM-dd HH:mm:ss}; later transactions in this log are discarded."
+            : $"Valid range: after {Earliest:yyyy-MM-dd HH:mm:ss} up to {Latest:yyyy-MM-dd HH:mm:ss}.";
+    }
+
+    partial void OnStopAtTextChanged(string value) => Validate();
+
+    partial void OnUseChanged(bool value) => Validate();
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -121,34 +121,11 @@ public partial class RestoreViewModel : ViewModelBase
     // 14:30. The target is bounded to within the selected log's window; to stop earlier the
     // user picks an earlier restore point, which keeps the generated chain correct.
 
-    /// <summary>True when the selected restore point is a log, so STOPAT applies.</summary>
-    [ObservableProperty]
-    private bool _canUsePointInTime;
-
-    [ObservableProperty]
-    private bool _usePointInTime;
-
-    /// <summary>User-entered target time, parsed into <see cref="StopAtDateTime"/>.</summary>
-    [ObservableProperty]
-    private string _stopAtText = string.Empty;
-
-    /// <summary>Parsed and validated target, or null when unusable.</summary>
-    [ObservableProperty]
-    private DateTime? _stopAtDateTime;
-
-    /// <summary>Exclusive lower bound: the end of the previous set in the chain.</summary>
-    [ObservableProperty]
-    private DateTime? _stopAtEarliest;
-
-    /// <summary>Inclusive upper bound: the end of the selected log backup.</summary>
-    [ObservableProperty]
-    private DateTime? _stopAtLatest;
-
-    [ObservableProperty]
-    private string _pointInTimeMessage = string.Empty;
-
-    [ObservableProperty]
-    private bool _hasPointInTimeError;
+    /// <summary>
+    /// The STOPAT target and the window it has to fall inside (#115 seam 3). The window itself is
+    /// chain reasoning, so this class works it out and hands it down.
+    /// </summary>
+    public PointInTimeViewModel PointInTime { get; } = new();
 
     // ── Chain gap detection ──────────────────────────────────────────────────────
     // Structural validation of the selected chain, run at selection time. The app otherwise
@@ -609,6 +586,14 @@ public partial class RestoreViewModel : ViewModelBase
                 OnSelectedRestorePointChanged(Timeline.SelectedPoint);
         };
 
+        // The STOPAT target feeds the generated script, so any change to it has to reach the
+        // script (#115 seam 3). Skipped while SetWindow is rewriting several properties at once -
+        // the caller updates once at the end rather than four times through a half-built state.
+        PointInTime.PropertyChanged += (_, _) =>
+        {
+            if (!PointInTime.IsUpdating) UpdateRestoreSummary();
+        };
+
         RefreshContainers();
     }
 
@@ -992,7 +977,7 @@ public partial class RestoreViewModel : ViewModelBase
         parts.Add($"Restore '{SelectedDatabaseName}' as '{TargetDatabaseName}'");
         parts.Add($"using {RestoreChain.Summary} ({RestoreChain.FileCount} files total).");
 
-        if (EffectiveStopAt is DateTime stopAt)
+        if (PointInTime.Effective is DateTime stopAt)
             parts.Add($"Stop at {stopAt:yyyy-MM-dd HH:mm:ss} (point-in-time recovery).");
         else if (Timeline.SelectedPoint is { Type: BackupType.TransactionLog } logPoint)
             parts.Add($"Restore to end of log backup at {logPoint.Timestamp:yyyy-MM-dd HH:mm:ss}.");
@@ -1026,35 +1011,15 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Recomputes the STOPAT window for the selected restore point. The window itself is
-    /// <see cref="BackupChain.StopAtWindow"/>; this only projects it onto the UI state.
+    /// Points the STOPAT box at the selected restore point's window, or turns it off.
+    ///
+    /// STOPAT only applies to a log restore, and only inside the LAST log's window - which is what
+    /// <see cref="BackupChain.StopAtWindow"/> works out. Deciding whether there is a window is
+    /// chain reasoning and stays here; validating against it does not.
     /// </summary>
     private void UpdatePointInTimeWindow(RestorePoint? point)
-    {
-        var window = point?.Type == BackupType.TransactionLog
-            ? RestoreChain?.StopAtWindow
-            : null;
-
-        if (window == null)
-        {
-            CanUsePointInTime = false;
-            UsePointInTime = false;
-            StopAtEarliest = null;
-            StopAtLatest = null;
-            StopAtText = string.Empty;
-            StopAtDateTime = null;
-            PointInTimeMessage = string.Empty;
-            HasPointInTimeError = false;
-            return;
-        }
-
-        CanUsePointInTime = true;
-        StopAtEarliest = window.Value.Earliest;
-        StopAtLatest = window.Value.Latest;
-        UsePointInTime = false;
-        StopAtText = window.Value.Latest.ToString(StopAtFormat);
-        ValidatePointInTime();
-    }
+        => PointInTime.SetWindow(
+            point?.Type == BackupType.TransactionLog ? RestoreChain?.StopAtWindow : null);
 
     /// <summary>
     /// Reads RESTORE HEADERONLY for every member of the selected chain and validates the LSN
@@ -1279,81 +1244,6 @@ public partial class RestoreViewModel : ViewModelBase
                 : $"{warnings} warning(s) about this chain";
     }
 
-    private const string StopAtFormat = "yyyy-MM-dd HH:mm:ss";
-
-    private static readonly string[] StopAtAcceptedFormats =
-    [
-        "yyyy-MM-dd HH:mm:ss",
-        "yyyy-MM-ddTHH:mm:ss",
-        "yyyy-MM-dd HH:mm",
-        "yyyy-MM-ddTHH:mm"
-    ];
-
-    private void ValidatePointInTime()
-    {
-        if (!CanUsePointInTime)
-        {
-            StopAtDateTime = null;
-            PointInTimeMessage = string.Empty;
-            HasPointInTimeError = false;
-            return;
-        }
-
-        if (!DateTime.TryParseExact(
-                StopAtText?.Trim(), StopAtAcceptedFormats,
-                CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
-        {
-            StopAtDateTime = null;
-            HasPointInTimeError = UsePointInTime;
-            PointInTimeMessage = $"Enter a time as {StopAtFormat}.";
-            UpdateRestoreSummary();
-            return;
-        }
-
-        // Exclusive lower bound: at exactly the previous set's time nothing from this log has
-        // been applied yet, which is the earlier restore point, not this one.
-        if (parsed <= StopAtEarliest)
-        {
-            StopAtDateTime = null;
-            HasPointInTimeError = UsePointInTime;
-            PointInTimeMessage =
-                $"Must be after {StopAtEarliest:yyyy-MM-dd HH:mm:ss} — to stop earlier, " +
-                "select an earlier restore point on the timeline.";
-            UpdateRestoreSummary();
-            return;
-        }
-
-        if (parsed > StopAtLatest)
-        {
-            StopAtDateTime = null;
-            HasPointInTimeError = UsePointInTime;
-            PointInTimeMessage =
-                $"Must be at or before {StopAtLatest:yyyy-MM-dd HH:mm:ss} — to stop later, " +
-                "select a later restore point on the timeline.";
-            UpdateRestoreSummary();
-            return;
-        }
-
-        StopAtDateTime = parsed;
-        HasPointInTimeError = false;
-        PointInTimeMessage = UsePointInTime
-            ? $"Recovery will stop at {parsed:yyyy-MM-dd HH:mm:ss}; later transactions in this log are discarded."
-            : $"Valid range: after {StopAtEarliest:yyyy-MM-dd HH:mm:ss} up to {StopAtLatest:yyyy-MM-dd HH:mm:ss}.";
-        UpdateRestoreSummary();
-    }
-
-    /// <summary>The STOPAT value to generate, or null to restore the whole log chain.</summary>
-    private DateTime? EffectiveStopAt =>
-        CanUsePointInTime && UsePointInTime && !HasPointInTimeError ? StopAtDateTime : null;
-
-    partial void OnStopAtTextChanged(string value) => ValidatePointInTime();
-
-    partial void OnUsePointInTimeChanged(bool value)
-    {
-        ValidatePointInTime();
-        UpdateRestoreSummary();
-    }
-
     partial void OnWithReplaceChanged(bool value) => UpdateRestoreSummary();
     partial void OnDisconnectSessionsChanged(bool value) => UpdateRestoreSummary();
     partial void OnRecoveryModeChanged(RecoveryMode oldValue, RecoveryMode newValue)
@@ -1469,9 +1359,9 @@ public partial class RestoreViewModel : ViewModelBase
 
         // Refuse to silently fall back to a full-chain restore when the user asked to stop at a
         // time we could not use - that would replay exactly the transactions they meant to skip.
-        if (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null)
+        if (PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null)
         {
-            SetError($"Point-in-time target is not valid. {PointInTimeMessage}");
+            SetError($"Point-in-time target is not valid. {PointInTime.Message}");
             return;
         }
 
@@ -1556,7 +1446,7 @@ public partial class RestoreViewModel : ViewModelBase
 
         if (RestoreChain == null
             || string.IsNullOrWhiteSpace(TargetDatabaseName)
-            || (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null)
+            || (PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null)
             || !HasStandbyFileIfNeeded)
         {
             GeneratedScript = string.Empty;
@@ -1574,7 +1464,7 @@ public partial class RestoreViewModel : ViewModelBase
             StandbyFilePath = string.IsNullOrWhiteSpace(StandbyFilePath) ? null : StandbyFilePath,
             DisconnectSessions = DisconnectSessions,
             StatsPercent = StatsPercent,
-            StopAt = EffectiveStopAt,
+            StopAt = PointInTime.Effective,
             KeepReplication = KeepReplication,
             EnableBroker = EnableBroker,
             NewBroker = NewBroker,
@@ -1942,7 +1832,7 @@ public partial class RestoreViewModel : ViewModelBase
             _log.ServerChange(server.ServerName,
                 $"restore starting: target [{TargetDatabaseName}], " +
                 $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={WithReplace}, " +
-                $"recovery={RecoveryMode}, stopAt={EffectiveStopAt?.ToString("s") ?? "none"}");
+                $"recovery={RecoveryMode}, stopAt={PointInTime.Effective?.ToString("s") ?? "none"}");
 
             AppendLog("Beginning restore execution...\n");
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1037,22 +1037,35 @@
 
                             <!-- Point-in-time (STOPAT): only shown for a log restore point, where
                                  stopping partway through the log is meaningful. -->
-                            <StackPanel Visibility="{Binding CanUsePointInTime, Converter={StaticResource BoolToVis}}">
+                            <StackPanel Visibility="{Binding PointInTime.CanUse, Converter={StaticResource BoolToVis}}">
                                 <TextBlock Text="POINT IN TIME" Style="{StaticResource LabelText}" />
                                 <CheckBox Content="Stop at a specific time (STOPAT)"
-                                          IsChecked="{Binding UsePointInTime}"
+                                          IsChecked="{Binding PointInTime.Use}"
                                           Style="{StaticResource DarkCheckBox}"
                                           Margin="0,4,0,8"
                                           ToolTip="Recover to an exact moment inside the selected log backup instead of restoring the whole log." />
-                                <TextBox Text="{Binding StopAtText, UpdateSourceTrigger=PropertyChanged}"
+                                <TextBox Text="{Binding PointInTime.StopAtText, UpdateSourceTrigger=PropertyChanged}"
                                          Style="{StaticResource DarkTextBox}"
-                                         IsEnabled="{Binding UsePointInTime}"
+                                         IsEnabled="{Binding PointInTime.Use}"
                                          Width="180" HorizontalAlignment="Left"
                                          ToolTip="yyyy-MM-dd HH:mm:ss" />
-                                <TextBlock Text="{Binding PointInTimeMessage}"
-                                           Style="{StaticResource SecondaryText}"
+                                <!-- "Must be after 14:15" is a rejection, not a hint, and it was
+                                     drawn in the same muted grey as "Valid range: ...". Execute is
+                                     already blocked at that point, so the message is the only thing
+                                     saying why. -->
+                                <TextBlock Text="{Binding PointInTime.Message}"
                                            TextWrapping="Wrap"
-                                           Margin="0,4,0,16" />
+                                           Margin="0,4,0,16">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding PointInTime.HasError}" Value="True">
+                                                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                             </StackPanel>
 
                             <TextBlock Text="STATS PERCENT" Style="{StaticResource LabelText}" />


### PR DESCRIPTION
Third seam of #115.

STOPAT was ~130 lines in the middle of the class with **no test of its own**. Reaching it meant a container, a listing, a chain and a selected log restore point — so the rules that decide whether a restore stops at 14:23:41 or discards the afternoon were only ever checked by hand.

`PointInTimeViewModel` owns the target, the bounds and the validation. Working out whether there *is* a window stays in `RestoreViewModel` — that is chain reasoning, and `BackupChain.StopAtWindow` does it — but validating against one does not. `RestoreViewModel` drops to 2,141 lines.

## Tests

26 for behaviour that was previously unreachable:

- The lower bound is exclusive and the upper bound inclusive — at exactly the previous set's time nothing from this log has been applied yet, which is the *earlier* restore point.
- Every accepted input shape (with and without seconds, space or `T`), and that an ambiguous one like `10/01/2026` is refused outright rather than guessed at. A target read as 3 February when the user meant 3 March is a month of transactions silently discarded.
- A bad value is not an error until the box is ticked — half-typed input in a box nobody is using is not a reason to block the restore.
- Moving to a different log starts unticked, so a target is never carried across and silently applied to a window it was not typed for.
- A ticked-but-rejected target generates **no script**, rather than falling back to the whole log. Restoring past the moment someone explicitly asked to stop at is the failure that matters here.

Plus three at the `RestoreViewModel` level for the wiring that has to reach the RESTORE that actually runs: the target reaching `STOPAT` in the generated script, an invalid one leaving no script, and selecting a full or differential point taking the STOPAT with it.

## Also

"Must be at or before 22:15" was drawn in the same muted grey as "Valid range: ...". Execute is already blocked at that point, so that message is the only thing on screen saying why. It reads as an error now — pinned by a test that fails if the trigger goes.

793 tests pass, build clean at `-warnaserror`.

## Remaining seams

4 (container listing and discovery), 5 (server-side credentials), 6 (execution), 7 (options and script generation). 7 next — with the options on their own type raising a single `OptionsChanged`, the #110 class of bug becomes structurally impossible rather than something to remember for every new option.
