### PR TITLE
Add the package Entra authentication actually needs (#30)

### DIFF
--- a/src/NineLives.Tests/EntraSqlAuthTests.cs
+++ b/src/NineLives.Tests/EntraSqlAuthTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.SqlClient;
+﻿using Microsoft.Data.SqlClient;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Xunit;
@@ -182,5 +182,46 @@ public class EntraSqlAuthTests
     public void TheStoredValuesArePinned(AuthMode mode, int expected)
     {
         Assert.Equal(expected, (int)mode);
+    }
+
+    // ── the provider has to exist ───────────────────────────────────────────────
+
+    /// <summary>
+    /// The regression, and the one thing about Entra that IS checkable without a tenant.
+    ///
+    /// Microsoft.Data.SqlClient 7.0 moved the Entra providers out of the main package and into
+    /// Microsoft.Data.SqlClient.Extensions.Azure. Without that package every Entra connection fails
+    /// at open with "Cannot find an authentication provider for 'ActiveDirectoryInteractive'" -
+    /// which is what the first person to try it hit.
+    ///
+    /// MSAL being present transitively is necessary but not sufficient, and checking for MSAL is
+    /// what was done instead of checking for this. Reverting the package reference fails all three.
+    /// </summary>
+    [Theory]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryInteractive)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryIntegrated)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryDefault)]
+    public void SomethingCanActuallyServiceTheAuthenticationMethod(SqlAuthenticationMethod method)
+    {
+        Assert.NotNull(SqlAuthenticationProvider.GetProvider(method));
+    }
+
+    /// <summary>
+    /// And it is the real provider from the Azure extension package, not some placeholder that
+    /// would fail later with a less helpful message.
+    ///
+    /// The driver discovers this at runtime. Discovery was checked against an actual single-file
+    /// self-contained publish - the shape this app ships in, where an assembly nothing references
+    /// from code could plausibly have been left behind - and it resolves there too.
+    /// </summary>
+    [Fact]
+    public void TheProviderIsTheOneFromTheAzureExtensionPackage()
+    {
+        var provider = SqlAuthenticationProvider.GetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive);
+
+        Assert.Equal(
+            "Microsoft.Data.SqlClient.ActiveDirectoryAuthenticationProvider",
+            provider!.GetType().FullName);
     }
 }

--- a/src/NineLives.Tests/packages.lock.json
+++ b/src/NineLives.Tests/packages.lock.json
@@ -112,6 +112,20 @@
           "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)"
         }
       },
+      "Microsoft.Data.SqlClient.Extensions.Azure": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "mJhONie3MuVXvSfBbtqGQAOGgeQDbOTfO5d0ZYo3KE4Vb7mua4O23lPJrsTYzvWn5od2CPAh0dHMZEWtJXcpxQ==",
+        "dependencies": {
+          "Azure.Core": "1.51.1",
+          "Azure.Identity": "1.18.0",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.Broker": "4.84.2"
+        }
+      },
       "Microsoft.Data.SqlClient.Internal.Logging": {
         "type": "Transitive",
         "resolved": "7.0.2",
@@ -208,10 +222,19 @@
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
-        "resolved": "4.83.1",
-        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "resolved": "4.84.2",
+        "contentHash": "Va9FjmABSgj/lcUfHH0pBNQkmS7SNyepz2ERV7Yynp6QgEYpFdSqR6Vzy1WWipN8GS5pBHuXoZbqaDWuARCrHQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Broker": {
+        "type": "Transitive",
+        "resolved": "4.84.2",
+        "contentHash": "928ySLeGz1xtvydwq6h9tv7TbxrtA4ZzavLKUqRJh0PW6BGcEJwpI8W8vf2PlQdYemGm/oyGjdzYzdY/I8r/4A==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.NativeInterop": "0.20.6"
         }
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
@@ -221,6 +244,11 @@
         "dependencies": {
           "Microsoft.Identity.Client": "4.83.1"
         }
+      },
+      "Microsoft.Identity.Client.NativeInterop": {
+        "type": "Transitive",
+        "resolved": "0.20.6",
+        "contentHash": "noyfdMfVxyWpM6xUDmlW6gUvZ5ci24z7Qoy15JvynTQfZV5vTD2NEdsnT5Gy4ngViwgdIp5iRjRy10jAKXFAgw=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -363,7 +391,8 @@
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
           "CommunityToolkit.Mvvm": "[8.4.2, )",
-          "Microsoft.Data.SqlClient": "[7.0.2, )"
+          "Microsoft.Data.SqlClient": "[7.0.2, )",
+          "Microsoft.Data.SqlClient.Extensions.Azure": "[7.0.2, )"
         }
       }
     }

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -33,6 +33,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NineLives/packages.lock.json
+++ b/src/NineLives/packages.lock.json
@@ -43,6 +43,21 @@
           "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)"
         }
       },
+      "Microsoft.Data.SqlClient.Extensions.Azure": {
+        "type": "Direct",
+        "requested": "[7.0.2, )",
+        "resolved": "7.0.2",
+        "contentHash": "mJhONie3MuVXvSfBbtqGQAOGgeQDbOTfO5d0ZYo3KE4Vb7mua4O23lPJrsTYzvWn5od2CPAh0dHMZEWtJXcpxQ==",
+        "dependencies": {
+          "Azure.Core": "1.51.1",
+          "Azure.Identity": "1.18.0",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.Broker": "4.84.2"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.55.0",
@@ -180,10 +195,19 @@
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
-        "resolved": "4.83.1",
-        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "resolved": "4.84.2",
+        "contentHash": "Va9FjmABSgj/lcUfHH0pBNQkmS7SNyepz2ERV7Yynp6QgEYpFdSqR6Vzy1WWipN8GS5pBHuXoZbqaDWuARCrHQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Broker": {
+        "type": "Transitive",
+        "resolved": "4.84.2",
+        "contentHash": "928ySLeGz1xtvydwq6h9tv7TbxrtA4ZzavLKUqRJh0PW6BGcEJwpI8W8vf2PlQdYemGm/oyGjdzYzdY/I8r/4A==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.NativeInterop": "0.20.6"
         }
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
@@ -193,6 +217,11 @@
         "dependencies": {
           "Microsoft.Identity.Client": "4.83.1"
         }
+      },
+      "Microsoft.Identity.Client.NativeInterop": {
+        "type": "Transitive",
+        "resolved": "0.20.6",
+        "contentHash": "noyfdMfVxyWpM6xUDmlW6gUvZ5ci24z7Qoy15JvynTQfZV5vTD2NEdsnT5Gy4ngViwgdIp5iRjRy10jAKXFAgw=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -298,6 +327,11 @@
         "type": "Transitive",
         "resolved": "6.0.2",
         "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.Identity.Client.NativeInterop": {
+        "type": "Transitive",
+        "resolved": "0.20.6",
+        "contentHash": "noyfdMfVxyWpM6xUDmlW6gUvZ5ci24z7Qoy15JvynTQfZV5vTD2NEdsnT5Gy4ngViwgdIp5iRjRy10jAKXFAgw=="
       }
     }
   }


### PR DESCRIPTION
Follow-up to #139. The first real attempt to connect with an Entra account failed at open:

> Connection failed: Cannot find an authentication provider for 'ActiveDirectoryInteractive'. Install the 'Microsoft.Data.SqlClient.Extensions.Azure' NuGet package to use Active Directory (Entra ID) authentication methods.

## What went wrong

`Microsoft.Data.SqlClient` 7.0 moved the Entra providers out of the main package and into `Microsoft.Data.SqlClient.Extensions.Azure`.

In #139 I checked that MSAL was present transitively and concluded no package was needed. MSAL is *necessary* but not *sufficient* — it does the token acquisition, but the thing that plugs it into the driver ships separately. I checked for the dependency instead of the capability, and everything I wrote passed because none of it opened a connection.

## The fix, and why it will not come back

One package reference. What matters more is that **this turned out to be the one part of Entra that is checkable offline** — no tenant needed to ask whether anything can service the authentication method:

```csharp
Assert.NotNull(SqlAuthenticationProvider.GetProvider(method));
```

Three tests, one per method, plus one pinning that the provider is the real `ActiveDirectoryAuthenticationProvider` rather than a placeholder that would fail later with a worse message. All four fail with the package reference reverted — checked, not assumed.

That is the gap in #139 closed properly: it had tests for the connection string and nothing for whether the driver could act on it.

## One thing verified rather than assumed

The driver discovers the provider at runtime, and the release is a **single-file self-contained** publish — where an assembly nothing references from code could plausibly be left behind, and where the test host proves nothing because it is an ordinary directory of DLLs.

I nearly shipped an explicit `SqlAuthenticationProvider.SetProvider` call as insurance. Instead I built that exact publish shape and checked: all three methods resolve. So the insurance came back out — speculative code justified by an unverified hypothesis is worse than no code.

## Still untested end to end

The caveat on the form stays until a sign-in is confirmed working. We now know the connection string reaches the driver correctly, since the failure was on the far side of it.

864 tests pass, build clean at `-warnaserror`. Fresh Release build in `publish/`.
