### PR TITLE
Say who was refused and what role is missing (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,19 +199,22 @@ The executable will be created at `./publish/NineLives.exe`.
 
 #### Entra ID for Blob Storage
 
-> **Untested against a real tenant.** There is no Entra-enabled storage account to develop this
-> against, so what is verified is which credential the app uses and what it stops storing — not that
-> a token is accepted. **Test Connection** will tell you honestly whether it works; please open an
-> issue either way.
-
 | Mode | What it does | When to pick it |
 | --- | --- | --- |
 | **Interactive (MFA)** | Opens a browser to sign in. The sign-in lasts as long as the app is running and is written nowhere | Any Entra-enabled account, including MFA |
 | **Default** | Environment, then managed identity, then Azure CLI / Visual Studio sign-in, then a prompt | Running the app on an Azure VM with a managed identity |
 
-Your account needs **Storage Blob Data Reader** on the container. Owner or Contributor on the
-subscription is not enough on its own — the data-plane roles are separate from the management-plane
-ones, which is the usual first surprise.
+Your account needs **Storage Blob Data Reader** on the container. Owner or Contributor is **not**
+enough — blob *data* access is a separate set of roles from the ones that administer the account,
+which is the usual first surprise.
+
+If another tool works with the same account, that is not a contradiction. Azure Storage Explorer
+commonly falls back to the storage **account key**, which Owner *can* fetch through the management
+plane, so it never exercises the role at all.
+
+When a permission error does appear, **Test Connection names the account it signed in as**. Checking
+that first is worth doing — a 403 against an account that demonstrably has access usually means a
+different account or tenant was used than the one being thought about.
 
 Switching a container from SAS to Entra deletes its stored token from Windows Credential Manager. An
 organisation that has banned long-lived SAS has banned it wherever it is sitting.

--- a/src/NineLives.Tests/EntraDiagnosticsTests.cs
+++ b/src/NineLives.Tests/EntraDiagnosticsTests.cs
@@ -1,0 +1,267 @@
+using System.Text;
+using System.Text.Json;
+using Azure;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Making an Azure permission failure answerable (#29).
+///
+/// Azure refuses a data-plane request with 403 AuthorizationPermissionMismatch and nothing else -
+/// one message covering "the role is on the management plane", "the role is on the wrong scope" and
+/// "this is not the account you think it is". The response carries a request id, the original XML
+/// and eleven headers, and says nothing about what to change.
+///
+/// Same instinct as the recovery guidance after a failed restore (#14): the moment it fails is the
+/// moment to say what to do about it.
+/// </summary>
+public class EntraDiagnosticsTests
+{
+    private static BlobContainerConfig Container(BlobAuthMode mode = BlobAuthMode.EntraInteractive) => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/sqlbackups",
+        AuthMode = mode
+    };
+
+    private static RequestFailedException Failure(string errorCode, int status = 403) =>
+        new(status, "This request is not authorized to perform this operation using this permission.\n"
+            + "RequestId:d0733940-001e-000f-16ae-255e25000000\n"
+            + "Time:2026-08-06T14:20:06.5131329Z", errorCode, innerException: null);
+
+    // ── who was refused ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A token is a JWT: three base64url segments, the middle one a JSON claims object. Reading the
+    /// account out of it is the only way the app can say WHICH identity Azure turned down.
+    /// </summary>
+    private static string Jwt(object payload)
+    {
+        static string Segment(string json) =>
+            Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
+                .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        return $"{Segment("{\"alg\":\"RS256\"}")}.{Segment(JsonSerializer.Serialize(payload))}.signature";
+    }
+
+    [Fact]
+    public void AUserTokenIsDescribedByTheAccountAndTenant()
+    {
+        var token = Jwt(new { upn = "dba@example.com", tid = "11111111-2222-3333-4444-555555555555" });
+
+        Assert.Equal(
+            "dba@example.com (tenant 11111111-2222-3333-4444-555555555555)",
+            EntraIdentity.Describe(token));
+    }
+
+    /// <summary>Not every token carries upn - a guest or a personal account often has only this.</summary>
+    [Fact]
+    public void PreferredUsernameIsUsedWhenThereIsNoUpn()
+    {
+        var token = Jwt(new { preferred_username = "guest@other.com", tid = "abc" });
+
+        Assert.Equal("guest@other.com (tenant abc)", EntraIdentity.Describe(token));
+    }
+
+    /// <summary>
+    /// A managed identity or service principal has no user at all. Its object id is still the thing
+    /// a role assignment is checked against, so it is worth naming.
+    /// </summary>
+    [Fact]
+    public void AManagedIdentityIsDescribedByItsObjectId()
+    {
+        var token = Jwt(new { oid = "99999999-0000-0000-0000-000000000000", tid = "abc" });
+
+        Assert.Equal("99999999-0000-0000-0000-000000000000 (tenant abc)", EntraIdentity.Describe(token));
+    }
+
+    /// <summary>
+    /// A bearer token is a live credential for as long as it lasts, and this text goes on screen
+    /// and into the log. None of it may come back.
+    /// </summary>
+    [Fact]
+    public void NoPartOfTheTokenIsEverReturned()
+    {
+        var token = Jwt(new { upn = "dba@example.com", tid = "abc" });
+
+        var described = EntraIdentity.Describe(token);
+
+        Assert.NotNull(described);
+        foreach (var segment in token.Split('.'))
+            Assert.DoesNotContain(segment, described);
+    }
+
+    /// <summary>
+    /// This only ever runs to improve an error message. Failing to improve one must not replace it
+    /// with a different error.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-token")]
+    [InlineData("only.two")]
+    [InlineData("aaa.!!!not-base64!!!.ccc")]
+    [InlineData("aaa.eyJub3QiOiJhbiBvYmplY3QifQ.ccc")]
+    public void AnUnreadableTokenIsNotAnError(string token)
+    {
+        var ex = Record.Exception(() => EntraIdentity.Describe(token));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ATokenWithNothingIdentifyingGivesNothing()
+    {
+        Assert.Null(EntraIdentity.Describe(Jwt(new { aud = "https://storage.azure.com" })));
+    }
+
+    // ── what to do about it ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The one worth spelling out. Blob DATA access is a separate set of roles from the ones that
+    /// administer the account, so the reflex of "but I'm Owner" is exactly the wrong fix.
+    /// </summary>
+    [Fact]
+    public void APermissionMismatchUnderEntraNamesTheRoleThatIsMissing()
+    {
+        var guidance = BlobFailureExplainer.Explain(
+            Failure("AuthorizationPermissionMismatch"), Container());
+
+        Assert.NotNull(guidance);
+        Assert.Contains("Storage Blob Data Reader", guidance);
+        Assert.Contains("Owner and Contributor do not include it", guidance);
+        // Names the container, so it is clear what scope the assignment goes on.
+        Assert.Contains("sqlbackups", guidance);
+    }
+
+    /// <summary>
+    /// The other tool "working" is the most misleading evidence there is, and it comes up first.
+    /// Storage Explorer commonly falls back to the account key - which Owner CAN fetch - so it
+    /// never exercises the role at all.
+    /// </summary>
+    [Fact]
+    public void ItExplainsWhyStorageExplorerDisagrees()
+    {
+        var guidance = BlobFailureExplainer.Explain(
+            Failure("AuthorizationPermissionMismatch"), Container());
+
+        Assert.Contains("Storage Explorer", guidance);
+        Assert.Contains("account key", guidance);
+    }
+
+    /// <summary>The same code under SAS means something completely different.</summary>
+    [Fact]
+    public void APermissionMismatchUnderSasTalksAboutTheToken()
+    {
+        var guidance = BlobFailureExplainer.Explain(
+            Failure("AuthorizationPermissionMismatch"), Container(BlobAuthMode.SasToken));
+
+        Assert.NotNull(guidance);
+        Assert.Contains("List and Read", guidance);
+        Assert.DoesNotContain("Storage Blob Data Reader", guidance);
+    }
+
+    [Theory]
+    [InlineData("ContainerNotFound", "case-sensitive")]
+    [InlineData("AccountIsDisabled", "disabled")]
+    [InlineData("InvalidResourceName", "legal Azure container name")]
+    public void TheOtherCommonFailuresAreExplainedToo(string code, string expected)
+    {
+        Assert.Contains(expected, BlobFailureExplainer.Explain(Failure(code, 404), Container()));
+    }
+
+    /// <summary>
+    /// Only where there is something worth adding. Inventing guidance for an unrecognised failure
+    /// would bury Azure's own message under a guess.
+    /// </summary>
+    [Fact]
+    public void AnUnrecognisedFailureGetsNoGuidance()
+    {
+        Assert.Null(BlobFailureExplainer.Explain(Failure("SomethingNewFromAzure", 500), Container()));
+    }
+
+    [Fact]
+    public void ANonAzureFailureGetsNoGuidance()
+    {
+        Assert.Null(BlobFailureExplainer.Explain(
+            new InvalidOperationException("No SAS token found."), Container()));
+    }
+
+    // ── what the user ends up reading ───────────────────────────────────────────
+
+    /// <summary>
+    /// All three parts, in the order that answers the question fastest: what failed, who was
+    /// refused, then what to change. The identity comes before the guidance because it settles the
+    /// most common confusion - a permission error against an account that demonstrably has access
+    /// usually means a different account was used than the one being thought about.
+    /// </summary>
+    [Fact]
+    public async Task TheTestResultSaysWhatFailedWhoWasRefusedAndWhatToChange()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            ListThrows = Failure("AuthorizationPermissionMismatch"),
+            SignedInIdentity = "someone.else@example.com (tenant abc)"
+        };
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/sqlbackups";
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.False(vm.TestSuccess);
+        Assert.Contains("Connection failed", vm.TestResult);
+        Assert.Contains("someone.else@example.com", vm.TestResult);
+        Assert.Contains("Storage Blob Data Reader", vm.TestResult);
+    }
+
+    /// <summary>
+    /// Azure appends the request id, the timestamp, the original XML and every response header to
+    /// its exception message. Only the first line is worth putting at the top.
+    /// </summary>
+    [Fact]
+    public async Task TheHeadersAndRequestIdDoNotGetInTheWay()
+    {
+        var blob = new FakeBlobStorageService { ListThrows = Failure("AuthorizationPermissionMismatch") };
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/sqlbackups";
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.DoesNotContain("RequestId:", vm.TestResult);
+        Assert.DoesNotContain("Time:2026", vm.TestResult);
+    }
+
+    /// <summary>A SAS container has no signed-in account, so nothing is claimed about one.</summary>
+    [Fact]
+    public async Task ASasFailureDoesNotClaimAnIdentity()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            ListThrows = Failure("AuthorizationPermissionMismatch"),
+            SignedInIdentity = "should-not-be-used@example.com"
+        };
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/sqlbackups";
+        vm.EditSasToken = "sv=2024-01-01&sig=x";
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.DoesNotContain("Signed in as", vm.TestResult);
+        Assert.DoesNotContain("should-not-be-used", vm.TestResult);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -90,6 +90,13 @@ public sealed class FakeBlobStorageService : IBlobStorageService
         return Task.FromResult(true);
     }
 
+    /// <summary>What DescribeSignedInIdentityAsync should answer.</summary>
+    public string? SignedInIdentity { get; set; }
+
+    public Task<string?> DescribeSignedInIdentityAsync(
+        BlobContainerConfig config, CancellationToken ct = default)
+        => Task.FromResult(config.AuthMode.IsEntra() ? SignedInIdentity : null);
+
     public Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default)
         => Task.FromResult(new List<string>());
 

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -98,7 +98,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
                 var labels = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
                 Assert.DoesNotContain("SAS TOKEN", labels);
-                Assert.Contains(labels, t => t.Contains("has not been tested", StringComparison.Ordinal));
+                Assert.Contains(labels, t => t.Contains("Owner or Contributor is NOT enough", StringComparison.Ordinal));
                 Assert.Contains(labels, t => t.Contains("Storage Blob Data Reader", StringComparison.Ordinal));
 
                 listener.AssertNone("BlobConfigView Entra");
@@ -123,7 +123,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             var labels = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
             Assert.Contains("SAS TOKEN", labels);
-            Assert.DoesNotContain(labels, t => t.Contains("has not been tested", StringComparison.Ordinal));
+            Assert.DoesNotContain(labels, t => t.Contains("Owner or Contributor is NOT enough", StringComparison.Ordinal));
         });
     }
 

--- a/src/NineLives/Services/BlobFailureExplainer.cs
+++ b/src/NineLives/Services/BlobFailureExplainer.cs
@@ -1,0 +1,78 @@
+using Azure;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Turns an Azure storage failure into something a DBA can act on (#29).
+///
+/// Azure's own messages are accurate and useless in equal measure. "This request is not authorized
+/// to perform this operation using this permission" arrives with a request id, a timestamp, the
+/// original XML and eleven headers, and says nothing about what to actually change.
+///
+/// The same instinct as the recovery guidance after a failed restore (#14): the moment something
+/// fails is the moment to say what to do about it, not to hand over the raw wire response and let
+/// someone go and search for it.
+/// </summary>
+internal static class BlobFailureExplainer
+{
+    /// <summary>
+    /// Guidance for a failure, or null when there is nothing useful to add and Azure's own message
+    /// should stand on its own.
+    /// </summary>
+    internal static string? Explain(Exception exception, BlobContainerConfig config)
+    {
+        if (exception is not RequestFailedException failure) return null;
+
+        return failure.ErrorCode switch
+        {
+            "AuthorizationPermissionMismatch" when config.AuthMode.IsEntra() => EntraRoleMissing(config),
+            "AuthorizationPermissionMismatch" => SasTooNarrow(),
+            "AuthenticationFailed" when config.AuthMode.IsEntra() =>
+                "The sign-in itself was rejected. Check the account has access to the tenant that "
+                + "owns this storage account - an account from another tenant can sign in "
+                + "successfully and still be unknown here.",
+            "AuthenticationFailed" =>
+                "The SAS token was rejected. It may be malformed, expired, or issued for a "
+                + "different storage account.",
+            "ContainerNotFound" =>
+                "The account was reached but the container does not exist. Check the last segment "
+                + "of the URL - it is the container name, and it is case-sensitive.",
+            "AccountIsDisabled" => "The storage account is disabled.",
+            "InvalidResourceName" =>
+                "The container name in the URL is not a legal Azure container name.",
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// The one worth spelling out, because the fix is not the one people reach for first.
+    ///
+    /// Blob DATA access is a separate set of roles from the ones that manage the account. Owner and
+    /// Contributor - which is what someone who can see the container in the portal usually has -
+    /// grant neither. And it is why other tools appear to disagree: Azure Storage Explorer often
+    /// falls back to fetching the account KEY through the management plane, which Owner does allow,
+    /// so it never exercises the role at all.
+    /// </summary>
+    private static string EntraRoleMissing(BlobContainerConfig config)
+    {
+        var scope = config.ContainerName is { Length: > 0 } name
+            ? $"the \"{name}\" container (or the storage account above it)"
+            : "the container or the storage account above it";
+
+        return
+            $"Signed in successfully, but this account has no permission to READ BLOB DATA in {scope}.\n\n"
+            + "Blob data access is a separate set of roles from the ones that administer the account. "
+            + "Owner and Contributor do not include it. Assign Storage Blob Data Reader (or Storage "
+            + "Blob Data Contributor) to the account named above, at the container or storage "
+            + "account scope.\n\n"
+            + "If Azure Storage Explorer works with the same account, that is not a contradiction - "
+            + "it commonly falls back to the account key, which Owner can fetch, so it never uses "
+            + "the role at all.\n\n"
+            + "Role assignments can take a few minutes to take effect.";
+    }
+
+    private static string SasTooNarrow() =>
+        "The SAS token was accepted but does not permit this operation. It needs at least List and "
+        + "Read permissions, and its resource type must include the container.";
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -76,6 +76,36 @@ public class BlobStorageService : IBlobStorageService
 
     internal static TokenCredential CredentialForTests(BlobAuthMode mode) => CredentialFor(mode);
 
+    /// <summary>
+    /// Asks the credential for a token purely so the account behind it can be named.
+    ///
+    /// Only called after something has already failed, so the extra round trip costs nothing on the
+    /// happy path - and by then it is usually the single most useful fact available, because a 403
+    /// from Azure never says which identity it refused.
+    /// </summary>
+    public async Task<string?> DescribeSignedInIdentityAsync(
+        BlobContainerConfig config, CancellationToken ct = default)
+    {
+        if (!config.AuthMode.IsEntra()) return null;
+
+        try
+        {
+            var token = await CredentialFor(config.AuthMode).GetTokenAsync(
+                new TokenRequestContext([StorageScope]), ct);
+
+            return EntraIdentity.Describe(token.Token);
+        }
+        catch
+        {
+            // This exists to explain a failure. It must not create one.
+            return null;
+        }
+    }
+
+    /// <summary>What a token for blob data is asked for. The credential normally handles this
+    /// itself; it is only spelled out here because the diagnostic asks directly.</summary>
+    private const string StorageScope = "https://storage.azure.com/.default";
+
     public async Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
     {
         var client = CreateClient(config);

--- a/src/NineLives/Services/EntraIdentity.cs
+++ b/src/NineLives/Services/EntraIdentity.cs
@@ -1,0 +1,89 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Who a token was issued to, read from the token itself (#29).
+///
+/// Azure answers a data-plane permission failure with 403 AuthorizationPermissionMismatch and
+/// nothing else. That is one message for several very different problems - the role is assigned but
+/// on the management plane, the role is on the wrong scope, or the token is for a different account
+/// or tenant than the one that was granted access. Being told WHICH identity was refused is usually
+/// enough to tell them apart, and there is no other way to find out from inside the app.
+///
+/// The claims are read WITHOUT validating the signature, deliberately. This app is not the resource
+/// server - it is not deciding whether to trust the token, it is repeating back who Azure said it
+/// belongs to so a human can spot that it is the wrong person. Azure has already validated it, and
+/// the only thing done with the result is display.
+/// </summary>
+internal static class EntraIdentity
+{
+    /// <summary>
+    /// A short description of the account a token belongs to, or null if it cannot be read.
+    ///
+    /// Never returns any part of the token itself. A JWT bearer token is a live credential for as
+    /// long as it lasts, and this text goes on screen and into the log.
+    /// </summary>
+    internal static string? Describe(string accessToken)
+    {
+        var claims = ReadClaims(accessToken);
+        if (claims == null) return null;
+
+        // A user token names the person; a managed identity or service principal has no user at
+        // all, only an object id - which is still the thing to check a role assignment against.
+        var who = First(claims, "upn", "preferred_username", "unique_name", "email")
+            ?? First(claims, "appid", "azp")
+            ?? First(claims, "oid");
+
+        var tenant = First(claims, "tid");
+
+        if (who == null && tenant == null) return null;
+        if (who == null) return $"tenant {tenant}";
+        return tenant == null ? who : $"{who} (tenant {tenant})";
+    }
+
+    private static string? First(Dictionary<string, string> claims, params string[] names)
+    {
+        foreach (var name in names)
+            if (claims.TryGetValue(name, out var value) && !string.IsNullOrWhiteSpace(value))
+                return value;
+        return null;
+    }
+
+    /// <summary>
+    /// The payload segment's claims. Anything malformed comes back null rather than throwing - this
+    /// only ever runs to improve an error message, and failing to improve one must not replace it
+    /// with a different error.
+    /// </summary>
+    private static Dictionary<string, string>? ReadClaims(string accessToken)
+    {
+        try
+        {
+            var parts = accessToken.Split('.');
+            if (parts.Length < 2) return null;
+
+            using var document = JsonDocument.Parse(FromBase64Url(parts[1]));
+            if (document.RootElement.ValueKind != JsonValueKind.Object) return null;
+
+            var claims = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var property in document.RootElement.EnumerateObject())
+                if (property.Value.ValueKind == JsonValueKind.String)
+                    claims[property.Name] = property.Value.GetString() ?? string.Empty;
+
+            return claims;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Base64url, which is base64 with two characters swapped and the padding dropped.</summary>
+    private static byte[] FromBase64Url(string value)
+    {
+        var padded = new StringBuilder(value.Replace('-', '+').Replace('_', '/'));
+        while (padded.Length % 4 != 0) padded.Append('=');
+        return Convert.FromBase64String(padded.ToString());
+    }
+}

--- a/src/NineLives/Services/IBlobStorageService.cs
+++ b/src/NineLives/Services/IBlobStorageService.cs
@@ -12,6 +12,14 @@ public interface IBlobStorageService
 {
     Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default);
 
+    /// <summary>
+    /// Who the Entra sign-in actually is, for putting in a permission error. Null when the
+    /// container does not use Entra, or when it cannot be determined - it only ever improves a
+    /// message, so failing to answer must never become an error of its own (#29).
+    /// </summary>
+    Task<string?> DescribeSignedInIdentityAsync(
+        BlobContainerConfig config, CancellationToken ct = default);
+
     Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default);
 
     Task<List<BackupFileInfo>> ListBackupFilesAsync(BlobContainerConfig config, CancellationToken ct = default);

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Text;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -741,8 +742,13 @@ public partial class BlobConfigViewModel : ViewModelBase
         catch (Exception ex)
         {
             TestSuccess = false;
-            TestResult = $"Connection failed: {ex.Message}";
             ContainerSummary = null;
+
+            // Azure's own message is accurate and useless in equal measure - a permission failure
+            // arrives with a request id, the original XML and eleven headers, and says nothing
+            // about what to change. Same instinct as the recovery guidance after a failed restore
+            // (#14): the moment it fails is the moment to say what to do about it.
+            TestResult = await ExplainFailureAsync(ex, config, ct);
         }
         finally
         {
@@ -750,6 +756,51 @@ public partial class BlobConfigViewModel : ViewModelBase
             IsBusy = false;
             CanCancelTest = false;
         }
+    }
+
+    /// <summary>
+    /// The failure, then who was refused, then what to do about it.
+    ///
+    /// The identity comes first among the details because it is the fact that settles the most
+    /// common confusion: a permission error against an account that demonstrably has access
+    /// usually means a different account was used than the one being thought about.
+    /// </summary>
+    private async Task<string> ExplainFailureAsync(
+        Exception ex, BlobContainerConfig config, CancellationToken ct)
+    {
+        var message = new StringBuilder($"Connection failed: {FirstLine(ex.Message)}");
+
+        if (config.AuthMode.IsEntra())
+        {
+            string? identity = null;
+            try
+            {
+                identity = await _blobService.DescribeSignedInIdentityAsync(config, ct);
+            }
+            catch
+            {
+                // Explaining a failure must not produce one.
+            }
+
+            if (identity != null)
+                message.Append($"{Environment.NewLine}{Environment.NewLine}Signed in as: {identity}");
+        }
+
+        var guidance = BlobFailureExplainer.Explain(ex, config);
+        if (guidance != null)
+            message.Append($"{Environment.NewLine}{Environment.NewLine}{guidance}");
+
+        return message.ToString();
+    }
+
+    /// <summary>
+    /// Azure appends the request id, the timestamp, the original XML and every response header to
+    /// its exception message. The first line is the part a human reads; the rest buries it.
+    /// </summary>
+    private static string FirstLine(string message)
+    {
+        var end = message.IndexOfAny(['\r', '\n']);
+        return end < 0 ? message : message[..end].TrimEnd();
     }
 
     /// <summary>Stops an in-progress connection test.</summary>

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -360,9 +360,9 @@
                                     Visibility="{Binding IsEntraAuth, Converter={StaticResource BoolToVis}}">
                                 <StackPanel>
                                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
-                                               Text="Entra sign-in is built but has not been tested against a real tenant - there is no Entra-enabled storage account to develop it against. Test Connection will tell you honestly whether it works. Please report what happens either way." />
+                                               Text="Your account needs the Storage Blob Data Reader role on this container. Owner or Contributor is NOT enough - blob data access is a separate set of roles from the ones that administer the account, which is the usual reason a permission error appears against an account that can plainly see the container in the portal." />
                                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,8,0,0"
-                                               Text="Your account needs the Storage Blob Data Reader role on this container - Owner or Contributor on the subscription is not enough on its own. This covers browsing only: the RESTORE itself runs on SQL Server, which needs its own credential for the container URL." />
+                                               Text="This covers browsing only: the RESTORE itself runs on SQL Server, which needs its own credential for the container URL. Test Connection names the account it signed in as, which is worth checking first if the permission looks right." />
                                 </StackPanel>
                             </Border>
 


### PR DESCRIPTION
An Entra container came back with a 403 `AuthorizationPermissionMismatch` against an account that appeared to have access — and the app had nothing useful to say about it. Just Azure's wire response: a request id, the original XML, and eleven headers.

That single error code covers several very different problems:

- the role is assigned, but it is a **management-plane** role
- the role is on the wrong **scope**
- the token belongs to a **different account or tenant** than the one that was granted access

Nothing in the response distinguishes them, and the app made no attempt to.

## Who was refused

The account the token was actually issued to, read from the token's own claims. There is no other way to find this out from inside the app, and it is usually the fact that settles it — a permission error against an account that demonstrably has access generally means a *different* account was used than the one being thought about.

Claims are read **without validating the signature**, deliberately. This app is not the resource server; it is not deciding whether to trust the token, it is repeating back who Azure said it belongs to so a human can spot the wrong name. Azure has already validated it, and the only thing done with the result is display.

**No part of the token itself is ever returned** — a bearer token is a live credential for as long as it lasts, and this text goes on screen and into the log. There is a test for exactly that.

## What to change

Guidance naming the role and the scope. The key point, because the reflex is the wrong fix:

> Blob data access is a separate set of roles from the ones that administer the account. Owner and Contributor do not include it.

And the misleading evidence that comes up first:

> If Azure Storage Explorer works with the same account, that is not a contradiction — it commonly falls back to the account key, which Owner can fetch, so it never uses the role at all.

Also covers `ContainerNotFound` (the container name is case-sensitive), `AccountIsDisabled`, and a SAS that is too narrow. Unrecognised failures get **no** guidance — inventing some would bury Azure's own message under a guess.

## Presentation

Azure's message is trimmed to its first line at the top. The request id, timestamp, XML and headers were burying the one sentence worth reading. Order is: what failed → who was refused → what to change.

The container form's caveat is rewritten from "this is untested" — now stale, since we know sign-in works and this is a permissions question — to the thing that actually catches people out.

## Cost

The identity lookup is an extra token request, made **only after something has already failed**, and wrapped so that a failure to explain can never become a failure of its own.

21 new tests, 899 pass, build clean at `-warnaserror`.
