### PR TITLE
Test Connection has to know the container uses Entra (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,11 +233,6 @@ perfectly valid combination.
 
 #### Entra ID authentication
 
-> **Untested against a real tenant.** There is no Entra-enabled instance to develop this against, so
-> what is verified is the connection string handed to the driver, not that a sign-in succeeds. The
-> token flow itself belongs to `Microsoft.Data.SqlClient`. **Test Connection** will tell you honestly
-> whether it works — please open an issue either way.
-
 Three modes, all of which store nothing:
 
 | Mode | What it does | When to pick it |

--- a/src/NineLives.Tests/EntraBlobAuthTests.cs
+++ b/src/NineLives.Tests/EntraBlobAuthTests.cs
@@ -234,6 +234,81 @@ public class EntraBlobAuthTests
         Assert.True(vm.HasUnsavedChanges);
     }
 
+    // ── Test Connection ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The regression. Test Connection builds its own config from the form rather than using the
+    /// saved one, and it was not carrying the authentication mode - so an Entra container fell
+    /// through to the SAS path and was refused with "No SAS token found. Please configure the SAS
+    /// token for this container" for a container that is never going to have one.
+    ///
+    /// The Save path had tests. This one did not, and it is the button people press first.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public async Task TestingANewEntraContainerUsesEntraRatherThanLookingForASasToken(BlobAuthMode mode)
+    {
+        var blob = new FakeBlobStorageService();
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditAuthMode = mode;
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.False(vm.HasError, vm.ErrorMessage);
+        Assert.NotNull(blob.LastConfig);
+        Assert.Equal(mode, blob.LastConfig.AuthMode);
+        Assert.Equal("https://mystorageaccount.blob.core.windows.net/backups", blob.LastConfig.ContainerUrl);
+    }
+
+    /// <summary>
+    /// And switching an existing SAS container to Entra tests as Entra, before it is saved -
+    /// otherwise Test Connection answers for the mode the container used to be in.
+    /// </summary>
+    [Fact]
+    public async Task TestingAfterSwitchingAnExistingContainerUsesTheNewMode()
+    {
+        var store = new FakeCredentialStore();
+        var existing = Container(BlobAuthMode.SasToken);
+        store.Config.BlobContainers.Add(existing);
+        store.SaveSasToken(existing, "sv=2024-01-01&sig=old");
+
+        var blob = new FakeBlobStorageService();
+        var vm = new BlobConfigViewModel(store, blob);
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.Equal(BlobAuthMode.EntraInteractive, blob.LastConfig!.AuthMode);
+    }
+
+    /// <summary>
+    /// A SAS container still tests with the token being typed, unsaved - the #12 behaviour, which
+    /// the Entra branch must not have disturbed.
+    /// </summary>
+    [Fact]
+    public async Task TestingASasContainerStillUsesTheUnsavedToken()
+    {
+        var blob = new FakeBlobStorageService();
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2024-01-01&sig=being-typed";
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.Equal(BlobAuthMode.SasToken, blob.LastConfig!.AuthMode);
+        Assert.Equal("sv=2024-01-01&sig=being-typed", blob.LastConfig.UnsavedSasToken);
+    }
+
     /// <summary>
     /// The stored values are what config.json holds. Reordering would silently repoint every saved
     /// container at a different authentication mode, and a container written before this existed

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -78,8 +78,17 @@ public sealed class FakeBlobStorageService : IBlobStorageService
 
     public int ListCalls { get; private set; }
 
+    /// <summary>
+    /// The config the ViewModel actually handed over. What is on the form has to reach the service
+    /// intact - the authentication mode failing to make that trip is what shipped broken in #29.
+    /// </summary>
+    public BlobContainerConfig? LastConfig { get; private set; }
+
     public Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
-        => Task.FromResult(true);
+    {
+        LastConfig = config;
+        return Task.FromResult(true);
+    }
 
     public Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default)
         => Task.FromResult(new List<string>());

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -681,7 +681,22 @@ public partial class BlobConfigViewModel : ViewModelBase
         BlobContainerConfig? config;
         if (IsEditing)
         {
-            if (HasStoredSasToken && string.IsNullOrWhiteSpace(EditSasToken))
+            if (IsEntraAuth)
+            {
+                // Nothing stored to fall back on, and nothing needed - the token comes from the
+                // signed-in account. Built from the form, so what is tested is the URL on screen.
+                //
+                // Carrying the mode is the whole point: without it this fell through to the SAS
+                // branch below and refused with "No SAS token found" for a container that is never
+                // going to have one (#29).
+                config = new BlobContainerConfig
+                {
+                    Name = EditName,
+                    ContainerUrl = EditContainerUrl,
+                    AuthMode = EditAuthMode
+                };
+            }
+            else if (HasStoredSasToken && string.IsNullOrWhiteSpace(EditSasToken))
                 config = SelectedContainer; // Use stored token for test
             else
             {

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -42,8 +42,6 @@ public partial class ServerManagerViewModel : ViewModelBase
     /// </summary>
     public bool ShowsUsername => EditAuthMode.AcceptsUsername();
 
-    public bool IsEntraAuth => EditAuthMode.IsEntra();
-
     public string UsernameLabel => EditAuthMode == AuthMode.EntraInteractive
         ? "USERNAME (OPTIONAL - PRE-SELECTS THE ACCOUNT)"
         : "USERNAME";
@@ -52,7 +50,6 @@ public partial class ServerManagerViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(IsSqlAuth));
         OnPropertyChanged(nameof(ShowsUsername));
-        OnPropertyChanged(nameof(IsEntraAuth));
         OnPropertyChanged(nameof(UsernameLabel));
     }
 

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -303,18 +303,6 @@
                                              ToolTip="Lets the driver choose: environment, then managed identity, then the signed-in account, then a prompt. The one to pick for SQL Server on an Azure VM." />
                             </StackPanel>
 
-                            <!-- Untested against a real tenant - see the note in the README. Said
-                                 here rather than only in the docs, because the person who finds out
-                                 is the one standing in front of this screen. -->
-                            <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
-                                    BorderBrush="{DynamicResource WarningPanelBorderBrush}"
-                                    BorderThickness="1" CornerRadius="4" Padding="10"
-                                    Margin="0,0,0,16"
-                                    Visibility="{Binding IsEntraAuth, Converter={StaticResource BoolToVis}}">
-                                <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
-                                           Text="Entra sign-in is built but has not been tested against a real tenant - there is no Entra-enabled instance to develop it against. The connection string is what Microsoft documents, and Test Connection will tell you honestly whether it works. Please report what happens either way." />
-                            </Border>
-
                             <!-- Username: required for SQL auth, an optional account hint for
                                  interactive Entra. Password: SQL auth only - the Entra modes have
                                  no secret for the app to hold, which is the point of using them. -->


### PR DESCRIPTION
Two things, both following on from a real Entra session.

## Test Connection thought every container used SAS

Testing an Entra container was refused with:

> Connection failed: No SAS token found. Please configure the SAS token for this container.

…for a container that is never going to have one.

Test Connection deliberately builds its **own** config from the form rather than using the saved one, so that the URL being typed is the one tested. That config was not carrying `AuthMode`, so every test fell through to the SAS path regardless of what was selected.

Two distinct cases, both real:

| Case | What happened |
| --- | --- |
| New Entra container | Reached the "unsaved token" branch, which carried no mode |
| Existing SAS container switched to Entra | Fell to "use the stored token", testing as the mode it *used to be* in |

The Save path had tests for all of this. Test Connection had none — and it is the button people press first. That is the actual lesson here: I tested the path that persists and skipped the path that validates, when validation is what runs first and what the user judges the feature by.

`FakeBlobStorageService` now records the config it was handed, so a test can assert that what is on the form reaches the service intact. That is precisely the trip the mode failed to make. Verified by disabling each branch in turn and watching the corresponding test fail.

## The SQL caveat comes off

Entra sign-in to SQL Server is **confirmed working against a real tenant**, so the "untested" panel is gone from the server form and the matching blockquote from the README. It took two fixes to get there — the missing `Microsoft.Data.SqlClient.Extensions.Azure` package (#141) and the parent window handle for the WAM broker (#142).

The blob caveat stays until the same is true there.

Incidentally removed `IsEntraAuth` from `ServerManagerViewModel`, which the deleted panel was the only consumer of.

878 tests pass, build clean at `-warnaserror`.
