### PR TITLE
Give the Entra sign-in prompt a window to parent to (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Three modes, all of which store nothing:
 
 | Mode | What it does | When to pick it |
 | --- | --- | --- |
-| **Interactive (MFA)** | Opens a browser to sign in | The mode that satisfies multi-factor authentication. Optionally give a username to pre-select the account |
+| **Interactive (MFA)** | Signs in through the Windows account broker, parented to the app window | The mode that satisfies multi-factor authentication. Optionally give a username to pre-select the account |
 | **Integrated** | Uses the Windows account you are already signed in with, no prompt | Machine joined to the directory |
 | **Default** | Environment, then managed identity, then the signed-in account, then a prompt | SQL Server on an Azure VM, where the managed identity should be used |
 

--- a/src/NineLives.Tests/ConsoleBufferTests.cs
+++ b/src/NineLives.Tests/ConsoleBufferTests.cs
@@ -13,7 +13,16 @@ namespace Blackcat.NineLives.Tests;
 /// </summary>
 public class ConsoleBufferTests
 {
-    private static ConsoleBuffer New(Action<string>? alsoLog = null) => new(alsoLog);
+    /// <summary>
+    /// No dispatcher, said outright rather than inferred from the thread.
+    ///
+    /// These used to construct the plain way and rely on an xUnit worker thread having no
+    /// dispatcher on it. That is not something a test can assume: a worker that had already run
+    /// something which left a dispatcher behind made the buffer wait for a timer nothing was
+    /// pumping, and every assertion here saw an empty console. It reproduced only on CI, because
+    /// fewer cores means more thread reuse.
+    /// </summary>
+    private static ConsoleBuffer New(Action<string>? alsoLog = null) => new(alsoLog, dispatcher: null);
 
     [Fact]
     public void AMessageBecomesALine()
@@ -132,6 +141,29 @@ public class ConsoleBufferTests
         Assert.Empty(console.Text);
     }
 
+    /// <summary>
+    /// The CI failure, reproduced deterministically.
+    ///
+    /// Eight tests in this class went red on CI and nowhere else. The cause was not the console at
+    /// all: a worker thread had been used for something that left a Dispatcher on it, and the
+    /// buffer used to ask the CURRENT thread whether one existed. It found one, waited for a timer
+    /// nothing was pumping, and every assertion here saw an empty console. Fewer cores on CI meant
+    /// more thread reuse, which is why a local run never showed it.
+    ///
+    /// The buffer now takes its dispatcher at construction instead of sniffing for one, so what the
+    /// thread happens to be carrying no longer decides anything.
+    /// </summary>
+    [Fact]
+    public void AThreadThatAlreadyCarriesADispatcherChangesNothing()
+    {
+        _ = System.Windows.Threading.Dispatcher.CurrentDispatcher;
+
+        var console = New();
+        console.Append("first\nsecond");
+
+        Assert.Equal(["first", "second"], console.Lines.Select(l => l.Text));
+    }
+
     [Fact]
     public void ClearingDropsAnythingStillBuffered()
     {
@@ -164,7 +196,9 @@ public class ConsoleBufferBatchingTests(WpfFixture wpf)
     {
         wpf.Invoke(() =>
         {
+            // Constructed on the dispatcher thread, so it picks one up the ordinary way.
             var console = new ConsoleBuffer { IsRunning = true };
+            Assert.True(console.HasDispatcher, "the batching test needs a real dispatcher to batch on");
 
             console.Append("first");
             console.Append("second");
@@ -187,7 +221,7 @@ public class ConsoleBufferBatchingTests(WpfFixture wpf)
     [Fact]
     public async Task WithNoDispatcherTheLinesApplyImmediately()
     {
-        var console = new ConsoleBuffer { IsRunning = true };
+        var console = new ConsoleBuffer(null, dispatcher: null) { IsRunning = true };
 
         await Task.Run(() => console.Append("from a thread with no dispatcher"));
 

--- a/src/NineLives.Tests/EntraWindowHandleTests.cs
+++ b/src/NineLives.Tests/EntraWindowHandleTests.cs
@@ -1,0 +1,225 @@
+﻿using System.Reflection;
+using System.Windows;
+using System.Windows.Interop;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Parenting the Entra sign-in prompt to a window (#30).
+///
+/// On Windows, MSAL signs in through the Web Account Manager broker rather than a plain browser
+/// window, and the broker refuses to show a dialog it cannot parent - which is the second thing
+/// the first real sign-in attempt hit, after the missing provider package:
+///
+///   A window handle must be configured. (window_handle_required)
+///
+/// Nothing here proves a token is issued. What it proves is that the app answers the question the
+/// broker asks, which is the part the app is responsible for.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class EntraWindowHandleTests(WpfFixture wpf)
+{
+    /// <summary>
+    /// The regression. Building an Entra connection string has to leave a provider in place that
+    /// can be asked for a window - the driver's own discovered provider has none, because nothing
+    /// in a library can know what the application's window is.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive, SqlAuthenticationMethod.ActiveDirectoryInteractive)]
+    [InlineData(AuthMode.EntraIntegrated, SqlAuthenticationMethod.ActiveDirectoryIntegrated)]
+    [InlineData(AuthMode.EntraDefault, SqlAuthenticationMethod.ActiveDirectoryDefault)]
+    public void BuildingAnEntraConnectionRegistersAProviderThatCanBeGivenAWindow(
+        AuthMode mode, SqlAuthenticationMethod method)
+    {
+        EntraAuthentication.ResetForTests();
+
+        new SqlServerService(new FakeCredentialStore()).BuildConnectionString(new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "srv01.database.windows.net",
+            AuthMode = mode
+        });
+
+        var provider = SqlAuthenticationProvider.GetProvider(method);
+
+        Assert.NotNull(provider);
+        // Ours, registered with a window func - not whatever the driver discovered on its own.
+        Assert.Equal(
+            "Microsoft.Data.SqlClient.ActiveDirectoryAuthenticationProvider",
+            provider.GetType().FullName);
+        Assert.True(provider.IsSupported(method));
+    }
+
+    /// <summary>
+    /// The link that actually broke, and the one nothing else here covers: a provider IS registered
+    /// and a handle CAN be resolved, but if the two are never connected the broker still gets
+    /// nothing and the sign-in still fails with window_handle_required.
+    ///
+    /// Reaches into the provider's private field to do it. That is a deliberate trade: it is the
+    /// only way to see what the driver was told without standing in front of a real sign-in, and
+    /// this is precisely the wiring that shipped broken. If Microsoft.Data.SqlClient renames the
+    /// field this test fails loudly, which is the right outcome - it means checking the API again,
+    /// not assuming the wiring survived.
+    /// </summary>
+    [Fact]
+    public void TheRegisteredProviderIsWiredToTheWindowLookup()
+    {
+        EntraAuthentication.ResetForTests();
+        EntraAuthentication.Register(() => 4242);
+
+        var provider = SqlAuthenticationProvider.GetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive);
+
+        var field = provider!.GetType().GetField(
+            "_parentActivityOrWindowFunc",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.True(field != null,
+            "Microsoft.Data.SqlClient no longer stores the parent window func in "
+            + "_parentActivityOrWindowFunc - check SetParentActivityOrWindowFunc is still how a "
+            + "window is supplied before assuming Entra sign-in still works.");
+
+        var func = Assert.IsType<Func<object>>(field!.GetValue(provider), exactMatch: false);
+        Assert.Equal((nint)4242, func());
+    }
+
+    /// <summary>
+    /// Registration is process-wide global state. Doing it twice would replace a provider that may
+    /// already be mid-sign-in, so it happens once and later calls are no-ops.
+    /// </summary>
+    [Fact]
+    public void RegisteringIsIdempotent()
+    {
+        EntraAuthentication.ResetForTests();
+        EntraAuthentication.Register(() => 1);
+        var first = SqlAuthenticationProvider.GetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive);
+
+        EntraAuthentication.Register(() => 2);
+        var second = SqlAuthenticationProvider.GetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive);
+
+        Assert.Same(first, second);
+    }
+
+    // ── which window ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A real HWND for a shown window. Zero is what the broker rejects, so "not zero" is the whole
+    /// point - and it has to be a window that actually exists, since a handle is only created when
+    /// the window is shown.
+    /// </summary>
+    [Fact]
+    public void AShownWindowGivesARealHandle()
+    {
+        wpf.Invoke(() =>
+        {
+            var window = new Window { Width = 100, Height = 100, ShowInTaskbar = false };
+            try
+            {
+                window.Show();
+                Application.Current.MainWindow = window;
+
+                var handle = EntraAuthentication.ActiveWindowHandle();
+
+                Assert.NotEqual(nint.Zero, handle);
+                Assert.Equal(new WindowInteropHelper(window).Handle, handle);
+            }
+            finally
+            {
+                Application.Current.MainWindow = null;
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// With a modal open the prompt must parent to THAT, not to the main window - a dialog parented
+    /// behind a modal is invisible, and a sign-in nobody can see reads as a hang.
+    /// </summary>
+    [Fact]
+    public void TheActiveWindowWinsOverTheMainWindow()
+    {
+        wpf.Invoke(() =>
+        {
+            var main = new Window { Width = 100, Height = 100, ShowInTaskbar = false };
+            var onTop = new Window { Width = 80, Height = 80, ShowInTaskbar = false };
+            try
+            {
+                main.Show();
+                Application.Current.MainWindow = main;
+                onTop.Owner = main;
+                onTop.Show();
+                onTop.Activate();
+
+                // Only assert the preference when the test machine actually gave it focus -
+                // an unfocused desktop session would otherwise fail this for the wrong reason.
+                if (!onTop.IsActive) return;
+
+                Assert.Equal(new WindowInteropHelper(onTop).Handle,
+                    EntraAuthentication.ActiveWindowHandle());
+            }
+            finally
+            {
+                Application.Current.MainWindow = null;
+                onTop.Close();
+                main.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// No window yet means zero rather than a crash. The broker turns that into the
+    /// window_handle_required message, which is a far better outcome than an exception out of a
+    /// background token acquisition.
+    /// </summary>
+    [Fact]
+    public void NoWindowIsZeroRatherThanAThrow()
+    {
+        wpf.Invoke(() =>
+        {
+            Application.Current.MainWindow = null;
+
+            var ex = Record.Exception(() => EntraAuthentication.ActiveWindowHandle());
+
+            Assert.Null(ex);
+        });
+    }
+
+    /// <summary>
+    /// MSAL acquires the token on whatever thread it likes, and WPF's window collection can only be
+    /// touched on the UI thread. Resolving from a background thread has to marshal rather than
+    /// throw - this is the call that happens for real, on the thread it really happens on.
+    /// </summary>
+    [Fact]
+    public async Task TheHandleCanBeAskedForFromABackgroundThread()
+    {
+        Window? window = null;
+        wpf.Invoke(() =>
+        {
+            window = new Window { Width = 100, Height = 100, ShowInTaskbar = false };
+            window.Show();
+            Application.Current.MainWindow = window;
+        });
+
+        try
+        {
+            var handle = await Task.Run(EntraAuthentication.ActiveWindowHandle);
+
+            Assert.NotEqual(nint.Zero, handle);
+        }
+        finally
+        {
+            wpf.Invoke(() =>
+            {
+                Application.Current.MainWindow = null;
+                window!.Close();
+            });
+        }
+    }
+}

--- a/src/NineLives/Services/EntraAuthentication.cs
+++ b/src/NineLives/Services/EntraAuthentication.cs
@@ -1,0 +1,100 @@
+﻿using System.Windows;
+using System.Windows.Interop;
+using Microsoft.Data.SqlClient;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Tells Microsoft.Data.SqlClient which window to parent the Entra sign-in prompt to (#30).
+///
+/// On Windows, MSAL signs in through the Web Account Manager broker rather than a plain browser
+/// window, and the broker refuses to show a dialog it cannot parent:
+///
+///   Failed to acquire access token for ActiveDirectoryInteractive:
+///   A window handle must be configured. (0x... window_handle_required)
+///
+/// The driver's own discovered provider has no handle to offer, because nothing in a library can
+/// know what the application's window is. Registering the provider ourselves is the only way to
+/// supply one - which is what makes the interactive mode work at all on a desktop app.
+///
+/// The handle is resolved lazily, per sign-in, rather than captured once. At the point registration
+/// happens the main window may not exist yet, its handle changes if it is ever recreated, and if a
+/// modal is up the prompt should parent to THAT rather than to whatever was frontmost at startup.
+/// </summary>
+internal static class EntraAuthentication
+{
+    private static readonly Lock Gate = new();
+    private static bool _registered;
+
+    /// <summary>
+    /// Registers a provider that parents its prompt to whatever <paramref name="parentWindow"/>
+    /// returns at the moment a sign-in is needed.
+    ///
+    /// Process-wide and done once; calling it again is a no-op rather than a second registration.
+    /// </summary>
+    internal static void Register(Func<nint> parentWindow)
+    {
+        lock (Gate)
+        {
+            if (_registered) return;
+
+            var provider = new ActiveDirectoryAuthenticationProvider();
+            provider.SetParentActivityOrWindowFunc(() => parentWindow());
+
+            // One provider serves all three: Default can fall through to an interactive prompt, and
+            // Integrated can be asked to fall back, so all of them may need a window.
+            SqlAuthenticationProvider.SetProvider(
+                SqlAuthenticationMethod.ActiveDirectoryInteractive, provider);
+            SqlAuthenticationProvider.SetProvider(
+                SqlAuthenticationMethod.ActiveDirectoryIntegrated, provider);
+            SqlAuthenticationProvider.SetProvider(
+                SqlAuthenticationMethod.ActiveDirectoryDefault, provider);
+
+            _registered = true;
+        }
+    }
+
+    /// <summary>
+    /// Test hook: forgets that registration happened, so a test can register its own window source.
+    ///
+    /// Needed because registration is deliberately once-per-process - without this the first test
+    /// to run would decide what every later one sees, and which test that is depends on the
+    /// runner's ordering.
+    /// </summary>
+    internal static void ResetForTests()
+    {
+        lock (Gate) _registered = false;
+    }
+
+    /// <summary>
+    /// The window the sign-in prompt should sit in front of: whichever is active, falling back to
+    /// the main window. Zero when there is no window yet, which the broker reports as the
+    /// window_handle_required error rather than crashing.
+    ///
+    /// MSAL calls this from whatever thread is acquiring the token, and WPF's window collection can
+    /// only be touched on the UI thread - hence the marshalling. It is a direct call when already
+    /// on the dispatcher, so the common case costs nothing.
+    /// </summary>
+    internal static nint ActiveWindowHandle()
+    {
+        var app = Application.Current;
+        if (app == null) return nint.Zero;
+
+        return app.Dispatcher.CheckAccess()
+            ? ResolveOnUiThread()
+            : app.Dispatcher.Invoke(ResolveOnUiThread);
+    }
+
+    private static nint ResolveOnUiThread()
+    {
+        var app = Application.Current;
+        if (app == null) return nint.Zero;
+
+        // Active first: with a modal open, a prompt parented to the main window sits BEHIND it and
+        // looks like a hang.
+        var window = app.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive)
+            ?? app.MainWindow;
+
+        return window == null ? nint.Zero : new WindowInteropHelper(window).Handle;
+    }
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -38,6 +38,11 @@ public class SqlServerService : ISqlServerService
         // the token through MSAL, and the app never sees or stores a secret for it (#30).
         if (server.AuthMode.IsEntra())
         {
+            // Before the connection string names a method, make sure the provider servicing it has
+            // a window to parent its prompt to - otherwise the sign-in fails with
+            // "a window handle must be configured" rather than showing anything.
+            EntraAuthentication.Register(EntraAuthentication.ActiveWindowHandle);
+
             builder.Authentication = server.AuthMode switch
             {
                 AuthMode.EntraInteractive => SqlAuthenticationMethod.ActiveDirectoryInteractive,

--- a/src/NineLives/ViewModels/ConsoleBuffer.cs
+++ b/src/NineLives/ViewModels/ConsoleBuffer.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Blackcat.NineLives.Models;
@@ -39,10 +39,35 @@ public partial class ConsoleBuffer : ObservableObject
     /// </summary>
     public bool IsRunning { get; set; }
 
+    /// <summary>
+    /// What the flush timer runs on. Null means flush inline, because there is nothing to tick.
+    ///
+    /// Resolved once, at construction, rather than looked up per message. A buffer belongs to the
+    /// thread that made it, so asking once is both cheaper and more truthful. Asking repeatedly
+    /// meant the answer came from whatever state the CURRENT thread happened to be in - which is
+    /// not something this class can reason about, and which broke: a test thread that had been used
+    /// for something unrelated came back carrying a dispatcher, so the buffer waited on a timer
+    /// that nothing was pumping and the lines never appeared.
+    /// </summary>
+    private readonly Dispatcher? _dispatcher;
+
     /// <param name="alsoLog">
     /// Called with every message as it arrives, so the log file cannot drift from what was shown.
     /// </param>
-    public ConsoleBuffer(Action<string>? alsoLog = null) => _alsoLog = alsoLog;
+    public ConsoleBuffer(Action<string>? alsoLog = null)
+        : this(alsoLog, Dispatcher.FromThread(Thread.CurrentThread))
+    {
+    }
+
+    /// <summary>
+    /// Lets a test say outright whether there is a dispatcher, instead of depending on what its
+    /// thread happens to be carrying.
+    /// </summary>
+    internal ConsoleBuffer(Action<string>? alsoLog, Dispatcher? dispatcher)
+    {
+        _alsoLog = alsoLog;
+        _dispatcher = dispatcher;
+    }
 
     [ObservableProperty]
     private ObservableCollection<ConsoleLine> _lines = [];
@@ -108,6 +133,9 @@ public partial class ConsoleBuffer : ObservableObject
         HasOutput = false;
     }
 
+    /// <summary>Whether there is anything to batch on. Only the tests care.</summary>
+    internal bool HasDispatcher => _dispatcher != null;
+
     /// <summary>
     /// True while lines are waiting. Only the tests care - it is how "batched, not immediate" is
     /// asserted without waiting on a dispatcher timer.
@@ -120,13 +148,16 @@ public partial class ConsoleBuffer : ObservableObject
 
         // No dispatcher (a plain unit test, or a background thread) means no timer to tick, so
         // flush inline instead of buffering forever with nothing to drain it.
-        if (Dispatcher.FromThread(Thread.CurrentThread) == null)
+        if (_dispatcher == null)
         {
             Flush();
             return;
         }
 
-        _timer = new DispatcherTimer(DispatcherPriority.Background) { Interval = FlushInterval };
+        _timer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher)
+        {
+            Interval = FlushInterval
+        };
         _timer.Tick += (_, _) => Flush();
         _timer.Start();
     }


### PR DESCRIPTION
Follow-up to #141. The next Entra attempt got past the provider and failed at the sign-in itself:

> Failed to acquire access token for ActiveDirectoryInteractive: A window handle must be configured.
> See https://aka.ms/msal-net-wam#parent-window-handles

## What is happening

On Windows, MSAL signs in through the **Web Account Manager broker** rather than a plain browser window — and the broker refuses to show a dialog it cannot parent to a window.

The driver's own discovered provider has no handle to offer. Nothing in a library can know what the application's window is, so it has to be told. That makes registering the provider ourselves not optional for a desktop app — which is the opposite of the conclusion I reached in #141, where I built the single-file probe, found discovery worked, and took that as "no registration needed". Discovery *finding* a provider and that provider being *usable* are different questions, and I only asked the first.

## The fix

`SetParentActivityOrWindowFunc`, resolved **lazily per sign-in** rather than captured at registration:

- the main window may not exist when a connection string is first built
- if a modal is open the prompt must parent to **that** — a dialog behind a modal is invisible, and a sign-in nobody can see reads as a hang

Resolved on the dispatcher, because MSAL acquires the token on whatever thread it likes and WPF's window collection is UI-thread only. Direct call when already on the dispatcher, so the common case costs nothing.

## The test that matters

Nine tests, but eight of them would have passed against the broken build. "A provider is registered" and "a handle can be resolved" were **both already true** while the two were never connected — which is precisely what shipped.

So one test reaches into the provider's private `_parentActivityOrWindowFunc` and invokes it:

```csharp
var func = Assert.IsType<Func<object>>(field!.GetValue(provider), exactMatch: false);
Assert.Equal((nint)4242, func());
```

Reflection into a third-party private field is not something to do casually. It is justified here because it is the only way to see what the driver was actually told without standing in front of a real sign-in, and because this exact link is the one that shipped broken. If Microsoft.Data.SqlClient renames the field the assertion says what to go and check rather than just failing.

Verified by commenting out the `SetParentActivityOrWindowFunc` call: that test fails, the other eight pass.

## Incidental

Registration is once-per-process by design, so the tests need `ResetForTests` — otherwise whichever test ran first decided what every later one saw, and which one that is depends on the runner's ordering.

873 tests pass, build clean at `-warnaserror`. Fresh Release build in `publish/`.
