### PR TITLE
Stop a restore rewriting a credential it did not create (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ more detail on the user-facing changes; this file is the short history.
 - A **Stop** button for the server queries — verify, validate, the metadata reads and the
   post-failure recovery actions (#111)
 - Execute now says *why* it is disabled instead of just being greyed out (#117)
+- **Entra ID authentication for blob containers**, as an alternative to a SAS token, for
+  organisations that do not allow long-lived SAS. A permission failure names the account that was
+  refused and the role it is missing, which Azure's own error does not (#29)
+- **Entra MFA for SQL Server connections** (`ActiveDirectoryInteractive`), with the sign-in prompt
+  parented to the app window (#30)
 
 ### Fixed
 
@@ -43,6 +48,12 @@ more detail on the user-facing changes; this file is the short history.
 - Saving now writes the config *before* the secret, so a refused save cannot leave Credential
   Manager holding a password the config file does not match (#113)
 - The credential check no longer races itself and reports the container you just left (#111)
+- **A Managed Identity blob credential is no longer converted to SAS by running a restore.** The
+  check reduced every identity to "is it a SAS credential", so a credential authenticating as the
+  instance's own identity was reported as broken and then altered into a SAS one — changing how
+  anything else on that instance reached the same container. Execute now leaves any usable
+  credential alone, and never converts one it did not create: replacing an identity is what the
+  button on the panel is for, and it says so before it is pressed (#145)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,9 @@ Your SAS token needs the following minimum permissions:
 - **List (l)** - To enumerate blobs in the container
 - **Read (r)** - To read backup files
 
-For restore execution, the SQL Server instance must have a credential for the blob container URL (identity `SHARED ACCESS SIGNATURE`). You can create or update this credential from the app using "Create credential on server" in the Restore options; the SAS token is never included in generated scripts.
+For restore execution, the SQL Server instance must have a credential for the blob container URL. Two identities work: `SHARED ACCESS SIGNATURE`, and — on SQL Server 2022 and later or Azure SQL MI — `Managed Identity`. You can create the SAS kind from the app using "Create credential on server" in the Restore options; the SAS token is never included in generated scripts.
+
+A credential that already exists is never rewritten by running a restore. If it holds a managed identity the app reports it as valid and leaves it alone, since replacing it would change how the whole instance reaches that container. Replacing one is a deliberate press of the button on the credential panel, which says exactly what it would do.
 
 Example SAS token permissions: `sp=rl` (read + list)
 
@@ -409,8 +411,10 @@ NineLives/
 
 - Windows only (WPF application)
 - x64 architecture only
-- SAS token authentication only (no Azure AD/Managed Identity yet)
 - Single container per restore operation
+- Browsing a container works with a SAS token or Entra ID. The **server-side** credential that
+  `RESTORE FROM URL` needs can only be created from here as a SAS credential — a Managed Identity
+  credential is recognised and left alone, but has to be created on the instance itself
 
 ## Troubleshooting
 
@@ -418,6 +422,9 @@ NineLives/
 - Verify your SAS token has `list` permission
 - Check the token hasn't expired
 - Ensure the container URL is correct (no trailing slash)
+- On Entra ID, the account needs **Storage Blob Data Reader** on the container. Owner or
+  Contributor is not enough — see [Entra ID for Blob Storage](#entra-id-for-blob-storage) above.
+  Test Connection names the account it signed in as
 
 ### "File cannot be restored to..." error
 - Enable **WITH MOVE** option

--- a/src/NineLives.Tests/CredentialIdentityTests.cs
+++ b/src/NineLives.Tests/CredentialIdentityTests.cs
@@ -1,0 +1,97 @@
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Reading a credential's identity, and saying what was found (#145).
+///
+/// This used to be one bool - "is the identity SHARED ACCESS SIGNATURE" - which put a managed
+/// identity, a Windows account and a typo in the same bucket. The restore path then acted on that
+/// bucket by overwriting it, so the classification is what the destructive decision hangs off.
+/// </summary>
+public class CredentialIdentityTests
+{
+    [Theory]
+    [InlineData("SHARED ACCESS SIGNATURE")]
+    [InlineData("shared access signature")]
+    public void ASasIdentityIsRecognisedWhateverItsCase(string identity)
+        => Assert.Equal(
+            BlobCredentialIdentity.SharedAccessSignature,
+            SqlServerService.ClassifyIdentity(identity));
+
+    /// <summary>
+    /// Case is not guaranteed here either: the docs write it both ways, and whoever created the
+    /// credential typed one of them. Getting this wrong is not a cosmetic miss - an unrecognised
+    /// managed identity is exactly the input that used to be overwritten.
+    /// </summary>
+    [Theory]
+    [InlineData("Managed Identity")]
+    [InlineData("MANAGED IDENTITY")]
+    [InlineData("managed identity")]
+    public void AManagedIdentityIsRecognisedWhateverItsCase(string identity)
+        => Assert.Equal(
+            BlobCredentialIdentity.ManagedIdentity,
+            SqlServerService.ClassifyIdentity(identity));
+
+    [Theory]
+    [InlineData("MYDOMAIN\\svc_sql")]
+    [InlineData("mystorageaccount")]
+    [InlineData("")]
+    public void AnythingElseIsOther(string identity)
+        => Assert.Equal(BlobCredentialIdentity.Other, SqlServerService.ClassifyIdentity(identity));
+
+    [Theory]
+    [InlineData(BlobCredentialIdentity.SharedAccessSignature, true)]
+    [InlineData(BlobCredentialIdentity.ManagedIdentity, true)]
+    [InlineData(BlobCredentialIdentity.Other, false)]
+    [InlineData(BlobCredentialIdentity.Missing, false)]
+    public void OnlyTheTwoIdentitiesARestoreCanUseCountAsUsable(
+        BlobCredentialIdentity kind, bool expected)
+        => Assert.Equal(expected, new BlobCredentialStatus(kind, "x").CanRestoreFromUrl);
+
+    [Fact]
+    public void OnlyAMissingCredentialReportsThatItIsAbsent()
+    {
+        Assert.False(BlobCredentialStatus.Missing.Exists);
+        Assert.True(new BlobCredentialStatus(BlobCredentialIdentity.Other, "x").Exists);
+    }
+
+    /// <summary>
+    /// The panel's wording. A managed identity must not be described as a problem: the old message
+    /// said "restore may fail" about a credential that would have worked, which is the sentence
+    /// that invited somebody to press the button and convert it.
+    /// </summary>
+    [Fact]
+    public void AManagedIdentityIsDescribedAsValid()
+    {
+        var message = RestoreViewModel.DescribeCredential(
+            new BlobCredentialStatus(BlobCredentialIdentity.ManagedIdentity, "Managed Identity"));
+
+        Assert.Contains("valid", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Managed Identity", message);
+        Assert.DoesNotContain("may fail", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// An unusable one is named. "Not a SAS credential" was true of every identity that is not a
+    /// SAS credential, which left no way to tell a mistake from somebody's deliberate arrangement.
+    /// </summary>
+    [Fact]
+    public void AnUnusableCredentialIsNamedRatherThanJustRejected()
+    {
+        var message = RestoreViewModel.DescribeCredential(
+            new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql"));
+
+        Assert.Contains("MYDOMAIN\\svc_sql", message);
+    }
+
+    [Fact]
+    public void AMissingCredentialSaysSo()
+    {
+        var message = RestoreViewModel.DescribeCredential(BlobCredentialStatus.Missing);
+
+        Assert.Contains("not present", message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/NineLives.Tests/CredentialLifecycleTests.cs
+++ b/src/NineLives.Tests/CredentialLifecycleTests.cs
@@ -93,6 +93,9 @@ public class CredentialLifecycleTests
     /// <summary>
     /// A credential sitting there under some other identity cannot serve a RESTORE FROM URL, so
     /// ALTER resets IDENTITY too rather than leaving a broken credential to fail the restore.
+    ///
+    /// This is the service doing what it is told. Since #145 only the explicit button asks for it -
+    /// the execute path stops rather than converting an identity it did not create.
     /// </summary>
     [RequiresSqlFact]
     public async Task NonSasCredential_IsConvertedToSharedAccessSignature()
@@ -103,14 +106,48 @@ public class CredentialLifecycleTests
             await DropCredentialIfExists(name);
             await CreateNonSasCredential(name);
 
-            Assert.False((await Service().CredentialExistsAsync(TestServer(), name)).IsSharedAccessSignature);
+            var before = await Service().CredentialExistsAsync(TestServer(), name);
+            Assert.Equal(BlobCredentialIdentity.Other, before.Kind);
+            Assert.False(before.CanRestoreFromUrl);
 
             var change = await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, FirstSas);
 
             Assert.Equal(CredentialChange.Updated, change);
-            var (exists, isSas) = await Service().CredentialExistsAsync(TestServer(), name);
-            Assert.True(exists);
-            Assert.True(isSas);
+            var after = await Service().CredentialExistsAsync(TestServer(), name);
+            Assert.True(after.Exists);
+            Assert.Equal(BlobCredentialIdentity.SharedAccessSignature, after.Kind);
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    /// <summary>
+    /// A managed-identity credential read back off a real instance (#145).
+    ///
+    /// The classification is a string comparison against what sys.credentials returns, and this is
+    /// the only way to know that is the text SQL Server actually stores rather than the text the
+    /// documentation prints. It proves the read, not the restore: authenticating with a managed
+    /// identity needs an Azure VM, an Arc-enabled instance or SQL MI, and CREATE CREDENTIAL takes
+    /// the identity as free text on any of them, so this runs anywhere.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ManagedIdentityCredential_IsRecognisedRatherThanTreatedAsBroken()
+    {
+        const string name = "ninelives-test-lifecycle-managed-identity";
+        try
+        {
+            await DropCredentialIfExists(name);
+            await CreateManagedIdentityCredential(name);
+
+            var credential = await Service().CredentialExistsAsync(TestServer(), name);
+
+            Assert.True(credential.Exists);
+            Assert.Equal(BlobCredentialIdentity.ManagedIdentity, credential.Kind);
+
+            // The bit that matters: the execute path reads this and leaves the credential alone.
+            Assert.True(credential.CanRestoreFromUrl);
         }
         finally
         {
@@ -126,10 +163,10 @@ public class CredentialLifecycleTests
         const string name = "ninelives-test-lifecycle-absent";
         await DropCredentialIfExists(name);
 
-        var (exists, isSas) = await Service().CredentialExistsAsync(TestServer(), name);
+        var credential = await Service().CredentialExistsAsync(TestServer(), name);
 
-        Assert.False(exists);
-        Assert.False(isSas);
+        Assert.False(credential.Exists);
+        Assert.Equal(BlobCredentialIdentity.Missing, credential.Kind);
         Assert.False(await CredentialExists(name));
     }
 
@@ -171,6 +208,19 @@ public class CredentialLifecycleTests
         await using var conn = await OpenAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = $"CREATE CREDENTIAL {TSql.QuoteName(name)} WITH IDENTITY = 'ninelives-test-identity', SECRET = 'not-a-sas'";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// No SECRET, which is how a managed-identity credential is written. SQL Server takes the
+    /// identity as free text, so this creates on any edition - it only fails when something tries
+    /// to authenticate with it.
+    /// </summary>
+    private static async Task CreateManagedIdentityCredential(string name)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"CREATE CREDENTIAL {TSql.QuoteName(name)} WITH IDENTITY = 'Managed Identity'";
         await cmd.ExecuteNonQueryAsync();
     }
 

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -150,8 +150,12 @@ public sealed class FakeSqlServerService : ISqlServerService
 
     public List<string> VerifiedUrls { get; } = [];
 
-    public bool CredentialExists { get; set; } = true;
-    public bool CredentialIsSas { get; set; } = true;
+    /// <summary>What a credential lookup finds. Defaults to the happy path: a SAS credential.</summary>
+    public BlobCredentialStatus Credential { get; set; } =
+        new(BlobCredentialIdentity.SharedAccessSignature, "SHARED ACCESS SIGNATURE");
+
+    /// <summary>Every name a credential write was asked for, so a test can prove none happened.</summary>
+    public List<string> CredentialWrites { get; } = [];
 
     public VerifyOnlyResult VerifyResult { get; set; } = new(true, "The backup set is valid.");
 
@@ -233,12 +237,15 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.CompletedTask;
     }
 
-    public Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+    public Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default)
-        => Task.FromResult((CredentialExists, CredentialIsSas));
+        => Task.FromResult(Credential);
 
     public Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
         CancellationToken ct = default)
-        => Task.FromResult(CredentialChange.None);
+    {
+        CredentialWrites.Add(credentialName);
+        return Task.FromResult(CredentialChange.None);
+    }
 }

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -140,8 +140,8 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
         RunOnUi(async () =>
         {
             var (vm, sql) = await ReadyToExecute(server, store);
-            sql.CredentialExists = true;
-            sql.CredentialIsSas = true;
+            sql.Credential = new BlobCredentialStatus(
+                BlobCredentialIdentity.SharedAccessSignature, "SHARED ACCESS SIGNATURE");
             store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
 
             await vm.ExecuteScriptCommand.ExecuteAsync(null);
@@ -149,6 +149,137 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
         });
 
         Assert.Contains("Server state not modified", log);
+    }
+
+    /// <summary>
+    /// The #145 regression, and the reason it mattered.
+    ///
+    /// A managed-identity credential restores perfectly well, but the old check reduced every
+    /// identity to "is it SAS", so this arrived at the same branch as a broken one and was ALTERed -
+    /// which resets IDENTITY. The instance stopped authenticating to that container as itself, and
+    /// so did every other job pointed at the same URL, under the log line "Credential updated on
+    /// the server".
+    /// </summary>
+    [Fact]
+    public void AManagedIdentityCredentialIsLeftAloneRatherThanConvertedToSas()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var store = new FakeCredentialStore();
+        string log = string.Empty;
+        List<string> writes = [];
+        List<string> executed = [];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, store);
+            sql.Credential = new BlobCredentialStatus(
+                BlobCredentialIdentity.ManagedIdentity, "Managed Identity");
+
+            // A SAS token IS stored for the container - that is what made this reachable. Browsing
+            // with one and restoring with the instance's identity is an ordinary pairing.
+            store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+
+            log = vm.Console.Text;
+            writes = sql.CredentialWrites;
+            executed = sql.ExecutedScripts;
+        });
+
+        Assert.Empty(writes);
+        Assert.Contains("Managed Identity", log);
+        Assert.Contains("Server state not modified", log);
+
+        // Left alone, not skipped: the restore still ran.
+        Assert.Single(executed);
+    }
+
+    /// <summary>
+    /// An identity that genuinely cannot serve a restore is still not this app's to overwrite on
+    /// the way past. Converting it is a real option - it is what the button on the panel does -
+    /// but it changes shared state on someone's instance, so it takes a decision rather than a
+    /// side effect of pressing Execute (#145).
+    /// </summary>
+    [Fact]
+    public void AnUnusableCredentialStopsTheRestoreInsteadOfBeingOverwritten()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var store = new FakeCredentialStore();
+        var history = new FakeRestoreHistoryStore();
+        string log = string.Empty;
+        string error = string.Empty;
+        List<string> writes = [];
+        List<string> executed = [];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, store, history);
+            sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql");
+            store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+
+            log = vm.Console.Text;
+            error = vm.ErrorMessage;
+            writes = sql.CredentialWrites;
+            executed = sql.ExecutedScripts;
+        });
+
+        Assert.Empty(writes);
+        Assert.Empty(executed);
+
+        // Named, so it is obvious whether the credential is a mistake or somebody's arrangement.
+        Assert.Contains("MYDOMAIN\\svc_sql", error);
+        Assert.Contains("MYDOMAIN\\svc_sql", log);
+
+        // Nothing was attempted, so this is not an execution to file.
+        Assert.Empty(history.Entries);
+    }
+
+    /// <summary>
+    /// The one case that does still write: nothing of that name exists, so there is nothing to
+    /// destroy and the restore cannot proceed without it.
+    /// </summary>
+    [Fact]
+    public void AMissingCredentialIsStillCreated()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var store = new FakeCredentialStore();
+        List<string> writes = [];
+        List<string> executed = [];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, store);
+            sql.Credential = BlobCredentialStatus.Missing;
+            store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+
+            writes = sql.CredentialWrites;
+            executed = sql.ExecutedScripts;
+        });
+
+        Assert.Single(writes);
+        Assert.Single(executed);
     }
 
     /// <summary>The script that runs is the one on screen, not one rebuilt on the way out.</summary>

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -263,15 +263,46 @@ public class XamlLoadTests(WpfFixture wpf)
             var view = new RestoreView { DataContext = vm };
 
             vm.CredentialExistsOnServer = false;
-            vm.CredentialIsValidSas = false;
+            vm.CredentialIdentityKind = BlobCredentialIdentity.Missing;
             Realise(view);
             Assert.Contains(FindAll<Button>(view), b => (b.Content as string) == "Create credential on server");
 
             vm.CredentialExistsOnServer = true;
-            vm.CredentialIsValidSas = true;
+            vm.CredentialIdentityKind = BlobCredentialIdentity.SharedAccessSignature;
             Realise(view);
             Assert.Contains(FindAll<Button>(view),
                 b => (b.Content as string) == "Refresh credential with stored SAS token");
+        });
+    }
+
+    /// <summary>
+    /// The same button under a managed identity. "Refresh credential with stored SAS token" reads
+    /// as a harmless top-up, and the press would convert the instance's managed identity into a
+    /// SAS credential - so the label has to say that before it is pressed, not after (#145).
+    /// </summary>
+    [Fact]
+    public void TheCredentialButtonSaysItWouldReplaceAManagedIdentity()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.SelectedContainer = new BlobContainerConfig
+            {
+                Id = BlobContainerConfig.NewId(),
+                Name = "prod",
+                ContainerUrl = "https://acct.blob.core.windows.net/backups"
+            };
+            vm.IsConnectedToServer = true;
+            vm.CredentialSectionVisible = true;
+
+            var view = new RestoreView { DataContext = vm };
+
+            vm.CredentialExistsOnServer = true;
+            vm.CredentialIdentityKind = BlobCredentialIdentity.ManagedIdentity;
+            Realise(view);
+
+            Assert.Contains(FindAll<Button>(view),
+                b => (b.Content as string) == "Replace Managed Identity with stored SAS token");
         });
     }
 

--- a/src/NineLives/Services/BlobCredentialIdentity.cs
+++ b/src/NineLives/Services/BlobCredentialIdentity.cs
@@ -1,0 +1,49 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Which IDENTITY a server-side credential was created with, as far as RESTORE FROM URL cares (#145).
+///
+/// This used to be a bool - "is it SHARED ACCESS SIGNATURE" - which made a managed-identity
+/// credential indistinguishable from a Windows account or a typo. Those need opposite treatment:
+/// one authenticates a restore perfectly well, the others cannot, and the app was overwriting
+/// both on the strength of the same false answer.
+/// </summary>
+public enum BlobCredentialIdentity
+{
+    /// <summary>No credential of that name exists on the instance.</summary>
+    Missing,
+
+    /// <summary>WITH IDENTITY = 'SHARED ACCESS SIGNATURE' - the only kind this app creates.</summary>
+    SharedAccessSignature,
+
+    /// <summary>
+    /// WITH IDENTITY = 'Managed Identity' - the instance authenticating to storage as itself, on
+    /// SQL Server 2022+ or Azure SQL MI. Valid for a restore, and not something this app can
+    /// create yet, so wherever one is found it belongs to somebody else's deliberate setup.
+    /// </summary>
+    ManagedIdentity,
+
+    /// <summary>Anything else: a Windows account, a storage account key, a mistake. Not usable.</summary>
+    Other
+}
+
+/// <summary>
+/// What a credential lookup found. The identity string is carried alongside so an unusable
+/// credential can be named rather than merely rejected - the same reasoning as the Entra sign-in
+/// diagnostics (#29): being told WHAT is there is usually enough to see why it is wrong.
+///
+/// It is never the secret. SQL Server does not return credential secrets, and
+/// <c>credential_identity</c> for a SAS credential is the literal text 'SHARED ACCESS SIGNATURE'.
+/// </summary>
+public readonly record struct BlobCredentialStatus(BlobCredentialIdentity Kind, string? Identity)
+{
+    /// <summary>A credential of that name is on the instance, whatever it turned out to be.</summary>
+    public bool Exists => Kind != BlobCredentialIdentity.Missing;
+
+    /// <summary>Whether a RESTORE FROM URL can authenticate with it as it stands.</summary>
+    public bool CanRestoreFromUrl =>
+        Kind is BlobCredentialIdentity.SharedAccessSignature or BlobCredentialIdentity.ManagedIdentity;
+
+    /// <summary>Nothing of that name on the server.</summary>
+    public static BlobCredentialStatus Missing => new(BlobCredentialIdentity.Missing, null);
+}

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -49,7 +49,7 @@ public interface ISqlServerService
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default);
 
-    Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+    Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default);
 
     Task<CredentialChange> EnsureCredentialExistsAsync(

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -624,12 +624,19 @@ public class SqlServerService : ISqlServerService
 
     private static readonly Regex WhitespaceRun = new(@"\s+", RegexOptions.Compiled);
 
-    /// <summary>Checks if a credential with the given name exists on the server and has identity SHARED ACCESS SIGNATURE (for blob URL restores).</summary>
-    public async Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+    /// <summary>
+    /// Which credential of that name is on the server, if any, and what it authenticates as.
+    ///
+    /// Reports the identity rather than "is it SAS" (#145). The two identities a restore from URL
+    /// can use are SHARED ACCESS SIGNATURE and, on SQL Server 2022+ or Azure SQL MI, Managed
+    /// Identity; collapsing them into one bool told the caller a working managed-identity
+    /// credential was broken, and the caller then overwrote it.
+    /// </summary>
+    public async Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(credentialName))
-            return (false, false);
+            return BlobCredentialStatus.Missing;
 
         await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
@@ -643,11 +650,24 @@ public class SqlServerService : ISqlServerService
 
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         if (!await reader.ReadAsync(ct))
-            return (false, false);
+            return BlobCredentialStatus.Missing;
 
-        var identity = reader["credential_identity"]?.ToString() ?? "";
-        var isSas = identity.Equals("SHARED ACCESS SIGNATURE", StringComparison.OrdinalIgnoreCase);
-        return (true, isSas);
+        var identity = (reader["credential_identity"]?.ToString() ?? "").Trim();
+        return new BlobCredentialStatus(ClassifyIdentity(identity), identity);
+    }
+
+    /// <summary>
+    /// The identity text as stored in sys.credentials, matched loosely. Case is not guaranteed -
+    /// the docs write 'Managed Identity' and 'MANAGED IDENTITY' in different places, and whoever
+    /// created the credential typed one of them.
+    /// </summary>
+    internal static BlobCredentialIdentity ClassifyIdentity(string identity)
+    {
+        if (identity.Equals("SHARED ACCESS SIGNATURE", StringComparison.OrdinalIgnoreCase))
+            return BlobCredentialIdentity.SharedAccessSignature;
+        if (identity.Equals("Managed Identity", StringComparison.OrdinalIgnoreCase))
+            return BlobCredentialIdentity.ManagedIdentity;
+        return BlobCredentialIdentity.Other;
     }
 
     // CREATE/DROP CREDENTIAL cannot take the name as a parameter - it is an identifier, not a
@@ -682,8 +702,14 @@ public class SqlServerService : ISqlServerService
         checkCmd.Parameters.AddWithValue("@name", credentialName);
         var exists = (int)(await checkCmd.ExecuteScalarAsync(ct))! > 0;
 
-        // ALTER also resets IDENTITY, so a credential that exists under some other identity is
-        // converted rather than left in place to fail the restore later.
+        // ALTER resets IDENTITY as well as the secret, so a credential sitting under some other
+        // identity is converted rather than left to fail the restore later.
+        //
+        // That conversion is destructive and this method cannot tell a mistake from a deliberate
+        // setup, so it must only ever be reached because somebody asked for it. The execute path
+        // no longer calls this to "fix" an identity it does not recognise - it stops and says what
+        // it found, because the identity it would have replaced could be a managed identity the
+        // instance genuinely restores with (#145).
         var cleanSas = sasToken.TrimStart('?');
         await using var writeCmd = conn.CreateCommand();
         writeCmd.CommandText = $@"

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -323,8 +323,31 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool? _credentialExistsOnServer; // null = not checked
 
+    // What the credential of that name actually authenticates as. The three views below are
+    // derived rather than stored: they used to be one bool that conflated "not a SAS credential"
+    // with "unusable", which is how a managed identity came to be treated as damage (#145).
     [ObservableProperty]
-    private bool _credentialIsValidSas; // true when exists and identity is SHARED ACCESS SIGNATURE
+    private BlobCredentialIdentity _credentialIdentityKind = BlobCredentialIdentity.Missing;
+
+    /// <summary>A restore can authenticate with what is on the server as it stands.</summary>
+    public bool CredentialIsUsable =>
+        CredentialIdentityKind is BlobCredentialIdentity.SharedAccessSignature
+            or BlobCredentialIdentity.ManagedIdentity;
+
+    /// <summary>The credential holds a SAS, so the stored token is the thing that can go stale.</summary>
+    public bool CredentialIsSharedAccessSignature =>
+        CredentialIdentityKind == BlobCredentialIdentity.SharedAccessSignature;
+
+    /// <summary>The instance authenticates to storage as itself, and this app must not touch it.</summary>
+    public bool CredentialIsManagedIdentity =>
+        CredentialIdentityKind == BlobCredentialIdentity.ManagedIdentity;
+
+    partial void OnCredentialIdentityKindChanged(BlobCredentialIdentity value)
+    {
+        OnPropertyChanged(nameof(CredentialIsUsable));
+        OnPropertyChanged(nameof(CredentialIsSharedAccessSignature));
+        OnPropertyChanged(nameof(CredentialIsManagedIdentity));
+    }
 
     [ObservableProperty]
     private string _credentialStatusMessage = string.Empty;
@@ -386,7 +409,7 @@ public partial class RestoreViewModel : ViewModelBase
         {
             CredentialExistsOnServer = null;
             CredentialStatusMessage = string.Empty;
-            CredentialIsValidSas = false;
+            CredentialIdentityKind = BlobCredentialIdentity.Missing;
             return;
         }
 
@@ -400,12 +423,10 @@ public partial class RestoreViewModel : ViewModelBase
         var server = ConnectedServer;
         try
         {
-            var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName, ct);
-            CredentialExistsOnServer = exists;
-            CredentialIsValidSas = exists && isSas;
-            CredentialStatusMessage = exists
-                ? (isSas ? "Credential is present and valid (SHARED ACCESS SIGNATURE)." : "Credential exists but is not a SAS credential; restore may fail.")
-                : "Credential is not present on this server. Restore will fail unless you create it.";
+            var credential = await _sqlService.CredentialExistsAsync(server, SqlCredentialName, ct);
+            CredentialExistsOnServer = credential.Exists;
+            CredentialIdentityKind = credential.Kind;
+            CredentialStatusMessage = DescribeCredential(credential);
         }
         catch (OperationCanceledException)
         {
@@ -416,7 +437,7 @@ public partial class RestoreViewModel : ViewModelBase
         catch (Exception ex)
         {
             CredentialExistsOnServer = null;
-            CredentialIsValidSas = false;
+            CredentialIdentityKind = BlobCredentialIdentity.Missing;
             CredentialStatusMessage = $"Could not check credential: {ex.Message}";
         }
         finally
@@ -432,6 +453,24 @@ public partial class RestoreViewModel : ViewModelBase
             }
         }
     }
+
+    /// <summary>
+    /// The panel's one line about what is on the server. An unusable credential is named rather
+    /// than just rejected: "not a SAS credential" was the same sentence for a managed identity
+    /// that would have restored perfectly well and for a Windows account that never could (#145).
+    /// </summary>
+    internal static string DescribeCredential(BlobCredentialStatus credential) => credential.Kind switch
+    {
+        BlobCredentialIdentity.SharedAccessSignature =>
+            "Credential is present and valid (SHARED ACCESS SIGNATURE).",
+        BlobCredentialIdentity.ManagedIdentity =>
+            "Credential is present and valid (Managed Identity). The restore authenticates as the " +
+            "instance's own identity, so no SAS token is involved and this app will not modify it.",
+        BlobCredentialIdentity.Other =>
+            $"Credential exists with identity '{credential.Identity}', which a restore from URL " +
+            "cannot use. Replace it below, or point at a different credential.",
+        _ => "Credential is not present on this server. Restore will fail unless you create it."
+    };
 
     [ObservableProperty]
     private ObservableCollection<FileMoveOption> _fileMoves = [];
@@ -1432,15 +1471,28 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
+        // What is about to be overwritten, read before the write. This is the only route by which
+        // a managed identity gets replaced by a SAS token, and it should say so afterwards rather
+        // than reporting a routine "updated" for a change to how the instance authenticates (#145).
+        var replaced = CredentialIdentityKind;
+
         try
         {
             var change = await _sqlService.EnsureCredentialExistsAsync(
                 ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken,
                 _queryCancellation.Begin());
             await RefreshCredentialStatusAsync();
-            SetStatus(change == CredentialChange.Created
-                ? "Credential created on server."
-                : "Credential updated on server with the stored SAS token.");
+            SetStatus(change switch
+            {
+                CredentialChange.Created => "Credential created on server.",
+                _ when replaced == BlobCredentialIdentity.ManagedIdentity =>
+                    "Credential replaced on server: it authenticated as the instance's managed " +
+                    "identity and now holds the stored SAS token.",
+                _ => "Credential updated on server with the stored SAS token."
+            });
+            if (replaced == BlobCredentialIdentity.ManagedIdentity)
+                _log.ServerChange(ConnectedServer.ServerName,
+                    $"credential [{SqlCredentialName}] identity changed from Managed Identity to SAS");
         }
         catch (Exception ex)
         {
@@ -1737,16 +1789,38 @@ public partial class RestoreViewModel : ViewModelBase
                     // a rotated SAS that no longer works - that is unknowable from here, since the
                     // secret cannot be read back - so the fix for that case is the explicit
                     // refresh button, not silently rewriting server state on every run.
-                    var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
-                    if (exists && isSas)
+                    //
+                    // A managed identity is left alone for a stronger reason: it restores perfectly
+                    // well, this app cannot create one, and ALTER would reset the identity. Reading
+                    // "not SAS" as "broken" is what silently converted somebody's working managed
+                    // identity into a SAS token here, taking every other job on that container with
+                    // it, under the log line "Credential updated on the server" (#145).
+                    var credential = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
+                    if (credential.CanRestoreFromUrl)
                     {
-                        AppendLog($"Using the existing SQL credential [{SqlCredentialName}]. Server state not modified.");
+                        AppendLog(credential.Kind == BlobCredentialIdentity.ManagedIdentity
+                            ? $"Using the existing SQL credential [{SqlCredentialName}] (Managed Identity). Server state not modified."
+                            : $"Using the existing SQL credential [{SqlCredentialName}]. Server state not modified.");
+                    }
+                    else if (credential.Exists)
+                    {
+                        // Neither usable nor ours to reinterpret. Converting it is a real option -
+                        // it is what the button on the panel does - but it must be a decision
+                        // somebody made, not a side effect of pressing Execute. Stopping here costs
+                        // a restore that was about to fail on blob access anyway.
+                        attempted = false;
+                        var message =
+                            $"Credential [{SqlCredentialName}] exists with identity " +
+                            $"'{credential.Identity}', which a restore from URL cannot use. Left " +
+                            "untouched: replacing it with the stored SAS token is what " +
+                            "\"Create credential on server\" does, so that it is a deliberate change.";
+                        AppendLog(message);
+                        SetError(message);
+                        return;
                     }
                     else
                     {
-                        AppendLog(exists
-                            ? $"Credential [{SqlCredentialName}] exists but is not a SAS credential - updating it..."
-                            : $"Credential [{SqlCredentialName}] is missing - creating it...");
+                        AppendLog($"Credential [{SqlCredentialName}] is missing - creating it...");
 
                         // This statement carries the SAS token to the server. It is the one moment
                         // in a restore where a secret crosses the wire, so if the connection is

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1101,7 +1101,7 @@
                                                     <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
                                                     <Setter Property="BorderThickness" Value="0" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CredentialIsValidSas}" Value="True">
+                                                        <DataTrigger Binding="{Binding CredentialIsUsable}" Value="True">
                                                             <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
@@ -1118,7 +1118,7 @@
                                                         <MultiDataTrigger>
                                                             <MultiDataTrigger.Conditions>
                                                                 <Condition Binding="{Binding CredentialExistsOnServer}" Value="True" />
-                                                                <Condition Binding="{Binding CredentialIsValidSas}" Value="False" />
+                                                                <Condition Binding="{Binding CredentialIsUsable}" Value="False" />
                                                             </MultiDataTrigger.Conditions>
                                                             <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource WarningBrush}" />
@@ -1133,17 +1133,24 @@
                                                        Style="{StaticResource SecondaryText}"
                                                        TextWrapping="Wrap" />
                                         </Border>
-                                        <TextBlock Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                        <TextBlock Visibility="{Binding CredentialIsUsable, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
-                                            <Run Text="Restore from URL requires a SQL credential (SHARED ACCESS SIGNATURE) for the container. You can create it from here, or create it on the server yourself before running the script. Execute will create it for you if it is missing. The SAS token is never included in the generated script." />
+                                            <Run Text="Restore from URL needs a SQL credential for the container, holding either a SHARED ACCESS SIGNATURE or - on SQL Server 2022 and later - the instance's Managed Identity. You can create the SAS kind from here, or create either on the server yourself before running the script. Execute will create one for you only if there is nothing of that name: a credential that already exists is never rewritten behind your back. The SAS token is never included in the generated script." />
                                         </TextBlock>
                                         <!-- Stays available once the credential is valid, because "valid" only means a SAS
                                              credential of that name exists. SQL Server will not return its secret, so a
                                              rotated or expired token is indistinguishable from a working one, and this is
                                              the only way to push a fresh one. -->
-                                        <TextBlock Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}}"
+                                        <TextBlock Visibility="{Binding CredentialIsSharedAccessSignature, Converter={StaticResource BoolToVis}}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
                                             <Run Text="Execute will leave this credential alone. If the SAS token has been rotated or has expired since the credential was created, the restore will fail on blob access - refresh it below to push the token currently stored for this container." />
+                                        </TextBlock>
+                                        <!-- A managed identity is somebody else's deliberate setup: this app cannot create
+                                             one, and the button below would ALTER it into a SAS credential, which is a
+                                             change to how the whole instance authenticates to that container (#145). -->
+                                        <TextBlock Visibility="{Binding CredentialIsManagedIdentity, Converter={StaticResource BoolToVis}}"
+                                                   Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
+                                            <Run Text="Execute will leave this credential alone and no SAS token is sent to the server. The instance authenticates to the container as itself, so the restore depends on its identity holding a role on the storage account rather than on anything stored here. The button below would replace that with a SAS credential - which would also change how anything else on this instance reaches the same container." />
                                         </TextBlock>
                                         <Button Command="{Binding CreateCredentialOnServerCommand}"
                                                 Margin="0,0,0,0" Padding="10,6"
@@ -1153,8 +1160,14 @@
                                                 <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
                                                     <Setter Property="Content" Value="Create credential on server" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CredentialIsValidSas}" Value="True">
+                                                        <DataTrigger Binding="{Binding CredentialIsSharedAccessSignature}" Value="True">
                                                             <Setter Property="Content" Value="Refresh credential with stored SAS token" />
+                                                        </DataTrigger>
+                                                        <!-- Says what the press would actually do. The same button under the
+                                                             old label read as a harmless refresh while it converted the
+                                                             instance's managed identity to a SAS token (#145). -->
+                                                        <DataTrigger Binding="{Binding CredentialIsManagedIdentity}" Value="True">
+                                                            <Setter Property="Content" Value="Replace Managed Identity with stored SAS token" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>


### PR DESCRIPTION
@
Closes #145.

## The bug

`CredentialExistsAsync` answered one question - *is the identity `SHARED ACCESS SIGNATURE`* - so every other identity landed in the same bucket. A credential created `WITH IDENTITY = Managed Identity` restores perfectly well on SQL Server 2022+ and Azure SQL MI, and it was in that bucket.

The panel called it broken: *"Credential exists but is not a SAS credential; restore may fail."*

Then Execute acted on the same answer. Its `else` branch treated "exists but not SAS" as a reason to write, and `EnsureCredentialExistsAsync` ALTERs - which resets IDENTITY. **Running a restore silently converted a working managed identity into a SAS credential.** A credential is server-scoped and matched by URL prefix, so anything else on that instance using the same container went with it - a backup job writing there, most obviously. The only trace was "Credential updated on the server."

## The fix

- **`CredentialExistsAsync` returns `BlobCredentialStatus`** - the identity kind (missing / SAS / managed identity / other) plus the identity text. The seam was already anticipated in a comment above `RestoreFileListOnlyAsync`: *"keyed off the identity type that CredentialExistsAsync already reports - not off a flag."*
- **A managed identity reads as valid** in the panel and on the execute path, and no SAS token is sent.
- **Execute never converts a credential it did not create.** An identity it cannot use stops the run with that identity named, rather than being overwritten in passing. The restore it stops was going to fail on blob access anyway, and the credential is still there to look at. Nothing is filed in the history, because nothing was attempted.
- **The button says what the press would do.** Under a managed identity it read "Refresh credential with stored SAS token" - refreshing is not what that would have done. It now reads "Replace Managed Identity with stored SAS token", and the panel spells out that this changes how the whole instance reaches the container. Converting is still available; it just has to be chosen.
- **An unusable credential is named**, not merely rejected. "Not a SAS credential" was true of a managed identity and of a Windows account, which left no way to tell somebodys arrangement from a mistake.

## Tests

**919 passing, 24 skipped, 943 total.** New:

- `CredentialIdentityTests` - classification in every case the docs write it (`Managed Identity`, `MANAGED IDENTITY`, `managed identity`), what counts as usable, and the panel wording: a managed identity must not be described with "may fail", and an unusable one must name what it found.
- `RestoreExecutionViewModelTests` - the regression itself: with a managed identity on the server **and** a SAS token stored for the container, Execute writes nothing and the restore still runs; an unusable identity stops the run and writes nothing; a missing credential is still created.
- `XamlLoadTests` - the button label under a managed identity.
- `CredentialLifecycleTests` - a live pin, **run against a local SQL Express** (5/5 green): a credential created `WITH IDENTITY = Managed Identity` reads back as one. Worth having live because the classification is a string match against what `sys.credentials` actually stores. It proves the read, not the restore - `CREATE CREDENTIAL` takes the identity as free text on any edition, so this runs anywhere.

## Also in here

- **CHANGELOG entries for #29 and #30.** Both merged without any, so the two headline features of the release were missing from it.
- The **Known Limitations** line saying "SAS token authentication only (no Azure AD/Managed Identity yet)" is gone - it contradicted the Entra section three hundred lines above it. Replaced with the limitation that is actually true: the app can only create the SAS kind of server-side credential.

## Not in here

Creating managed-identity credentials from the app (`WITH IDENTITY = Managed Identity`, no secret, gated on `ProductMajorVersion >= 16` or `EngineEdition = 8`). It needs an Azure VM, Arc-enabled instance or SQL MI to verify against, and there is none here - on-prem only. Filing it separately rather than shipping it untested.
@