### PR TITLE
Make an option that never reaches the script impossible (#115)

### DIFF
--- a/src/NineLives.Tests/RestoreOptionsViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreOptionsViewModelTests.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The RESTORE options, extracted from RestoreViewModel in #115 seam 7.
+///
+/// The point of the seam is that #110 cannot happen again. Four options - both WITH MOVE paths,
+/// the STANDBY undo file and STATS - reached a release with no change handler at all, so editing
+/// them moved the box on screen and left the generated script alone. People read that script before
+/// running it against production.
+///
+/// Both halves of that bug were "someone has to remember": remember to write a change handler, and
+/// remember to copy the field into the options object three hundred lines away. The subscription
+/// side is structural now - one handler covers every option. The copy side is what
+/// <see cref="EveryOptionOnTheViewModelReachesTheGeneratedOptions"/> pins.
+/// </summary>
+public class RestoreOptionsViewModelTests
+{
+    /// <summary>The options a user can set - the ones Build has to copy.</summary>
+    private static List<PropertyInfo> Settable() =>
+        typeof(RestoreOptionsViewModel)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p is { CanRead: true, CanWrite: true })
+            .ToList();
+
+    /// <summary>Something this property is definitely not already set to.</summary>
+    private static object DistinctFrom(PropertyInfo property, object? current) => current switch
+    {
+        bool b => !b,
+        int i => i + 7,
+        string => $"set-{property.Name}",
+        RecoveryMode m => m == RecoveryMode.Recovery ? RecoveryMode.NoRecovery : RecoveryMode.Recovery,
+        _ => throw new NotSupportedException(
+            $"{property.Name} is a {property.PropertyType.Name}, which this test does not know how " +
+            "to vary. Add a case above so the option is still covered.")
+    };
+
+    /// <summary>
+    /// Every option the user can set has to arrive in the object the script generator reads.
+    ///
+    /// This is the #110 guard, and it is deliberately written by reflection rather than as a list:
+    /// a hand-written list of options is one more thing to remember to update, which is the failure
+    /// it is guarding against. An option added to the ViewModel and not to Build fails here.
+    /// </summary>
+    [Fact]
+    public void EveryOptionOnTheViewModelReachesTheGeneratedOptions()
+    {
+        var vm = new RestoreOptionsViewModel();
+        var options = Settable();
+
+        Assert.NotEmpty(options);
+
+        // Move every option off its default, so a field Build never copies shows up as the
+        // RestoreOptions default rather than what was set.
+        foreach (var p in options)
+            p.SetValue(vm, DistinctFrom(p, p.GetValue(vm)));
+
+        var built = vm.Build("MyDb_Restored", null, []);
+
+        foreach (var p in options)
+        {
+            var onOptions = typeof(RestoreOptions).GetProperty(p.Name);
+            Assert.True(onOptions != null,
+                $"{p.Name} is set on the options screen but has no matching field on " +
+                "RestoreOptions, so nothing can carry it into the generated script.");
+
+            Assert.True(
+                Equals(p.GetValue(vm), onOptions.GetValue(built)),
+                $"{p.Name} never reaches the generated script - RestoreOptionsViewModel.Build " +
+                "does not copy it. This is #110: the box on screen moves and the script does not.");
+        }
+    }
+
+    /// <summary>
+    /// The three things Build takes as arguments are the ones that are NOT options - each is worked
+    /// out somewhere that knows about the chain or the server.
+    /// </summary>
+    [Fact]
+    public void TheTargetTheStopAtAndTheFileMovesComeFromTheCaller()
+    {
+        var moves = new List<FileMoveOption>
+        {
+            new() { LogicalName = "MyDb", PhysicalName = @"C:\Data\MyDb.mdf", NewPhysicalName = @"E:\Data\MyDb.mdf" }
+        };
+        var stopAt = new DateTime(2026, 1, 10, 22, 10, 30);
+
+        var built = new RestoreOptionsViewModel().Build("MyDb_Restored", stopAt, moves);
+
+        Assert.Equal("MyDb_Restored", built.TargetDatabaseName);
+        Assert.Equal(stopAt, built.StopAt);
+        Assert.Same(moves, built.FileMoves);
+    }
+
+    // ── STANDBY ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Blank produced <c>STANDBY = ''</c>, which SQL Server rejects - as the LAST statement of the
+    /// chain, so it failed after SET SINGLE_USER and WITH REPLACE had already dropped and
+    /// overwritten the target.
+    /// </summary>
+    [Fact]
+    public void StandbyWithNoUndoFileIsNotUsable()
+    {
+        var vm = new RestoreOptionsViewModel { RecoveryMode = RecoveryMode.Standby };
+
+        Assert.True(vm.IsStandbyMode);
+        Assert.False(vm.HasStandbyFileIfNeeded);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WhitespaceIsNotAnUndoFile(string path)
+    {
+        var vm = new RestoreOptionsViewModel
+        {
+            RecoveryMode = RecoveryMode.Standby,
+            StandbyFilePath = path
+        };
+
+        Assert.False(vm.HasStandbyFileIfNeeded);
+        Assert.Null(vm.Build("MyDb", null, []).StandbyFilePath);
+    }
+
+    [Fact]
+    public void StandbyWithAnUndoFileIsUsable()
+    {
+        var vm = new RestoreOptionsViewModel
+        {
+            RecoveryMode = RecoveryMode.Standby,
+            StandbyFilePath = @"E:\Standby\MyDb.undo"
+        };
+
+        Assert.True(vm.HasStandbyFileIfNeeded);
+        Assert.Equal(@"E:\Standby\MyDb.undo", vm.Build("MyDb", null, []).StandbyFilePath);
+    }
+
+    /// <summary>The undo file only applies to STANDBY, so the other modes are never blocked by it.</summary>
+    [Theory]
+    [InlineData(RecoveryMode.Recovery)]
+    [InlineData(RecoveryMode.NoRecovery)]
+    public void TheOtherRecoveryModesNeedNoUndoFile(RecoveryMode mode)
+    {
+        var vm = new RestoreOptionsViewModel { RecoveryMode = mode };
+
+        Assert.False(vm.IsStandbyMode);
+        Assert.True(vm.HasStandbyFileIfNeeded);
+    }
+
+    /// <summary>
+    /// Both are computed, so the view needs telling when the things they are computed from move -
+    /// otherwise the undo-file box does not appear when STANDBY is picked.
+    /// </summary>
+    [Fact]
+    public void TheComputedStandbyStateIsAnnouncedWhenItChanges()
+    {
+        var vm = new RestoreOptionsViewModel();
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.RecoveryMode = RecoveryMode.Standby;
+
+        Assert.Contains(nameof(RestoreOptionsViewModel.IsStandbyMode), raised);
+        Assert.Contains(nameof(RestoreOptionsViewModel.HasStandbyFileIfNeeded), raised);
+
+        raised.Clear();
+        vm.StandbyFilePath = @"E:\Standby\MyDb.undo";
+
+        Assert.Contains(nameof(RestoreOptionsViewModel.HasStandbyFileIfNeeded), raised);
+    }
+
+    /// <summary>
+    /// One subscription keeps the script in step with every option, so each one has to announce
+    /// itself. An [ObservableProperty] does this for free - this is here so that an option added
+    /// later as a plain property, which would not, is caught.
+    /// </summary>
+    [Fact]
+    public void EveryOptionAnnouncesItsOwnChange()
+    {
+        foreach (var p in Settable())
+        {
+            var vm = new RestoreOptionsViewModel();
+            var raised = new List<string?>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+            p.SetValue(vm, DistinctFrom(p, p.GetValue(vm)));
+
+            Assert.True(raised.Contains(p.Name),
+                $"Changing {p.Name} raised no PropertyChanged for it, so the generated script " +
+                "would not follow it.");
+        }
+    }
+}

--- a/src/NineLives.Tests/ScriptStaysInStepTests.cs
+++ b/src/NineLives.Tests/ScriptStaysInStepTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -123,7 +123,7 @@ public class ScriptStaysInStepTests
     {
         var vm = await Loaded();
 
-        vm.RecoveryMode = RecoveryMode.Standby;
+        vm.Options.RecoveryMode = RecoveryMode.Standby;
 
         // STANDBY = '' is the last statement of the chain, so it fails AFTER the target has been
         // dropped and overwritten. Refusing to produce a script is the only safe answer.
@@ -136,8 +136,8 @@ public class ScriptStaysInStepTests
     {
         var vm = await Loaded();
 
-        vm.RecoveryMode = RecoveryMode.Standby;
-        vm.StandbyFilePath = @"E:\Standby\MyDb.undo";
+        vm.Options.RecoveryMode = RecoveryMode.Standby;
+        vm.Options.StandbyFilePath = @"E:\Standby\MyDb.undo";
 
         Assert.Contains(@"STANDBY = 'E:\Standby\MyDb.undo'", vm.GeneratedScript);
     }
@@ -146,7 +146,7 @@ public class ScriptStaysInStepTests
     public async Task GenerateSaysWhyWhenStandbyHasNoUndoFile()
     {
         var vm = await Loaded();
-        vm.RecoveryMode = RecoveryMode.Standby;
+        vm.Options.RecoveryMode = RecoveryMode.Standby;
 
         vm.GenerateScriptCommand.Execute(null);
 
@@ -161,7 +161,7 @@ public class ScriptStaysInStepTests
     {
         var vm = await Loaded();
 
-        vm.StatsPercent = 25;
+        vm.Options.StatsPercent = 25;
 
         Assert.Contains("STATS = 25;", vm.GeneratedScript);
         Assert.DoesNotContain("STATS = 10;", vm.GeneratedScript);

--- a/src/NineLives/ViewModels/RestoreOptionsViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreOptionsViewModel.cs
@@ -1,0 +1,108 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The RESTORE options a user can set, and the one place they are turned into a
+/// <see cref="RestoreOptions"/>.
+///
+/// Seventh seam out of RestoreViewModel (#115), and the one that pays for itself. Each option used
+/// to be a property on a 2,500-line class with its own one-line change handler, and was copied by
+/// hand into the options object in a method three hundred lines away. Forgetting either half is
+/// invisible: the box on screen moves, and the script does not follow.
+///
+/// That is #110 - WITH MOVE's two paths, the STANDBY undo file and STATS all reached a release with
+/// no change handler at all, so editing them changed the display and nothing else. People read the
+/// generated T-SQL before running it against production, so a script that quietly disagrees with
+/// the boxes above it is worse than no script: it looks authoritative and is not.
+///
+/// Both halves are structural now. One <see cref="ObservableObject.PropertyChanged"/> subscription
+/// covers every option, whatever gets added later, and <see cref="Build"/> sits next to the fields
+/// it copies rather than in another file.
+/// </summary>
+public partial class RestoreOptionsViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _withReplace = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsStandbyMode))]
+    [NotifyPropertyChangedFor(nameof(HasStandbyFileIfNeeded))]
+    private RecoveryMode _recoveryMode = RecoveryMode.Recovery;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasStandbyFileIfNeeded))]
+    private string _standbyFilePath = string.Empty;
+
+    [ObservableProperty]
+    private bool _disconnectSessions = true;
+
+    [ObservableProperty]
+    private int _statsPercent = 10;
+
+    [ObservableProperty]
+    private bool _keepReplication;
+
+    [ObservableProperty]
+    private bool _enableBroker;
+
+    [ObservableProperty]
+    private bool _newBroker;
+
+    /// <summary>
+    /// Verify backup checksums as each page is read. Only meaningful if the backup was taken
+    /// WITH CHECKSUM - against one that was not, SQL Server fails the restore rather than skipping
+    /// the check, which is why this is off by default.
+    /// </summary>
+    [ObservableProperty]
+    private bool _withChecksum;
+
+    /// <summary>
+    /// Carry on restoring after a checksum or page error instead of stopping. This produces a
+    /// database SQL Server has already said is damaged; it exists for the case where a partial
+    /// recovery beats none.
+    /// </summary>
+    [ObservableProperty]
+    private bool _continueAfterError;
+
+    /// <summary>Whether the undo-file box applies, for the view.</summary>
+    public bool IsStandbyMode => RecoveryMode == RecoveryMode.Standby;
+
+    /// <summary>
+    /// STANDBY needs somewhere to put its undo file. Blank produced <c>STANDBY = ''</c>, which SQL
+    /// Server rejects - as the LAST statement of the chain, so it failed after SET SINGLE_USER and
+    /// WITH REPLACE had already dropped and overwritten the target, leaving it in RESTORING and
+    /// single-user with nothing to show for it.
+    /// </summary>
+    public bool HasStandbyFileIfNeeded =>
+        RecoveryMode != RecoveryMode.Standby || !string.IsNullOrWhiteSpace(StandbyFilePath);
+
+    /// <summary>
+    /// Everything on this type, copied into the object the script generator reads.
+    ///
+    /// The three arguments are the things that are NOT options: which database is being restored,
+    /// where the point-in-time target ended up, and where the files are being moved to - each of
+    /// which is worked out somewhere that knows about the chain or the server.
+    ///
+    /// Adding an option means adding a field above and a line here, and nothing else. When the copy
+    /// lived in another file it was possible to do one and not the other, which is what #110 was.
+    /// </summary>
+    public RestoreOptions Build(
+        string targetDatabaseName, DateTime? stopAt, List<FileMoveOption> fileMoves) => new()
+    {
+        TargetDatabaseName = targetDatabaseName,
+        WithReplace = WithReplace,
+        RecoveryMode = RecoveryMode,
+        StandbyFilePath = string.IsNullOrWhiteSpace(StandbyFilePath) ? null : StandbyFilePath,
+        DisconnectSessions = DisconnectSessions,
+        StatsPercent = StatsPercent,
+        StopAt = stopAt,
+        KeepReplication = KeepReplication,
+        EnableBroker = EnableBroker,
+        NewBroker = NewBroker,
+        WithChecksum = WithChecksum,
+        ContinueAfterError = ContinueAfterError,
+        FileMoves = fileMoves
+    };
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -100,19 +100,12 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private ObservableCollection<BackupSet> _chainSets = [];
 
-    // Options
-    [ObservableProperty]
-    private bool _withReplace = true;
-
-    [ObservableProperty]
-    private RecoveryMode _recoveryMode = RecoveryMode.Recovery;
-
-    public bool IsStandbyMode => RecoveryMode == RecoveryMode.Standby;
-
-    // OnRecoveryModeChanged is defined later to also update restore summary
-
-    [ObservableProperty]
-    private string _standbyFilePath = string.Empty;
+    /// <summary>
+    /// The RESTORE options, and the one place they become a <see cref="RestoreOptions"/>
+    /// (#115 seam 7). One subscription in the constructor keeps the script in step with all of
+    /// them, whatever gets added later.
+    /// </summary>
+    public RestoreOptionsViewModel Options { get; } = new();
 
     // ── Point-in-time (STOPAT) ───────────────────────────────────────────────────
     // Only meaningful for a transaction-log restore point. Without this the granularity of a
@@ -278,26 +271,6 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _hasVerifyFailures;
 
-    [ObservableProperty]
-    private bool _disconnectSessions = true;
-
-    [ObservableProperty]
-    private int _statsPercent = 10;
-
-    [ObservableProperty]
-    private bool _keepReplication;
-
-    [ObservableProperty]
-    private bool _enableBroker;
-
-    [ObservableProperty]
-    private bool _newBroker;
-
-    [ObservableProperty]
-    private bool _withChecksum;
-
-    [ObservableProperty]
-    private bool _continueAfterError;
 
     [ObservableProperty]
     private bool _useWithMove;
@@ -593,6 +566,11 @@ public partial class RestoreViewModel : ViewModelBase
         {
             if (!PointInTime.IsUpdating) UpdateRestoreSummary();
         };
+
+        // One subscription in place of a one-line change handler per option (#115 seam 7). An
+        // option added later is kept in step with the script by existing, rather than by whoever
+        // adds it remembering to write a handler - which is what #110 was.
+        Options.PropertyChanged += (_, _) => UpdateRestoreSummary();
 
         RefreshContainers();
     }
@@ -984,14 +962,14 @@ public partial class RestoreViewModel : ViewModelBase
 
         var optionsList = new List<string>();
 
-        if (WithReplace)
+        if (Options.WithReplace)
             optionsList.Add("overwrite existing database (WITH REPLACE)");
-        if (DisconnectSessions)
+        if (Options.DisconnectSessions)
             optionsList.Add("disconnect active sessions");
         if (UseWithMove)
             optionsList.Add($"relocate data files (WITH MOVE)");
 
-        var recoveryDesc = RecoveryMode switch
+        var recoveryDesc = Options.RecoveryMode switch
         {
             RecoveryMode.Recovery => "brought online for use (RECOVERY)",
             RecoveryMode.NoRecovery => "left in restoring state (NORECOVERY)",
@@ -1000,9 +978,9 @@ public partial class RestoreViewModel : ViewModelBase
         };
         optionsList.Add($"database will be {recoveryDesc}");
 
-        if (KeepReplication) optionsList.Add("preserve replication settings");
-        if (EnableBroker) optionsList.Add("enable Service Broker");
-        if (NewBroker) optionsList.Add("create new Service Broker ID");
+        if (Options.KeepReplication) optionsList.Add("preserve replication settings");
+        if (Options.EnableBroker) optionsList.Add("enable Service Broker");
+        if (Options.NewBroker) optionsList.Add("create new Service Broker ID");
 
         if (optionsList.Count > 0)
             parts.Add("Options: " + string.Join("; ", optionsList) + ".");
@@ -1131,7 +1109,7 @@ public partial class RestoreViewModel : ViewModelBase
 
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 var result = await _sqlService.RestoreVerifyOnlyAsync(
-                    ConnectedServer, urls, WithChecksum, fileMoves, ct);
+                    ConnectedServer, urls, Options.WithChecksum, fileMoves, ct);
 
                 ChainVerifyResults.Add(new ChainVerifyResult { Set = set, Result = result });
                 HasVerifyResults = true;
@@ -1244,28 +1222,15 @@ public partial class RestoreViewModel : ViewModelBase
                 : $"{warnings} warning(s) about this chain";
     }
 
-    partial void OnWithReplaceChanged(bool value) => UpdateRestoreSummary();
-    partial void OnDisconnectSessionsChanged(bool value) => UpdateRestoreSummary();
-    partial void OnRecoveryModeChanged(RecoveryMode oldValue, RecoveryMode newValue)
-    {
-        OnPropertyChanged(nameof(IsStandbyMode));
-        UpdateRestoreSummary();
-    }
-    partial void OnKeepReplicationChanged(bool value) => UpdateRestoreSummary();
-    partial void OnEnableBrokerChanged(bool value) => UpdateRestoreSummary();
-    partial void OnNewBrokerChanged(bool value) => UpdateRestoreSummary();
-    partial void OnWithChecksumChanged(bool value) => UpdateRestoreSummary();
-    partial void OnContinueAfterErrorChanged(bool value) => UpdateRestoreSummary();
-
-    // These four are typed into text boxes rather than ticked, and every one of them was missing
-    // its handler - so the script on screen did not change when they did. That is the exact
+    // The WITH MOVE paths are typed into text boxes rather than ticked, and both were missing
+    // their handler - so the script on screen did not change when they did. That is the exact
     // failure RegenerateScript exists to prevent: typing a new data-file path, watching the box
-    // update, and running a script that still had the old one - or, for WITH MOVE, no MOVE clause
-    // at all, sending the restore to the file paths baked into the backup.
+    // update, and running a script that still had the old one - or no MOVE clause at all, sending
+    // the restore to the file paths baked into the backup. The rest of that class of bug is gone
+    // structurally with #115 seam 7; these two are still here because the moves are worked out from
+    // the chain and the server rather than being options.
     partial void OnMoveDataFilePathChanged(string value) => UpdateRestoreSummary();
     partial void OnMoveLogFilePathChanged(string value) => UpdateRestoreSummary();
-    partial void OnStandbyFilePathChanged(string value) => UpdateRestoreSummary();
-    partial void OnStatsPercentChanged(int value) => UpdateRestoreSummary();
 
     // Verification opens its own connection and reads whole backups. Letting it start while a
     // restore is running would put a second heavy reader on the same server at the worst moment.
@@ -1330,15 +1295,6 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// STANDBY needs somewhere to put its undo file. Blank produced <c>STANDBY = ''</c>, which
-    /// SQL Server rejects - as the LAST statement of the chain, so it failed after SET SINGLE_USER
-    /// and WITH REPLACE had already dropped and overwritten the target, leaving it in RESTORING
-    /// and single-user with nothing to show for it.
-    /// </summary>
-    private bool HasStandbyFileIfNeeded =>
-        RecoveryMode != RecoveryMode.Standby || !string.IsNullOrWhiteSpace(StandbyFilePath);
-
-    /// <summary>
     /// Explicit Generate. Same work as the live rebuild, but it says why nothing was produced -
     /// the live path stays silent because reporting an error on every keystroke would be noise.
     /// </summary>
@@ -1365,7 +1321,7 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        if (!HasStandbyFileIfNeeded)
+        if (!Options.HasStandbyFileIfNeeded)
         {
             SetError("STANDBY needs an undo file path. Without one the script would end in " +
                      "STANDBY = '', which fails after the database has already been overwritten.");
@@ -1447,31 +1403,17 @@ public partial class RestoreViewModel : ViewModelBase
         if (RestoreChain == null
             || string.IsNullOrWhiteSpace(TargetDatabaseName)
             || (PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null)
-            || !HasStandbyFileIfNeeded)
+            || !Options.HasStandbyFileIfNeeded)
         {
             GeneratedScript = string.Empty;
             HasScript = false;
             return;
         }
 
-        var fileMoves = BuildFileMoves();
-
-        var options = new RestoreOptions
-        {
-            TargetDatabaseName = TargetDatabaseName,
-            WithReplace = WithReplace,
-            RecoveryMode = RecoveryMode,
-            StandbyFilePath = string.IsNullOrWhiteSpace(StandbyFilePath) ? null : StandbyFilePath,
-            DisconnectSessions = DisconnectSessions,
-            StatsPercent = StatsPercent,
-            StopAt = PointInTime.Effective,
-            KeepReplication = KeepReplication,
-            EnableBroker = EnableBroker,
-            NewBroker = NewBroker,
-            WithChecksum = WithChecksum,
-            ContinueAfterError = ContinueAfterError,
-            FileMoves = fileMoves
-        };
+        // The three things that are not options: which database, where the point-in-time target
+        // ended up, and where the files land - each worked out somewhere that knows about the
+        // chain or the server.
+        var options = Options.Build(TargetDatabaseName, PointInTime.Effective, BuildFileMoves());
 
         GeneratedScript = _scriptGenerator.Generate(RestoreChain, options);
         HasScript = true;
@@ -1831,8 +1773,8 @@ public partial class RestoreViewModel : ViewModelBase
 
             _log.ServerChange(server.ServerName,
                 $"restore starting: target [{TargetDatabaseName}], " +
-                $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={WithReplace}, " +
-                $"recovery={RecoveryMode}, stopAt={PointInTime.Effective?.ToString("s") ?? "none"}");
+                $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={Options.WithReplace}, " +
+                $"recovery={Options.RecoveryMode}, stopAt={PointInTime.Effective?.ToString("s") ?? "none"}");
 
             AppendLog("Beginning restore execution...\n");
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -821,43 +821,43 @@
                                      ToolTip="The name of the database to restore to." />
 
                             <CheckBox Content="WITH REPLACE"
-                                      IsChecked="{Binding WithReplace}"
+                                      IsChecked="{Binding Options.WithReplace}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Overwrite the existing database even if it already exists." />
 
                             <CheckBox Content="Disconnect Sessions"
-                                      IsChecked="{Binding DisconnectSessions}"
+                                      IsChecked="{Binding Options.DisconnectSessions}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="SET SINGLE_USER WITH ROLLBACK IMMEDIATE before restore." />
 
                             <CheckBox Content="KEEP_REPLICATION"
-                                      IsChecked="{Binding KeepReplication}"
+                                      IsChecked="{Binding Options.KeepReplication}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Preserves replication settings during restore." />
 
                             <CheckBox Content="ENABLE_BROKER"
-                                      IsChecked="{Binding EnableBroker}"
+                                      IsChecked="{Binding Options.EnableBroker}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Enables Service Broker with the existing contract." />
 
                             <CheckBox Content="NEW_BROKER"
-                                      IsChecked="{Binding NewBroker}"
+                                      IsChecked="{Binding Options.NewBroker}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Creates a new Service Broker identifier." />
 
                             <CheckBox Content="CHECKSUM"
-                                      IsChecked="{Binding WithChecksum}"
+                                      IsChecked="{Binding Options.WithChecksum}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Verify backup checksums while restoring. Only works if the backup was taken WITH CHECKSUM - against one that was not, SQL Server fails the restore rather than skipping the check." />
 
                             <CheckBox Content="CONTINUE_AFTER_ERROR"
-                                      IsChecked="{Binding ContinueAfterError}"
+                                      IsChecked="{Binding Options.ContinueAfterError}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,4"
                                       ToolTip="Keep restoring past a damaged page or a failed checksum instead of stopping. The database this produces may be corrupt." />
@@ -866,7 +866,7 @@
                                        FontSize="10" TextWrapping="Wrap"
                                        Foreground="{DynamicResource WarningBrush}"
                                        Margin="0,0,0,12"
-                                       Visibility="{Binding ContinueAfterError, Converter={StaticResource BoolToVis}}"
+                                       Visibility="{Binding Options.ContinueAfterError, Converter={StaticResource BoolToVis}}"
                                        Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
 
                             <CheckBox Content="WITH MOVE (relocate files)"
@@ -1013,27 +1013,27 @@
                             <StackPanel Margin="0,4,0,16">
                                 <RadioButton Content="RECOVERY"
                                              Style="{StaticResource DarkRadioButton}"
-                                             IsChecked="{Binding RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=Recovery}"
+                                             IsChecked="{Binding Options.RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=Recovery}"
                                              Margin="0,0,0,6" GroupName="RecoveryMode"
                                              ToolTip="Database is fully recovered and ready for use." />
                                 <RadioButton Content="NORECOVERY"
                                              Style="{StaticResource DarkRadioButton}"
-                                             IsChecked="{Binding RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=NoRecovery}"
+                                             IsChecked="{Binding Options.RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=NoRecovery}"
                                              Margin="0,0,0,6" GroupName="RecoveryMode"
                                              ToolTip="Leaves database in restoring state for additional restores." />
                                 <RadioButton Content="STANDBY"
                                              Style="{StaticResource DarkRadioButton}"
-                                             IsChecked="{Binding RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=Standby}"
+                                             IsChecked="{Binding Options.RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=Standby}"
                                              GroupName="RecoveryMode"
                                              ToolTip="Read-only with undo file." />
                             </StackPanel>
 
                             <TextBlock Text="STANDBY FILE PATH" Style="{StaticResource LabelText}"
-                                       Visibility="{Binding IsStandbyMode, Converter={StaticResource BoolToVis}}" />
-                            <TextBox Text="{Binding StandbyFilePath, UpdateSourceTrigger=PropertyChanged}"
+                                       Visibility="{Binding Options.IsStandbyMode, Converter={StaticResource BoolToVis}}" />
+                            <TextBox Text="{Binding Options.StandbyFilePath, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,16"
-                                     Visibility="{Binding IsStandbyMode, Converter={StaticResource BoolToVis}}" />
+                                     Visibility="{Binding Options.IsStandbyMode, Converter={StaticResource BoolToVis}}" />
 
                             <!-- Point-in-time (STOPAT): only shown for a log restore point, where
                                  stopping partway through the log is meaningful. -->
@@ -1069,7 +1069,7 @@
                             </StackPanel>
 
                             <TextBlock Text="STATS PERCENT" Style="{StaticResource LabelText}" />
-                            <TextBox Text="{Binding StatsPercent, UpdateSourceTrigger=PropertyChanged}"
+                            <TextBox Text="{Binding Options.StatsPercent, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Width="80" HorizontalAlignment="Left"
                                      Margin="0,0,0,16" />


### PR DESCRIPTION
Seventh seam of #115 — taken out of order because it is the one with the live defect history.

Each RESTORE option was a property on the big class with **its own one-line change handler**, and was copied by hand into `RestoreOptions` in a method three hundred lines away. Forgetting either half is invisible: the box on screen moves and the script does not follow.

That is #110. Both WITH MOVE paths, the STANDBY undo file and STATS all reached a release with no change handler at all. People read the generated T-SQL before running it against production, so a script that quietly disagrees with the boxes above it is worse than no script — it looks authoritative and is not.

## Both halves are structural now

- **One `PropertyChanged` subscription** replaces eleven one-line handlers, and covers whatever gets added later by existing rather than by whoever adds it remembering to write one.
- **`RestoreOptionsViewModel.Build`** sits next to the fields it copies. Adding an option means adding a field and the line under it, in one file.

## The guard

A reflection test walks every settable option, moves it off its default, builds, and fails if any of them arrives at the `RestoreOptions` default instead:

> `WithChecksum` never reaches the generated script — `RestoreOptionsViewModel.Build` does not copy it. This is #110: the box on screen moves and the script does not.

Deliberately not a hand-written list of options, since a list somebody has to keep updated is exactly the failure it is guarding against. Proved by deleting one line from `Build` and watching it fail.

A second walks every option and fails if one raises no `PropertyChanged` — that is the other half, and it catches an option added later as a plain property rather than an `[ObservableProperty]`.

Plus tests for the STANDBY undo file, which is the option whose absence fails *after* the target has been dropped and overwritten.

## Numbers

`RestoreViewModel` 2,141 → 2,083 lines. 803 tests pass, build clean at `-warnaserror`.

The options panel was rendered and checked — all twenty binding renames resolve, and the generated script stayed in step with them (STANDBY path, CONTINUE_AFTER_ERROR with its warning, STOPAT, STATS = 25).

## Remaining seams

4 (container listing and discovery), 5 (server-side credentials), 6 (execution). The two big ones are 4 and 6; what is left after them is a coordinator wiring six children, which is roughly what the class has been pretending to be.
