### PR TITLE
Entra ID authentication for SQL Server (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Nine Lives points at a container, discovers every backup, groups striped sets, c
 
 ### SQL Server Connectivity
 - Windows Authentication and SQL Server Authentication support
+- Entra ID authentication — interactive (MFA), integrated, and default — for Azure SQL Managed Instance and Entra-enabled estates ([see the caveat](#entra-id-authentication))
 - Configurable connection options (Encrypt, Trust Server Certificate, Timeout)
 - Persistent server configurations with secure password storage
 - Real-time connection status visible across all views
@@ -203,6 +204,28 @@ The executable will be created at `./publish/NineLives.exe`.
 5. Click **Test Connection** to verify
 6. Click **Save**
 7. Select the server and click **Connect** to establish a session
+
+#### Entra ID authentication
+
+> **Untested against a real tenant.** There is no Entra-enabled instance to develop this against, so
+> what is verified is the connection string handed to the driver, not that a sign-in succeeds. The
+> token flow itself belongs to `Microsoft.Data.SqlClient`. **Test Connection** will tell you honestly
+> whether it works — please open an issue either way.
+
+Three modes, all of which store nothing:
+
+| Mode | What it does | When to pick it |
+| --- | --- | --- |
+| **Interactive (MFA)** | Opens a browser to sign in | The mode that satisfies multi-factor authentication. Optionally give a username to pre-select the account |
+| **Integrated** | Uses the Windows account you are already signed in with, no prompt | Machine joined to the directory |
+| **Default** | Environment, then managed identity, then the signed-in account, then a prompt | SQL Server on an Azure VM, where the managed identity should be used |
+
+Switching a saved connection from SQL Authentication to any other mode deletes its stored password
+from Windows Credential Manager — a secret nothing uses any more should not outlive the reason it
+was stored.
+
+Note that this covers **the app's own connection to SQL Server**. Restoring `FROM URL` still needs a
+credential on the *instance* for the blob container, which is separate and configured on the server.
 
 ### 3. Browse Backups
 

--- a/src/NineLives.Tests/EntraSqlAuthTests.cs
+++ b/src/NineLives.Tests/EntraSqlAuthTests.cs
@@ -1,0 +1,186 @@
+using Microsoft.Data.SqlClient;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Entra ID authentication to SQL Server (#30).
+///
+/// **Untested against a real tenant.** There is no Entra-enabled instance to develop against, so
+/// what is pinned here is the connection string the driver is handed and the promise that nothing
+/// is stored - not that a sign-in succeeds. The token flow itself belongs to
+/// Microsoft.Data.SqlClient and is Microsoft's to get right; what this project can get wrong is the
+/// string it hands over, and that is exactly what these tests cover.
+///
+/// The reason it matters is the estate that needs it: Azure SQL Managed Instance and Azure-VM SQL
+/// increasingly mandate Entra with MFA, which neither Windows nor SQL auth can satisfy.
+/// </summary>
+public class EntraSqlAuthTests
+{
+    private static SqlServerService Service() => new(new FakeCredentialStore());
+
+    private static ServerConnection Server(AuthMode mode, string? username = null) => new()
+    {
+        Id = ServerConnection.NewId(),
+        Name = "SRV01",
+        ServerName = "srv01.database.windows.net",
+        AuthMode = mode,
+        Username = username
+    };
+
+    private static SqlConnectionStringBuilder Built(AuthMode mode, string? username = null) =>
+        new(Service().BuildConnectionString(Server(mode, username)));
+
+    // ── the connection string ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive, SqlAuthenticationMethod.ActiveDirectoryInteractive)]
+    [InlineData(AuthMode.EntraIntegrated, SqlAuthenticationMethod.ActiveDirectoryIntegrated)]
+    [InlineData(AuthMode.EntraDefault, SqlAuthenticationMethod.ActiveDirectoryDefault)]
+    public void EachEntraModeMapsToItsDriverAuthenticationMethod(
+        AuthMode mode, SqlAuthenticationMethod expected)
+    {
+        Assert.Equal(expected, Built(mode).Authentication);
+    }
+
+    /// <summary>
+    /// Integrated Security and Authentication are mutually exclusive - the driver rejects a
+    /// connection string carrying both, so this is the difference between working and not opening
+    /// at all.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive)]
+    [InlineData(AuthMode.EntraIntegrated)]
+    [InlineData(AuthMode.EntraDefault)]
+    public void EntraNeverAlsoAsksForIntegratedSecurity(AuthMode mode)
+    {
+        Assert.False(Built(mode).IntegratedSecurity);
+    }
+
+    [Theory]
+    [InlineData(AuthMode.WindowsAuth)]
+    [InlineData(AuthMode.SqlAuth)]
+    public void TheExistingModesAskForNoAuthenticationMethod(AuthMode mode)
+    {
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, Built(mode).Authentication);
+    }
+
+    [Fact]
+    public void WindowsAuthStillUsesIntegratedSecurity()
+    {
+        Assert.True(Built(AuthMode.WindowsAuth).IntegratedSecurity);
+    }
+
+    // ── the username ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Interactive sign-in takes a username as a hint that pre-selects the account, which is worth
+    /// having on a machine signed in to several. It is not a credential - there is no password to
+    /// pair it with - so unlike the SQL auth username it is safe in the connection string.
+    /// </summary>
+    [Fact]
+    public void AnInteractiveHintIsPassedThroughToPreSelectTheAccount()
+    {
+        Assert.Equal("dba@example.com", Built(AuthMode.EntraInteractive, "dba@example.com").UserID);
+    }
+
+    [Fact]
+    public void InteractiveWithNoHintAsksForNoParticularAccount()
+    {
+        Assert.Empty(Built(AuthMode.EntraInteractive).UserID);
+    }
+
+    /// <summary>
+    /// The other two modes choose the account themselves - integrated from the signed-in Windows
+    /// account, default from the environment or a managed identity. Passing a username would either
+    /// be ignored or contradict what the mode is for.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraIntegrated)]
+    [InlineData(AuthMode.EntraDefault)]
+    public void TheNonInteractiveModesIgnoreAUsername(AuthMode mode)
+    {
+        Assert.Empty(Built(mode, "dba@example.com").UserID);
+    }
+
+    // ── nothing is stored ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The whole reason an organisation mandates Entra is to stop tools holding passwords. A
+    /// SqlCredential attached to an Entra connection would also make the driver reject it.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive)]
+    [InlineData(AuthMode.EntraIntegrated)]
+    [InlineData(AuthMode.EntraDefault)]
+    public void NoPasswordIsEverAttachedForAnEntraConnection(AuthMode mode)
+    {
+        var store = new FakeCredentialStore();
+        var server = Server(mode, "dba@example.com");
+
+        // Even with a password sitting in the vault from a previous SQL auth life.
+        store.SaveSqlPassword(server, "left-over-password");
+
+        using var conn = new SqlServerService(store).CreateConnection(server);
+
+        Assert.Null(conn.Credential);
+        Assert.DoesNotContain("left-over-password", conn.ConnectionString);
+    }
+
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive, false)]
+    [InlineData(AuthMode.EntraIntegrated, false)]
+    [InlineData(AuthMode.EntraDefault, false)]
+    [InlineData(AuthMode.WindowsAuth, false)]
+    [InlineData(AuthMode.SqlAuth, true)]
+    public void OnlySqlAuthNeedsAStoredPassword(AuthMode mode, bool expected)
+    {
+        Assert.Equal(expected, mode.NeedsStoredPassword());
+    }
+
+    // ── how it reads ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The list shows the username only when it identifies the login connecting. For interactive
+    /// Entra it is a hint for the account picker, not necessarily the account that ends up
+    /// connecting, so showing it would misstate who is connected to a production instance.
+    /// </summary>
+    [Fact]
+    public void TheListNamesTheModeRatherThanTheHint()
+    {
+        Assert.Equal(
+            "srv01.database.windows.net (Entra ID (interactive))",
+            Server(AuthMode.EntraInteractive, "dba@example.com").DisplayText);
+    }
+
+    [Fact]
+    public void SqlAuthStillShowsWhoIsConnecting()
+    {
+        Assert.Equal("srv01.database.windows.net (sa)", Server(AuthMode.SqlAuth, "sa").DisplayText);
+    }
+
+    [Fact]
+    public void WindowsAuthStillSaysSo()
+    {
+        Assert.Equal(
+            "srv01.database.windows.net (Windows Auth)", Server(AuthMode.WindowsAuth).DisplayText);
+    }
+
+    /// <summary>
+    /// The stored values are what config.json holds. Reordering the enum would silently repoint
+    /// every saved connection at a different authentication mode - a Windows auth entry quietly
+    /// becoming an Entra one is the kind of change nobody notices until a restore fails.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.WindowsAuth, 0)]
+    [InlineData(AuthMode.SqlAuth, 1)]
+    [InlineData(AuthMode.EntraInteractive, 2)]
+    [InlineData(AuthMode.EntraIntegrated, 3)]
+    [InlineData(AuthMode.EntraDefault, 4)]
+    public void TheStoredValuesArePinned(AuthMode mode, int expected)
+    {
+        Assert.Equal(expected, (int)mode);
+    }
+}

--- a/src/NineLives.Tests/SaveOrderingTests.cs
+++ b/src/NineLives.Tests/SaveOrderingTests.cs
@@ -154,4 +154,76 @@ public class SaveOrderingTests
         Assert.Equal("olduser", server.Username);
         Assert.Equal("oldpassword", store.GetSqlPassword(server));
     }
+
+    /// <summary>
+    /// Switching a saved connection away from SQL auth used to leave its password in Credential
+    /// Manager - a live secret for a login nothing uses any more, outliving the only reason it was
+    /// stored (#30).
+    ///
+    /// It matters most for the switch this was written for: moving to Entra is usually done
+    /// precisely to stop tools holding passwords, so leaving one behind defeats the point.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive)]
+    [InlineData(AuthMode.EntraIntegrated)]
+    [InlineData(AuthMode.EntraDefault)]
+    [InlineData(AuthMode.WindowsAuth)]
+    public void SwitchingAwayFromSqlAuthDestroysTheStoredPassword(AuthMode to)
+    {
+        var store = new FakeCredentialStore();
+        var existing = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "restoreadmin"
+        };
+        store.Config.Servers.Add(existing);
+        store.SaveSqlPassword(existing, "no-longer-needed");
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+        vm.SelectedServer = vm.Servers.Single();
+        vm.EditCommand.Execute(null);
+
+        vm.EditAuthMode = to;
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+        Assert.Null(store.GetSqlPassword(vm.Servers.Single()));
+    }
+
+    /// <summary>
+    /// And only once the mode change has actually reached the disk - the same ordering rule the
+    /// rest of this file is about. A refused save that had already destroyed the password would
+    /// leave a SQL auth connection in config.json with no credential behind it.
+    /// </summary>
+    [Fact]
+    public void ARefusedSwitchAwayFromSqlAuthKeepsThePassword()
+    {
+        var store = new FakeCredentialStore();
+        var existing = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "restoreadmin"
+        };
+        store.Config.Servers.Add(existing);
+        store.SaveSqlPassword(existing, "still-needed");
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+        vm.SelectedServer = vm.Servers.Single();
+        vm.EditCommand.Execute(null);
+
+        store.SaveConfigThrows = Locked();
+
+        vm.EditAuthMode = AuthMode.EntraInteractive;
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Equal(AuthMode.SqlAuth, vm.Servers.Single().AuthMode);
+        Assert.Equal("still-needed", store.GetSqlPassword(vm.Servers.Single()));
+    }
 }

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -7,10 +7,68 @@ using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.Models;
 
+/// <summary>
+/// How the app authenticates to the SQL Server instance.
+///
+/// The Entra modes are handled entirely by Microsoft.Data.SqlClient's own token flow - the app
+/// stores no secret for any of them, which is the point: an estate that has mandated Entra has
+/// usually done so precisely to stop tools holding passwords (#30).
+///
+/// The numbers are pinned. These values are serialised into config.json, so appending to the list
+/// without them would be fine but reordering would silently repoint every saved connection at a
+/// different authentication mode.
+/// </summary>
 public enum AuthMode
 {
-    WindowsAuth,
-    SqlAuth
+    WindowsAuth = 0,
+    SqlAuth = 1,
+
+    /// <summary>
+    /// Entra ID with an interactive browser prompt, which is the mode that satisfies MFA. The
+    /// username, if given, is only a hint for the account picker.
+    /// </summary>
+    EntraInteractive = 2,
+
+    /// <summary>Entra ID using the signed-in Windows account, with no prompt.</summary>
+    EntraIntegrated = 3,
+
+    /// <summary>
+    /// Entra ID letting the driver choose - environment variables, then managed identity, then the
+    /// signed-in account, then an interactive prompt. The mode to pick for SQL Server on an Azure
+    /// VM, where the managed identity is what should be used.
+    /// </summary>
+    EntraDefault = 4
+}
+
+/// <summary>Things every authentication mode has to answer.</summary>
+public static class AuthModes
+{
+    /// <summary>Whether the app has to hold a password for this mode. Only SQL auth does.</summary>
+    public static bool NeedsStoredPassword(this AuthMode mode) => mode == AuthMode.SqlAuth;
+
+    /// <summary>Whether a username is required rather than optional.</summary>
+    public static bool RequiresUsername(this AuthMode mode) => mode == AuthMode.SqlAuth;
+
+    /// <summary>
+    /// Whether a username box is worth showing. Interactive Entra accepts one as a hint that
+    /// pre-selects the account, which is worth having on a machine signed in to several.
+    /// </summary>
+    public static bool AcceptsUsername(this AuthMode mode) =>
+        mode is AuthMode.SqlAuth or AuthMode.EntraInteractive;
+
+    public static bool IsEntra(this AuthMode mode) =>
+        mode is AuthMode.EntraInteractive or AuthMode.EntraIntegrated or AuthMode.EntraDefault;
+
+    /// <summary>How the mode reads in a list, next to a server name.</summary>
+    public static string Describe(this AuthMode mode) => mode switch
+    {
+        AuthMode.WindowsAuth => "Windows Auth",
+        AuthMode.SqlAuth => "SQL Auth",
+        AuthMode.EntraInteractive => "Entra ID (interactive)",
+        AuthMode.EntraIntegrated => "Entra ID (integrated)",
+        AuthMode.EntraDefault => "Entra ID (default)",
+        _ => "Unknown"
+    };
 }
 
 public enum EncryptMode
@@ -144,7 +202,7 @@ public class ServerConnection : INotifyPropertyChanged
 
     /// <summary>
     /// Key used to look up password in Windows Credential Manager.
-    /// Only used when AuthMode is SqlAuth.
+    /// Only used when <see cref="AuthMode"/> needs a stored password, which is SQL auth alone.
     /// </summary>
     [JsonIgnore]
     public string CredentialKey =>
@@ -162,9 +220,14 @@ public class ServerConnection : INotifyPropertyChanged
     [JsonIgnore]
     public string? UnsavedPassword { get; set; }
 
-    public string DisplayText => AuthMode == AuthMode.WindowsAuth
-        ? $"{ServerName} (Windows Auth)"
-        : $"{ServerName} ({Username})";
+    /// <summary>
+    /// The server and how it authenticates, for the list. A username is only shown when it
+    /// identifies the login being used - for interactive Entra it is a hint for the account picker,
+    /// not the account that ends up connecting, so showing it would misstate who is connected.
+    /// </summary>
+    public string DisplayText => AuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(Username)
+        ? $"{ServerName} ({Username})"
+        : $"{ServerName} ({AuthMode.Describe()})";
 
     private bool _isConnectedServer;
 

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -34,7 +34,24 @@ public class SqlServerService : ISqlServerService
 
         builder.IntegratedSecurity = server.AuthMode == AuthMode.WindowsAuth;
 
-        // No UserID or Password here - SQL auth credentials go on the SqlConnection as a
+        // Entra is the driver's own token flow - Microsoft.Data.SqlClient acquires and refreshes
+        // the token through MSAL, and the app never sees or stores a secret for it (#30).
+        if (server.AuthMode.IsEntra())
+        {
+            builder.Authentication = server.AuthMode switch
+            {
+                AuthMode.EntraInteractive => SqlAuthenticationMethod.ActiveDirectoryInteractive,
+                AuthMode.EntraIntegrated => SqlAuthenticationMethod.ActiveDirectoryIntegrated,
+                _ => SqlAuthenticationMethod.ActiveDirectoryDefault
+            };
+
+            // A hint for the account picker, not a credential. Safe in the connection string for
+            // the same reason the SQL auth username is not: there is no password to pair it with.
+            if (server.AuthMode == AuthMode.EntraInteractive && !string.IsNullOrWhiteSpace(server.Username))
+                builder.UserID = server.Username;
+        }
+
+        // No UserID or Password here for SQL auth - those credentials go on the SqlConnection as a
         // SqlCredential instead (#20). A connection string is a long-lived managed string that
         // cannot be zeroed and turns up in crash dumps and memory captures; SqlCredential holds
         // the password in a SecureString the driver disposes. It also means anything that logs or
@@ -53,7 +70,8 @@ public class SqlServerService : ISqlServerService
     {
         var conn = new SqlConnection(BuildConnectionString(server));
 
-        if (server.AuthMode != AuthMode.SqlAuth)
+        // Windows auth and the Entra modes carry no password of ours - the driver handles both.
+        if (!server.AuthMode.NeedsStoredPassword())
             return conn;
 
         // Unsaved wins, so Test Connection can try a password without persisting it first (#12).

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -33,9 +33,28 @@ public partial class ServerManagerViewModel : ViewModelBase
     [ObservableProperty]
     private AuthMode _editAuthMode = AuthMode.WindowsAuth;
 
+    /// <summary>Whether to show the password box. Only SQL auth has a password to hold (#30).</summary>
     public bool IsSqlAuth => EditAuthMode == AuthMode.SqlAuth;
 
-    partial void OnEditAuthModeChanged(AuthMode value) => OnPropertyChanged(nameof(IsSqlAuth));
+    /// <summary>
+    /// Whether to show the username box. Interactive Entra takes one as an optional hint that
+    /// pre-selects the account, which is worth having on a machine signed in to several.
+    /// </summary>
+    public bool ShowsUsername => EditAuthMode.AcceptsUsername();
+
+    public bool IsEntraAuth => EditAuthMode.IsEntra();
+
+    public string UsernameLabel => EditAuthMode == AuthMode.EntraInteractive
+        ? "USERNAME (OPTIONAL - PRE-SELECTS THE ACCOUNT)"
+        : "USERNAME";
+
+    partial void OnEditAuthModeChanged(AuthMode value)
+    {
+        OnPropertyChanged(nameof(IsSqlAuth));
+        OnPropertyChanged(nameof(ShowsUsername));
+        OnPropertyChanged(nameof(IsEntraAuth));
+        OnPropertyChanged(nameof(UsernameLabel));
+    }
 
     [ObservableProperty]
     private string _editUsername = string.Empty;
@@ -225,7 +244,7 @@ public partial class ServerManagerViewModel : ViewModelBase
             return;
         }
 
-        if (EditAuthMode == AuthMode.SqlAuth && string.IsNullOrWhiteSpace(EditUsername))
+        if (EditAuthMode.RequiresUsername() && string.IsNullOrWhiteSpace(EditUsername))
         {
             SetError("Username is required for SQL Authentication.");
             return;
@@ -262,7 +281,9 @@ public partial class ServerManagerViewModel : ViewModelBase
         ReplaceTags(server.Tags, TagPalette.ParseTags(EditTags));
         server.ServerName = EditServerName;
         server.AuthMode = EditAuthMode;
-        server.Username = EditAuthMode == AuthMode.SqlAuth ? EditUsername : null;
+        server.Username = EditAuthMode.AcceptsUsername() && !string.IsNullOrWhiteSpace(EditUsername)
+            ? EditUsername
+            : null;
         server.ConnectionTimeoutSeconds = EditTimeout;
         server.TrustServerCertificate = EditTrustServerCert;
         server.Encrypt = EditEncrypt;
@@ -283,17 +304,31 @@ public partial class ServerManagerViewModel : ViewModelBase
             return;
         }
 
-        if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
+        if (EditAuthMode.NeedsStoredPassword())
         {
-            try
+            if (!string.IsNullOrWhiteSpace(EditPassword))
             {
-                _credentialStore.SaveSqlPassword(server, EditPassword);
+                try
+                {
+                    _credentialStore.SaveSqlPassword(server, EditPassword);
+                }
+                catch (Exception ex)
+                {
+                    SetError($"The server was saved, but the password could not be stored: {ex.Message}");
+                    return;
+                }
             }
-            catch (Exception ex)
-            {
-                SetError($"The server was saved, but the password could not be stored: {ex.Message}");
-                return;
-            }
+        }
+        else
+        {
+            // Switching away from SQL auth used to leave the password in Credential Manager - a
+            // live secret for a login nothing uses any more, outliving the only reason it was
+            // stored. Moving to Entra is usually done precisely to stop tools holding passwords,
+            // so leaving one behind defeats the point of the switch.
+            //
+            // After the config write, for the same reason Delete does it in that order: the
+            // password is only redundant once the mode change has actually landed on disk.
+            _credentialStore.DeleteSecret(server.CredentialKey);
         }
 
         SelectedServer = server;
@@ -308,7 +343,7 @@ public partial class ServerManagerViewModel : ViewModelBase
 
         // Same reasoning as deleting a container: a stored SQL password is removed from Credential
         // Manager and the app never displays it, so a single click should not be enough (#42).
-        var secretNote = SelectedServer.AuthMode == AuthMode.SqlAuth
+        var secretNote = SelectedServer.AuthMode.NeedsStoredPassword()
             ? "\n\nIts stored SQL password will be deleted from Windows Credential Manager."
             : string.Empty;
 
@@ -332,7 +367,7 @@ public partial class ServerManagerViewModel : ViewModelBase
             return;
         }
 
-        if (removed.AuthMode == AuthMode.SqlAuth)
+        if (removed.AuthMode.NeedsStoredPassword())
             _credentialStore.DeleteSecret(removed.CredentialKey);
 
         if (IsConnected && ConnectedServerDisplay == removed.DisplayText)
@@ -487,9 +522,9 @@ public partial class ServerManagerViewModel : ViewModelBase
             // In memory only. This used to call SaveSqlPassword, which is a durable write to
             // Credential Manager - so testing a mistyped password overwrote the working one
             // before the user had agreed to anything, and Cancel could not undo it (#12).
-            if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
+            if (EditAuthMode.NeedsStoredPassword() && !string.IsNullOrWhiteSpace(EditPassword))
                 server.UnsavedPassword = EditPassword;
-            else if (EditAuthMode == AuthMode.SqlAuth && !IsNew)
+            else if (EditAuthMode.NeedsStoredPassword() && !IsNew)
                 // No new password typed: test against the one already saved for this entry.
                 server.Id = SelectedServer?.Id;
 

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -282,16 +282,50 @@
                                 <RadioButton Content="SQL Server Authentication"
                                              Style="{StaticResource DarkRadioButton}"
                                              IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=SqlAuth}"
+                                             Margin="0,0,0,8"
                                              GroupName="AuthMode" />
+                                <RadioButton Content="Entra ID - interactive (MFA)"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraInteractive}"
+                                             Margin="0,0,0,8"
+                                             GroupName="AuthMode"
+                                             ToolTip="Opens a browser to sign in. The mode that satisfies multi-factor authentication. Nothing is stored." />
+                                <RadioButton Content="Entra ID - integrated"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraIntegrated}"
+                                             Margin="0,0,0,8"
+                                             GroupName="AuthMode"
+                                             ToolTip="Uses the Windows account you are already signed in with, without a prompt. Needs the machine joined to the directory." />
+                                <RadioButton Content="Entra ID - default"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraDefault}"
+                                             GroupName="AuthMode"
+                                             ToolTip="Lets the driver choose: environment, then managed identity, then the signed-in account, then a prompt. The one to pick for SQL Server on an Azure VM." />
                             </StackPanel>
 
-                            <!-- SQL Auth Fields -->
-                            <StackPanel Visibility="{Binding IsSqlAuth, Converter={StaticResource BoolToVis}}">
-                                <TextBlock Text="USERNAME" Style="{StaticResource LabelText}" />
+                            <!-- Untested against a real tenant - see the note in the README. Said
+                                 here rather than only in the docs, because the person who finds out
+                                 is the one standing in front of this screen. -->
+                            <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                    BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                    BorderThickness="1" CornerRadius="4" Padding="10"
+                                    Margin="0,0,0,16"
+                                    Visibility="{Binding IsEntraAuth, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
+                                           Text="Entra sign-in is built but has not been tested against a real tenant - there is no Entra-enabled instance to develop it against. The connection string is what Microsoft documents, and Test Connection will tell you honestly whether it works. Please report what happens either way." />
+                            </Border>
+
+                            <!-- Username: required for SQL auth, an optional account hint for
+                                 interactive Entra. Password: SQL auth only - the Entra modes have
+                                 no secret for the app to hold, which is the point of using them. -->
+                            <StackPanel Visibility="{Binding ShowsUsername, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Text="{Binding UsernameLabel}" Style="{StaticResource LabelText}" />
                                 <TextBox Text="{Binding EditUsername, UpdateSourceTrigger=PropertyChanged}"
                                          Style="{StaticResource DarkTextBox}"
                                          Margin="0,0,0,16" />
+                            </StackPanel>
 
+                            <StackPanel Visibility="{Binding IsSqlAuth, Converter={StaticResource BoolToVis}}">
                                 <TextBlock Text="PASSWORD" Style="{StaticResource LabelText}" />
                                 <PasswordBox x:Name="PasswordInput"
                                              Style="{StaticResource DarkPasswordBox}"


### PR DESCRIPTION
Closes #30.

Azure SQL Managed Instance and Azure-VM SQL estates increasingly mandate Entra ID with MFA, which neither Windows nor SQL auth can satisfy — so the tool is unusable there regardless of its merits.

## ⚠️ Untested against a real tenant

There is no Entra-enabled instance to develop this against. What is verified is **the connection string the driver is handed**, not that a sign-in succeeds — the token flow itself belongs to `Microsoft.Data.SqlClient` and is Microsoft's to get right. What this project can get wrong is the string it hands over, and that is what the tests cover.

That caveat is on the form itself as well as in the README, because the person who finds out is the one standing in front of the screen:

> Entra sign-in is built but has not been tested against a real tenant — there is no Entra-enabled instance to develop it against. The connection string is what Microsoft documents, and Test Connection will tell you honestly whether it works. Please report what happens either way.

## The three modes

| Mode | Driver method | When |
| --- | --- | --- |
| Interactive (MFA) | `ActiveDirectoryInteractive` | The mode that satisfies MFA. Optional username pre-selects the account |
| Integrated | `ActiveDirectoryIntegrated` | Signed-in Windows account, no prompt |
| Default | `ActiveDirectoryDefault` | Environment → managed identity → signed-in account → prompt. The one for SQL Server on an Azure VM |

**No new package** — MSAL is already present transitively via `Microsoft.Data.SqlClient`. And the app stores nothing for any of the three, which is the point: an estate mandates Entra precisely to stop tools holding passwords.

## Also fixed

Switching a saved connection away from SQL auth left its password in Windows Credential Manager — a live secret for a login nothing uses any more, outliving the only reason it was stored. It is destroyed now, *after* the config write lands, for the same ordering reason `Delete` uses: a refused save must not throw away a password the connection still needs.

This predates Entra (it applied to switching to Windows auth too) but Entra makes it worse — moving to Entra is usually done precisely to stop tools holding passwords, so leaving one behind defeats the point of the switch. Proved by reverting and watching all four cases fail.

## Notes

- The enum values are **pinned**. They are serialised into `config.json`, so reordering would silently repoint every saved connection at a different authentication mode — a Windows auth entry quietly becoming an Entra one is the kind of change nobody notices until a restore fails.
- `IntegratedSecurity` and `Authentication` are mutually exclusive in the driver, so a test pins that Entra never asks for both. That is the difference between working and not opening at all.
- The server list names the *mode* rather than the username hint for interactive Entra — the hint is not necessarily the account that ends up connecting, and misstating who is connected to a production instance is worth avoiding.
- Restoring `FROM URL` still needs a credential on the *instance* for the blob container. That is separate, server-side, and documented as such.

37 new tests, 837 pass, build clean at `-warnaserror`. Both auth panels rendered and checked.

A fresh Release build is in `publish/`.
