### PR TITLE
Entra ID authentication for Blob Storage (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nine Lives 🐈‍⬛
+﻿# Nine Lives 🐈‍⬛
 
 [![Build](https://github.com/jakemorgangit/NineLives/actions/workflows/build.yml/badge.svg)](https://github.com/jakemorgangit/NineLives/actions/workflows/build.yml)
 
@@ -28,7 +28,7 @@ Nine Lives points at a container, discovers every backup, groups striped sets, c
 ## Features
 
 ### Azure Blob Storage Integration
-- Connect to Azure Blob Storage containers using SAS tokens
+- Connect to Azure Blob Storage containers using SAS tokens, or Entra ID for organisations that prohibit long-lived SAS ([see the caveat](#entra-id-for-blob-storage))
 - Automatic discovery of backup files (Full, Differential, Transaction Log)
 - Intelligent parsing of blob path structures with customisable patterns
 - Support for striped backup sets (multiple files per backup)
@@ -186,7 +186,9 @@ The executable will be created at `./publish/NineLives.exe`.
 2. Click **+ Add Container**
 3. Enter a display name for the container
 4. Enter the full container URL (e.g., `https://mystorageaccount.blob.core.windows.net/sqlbackups`)
-5. Enter your SAS token (with at least `list` and `read` permissions)
+5. Choose how to authenticate:
+   - **SAS token** — paste one with at least `list` and `read` permissions
+   - **Entra ID** — nothing to paste, and nothing is stored ([caveat below](#entra-id-for-blob-storage))
 6. Configure the **Blob Path Structure** to match your backup folder layout:
    - Default: `{BackupType}/{ServerName}/{DatabaseName}/{FileName}`
    - Drag and drop components to rearrange
@@ -194,6 +196,30 @@ The executable will be created at `./publish/NineLives.exe`.
    - For Availability Group backups, select the AG source type (supports Ola Hallengren default AG naming and cluster/AG path tokens)
 7. Click **Test Connection** to verify access
 8. Click **Save**
+
+#### Entra ID for Blob Storage
+
+> **Untested against a real tenant.** There is no Entra-enabled storage account to develop this
+> against, so what is verified is which credential the app uses and what it stops storing — not that
+> a token is accepted. **Test Connection** will tell you honestly whether it works; please open an
+> issue either way.
+
+| Mode | What it does | When to pick it |
+| --- | --- | --- |
+| **Interactive (MFA)** | Opens a browser to sign in. The sign-in lasts as long as the app is running and is written nowhere | Any Entra-enabled account, including MFA |
+| **Default** | Environment, then managed identity, then Azure CLI / Visual Studio sign-in, then a prompt | Running the app on an Azure VM with a managed identity |
+
+Your account needs **Storage Blob Data Reader** on the container. Owner or Contributor on the
+subscription is not enough on its own — the data-plane roles are separate from the management-plane
+ones, which is the usual first surprise.
+
+Switching a container from SAS to Entra deletes its stored token from Windows Credential Manager. An
+organisation that has banned long-lived SAS has banned it wherever it is sitting.
+
+**This covers browsing only.** The RESTORE itself runs on SQL Server, which needs its own credential
+for the container URL — for Entra that is `CREATE CREDENTIAL ... WITH IDENTITY = 'Managed Identity'`
+on SQL Server 2022+ or Azure SQL MI. Entra on the client and a SAS credential on the server is a
+perfectly valid combination.
 
 ### 2. Configure SQL Server (Optional - for direct execution)
 

--- a/src/NineLives.Tests/EntraBlobAuthTests.cs
+++ b/src/NineLives.Tests/EntraBlobAuthTests.cs
@@ -1,0 +1,260 @@
+﻿using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Entra ID authentication to Blob Storage (#29).
+///
+/// **Untested against a real tenant.** There is no Entra-enabled storage account to develop
+/// against, so what is pinned here is the decision the app makes - which credential, and what it
+/// stops storing - not that a token is accepted. The token flow belongs to Azure.Identity.
+///
+/// The reason it matters: many organisations now prohibit long-lived SAS tokens outright, which
+/// made the tool unusable for them regardless of its merits.
+/// </summary>
+public class EntraBlobAuthTests
+{
+    private static BlobContainerConfig Container(BlobAuthMode mode) => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups",
+        AuthMode = mode
+    };
+
+    // ── no secret of ours ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The SAS path refuses to work without a token, which is right - but that refusal must not
+    /// apply to a mode that has no token by design. This is the whole feature in one assertion.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void AnEntraContainerNeedsNoStoredToken(BlobAuthMode mode)
+    {
+        var store = new FakeCredentialStore();
+        var config = Container(mode);
+
+        // No token stored anywhere, and no exception: the client is built from a credential.
+        Assert.Null(store.GetSasToken(config));
+        var ex = Record.Exception(() => new BlobStorageService(store).CreateClientForTests(config));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ASasContainerStillSaysSoWhenItHasNoToken()
+    {
+        var store = new FakeCredentialStore();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new BlobStorageService(store).CreateClientForTests(Container(BlobAuthMode.SasToken)));
+
+        Assert.Contains("No SAS token", ex.Message);
+    }
+
+    /// <summary>
+    /// The container URL is used as-is under Entra - no query string is appended, because there is
+    /// no signature to append. A stray "?" would be sent to Azure as an empty SAS.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void TheContainerUrlIsUsedUntouched(BlobAuthMode mode)
+    {
+        var client = new BlobStorageService(new FakeCredentialStore())
+            .CreateClientForTests(Container(mode));
+
+        Assert.Equal(
+            "https://mystorageaccount.blob.core.windows.net/backups", client.Uri.ToString());
+        Assert.Empty(client.Uri.Query);
+    }
+
+    /// <summary>
+    /// One credential per mode for the life of the process. A fresh one per operation means a fresh
+    /// sign-in per operation - for interactive mode, a browser window every time the container is
+    /// listed.
+    /// </summary>
+    [Fact]
+    public void TheSignInIsReusedRatherThanRepeatedPerOperation()
+    {
+        // Static, so it is shared across service instances too - the token cache belongs to the
+        // signed-in user, not to whichever service happened to ask for it first.
+        Assert.Same(
+            BlobStorageService.CredentialForTests(BlobAuthMode.EntraInteractive),
+            BlobStorageService.CredentialForTests(BlobAuthMode.EntraInteractive));
+    }
+
+    [Fact]
+    public void EachModeGetsItsOwnCredential()
+    {
+        Assert.NotSame(
+            BlobStorageService.CredentialForTests(BlobAuthMode.EntraInteractive),
+            BlobStorageService.CredentialForTests(BlobAuthMode.EntraDefault));
+    }
+
+    // ── expiry does not apply ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// An Entra container has no token of ours to expire, so it must never report itself expired -
+    /// otherwise the list shows a warning and a Refresh Token button for something that does not
+    /// exist.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void AnEntraContainerIsNeverExpired(BlobAuthMode mode)
+    {
+        var config = Container(mode);
+
+        // Even carrying a long-expired SAS from a previous life.
+        config.CacheSasToken("sv=2024-01-01&se=2020-01-01T00%3A00%3A00Z&sig=x");
+
+        Assert.False(config.IsExpired);
+    }
+
+    [Fact]
+    public void ASasContainerStillReportsExpiry()
+    {
+        var config = Container(BlobAuthMode.SasToken);
+        config.CacheSasToken("sv=2024-01-01&se=2020-01-01T00%3A00%3A00Z&sig=x");
+
+        Assert.True(config.IsExpired);
+    }
+
+    // ── the config screen ───────────────────────────────────────────────────────
+
+    private static BlobConfigViewModel NewVm(FakeCredentialStore store) =>
+        new(store, new FakeBlobStorageService());
+
+    [Fact]
+    public void ANewEntraContainerSavesWithoutASasToken()
+    {
+        var store = new FakeCredentialStore();
+        var vm = NewVm(store);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+        var saved = Assert.Single(store.Config.BlobContainers);
+        Assert.Equal(BlobAuthMode.EntraInteractive, saved.AuthMode);
+        Assert.Null(store.GetSasToken(saved));
+    }
+
+    [Fact]
+    public void ANewSasContainerStillDemandsAToken()
+    {
+        var store = new FakeCredentialStore();
+        var vm = NewVm(store);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Contains("SAS Token is required", vm.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Switching a container to Entra destroys its stored SAS token. An organisation that has
+    /// banned long-lived SAS has banned it wherever it is sitting, including in this machine's
+    /// Credential Manager - and the token is no longer used for anything.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void SwitchingToEntraDestroysTheStoredSasToken(BlobAuthMode to)
+    {
+        var store = new FakeCredentialStore();
+        var existing = Container(BlobAuthMode.SasToken);
+        store.Config.BlobContainers.Add(existing);
+        store.SaveSasToken(existing, "sv=2024-01-01&sig=no-longer-needed");
+
+        var vm = NewVm(store);
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        vm.EditAuthMode = to;
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+        Assert.Null(store.GetSasToken(vm.Containers.Single()));
+    }
+
+    /// <summary>
+    /// And only once the mode change has reached the disk - the same ordering rule the rest of the
+    /// save path follows. A refused save that had already destroyed the token would leave a SAS
+    /// container in config.json with nothing behind it.
+    /// </summary>
+    [Fact]
+    public void ARefusedSwitchToEntraKeepsTheToken()
+    {
+        var store = new FakeCredentialStore();
+        var existing = Container(BlobAuthMode.SasToken);
+        store.Config.BlobContainers.Add(existing);
+        store.SaveSasToken(existing, "sv=2024-01-01&sig=still-needed");
+
+        var vm = NewVm(store);
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        store.SaveConfigThrows = new InvalidOperationException("config.json is in use by another process");
+
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Equal(BlobAuthMode.SasToken, vm.Containers.Single().AuthMode);
+        Assert.Equal("sv=2024-01-01&sig=still-needed", store.GetSasToken(vm.Containers.Single()));
+    }
+
+    [Fact]
+    public void ChangingTheModeCountsAsAnUnsavedChange()
+    {
+        var store = new FakeCredentialStore();
+        var existing = Container(BlobAuthMode.SasToken);
+        store.Config.BlobContainers.Add(existing);
+
+        var vm = NewVm(store);
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+        Assert.False(vm.HasUnsavedChanges);
+
+        vm.EditAuthMode = BlobAuthMode.EntraDefault;
+
+        Assert.True(vm.HasUnsavedChanges);
+    }
+
+    /// <summary>
+    /// The stored values are what config.json holds. Reordering would silently repoint every saved
+    /// container at a different authentication mode, and a container written before this existed
+    /// has no value at all - which must land on SAS, the behaviour it already had.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.SasToken, 0)]
+    [InlineData(BlobAuthMode.EntraInteractive, 1)]
+    [InlineData(BlobAuthMode.EntraDefault, 2)]
+    public void TheStoredValuesArePinned(BlobAuthMode mode, int expected)
+    {
+        Assert.Equal(expected, (int)mode);
+    }
+
+    [Fact]
+    public void AContainerFromBeforeThisExistedIsASasContainer()
+    {
+        var legacy = System.Text.Json.JsonSerializer.Deserialize<BlobContainerConfig>(
+            """{"Name":"backups","ContainerUrl":"https://mystorageaccount.blob.core.windows.net/backups"}""");
+
+        Assert.NotNull(legacy);
+        Assert.Equal(BlobAuthMode.SasToken, legacy.AuthMode);
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -71,6 +71,62 @@ public class XamlLoadTests(WpfFixture wpf)
         => Check("BlobConfigView", () =>
             new BlobConfigView { DataContext = new BlobConfigViewModel(Store(), new BlobStorageService(Store())) });
 
+    /// <summary>
+    /// The container form under Entra: no SAS box, and the caveat panel on screen (#29).
+    ///
+    /// Worth its own case because the whole Entra section is collapsed in the default state the
+    /// plain load test exercises, so none of its bindings are ever evaluated there.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void TheContainerFormHidesTheSasBoxUnderEntra(BlobAuthMode mode)
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BlobConfigViewModel(Store(), new BlobStorageService(Store()));
+            vm.AddNewCommand.Execute(null);
+            vm.EditName = "backups";
+            vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+            vm.EditAuthMode = mode;
+
+            var view = new BlobConfigView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var labels = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+                Assert.DoesNotContain("SAS TOKEN", labels);
+                Assert.Contains(labels, t => t.Contains("has not been tested", StringComparison.Ordinal));
+                Assert.Contains(labels, t => t.Contains("Storage Blob Data Reader", StringComparison.Ordinal));
+
+                listener.AssertNone("BlobConfigView Entra");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    [Fact]
+    public void TheContainerFormShowsTheSasBoxUnderSasAuth()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BlobConfigViewModel(Store(), new BlobStorageService(Store()));
+            vm.AddNewCommand.Execute(null);
+
+            var view = new BlobConfigView { DataContext = vm };
+            Realise(view);
+
+            var labels = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+            Assert.Contains("SAS TOKEN", labels);
+            Assert.DoesNotContain(labels, t => t.Contains("has not been tested", StringComparison.Ordinal));
+        });
+    }
+
     [Fact]
     public void ServerManagerViewLoads()
         => Check("ServerManagerView", () =>

--- a/src/NineLives.Tests/packages.lock.json
+++ b/src/NineLives.Tests/packages.lock.json
@@ -43,6 +43,14 @@
           "System.Memory.Data": "10.0.3"
         }
       },
+      "Azure.Identity": {
+        "type": "Transitive",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Azure.Storage.Blobs": {
         "type": "Transitive",
         "resolved": "12.29.1",
@@ -352,6 +360,7 @@
       "ninelives": {
         "type": "Project",
         "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
           "CommunityToolkit.Mvvm": "[8.4.2, )",
           "Microsoft.Data.SqlClient": "[7.0.2, )"

--- a/src/NineLives/Converters/ValueConverters.cs
+++ b/src/NineLives/Converters/ValueConverters.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
+using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Converters;
 
@@ -314,6 +315,29 @@ public class BackupSourceTypeToDisplayConverter : IValueConverter
             _ => value?.ToString() ?? ""
         };
     }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>How a container's authentication mode reads on the detail panel (#29).</summary>
+public class BlobAuthModeToDisplayConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is BlobAuthMode mode ? mode.Describe() : string.Empty;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Shows the SAS-only parts of the detail panel. An expiry line against an Entra container would
+/// send someone hunting for a token that does not exist.
+/// </summary>
+public class BlobAuthModeIsSasConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is BlobAuthMode mode && mode.NeedsSasToken() ? Visibility.Visible : Visibility.Collapsed;
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         => throw new NotSupportedException();

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -22,6 +22,52 @@ public enum BackupSourceType
 }
 
 /// <summary>
+/// How the app authenticates to the container when listing backups (#29).
+///
+/// Many organisations now prohibit long-lived SAS tokens outright, which made the tool unusable for
+/// them regardless of its merits. The Entra modes hold no secret at all - the token is acquired and
+/// refreshed by Azure.Identity and never touches the credential store.
+///
+/// The numbers are pinned. These are serialised into config.json, so reordering would silently
+/// repoint every saved container at a different authentication mode.
+/// </summary>
+public enum BlobAuthMode
+{
+    /// <summary>A stored SAS token. The original mode, and still the default.</summary>
+    SasToken = 0,
+
+    /// <summary>
+    /// Entra ID with a browser sign-in, which is the mode that satisfies MFA. The sign-in is
+    /// remembered for the life of the process and written nowhere.
+    /// </summary>
+    EntraInteractive = 1,
+
+    /// <summary>
+    /// Entra ID letting Azure.Identity choose - environment variables, then a managed identity,
+    /// then the Azure CLI or Visual Studio sign-in, then a browser prompt. The mode to pick when
+    /// the app runs on an Azure VM with a managed identity assigned.
+    /// </summary>
+    EntraDefault = 2
+}
+
+/// <summary>Things every blob authentication mode has to answer.</summary>
+public static class BlobAuthModes
+{
+    /// <summary>Whether the app has to hold a SAS token for this mode.</summary>
+    public static bool NeedsSasToken(this BlobAuthMode mode) => mode == BlobAuthMode.SasToken;
+
+    public static bool IsEntra(this BlobAuthMode mode) => mode != BlobAuthMode.SasToken;
+
+    public static string Describe(this BlobAuthMode mode) => mode switch
+    {
+        BlobAuthMode.SasToken => "SAS token",
+        BlobAuthMode.EntraInteractive => "Entra ID (interactive)",
+        BlobAuthMode.EntraDefault => "Entra ID (default)",
+        _ => "Unknown"
+    };
+}
+
+/// <summary>
 /// A saved blob container. Implements INotifyPropertyChanged so the derived TagChips member
 /// notifies when Tags changes - see the note on Tags.
 /// </summary>
@@ -45,6 +91,13 @@ public class BlobContainerConfig : INotifyPropertyChanged
 
     public string Name { get; set; } = string.Empty;
     public string ContainerUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// How the app signs in to this container (#29). Absent from config files written before this
+    /// existed, which deserialise to <see cref="BlobAuthMode.SasToken"/> - the behaviour they
+    /// already had, so no migration is needed.
+    /// </summary>
+    public BlobAuthMode AuthMode { get; set; } = BlobAuthMode.SasToken;
 
     /// <summary>
     /// Whether backups are from standalone instances, AG (Ola default naming), or both.
@@ -156,7 +209,11 @@ public class BlobContainerConfig : INotifyPropertyChanged
     [JsonIgnore]
     public string? UnsavedSasToken { get; set; }
 
-    public bool IsExpired => ReadSasExpiry().IsExpired;
+    /// <summary>
+    /// Whether the stored SAS token has passed its expiry. Always false under Entra, which has no
+    /// token of ours to expire - the whole reason an organisation switches to it.
+    /// </summary>
+    public bool IsExpired => AuthMode.NeedsSasToken() && ReadSasExpiry().IsExpired;
 
     public DateTime? SasExpiry => GetSasExpiry();
 

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -1,4 +1,6 @@
 ﻿using System.Text.RegularExpressions;
+using Azure.Core;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Blackcat.NineLives.Models;
@@ -16,6 +18,13 @@ public class BlobStorageService : IBlobStorageService
 
     private BlobContainerClient CreateClient(BlobContainerConfig config)
     {
+        var baseUrl = config.ContainerUrl.TrimEnd('/');
+
+        // Entra: no secret of ours at all. Azure.Identity acquires and refreshes the token, and
+        // nothing is written to the credential store (#29).
+        if (config.AuthMode.IsEntra())
+            return new BlobContainerClient(new Uri(baseUrl), CredentialFor(config.AuthMode));
+
         // An unsaved token wins, so Test Connection can try one without it having to be persisted
         // first (#12). Null for every ordinary operation, which falls through to the stored token.
         var sasToken = config.UnsavedSasToken ?? _credentialStore.GetSasToken(config);
@@ -23,12 +32,49 @@ public class BlobStorageService : IBlobStorageService
             throw new InvalidOperationException(
                 "No SAS token found. Please configure the SAS token for this container.");
 
-        var baseUrl = config.ContainerUrl.TrimEnd('/');
         var cleanSas = sasToken.TrimStart('?');
         var separator = baseUrl.Contains('?') ? "&" : "?";
         var fullUri = new Uri($"{baseUrl}{separator}{cleanSas}");
         return new BlobContainerClient(fullUri);
     }
+
+    /// <summary>
+    /// One credential per mode for the life of the process.
+    ///
+    /// Deliberately shared rather than created per client. A credential holds the in-memory token
+    /// cache, so a fresh one per operation means a fresh sign-in per operation - which for
+    /// interactive mode is a browser window every time the container is listed, and for the rest is
+    /// a token request per call instead of one per hour.
+    ///
+    /// Static because the cache is genuinely process-wide: it belongs to the signed-in user, not to
+    /// whichever service instance happened to ask first.
+    /// </summary>
+    private static readonly Lock CredentialLock = new();
+    private static readonly Dictionary<BlobAuthMode, TokenCredential> Credentials = [];
+
+    private static TokenCredential CredentialFor(BlobAuthMode mode)
+    {
+        lock (CredentialLock)
+        {
+            if (Credentials.TryGetValue(mode, out var existing)) return existing;
+
+            TokenCredential created = mode == BlobAuthMode.EntraInteractive
+                ? new InteractiveBrowserCredential()
+                : new DefaultAzureCredential();
+
+            Credentials[mode] = created;
+            return created;
+        }
+    }
+
+    /// <summary>
+    /// Test hooks. Building a client makes no network call and acquires no token - a credential is
+    /// only exercised on the first request - so which credential the mode resolves to, and that a
+    /// SAS container still refuses without one, are both checkable offline (#29).
+    /// </summary>
+    internal BlobContainerClient CreateClientForTests(BlobContainerConfig config) => CreateClient(config);
+
+    internal static TokenCredential CredentialForTests(BlobAuthMode mode) => CredentialFor(mode);
 
     public async Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
     {

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -35,6 +35,17 @@ public partial class BlobConfigViewModel : ViewModelBase
     [ObservableProperty]
     private string _editContainerUrl = string.Empty;
 
+    /// <summary>
+    /// How this container signs in (#29). Entra holds no secret of ours, which is the point:
+    /// many organisations now prohibit long-lived SAS tokens outright.
+    /// </summary>
+    [ObservableProperty]
+    private BlobAuthMode _editAuthMode = BlobAuthMode.SasToken;
+
+    public bool IsSasAuth => EditAuthMode.NeedsSasToken();
+
+    public bool IsEntraAuth => EditAuthMode.IsEntra();
+
     [ObservableProperty]
     private string _editSasToken = string.Empty;
 
@@ -138,6 +149,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     private string _originalName = "";
     private string _originalUrl = "";
     private string _originalSas = "";
+    private BlobAuthMode _originalAuthMode = BlobAuthMode.SasToken;
     private string _originalPattern = "";
     private BackupSourceType _originalBackupSourceType = BackupSourceType.Standalone;
     private string? _originalAgPathPattern;
@@ -191,6 +203,13 @@ public partial class BlobConfigViewModel : ViewModelBase
     partial void OnEditNameChanged(string value) => CheckForUnsavedChanges();
     partial void OnEditContainerUrlChanged(string value) => CheckForUnsavedChanges();
     partial void OnEditSasTokenChanged(string value) => CheckForUnsavedChanges();
+    partial void OnEditAuthModeChanged(BlobAuthMode value)
+    {
+        OnPropertyChanged(nameof(IsSasAuth));
+        OnPropertyChanged(nameof(IsEntraAuth));
+        if (SelectedContainer != null) UpdateSasExpiryStatus(SelectedContainer);
+        CheckForUnsavedChanges();
+    }
     partial void OnEditPathPatternChanged(string value) => CheckForUnsavedChanges();
     partial void OnEditBackupSourceTypeChanged(BackupSourceType value)
     {
@@ -214,6 +233,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         HasUnsavedChanges =
             EditName != _originalName ||
             EditContainerUrl != _originalUrl ||
+            EditAuthMode != _originalAuthMode ||
             sasChanged ||
             EditPathPattern != _originalPattern ||
             EditBackupSourceType != _originalBackupSourceType ||
@@ -230,6 +250,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     {
         var name = container.Name;
         var url = container.ContainerUrl;
+        var authMode = container.AuthMode;
         var pattern = container.PathPattern;
         var sourceType = container.BackupSourceType;
         var agPattern = container.AgPathPattern;
@@ -240,6 +261,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         {
             container.Name = name;
             container.ContainerUrl = url;
+            container.AuthMode = authMode;
             container.PathPattern = pattern;
             container.BackupSourceType = sourceType;
             container.AgPathPattern = agPattern;
@@ -252,6 +274,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     {
         _originalName = EditName;
         _originalUrl = EditContainerUrl;
+        _originalAuthMode = EditAuthMode;
         _originalSas = HasStoredSasToken ? StoredSasSentinel : EditSasToken;
         _originalPattern = EditPathPattern;
         _originalBackupSourceType = EditBackupSourceType;
@@ -263,6 +286,15 @@ public partial class BlobConfigViewModel : ViewModelBase
 
     private void UpdateSasExpiryStatus(BlobContainerConfig container)
     {
+        // Entra has no token of ours to expire. Reporting "expired" against a container that never
+        // had a SAS would send someone hunting for a token that is not the problem.
+        if (EditAuthMode.IsEntra() || (!IsEditing && container.AuthMode.IsEntra()))
+        {
+            SasExpiryText = string.Empty;
+            IsSasExpired = false;
+            return;
+        }
+
         var expiry = _credentialStore.ReadSasTokenExpiry(container);
 
         if (expiry.CouldNotParse)
@@ -418,6 +450,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditName = string.Empty;
         EditTags = string.Empty;
         EditContainerUrl = string.Empty;
+        EditAuthMode = BlobAuthMode.SasToken;
         EditSasToken = string.Empty;
         EditPathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
         EditBackupSourceType = BackupSourceType.Standalone;
@@ -441,6 +474,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditName = SelectedContainer.Name;
         EditTags = TagPalette.FormatTags(SelectedContainer.Tags);
         EditContainerUrl = SelectedContainer.ContainerUrl;
+        EditAuthMode = SelectedContainer.AuthMode;
         var storedToken = _credentialStore.GetSasToken(SelectedContainer);
         HasStoredSasToken = !string.IsNullOrEmpty(storedToken);
         EditSasToken = string.Empty; // Never show stored token; user can only replace it
@@ -474,8 +508,8 @@ public partial class BlobConfigViewModel : ViewModelBase
             return;
         }
 
-        bool haveTokenToSave = !string.IsNullOrWhiteSpace(EditSasToken);
-        if (IsNew && !haveTokenToSave)
+        bool haveTokenToSave = IsSasAuth && !string.IsNullOrWhiteSpace(EditSasToken);
+        if (IsNew && IsSasAuth && !haveTokenToSave)
         {
             SetError("SAS Token is required.");
             return;
@@ -501,6 +535,7 @@ public partial class BlobConfigViewModel : ViewModelBase
                 Id = BlobContainerConfig.NewId(),
                 Name = EditName,
                 ContainerUrl = EditContainerUrl.TrimEnd('/'),
+                AuthMode = EditAuthMode,
                 PathPattern = EditPathPattern,
                 BackupSourceType = EditBackupSourceType,
                 AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim(),
@@ -522,6 +557,7 @@ public partial class BlobConfigViewModel : ViewModelBase
             // Mutate in place - see ReplaceTags.
             ReplaceTags(container.Tags, TagPalette.ParseTags(EditTags));
             container.ContainerUrl = EditContainerUrl.TrimEnd('/');
+            container.AuthMode = EditAuthMode;
             container.PathPattern = EditPathPattern;
             container.BackupSourceType = EditBackupSourceType;
             container.BackupServerTimeZoneId = EditBackupServerTimeZone?.Id;
@@ -560,6 +596,15 @@ public partial class BlobConfigViewModel : ViewModelBase
                 SetError($"The container was saved, but the SAS token could not be stored: {ex.Message}");
                 return;
             }
+        }
+        else if (IsEntraAuth)
+        {
+            // Switching to Entra leaves no reason to keep the SAS token, and an organisation that
+            // has banned long-lived SAS has banned it wherever it is sitting - including in this
+            // machine's Credential Manager. After the config write, for the same reason the save
+            // itself is ordered that way.
+            _credentialStore.DeleteSecret(container.CredentialKey);
+            HasStoredSasToken = false;
         }
 
         SelectedContainer = container;

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -9,6 +9,9 @@
         <converters:HexToBrushConverter x:Key="HexToBrush" />
         <converters:BoolToEyeIconConverter x:Key="BoolToEyeIcon" />
         <converters:BackupSourceTypeToDisplayConverter x:Key="BackupSourceTypeDisplay" />
+        <converters:EnumToBoolConverter x:Key="EnumToBool" />
+        <converters:BlobAuthModeToDisplayConverter x:Key="BlobAuthModeDisplay" />
+        <converters:BlobAuthModeIsSasConverter x:Key="BlobAuthModeIsSas" />
     </UserControl.Resources>
 
     <Grid>
@@ -172,10 +175,19 @@
                                            Style="{StaticResource BodyText}"
                                            Margin="0,0,0,12" />
 
-                                <TextBlock Text="SAS TOKEN STATUS" Style="{StaticResource LabelText}" />
-                                <TextBlock Text="{Binding SasExpiryText}"
+                                <TextBlock Text="AUTHENTICATION" Style="{StaticResource LabelText}" />
+                                <TextBlock Text="{Binding SelectedContainer.AuthMode, Converter={StaticResource BlobAuthModeDisplay}}"
                                            Style="{StaticResource BodyText}"
                                            Margin="0,0,0,12" />
+
+                                <!-- Only under SAS. An expiry line against a container that has no
+                                     token of ours would send someone hunting for the wrong thing. -->
+                                <StackPanel Visibility="{Binding SelectedContainer.AuthMode, Converter={StaticResource BlobAuthModeIsSas}}">
+                                    <TextBlock Text="SAS TOKEN STATUS" Style="{StaticResource LabelText}" />
+                                    <TextBlock Text="{Binding SasExpiryText}"
+                                               Style="{StaticResource BodyText}"
+                                               Margin="0,0,0,12" />
+                                </StackPanel>
 
                                 <TextBlock Text="BACKUPS AT THIS LOCATION" Style="{StaticResource LabelText}" />
                                 <TextBlock Margin="0,0,0,12">
@@ -317,6 +329,44 @@
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,16" />
 
+                            <TextBlock Text="AUTHENTICATION" Style="{StaticResource LabelText}" />
+                            <StackPanel Margin="0,4,0,16">
+                                <RadioButton Content="SAS token"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=SasToken}"
+                                             Margin="0,0,0,8"
+                                             GroupName="BlobAuthMode"
+                                             ToolTip="A shared access signature stored in Windows Credential Manager." />
+                                <RadioButton Content="Entra ID - interactive (MFA)"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraInteractive}"
+                                             Margin="0,0,0,8"
+                                             GroupName="BlobAuthMode"
+                                             ToolTip="Opens a browser to sign in. Nothing is stored - the sign-in lasts for as long as the app is running." />
+                                <RadioButton Content="Entra ID - default"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraDefault}"
+                                             GroupName="BlobAuthMode"
+                                             ToolTip="Environment, then managed identity, then the Azure CLI or Visual Studio sign-in, then a prompt. The one to pick when this app runs on an Azure VM." />
+                            </StackPanel>
+
+                            <!-- Untested against a real tenant - see the note in the README. Said
+                                 here rather than only in the docs, because the person who finds out
+                                 is the one standing in front of this screen. -->
+                            <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                    BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                    BorderThickness="1" CornerRadius="4" Padding="10"
+                                    Margin="0,0,0,16"
+                                    Visibility="{Binding IsEntraAuth, Converter={StaticResource BoolToVis}}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
+                                               Text="Entra sign-in is built but has not been tested against a real tenant - there is no Entra-enabled storage account to develop it against. Test Connection will tell you honestly whether it works. Please report what happens either way." />
+                                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,8,0,0"
+                                               Text="Your account needs the Storage Blob Data Reader role on this container - Owner or Contributor on the subscription is not enough on its own. This covers browsing only: the RESTORE itself runs on SQL Server, which needs its own credential for the container URL." />
+                                </StackPanel>
+                            </Border>
+
+                            <StackPanel Visibility="{Binding IsSasAuth, Converter={StaticResource BoolToVis}}">
                             <TextBlock Text="SAS TOKEN" Style="{StaticResource LabelText}" />
                             <TextBlock Text="Token is stored securely and cannot be displayed. Enter a new token below to replace it."
                                        Style="{StaticResource SecondaryText}" FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap"
@@ -356,6 +406,7 @@
                                             Cursor="Hand" ToolTip="Show/hide SAS token" />
                                 </Grid>
                             </Grid>
+                            </StackPanel>
 
                             <TextBlock Text="BACKUPS AT THIS LOCATION" Style="{StaticResource LabelText}" />
                             <TextBlock Text="Choose whether this container holds standalone instance backups, Availability Group backups (Ola default naming), or both."

--- a/src/NineLives/packages.lock.json
+++ b/src/NineLives/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     "net10.0-windows7.0": {
+      "Azure.Identity": {
+        "type": "Direct",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Azure.Storage.Blobs": {
         "type": "Direct",
         "requested": "[12.29.1, )",


### PR DESCRIPTION
Closes #29. Pairs with #139 (#30) — an organisation that has banned SAS has usually also mandated Entra for SQL.

Many organisations now prohibit long-lived SAS tokens outright, which made the tool unusable for them regardless of its merits.

## ⚠️ Untested against a real tenant

There is no Entra-enabled storage account to develop this against. What is verified is **which credential the app uses and what it stops storing** — not that a token is accepted. The token flow belongs to `Azure.Identity`.

That caveat is on the container form itself, along with the thing that actually catches people out:

> Your account needs the Storage Blob Data Reader role on this container — Owner or Contributor on the subscription is not enough on its own. This covers browsing only: the RESTORE itself runs on SQL Server, which needs its own credential for the container URL.

## The two modes

| Mode | Credential | When |
| --- | --- | --- |
| Interactive (MFA) | `InteractiveBrowserCredential` | Any Entra account, including MFA. The sign-in lasts as long as the app runs and is written nowhere |
| Default | `DefaultAzureCredential` | Environment → managed identity → Azure CLI / VS → prompt. The one for running on an Azure VM |

Adds `Azure.Identity` — contrary to what the issue said, it was *not* already there transitively; only `Azure.Core` was.

## Details worth knowing

**Credentials are cached per mode, statically, for the life of the process.** A fresh one per operation means a fresh sign-in per operation — for interactive mode, a browser window every time the container is listed. Static because the token cache belongs to the signed-in user, not to whichever service instance asked first.

**Switching a container to Entra destroys its stored SAS token**, after the config write lands — same ordering rule the rest of the save path follows, so a refused save cannot throw away a token the container still needs. An organisation that has banned long-lived SAS has banned it wherever it is sitting, including this machine's Credential Manager.

**An Entra container never reports itself expired.** It has no token of ours to expire, and a warning plus a Refresh Token button for something that does not exist sends people hunting for the wrong problem. The SAS-only parts of the detail panel are hidden too.

**No migration.** A config file written before this existed has no value for the field, which lands on `SasToken` — the behaviour it already had. Pinned by a test that deserialises a legacy entry. The enum values are pinned for the same reason as #30: reordering would silently repoint every saved container at a different mode.

## Tests

23 new. The ones that matter: an Entra container builds a client with no stored token while a SAS container still refuses without one; the container URL is used untouched (a stray `?` would be sent to Azure as an empty SAS); expiry does not apply; switching destroys the token, and a refused switch does not.

Two XAML cases as well — the Entra section is collapsed in the default state the plain load test exercises, so none of its bindings were ever being evaluated. One of them caught a missing `EnumToBool` converter resource before it left my machine.

860 pass, build clean at `-warnaserror`. A fresh Release build is in `publish/`.
