### PR TITLE
Lift the server-side credential out of RestoreViewModel (#115)

### DIFF
--- a/src/NineLives.Tests/CredentialIdentityTests.cs
+++ b/src/NineLives.Tests/CredentialIdentityTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Services;
+﻿using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
 
@@ -66,7 +66,7 @@ public class CredentialIdentityTests
     [Fact]
     public void AManagedIdentityIsDescribedAsValid()
     {
-        var message = RestoreViewModel.DescribeCredential(
+        var message = ServerCredentialViewModel.Describe(
             new BlobCredentialStatus(BlobCredentialIdentity.ManagedIdentity, "Managed Identity"));
 
         Assert.Contains("valid", message, StringComparison.OrdinalIgnoreCase);
@@ -81,7 +81,7 @@ public class CredentialIdentityTests
     [Fact]
     public void AnUnusableCredentialIsNamedRatherThanJustRejected()
     {
-        var message = RestoreViewModel.DescribeCredential(
+        var message = ServerCredentialViewModel.Describe(
             new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql"));
 
         Assert.Contains("MYDOMAIN\\svc_sql", message);
@@ -90,7 +90,7 @@ public class CredentialIdentityTests
     [Fact]
     public void AMissingCredentialSaysSo()
     {
-        var message = RestoreViewModel.DescribeCredential(BlobCredentialStatus.Missing);
+        var message = ServerCredentialViewModel.Describe(BlobCredentialStatus.Missing);
 
         Assert.Contains("not present", message, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -237,9 +237,15 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Lets a test hold a credential check open, or fail one. Without it the check completes
+    /// synchronously, so the sequencing between two overlapping checks cannot be reached.
+    /// </summary>
+    public Func<string, CancellationToken, Task<BlobCredentialStatus>>? OnCredentialCheck { get; set; }
+
     public Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default)
-        => Task.FromResult(Credential);
+        => OnCredentialCheck?.Invoke(credentialName, ct) ?? Task.FromResult(Credential);
 
     public Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,

--- a/src/NineLives.Tests/ServerCredentialViewModelTests.cs
+++ b/src/NineLives.Tests/ServerCredentialViewModelTests.cs
@@ -1,0 +1,276 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The server-side credential panel, on its own (#115 seam 5).
+///
+/// None of this had a test. Reaching it meant standing up a container, a listing and a connection
+/// through RestoreViewModel, and the two things most worth pinning - the sequencing between two
+/// overlapping checks, and what Execute decides before it runs - were the least reachable that way.
+/// </summary>
+public class ServerCredentialViewModelTests
+{
+    private static ServerConnection Server() => new()
+    {
+        Id = ServerConnection.NewId(),
+        Name = "SRV01",
+        ServerName = "SRV01"
+    };
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+    };
+
+    /// <summary>A log in a temp directory, never the user's real one.</summary>
+    private static OperationLog ThrowawayLog() => new(Path.Combine(
+        Path.GetTempPath(), "ninelives-credential-tests", Guid.NewGuid().ToString("n")));
+
+    private static (ServerCredentialViewModel vm, FakeSqlServerService sql, FakeCredentialStore store) New()
+    {
+        var sql = new FakeSqlServerService();
+        var store = new FakeCredentialStore();
+        var vm = new ServerCredentialViewModel(sql, store, ThrowawayLog(), new OperationCancellation());
+        return (vm, sql, store);
+    }
+
+    // ── what the panel is pointed at ────────────────────────────────────────────
+
+    [Fact]
+    public async Task PointingAtAContainerNamesTheCredentialAfterItsUrl()
+    {
+        var (vm, _, _) = New();
+        var container = Container();
+
+        await vm.PointAtAsync(container);
+
+        Assert.Equal(container.ContainerUrl, vm.Name);
+        Assert.True(vm.SectionVisible);
+    }
+
+    /// <summary>
+    /// Not connected yet, so there is no answer to give. Saying "not present on this server" here
+    /// would be a verdict about a server nobody has asked.
+    /// </summary>
+    [Fact]
+    public async Task WithNoServerThePanelOffersNoVerdict()
+    {
+        var (vm, _, _) = New();
+
+        await vm.PointAtAsync(Container());
+
+        Assert.Null(vm.ExistsOnServer);
+        Assert.Equal(string.Empty, vm.StatusMessage);
+        Assert.False(vm.IsUsable);
+    }
+
+    [Fact]
+    public async Task AManagedIdentityOnTheServerReadsAsUsable()
+    {
+        var (vm, sql, _) = New();
+        sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.ManagedIdentity, "Managed Identity");
+        vm.Server = Server();
+
+        await vm.PointAtAsync(Container());
+
+        Assert.True(vm.IsUsable);
+        Assert.True(vm.IsManagedIdentity);
+        Assert.False(vm.IsSharedAccessSignature);
+        Assert.Contains("Managed Identity", vm.StatusMessage);
+    }
+
+    // ── sequencing (#111) ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The check races itself. Two overlapping checks used to leave the panel showing whichever
+    /// finished LAST, which could be the container the user had already moved away from - and this
+    /// panel is what somebody reads before deciding whether to overwrite a credential.
+    ///
+    /// So the newer check wins even when the older one finishes after it.
+    /// </summary>
+    [Fact]
+    public async Task ASupersededCheckDoesNotGetTheLastWord()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        vm.Container = Container();
+        vm.Name = "first-container";
+
+        var firstCheckReached = new TaskCompletionSource();
+        var releaseFirstCheck = new TaskCompletionSource();
+
+        sql.OnCredentialCheck = async (name, ct) =>
+        {
+            if (name == "first-container")
+            {
+                firstCheckReached.SetResult();
+                await releaseFirstCheck.Task;
+
+                // The real service translates a cancelled command into this, so the fake must too:
+                // without it this test would pass against a viewmodel ignoring the token entirely.
+                ct.ThrowIfCancellationRequested();
+                return new BlobCredentialStatus(BlobCredentialIdentity.SharedAccessSignature, "SHARED ACCESS SIGNATURE");
+            }
+
+            return new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql");
+        };
+
+        var first = vm.RefreshAsync();
+        await firstCheckReached.Task;
+
+        // The user moves to another container while the first check is still in flight.
+        vm.Name = "second-container";
+        await vm.RefreshAsync();
+
+        releaseFirstCheck.SetResult();
+        await first;
+
+        Assert.Equal(BlobCredentialIdentity.Other, vm.IdentityKind);
+        Assert.Contains("MYDOMAIN\\svc_sql", vm.StatusMessage);
+        Assert.False(vm.IsChecking);
+    }
+
+    /// <summary>A check that fails leaves no verdict behind, rather than the previous one.</summary>
+    [Fact]
+    public async Task AFailedCheckSaysSoInsteadOfKeepingAStaleAnswer()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container());
+        Assert.True(vm.IsUsable);   // the default fake answer: a SAS credential
+
+        sql.OnCredentialCheck = (_, _) => throw new InvalidOperationException("Login failed for user.");
+        await vm.RefreshAsync();
+
+        Assert.Null(vm.ExistsOnServer);
+        Assert.False(vm.IsUsable);
+        Assert.Contains("Login failed for user.", vm.StatusMessage);
+        Assert.False(vm.IsChecking);
+    }
+
+    // ── creating one ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreatingWithNoStoredTokenReportsItAndWritesNothing()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container());
+
+        var reported = new List<(string Message, bool IsError)>();
+        vm.Reported += (m, e) => reported.Add((m, e));
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        Assert.Empty(sql.CredentialWrites);
+        var (message, isError) = Assert.Single(reported);
+        Assert.True(isError);
+        Assert.Contains("No SAS token stored", message);
+    }
+
+    /// <summary>
+    /// Replacing a managed identity is allowed - it is what the button is for - but it changes how
+    /// the whole instance reaches that container, so it must not be reported as a routine update
+    /// (#145).
+    /// </summary>
+    [Fact]
+    public async Task ReplacingAManagedIdentitySaysThatIsWhatHappened()
+    {
+        var (vm, sql, store) = New();
+        sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.ManagedIdentity, "Managed Identity");
+        vm.Server = Server();
+
+        var container = Container();
+        await vm.PointAtAsync(container);
+        store.SaveSasToken(container, "sv=2024-01-01&sig=x");
+
+        var reported = new List<string>();
+        vm.Reported += (m, _) => reported.Add(m);
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        Assert.Single(sql.CredentialWrites);
+        Assert.Contains(reported, m => m.Contains("managed identity", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── what Execute asks it ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An Entra container has no stored SAS token by design, so there is nothing this app could
+    /// write. Whatever is on the server is what the restore uses - most likely the managed identity
+    /// that pairs with browsing as Entra - and it is not this app's to guess at.
+    /// </summary>
+    [Fact]
+    public async Task WithNoStoredTokenTheRestoreProceedsWithoutTouchingTheServer()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container());
+
+        var checksAfterwards = 0;
+        sql.OnCredentialCheck = (_, _) =>
+        {
+            checksAfterwards++;
+            return Task.FromResult(sql.Credential);
+        };
+
+        var preflight = await vm.PrepareForRestoreAsync(Server(), _ => { });
+
+        Assert.True(preflight.CanProceed);
+        Assert.Empty(sql.CredentialWrites);
+        Assert.Equal(0, checksAfterwards);
+    }
+
+    [Fact]
+    public async Task AnUnusableIdentityStopsTheRestoreAndNamesItself()
+    {
+        var (vm, sql, store) = New();
+        sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql");
+        vm.Server = Server();
+
+        var container = Container();
+        await vm.PointAtAsync(container);
+        store.SaveSasToken(container, "sv=2024-01-01&sig=x");
+
+        var log = new List<string>();
+        var preflight = await vm.PrepareForRestoreAsync(Server(), log.Add);
+
+        Assert.False(preflight.CanProceed);
+        Assert.Contains("MYDOMAIN\\svc_sql", preflight.Refusal);
+        Assert.Contains(log, line => line.Contains("MYDOMAIN\\svc_sql", StringComparison.Ordinal));
+        Assert.Empty(sql.CredentialWrites);
+    }
+
+    /// <summary>
+    /// The SAS token is the one secret that crosses the wire during a restore, so an unverified
+    /// certificate is worth saying at the moment it happens rather than only in settings (#17).
+    /// </summary>
+    [Fact]
+    public async Task WritingAMissingCredentialWarnsWhenTheCertificateIsNotValidated()
+    {
+        var (vm, sql, store) = New();
+        sql.Credential = BlobCredentialStatus.Missing;
+
+        var server = Server();
+        server.TrustServerCertificate = true;
+        vm.Server = server;
+
+        var container = Container();
+        await vm.PointAtAsync(container);
+        store.SaveSasToken(container, "sv=2024-01-01&sig=x");
+
+        var log = new List<string>();
+        var preflight = await vm.PrepareForRestoreAsync(server, log.Add);
+
+        Assert.True(preflight.CanProceed);
+        Assert.Single(sql.CredentialWrites);
+        Assert.Contains(log, line => line.Contains("trusts the server certificate", StringComparison.Ordinal));
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -258,17 +258,17 @@ public class XamlLoadTests(WpfFixture wpf)
                 ContainerUrl = "https://acct.blob.core.windows.net/backups"
             };
             vm.IsConnectedToServer = true;
-            vm.CredentialSectionVisible = true;
+            vm.Credential.SectionVisible = true;
 
             var view = new RestoreView { DataContext = vm };
 
-            vm.CredentialExistsOnServer = false;
-            vm.CredentialIdentityKind = BlobCredentialIdentity.Missing;
+            vm.Credential.ExistsOnServer = false;
+            vm.Credential.IdentityKind = BlobCredentialIdentity.Missing;
             Realise(view);
             Assert.Contains(FindAll<Button>(view), b => (b.Content as string) == "Create credential on server");
 
-            vm.CredentialExistsOnServer = true;
-            vm.CredentialIdentityKind = BlobCredentialIdentity.SharedAccessSignature;
+            vm.Credential.ExistsOnServer = true;
+            vm.Credential.IdentityKind = BlobCredentialIdentity.SharedAccessSignature;
             Realise(view);
             Assert.Contains(FindAll<Button>(view),
                 b => (b.Content as string) == "Refresh credential with stored SAS token");
@@ -293,14 +293,17 @@ public class XamlLoadTests(WpfFixture wpf)
                 ContainerUrl = "https://acct.blob.core.windows.net/backups"
             };
             vm.IsConnectedToServer = true;
-            vm.CredentialSectionVisible = true;
+            vm.Credential.SectionVisible = true;
 
             var view = new RestoreView { DataContext = vm };
 
-            vm.CredentialExistsOnServer = true;
-            vm.CredentialIdentityKind = BlobCredentialIdentity.ManagedIdentity;
+            vm.Credential.ExistsOnServer = true;
+            vm.Credential.IdentityKind = BlobCredentialIdentity.ManagedIdentity;
             Realise(view);
 
+            // Present, not shown: the panel lives inside a section that needs a loaded backup
+            // set, which this fixture deliberately does not stand up. That the panel's own
+            // visibility binding resolves at all is covered by RestoreViewLoads.
             Assert.Contains(FindAll<Button>(view),
                 b => (b.Content as string) == "Replace Managed Identity with stored SAS token");
         });

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -251,9 +251,9 @@ public partial class MainViewModel : ViewModelBase
         ConnectedServerName = e.IsConnected ? e.ServerName : "Not connected";
         Restore.IsConnectedToServer = e.IsConnected;
         Restore.ConnectedServerName = e.ServerName;
+        // Setting ConnectedServer re-checks the credential itself (#115 seam 5).
         Restore.ConnectedServer = e.ConnectedServer;
         GlobalStatus = e.IsConnected ? $"Connected to {e.ServerName}" : "Ready";
-        _ = Restore.RefreshCredentialStatusAsync();
     }
 
     [RelayCommand]

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -42,11 +42,10 @@ public partial class RestoreViewModel : ViewModelBase
     private readonly OperationCancellation _queryCancellation = new();
 
     /// <summary>
-    /// The background credential check. Separate because it is not user-initiated and has no
-    /// button - and because it races itself: two overlapping checks would leave the panel showing
-    /// the result for whichever finished last, which could be the container the user just left.
+    /// The server-side credential the restore authenticates with: what is on the instance, what to
+    /// say about it, and what Execute should do before it runs (#115 seam 5).
     /// </summary>
-    private readonly OperationCancellation _credentialCheckCancellation = new();
+    public ServerCredentialViewModel Credential { get; }
 
     #region Observable Properties
 
@@ -277,7 +276,25 @@ public partial class RestoreViewModel : ViewModelBase
 
     public bool ShowMoveOptions => UseWithMove;
 
-    public ServerConnection? ConnectedServer { get; set; }
+    private ServerConnection? _connectedServer;
+
+    /// <summary>
+    /// The instance every server call on this screen runs against.
+    ///
+    /// Setting it re-checks the credential, rather than leaving the caller to remember: forgetting
+    /// left the panel describing the credential on the server someone had just disconnected from,
+    /// and that panel is what they read before deciding whether to create one (#115 seam 5).
+    /// </summary>
+    public ServerConnection? ConnectedServer
+    {
+        get => _connectedServer;
+        set
+        {
+            _connectedServer = value;
+            Credential.Server = value;
+            _ = Credential.RefreshAsync();
+        }
+    }
 
     /// <summary>
     /// Tags of the connected server, shown on the execute confirmation. Chips rather than plain
@@ -316,61 +333,15 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _restoreSummaryText = string.Empty;
 
-    [ObservableProperty]
-    private string _sqlCredentialName = string.Empty;
-
-    // Blob credential status on connected server (credential must exist for RESTORE FROM URL)
-    [ObservableProperty]
-    private bool? _credentialExistsOnServer; // null = not checked
-
-    // What the credential of that name actually authenticates as. The three views below are
-    // derived rather than stored: they used to be one bool that conflated "not a SAS credential"
-    // with "unusable", which is how a managed identity came to be treated as damage (#145).
-    [ObservableProperty]
-    private BlobCredentialIdentity _credentialIdentityKind = BlobCredentialIdentity.Missing;
-
-    /// <summary>A restore can authenticate with what is on the server as it stands.</summary>
-    public bool CredentialIsUsable =>
-        CredentialIdentityKind is BlobCredentialIdentity.SharedAccessSignature
-            or BlobCredentialIdentity.ManagedIdentity;
-
-    /// <summary>The credential holds a SAS, so the stored token is the thing that can go stale.</summary>
-    public bool CredentialIsSharedAccessSignature =>
-        CredentialIdentityKind == BlobCredentialIdentity.SharedAccessSignature;
-
-    /// <summary>The instance authenticates to storage as itself, and this app must not touch it.</summary>
-    public bool CredentialIsManagedIdentity =>
-        CredentialIdentityKind == BlobCredentialIdentity.ManagedIdentity;
-
-    partial void OnCredentialIdentityKindChanged(BlobCredentialIdentity value)
-    {
-        OnPropertyChanged(nameof(CredentialIsUsable));
-        OnPropertyChanged(nameof(CredentialIsSharedAccessSignature));
-        OnPropertyChanged(nameof(CredentialIsManagedIdentity));
-    }
-
-    [ObservableProperty]
-    private string _credentialStatusMessage = string.Empty;
-
-    [ObservableProperty]
-    private bool _isCheckingCredential;
-
-    [ObservableProperty]
-    private bool _credentialSectionVisible;
-
     partial void OnSelectedContainerChanged(BlobContainerConfig? value)
     {
-        if (value != null)
-            SqlCredentialName = value.ContainerUrl;
-        CredentialSectionVisible = value != null;
-
         // Everything on screen below this point came from the PREVIOUS container. Leaving it there
         // meant the credential panel and Create credential targeted the new container while the
         // script still restored from the old one's URLs - so Execute stayed armed and enabled, and
         // failed with Msg 3201 after WITH REPLACE had already dropped the target.
         ClearLoadedBackups();
 
-        _ = RefreshCredentialStatusAsync();
+        _ = Credential.PointAtAsync(value);
     }
 
     /// <summary>
@@ -400,77 +371,6 @@ public partial class RestoreViewModel : ViewModelBase
         ExecuteButtonText = "Execute on Server";
         _armTimeoutCts?.Cancel();
     }
-
-    /// <summary>Call when ConnectedServer or SelectedContainer changes so credential status is updated.</summary>
-    public async Task RefreshCredentialStatusAsync()
-    {
-        CredentialSectionVisible = SelectedContainer != null;
-        if (ConnectedServer == null || SelectedContainer == null)
-        {
-            CredentialExistsOnServer = null;
-            CredentialStatusMessage = string.Empty;
-            CredentialIdentityKind = BlobCredentialIdentity.Missing;
-            return;
-        }
-
-        // Cancels any check already in flight. Two overlapping checks left the panel showing the
-        // result of whichever finished LAST, which could be the container the user had just left -
-        // and that panel is what someone reads before deciding whether to create a credential.
-        var ct = _credentialCheckCancellation.Begin();
-
-        IsCheckingCredential = true;
-        CredentialStatusMessage = "Checking...";
-        var server = ConnectedServer;
-        try
-        {
-            var credential = await _sqlService.CredentialExistsAsync(server, SqlCredentialName, ct);
-            CredentialExistsOnServer = credential.Exists;
-            CredentialIdentityKind = credential.Kind;
-            CredentialStatusMessage = DescribeCredential(credential);
-        }
-        catch (OperationCanceledException)
-        {
-            // Superseded by a newer check - which is about to write its own answer here. Saying
-            // anything would just be the older check having the last word again.
-            return;
-        }
-        catch (Exception ex)
-        {
-            CredentialExistsOnServer = null;
-            CredentialIdentityKind = BlobCredentialIdentity.Missing;
-            CredentialStatusMessage = $"Could not check credential: {ex.Message}";
-        }
-        finally
-        {
-            // Only when this check is still the current one. Ending the newer check's source, or
-            // clearing its "Checking..." state, is how the previous version left the panel
-            // reporting the container the user had already moved away from.
-            if (!ct.IsCancellationRequested)
-            {
-                _credentialCheckCancellation.End();
-                IsCheckingCredential = false;
-                CreateCredentialOnServerCommand.NotifyCanExecuteChanged();
-            }
-        }
-    }
-
-    /// <summary>
-    /// The panel's one line about what is on the server. An unusable credential is named rather
-    /// than just rejected: "not a SAS credential" was the same sentence for a managed identity
-    /// that would have restored perfectly well and for a Windows account that never could (#145).
-    /// </summary>
-    internal static string DescribeCredential(BlobCredentialStatus credential) => credential.Kind switch
-    {
-        BlobCredentialIdentity.SharedAccessSignature =>
-            "Credential is present and valid (SHARED ACCESS SIGNATURE).",
-        BlobCredentialIdentity.ManagedIdentity =>
-            "Credential is present and valid (Managed Identity). The restore authenticates as the " +
-            "instance's own identity, so no SAS token is involved and this app will not modify it.",
-        BlobCredentialIdentity.Other =>
-            $"Credential exists with identity '{credential.Identity}', which a restore from URL " +
-            "cannot use. Replace it below, or point at a different credential.",
-        _ => "Credential is not present on this server. Restore will fail unless you create it."
-    };
 
     [ObservableProperty]
     private ObservableCollection<FileMoveOption> _fileMoves = [];
@@ -581,6 +481,14 @@ public partial class RestoreViewModel : ViewModelBase
         // Every console message is written to the log file as it arrives, so the file cannot drift
         // from what was on screen.
         Console = new ConsoleBuffer(message => _log.Info($"[execute] {message.Trim()}"));
+
+        // Shares _queryCancellation so the Stop button stops a credential write too (#111), and
+        // reports through the same status line as everything else on this screen (#115 seam 5).
+        Credential = new ServerCredentialViewModel(sqlService, credentialStore, _log, _queryCancellation);
+        Credential.Reported += (message, isError) =>
+        {
+            if (isError) SetError(message); else SetStatus(message);
+        };
 
         // IsBusy and TargetDatabaseName live on the base class, so they cannot have a generated
         // partial hook - but the busy strip is computed from them.
@@ -1458,55 +1366,6 @@ public partial class RestoreViewModel : ViewModelBase
         HasScript = true;
     }
 
-    /// <summary>Create or update the blob credential on the connected server (optional; not included in generated script).</summary>
-    [RelayCommand(CanExecute = nameof(CanCreateCredential))]
-    private async Task CreateCredentialOnServerAsync()
-    {
-        if (ConnectedServer == null || SelectedContainer == null) return;
-
-        var sasToken = _credentialStore.GetSasToken(SelectedContainer);
-        if (string.IsNullOrEmpty(sasToken))
-        {
-            SetError("No SAS token stored for this container. Add or refresh the token in Blob Storage config.");
-            return;
-        }
-
-        // What is about to be overwritten, read before the write. This is the only route by which
-        // a managed identity gets replaced by a SAS token, and it should say so afterwards rather
-        // than reporting a routine "updated" for a change to how the instance authenticates (#145).
-        var replaced = CredentialIdentityKind;
-
-        try
-        {
-            var change = await _sqlService.EnsureCredentialExistsAsync(
-                ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken,
-                _queryCancellation.Begin());
-            await RefreshCredentialStatusAsync();
-            SetStatus(change switch
-            {
-                CredentialChange.Created => "Credential created on server.",
-                _ when replaced == BlobCredentialIdentity.ManagedIdentity =>
-                    "Credential replaced on server: it authenticated as the instance's managed " +
-                    "identity and now holds the stored SAS token.",
-                _ => "Credential updated on server with the stored SAS token."
-            });
-            if (replaced == BlobCredentialIdentity.ManagedIdentity)
-                _log.ServerChange(ConnectedServer.ServerName,
-                    $"credential [{SqlCredentialName}] identity changed from Managed Identity to SAS");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to create credential: {ex.Message}");
-        }
-    }
-
-    // Deliberately available even when the credential is present and valid. SQL Server will not
-    // hand back a credential's secret, so "present and SAS" says nothing about whether the token
-    // inside it still works - a SAS that was rotated or has expired looks identical from here.
-    // Since Execute no longer rewrites the credential on every run, this button is the only way
-    // to push a fresh token, and hiding it left users with no route at all.
-    private bool CanCreateCredential() => IsConnectedToServer && SelectedContainer != null;
-
     [RelayCommand]
     private void CopyScript()
         => TryCopyToClipboard(GeneratedScript, "Script copied to clipboard.");
@@ -1774,75 +1633,15 @@ public partial class RestoreViewModel : ViewModelBase
                 return;
             }
 
-            if (SelectedContainer != null)
+            // Everything about the server-side credential lives on the child (#115 seam 5),
+            // including the decision not to touch one. A refusal has written nothing, so there is
+            // nothing to unwind - and nothing to file in the history either.
+            var preflight = await Credential.PrepareForRestoreAsync(server, AppendLog);
+            if (!preflight.CanProceed)
             {
-                var sasToken = _credentialStore.GetSasToken(SelectedContainer);
-                if (!string.IsNullOrEmpty(sasToken))
-                {
-                    // Only write to the server when the credential is genuinely missing or is not
-                    // a SAS credential. This used to drop and recreate on every single execute,
-                    // regardless of the status the panel above was displaying, which contradicted
-                    // the UI's own "creating it is optional" wording and briefly removed a
-                    // credential that other sessions may have been using.
-                    //
-                    // A credential that exists and is SAS is left alone. Its secret could still be
-                    // a rotated SAS that no longer works - that is unknowable from here, since the
-                    // secret cannot be read back - so the fix for that case is the explicit
-                    // refresh button, not silently rewriting server state on every run.
-                    //
-                    // A managed identity is left alone for a stronger reason: it restores perfectly
-                    // well, this app cannot create one, and ALTER would reset the identity. Reading
-                    // "not SAS" as "broken" is what silently converted somebody's working managed
-                    // identity into a SAS token here, taking every other job on that container with
-                    // it, under the log line "Credential updated on the server" (#145).
-                    var credential = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
-                    if (credential.CanRestoreFromUrl)
-                    {
-                        AppendLog(credential.Kind == BlobCredentialIdentity.ManagedIdentity
-                            ? $"Using the existing SQL credential [{SqlCredentialName}] (Managed Identity). Server state not modified."
-                            : $"Using the existing SQL credential [{SqlCredentialName}]. Server state not modified.");
-                    }
-                    else if (credential.Exists)
-                    {
-                        // Neither usable nor ours to reinterpret. Converting it is a real option -
-                        // it is what the button on the panel does - but it must be a decision
-                        // somebody made, not a side effect of pressing Execute. Stopping here costs
-                        // a restore that was about to fail on blob access anyway.
-                        attempted = false;
-                        var message =
-                            $"Credential [{SqlCredentialName}] exists with identity " +
-                            $"'{credential.Identity}', which a restore from URL cannot use. Left " +
-                            "untouched: replacing it with the stored SAS token is what " +
-                            "\"Create credential on server\" does, so that it is a deliberate change.";
-                        AppendLog(message);
-                        SetError(message);
-                        return;
-                    }
-                    else
-                    {
-                        AppendLog($"Credential [{SqlCredentialName}] is missing - creating it...");
-
-                        // This statement carries the SAS token to the server. It is the one moment
-                        // in a restore where a secret crosses the wire, so if the connection is
-                        // encrypted but unverified, say so here rather than only in settings (#17).
-                        if (server.TrustServerCertificate)
-                            AppendLog(
-                                "  Note: this connection trusts the server certificate without validating it, " +
-                                "and the SAS token is sent over it.");
-
-                        var change = await _sqlService.EnsureCredentialExistsAsync(
-                            server, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
-
-                        AppendLog(change == CredentialChange.Created
-                            ? "Credential created on the server."
-                            : "Credential updated on the server.");
-
-                        // Changing a credential is a change to shared state on someone's instance.
-                        // It belongs in the file, not only in a console that closes with the app.
-                        _log.ServerChange(server.ServerName,
-                            $"credential [{SqlCredentialName}] {change.ToString().ToLowerInvariant()}");
-                    }
-                }
+                attempted = false;
+                SetError(preflight.Refusal!);
+                return;
             }
 
             _log.ServerChange(server.ServerName,

--- a/src/NineLives/ViewModels/ServerCredentialViewModel.cs
+++ b/src/NineLives/ViewModels/ServerCredentialViewModel.cs
@@ -1,0 +1,340 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// Whether the connected instance can reach the container, and what to do when it cannot.
+///
+/// Fifth seam out of RestoreViewModel (#115). Small, but it was spread across four places that had
+/// to agree: the panel's status text, the button's label, what Execute does before it runs, and the
+/// sequencing that keeps a slow check from answering for a container the user has already left.
+/// They disagreed - #145 was the panel calling a managed identity broken and Execute then acting on
+/// that, which are two of those four places.
+///
+/// RESTORE FROM URL authenticates through a credential on the SERVER, named for the container URL
+/// and matched by prefix. Nothing here is about how this app reaches the container: that is the SAS
+/// token or Entra sign-in on the container config, and the two are independent - browsing with
+/// Entra while the instance restores with its own managed identity is an ordinary pairing.
+/// </summary>
+public partial class ServerCredentialViewModel : ObservableObject
+{
+    private readonly ISqlServerService _sql;
+    private readonly ICredentialStore _store;
+    private readonly OperationLog _log;
+
+    /// <summary>
+    /// Shared with the parent's other server calls, so the Stop button stops a credential write
+    /// too (#111). It is the parent's object: these are mutually exclusive buttons, and starting
+    /// one while another runs should stop the first.
+    /// </summary>
+    private readonly OperationCancellation _writeCancellation;
+
+    /// <summary>
+    /// The background check has its own source. It is not user-initiated, has no Stop button, and
+    /// races itself: two overlapping checks would leave the panel showing whichever finished last,
+    /// which could be the container the user just moved away from - and that panel is what someone
+    /// reads before deciding whether to create a credential (#111).
+    /// </summary>
+    private readonly OperationCancellation _checkCancellation = new();
+
+    public ServerCredentialViewModel(
+        ISqlServerService sql, ICredentialStore store, OperationLog log,
+        OperationCancellation writeCancellation)
+    {
+        _sql = sql;
+        _store = store;
+        _log = log;
+        _writeCancellation = writeCancellation;
+    }
+
+    /// <summary>
+    /// Something the user should see on the app's status line; true when it is an error.
+    ///
+    /// An event rather than a call back into the parent, so this type can be exercised without one.
+    /// <see cref="PrepareForRestoreAsync"/> deliberately does NOT raise it - a refusal there stops
+    /// the restore, and the execute path reports it alongside everything else it has to unwind.
+    /// </summary>
+    public event Action<string, bool>? Reported;
+
+    /// <summary>The instance the panel is describing, or null when not connected.</summary>
+    [ObservableProperty]
+    private ServerConnection? _server;
+
+    /// <summary>The container whose URL names the credential.</summary>
+    [ObservableProperty]
+    private BlobContainerConfig? _container;
+
+    /// <summary>
+    /// The credential name, which is the container URL by default and editable free text on screen.
+    /// Editable because the credential may already exist under a name somebody else chose.
+    /// </summary>
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    /// <summary>Null until a check has run, so "not checked yet" does not render as "missing".</summary>
+    [ObservableProperty]
+    private bool? _existsOnServer;
+
+    // What the credential of that name actually authenticates as. The three views below are derived
+    // rather than stored: they used to be one bool that conflated "not a SAS credential" with
+    // "unusable", which is how a managed identity came to be treated as damage (#145).
+    [ObservableProperty]
+    private BlobCredentialIdentity _identityKind = BlobCredentialIdentity.Missing;
+
+    /// <summary>A restore can authenticate with what is on the server as it stands.</summary>
+    public bool IsUsable =>
+        IdentityKind is BlobCredentialIdentity.SharedAccessSignature
+            or BlobCredentialIdentity.ManagedIdentity;
+
+    /// <summary>The credential holds a SAS, so the stored token is the thing that can go stale.</summary>
+    public bool IsSharedAccessSignature =>
+        IdentityKind == BlobCredentialIdentity.SharedAccessSignature;
+
+    /// <summary>The instance authenticates to storage as itself, and this app must not touch it.</summary>
+    public bool IsManagedIdentity => IdentityKind == BlobCredentialIdentity.ManagedIdentity;
+
+    partial void OnIdentityKindChanged(BlobCredentialIdentity value)
+    {
+        OnPropertyChanged(nameof(IsUsable));
+        OnPropertyChanged(nameof(IsSharedAccessSignature));
+        OnPropertyChanged(nameof(IsManagedIdentity));
+    }
+
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    [ObservableProperty]
+    private bool _isChecking;
+
+    /// <summary>The panel only means anything once a container is selected.</summary>
+    [ObservableProperty]
+    private bool _sectionVisible;
+
+    /// <summary>
+    /// Point this at a container: the credential is named for its URL, and everything on the panel
+    /// belongs to it. Clears the previous container's answer before asking about the new one, so a
+    /// stale verdict is never on screen under a different container's name.
+    /// </summary>
+    public Task PointAtAsync(BlobContainerConfig? container)
+    {
+        Container = container;
+        SectionVisible = container != null;
+        if (container != null) Name = container.ContainerUrl;
+        return RefreshAsync();
+    }
+
+    /// <summary>Call when the connected server or the selected container changes.</summary>
+    public async Task RefreshAsync()
+    {
+        SectionVisible = Container != null;
+        if (Server == null || Container == null)
+        {
+            ExistsOnServer = null;
+            StatusMessage = string.Empty;
+            IdentityKind = BlobCredentialIdentity.Missing;
+            return;
+        }
+
+        // Cancels any check already in flight. See _checkCancellation.
+        var ct = _checkCancellation.Begin();
+
+        IsChecking = true;
+        StatusMessage = "Checking...";
+        var server = Server;
+        try
+        {
+            var credential = await _sql.CredentialExistsAsync(server, Name, ct);
+            ExistsOnServer = credential.Exists;
+            IdentityKind = credential.Kind;
+            StatusMessage = Describe(credential);
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer check - which is about to write its own answer here. Saying
+            // anything would just be the older check having the last word again.
+            return;
+        }
+        catch (Exception ex)
+        {
+            ExistsOnServer = null;
+            IdentityKind = BlobCredentialIdentity.Missing;
+            StatusMessage = $"Could not check credential: {ex.Message}";
+        }
+        finally
+        {
+            // Only when this check is still the current one. Ending the newer check's source, or
+            // clearing its "Checking..." state, is how the previous version left the panel
+            // reporting the container the user had already moved away from.
+            if (!ct.IsCancellationRequested)
+            {
+                _checkCancellation.End();
+                IsChecking = false;
+                CreateOnServerCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The panel's one line about what is on the server. An unusable credential is named rather
+    /// than just rejected: "not a SAS credential" was the same sentence for a managed identity
+    /// that would have restored perfectly well and for a Windows account that never could (#145).
+    /// </summary>
+    internal static string Describe(BlobCredentialStatus credential) => credential.Kind switch
+    {
+        BlobCredentialIdentity.SharedAccessSignature =>
+            "Credential is present and valid (SHARED ACCESS SIGNATURE).",
+        BlobCredentialIdentity.ManagedIdentity =>
+            "Credential is present and valid (Managed Identity). The restore authenticates as the " +
+            "instance's own identity, so no SAS token is involved and this app will not modify it.",
+        BlobCredentialIdentity.Other =>
+            $"Credential exists with identity '{credential.Identity}', which a restore from URL " +
+            "cannot use. Replace it below, or point at a different credential.",
+        _ => "Credential is not present on this server. Restore will fail unless you create it."
+    };
+
+    /// <summary>Create or update the credential with the container's stored SAS token.</summary>
+    [RelayCommand(CanExecute = nameof(CanCreate))]
+    private async Task CreateOnServerAsync()
+    {
+        if (Server == null || Container == null) return;
+
+        var sasToken = _store.GetSasToken(Container);
+        if (string.IsNullOrEmpty(sasToken))
+        {
+            Reported?.Invoke(
+                "No SAS token stored for this container. Add or refresh the token in Blob Storage config.",
+                true);
+            return;
+        }
+
+        // What is about to be overwritten, read before the write. This is the only route by which
+        // a managed identity gets replaced by a SAS token, and it should say so afterwards rather
+        // than reporting a routine "updated" for a change to how the instance authenticates (#145).
+        var replaced = IdentityKind;
+
+        try
+        {
+            var change = await _sql.EnsureCredentialExistsAsync(
+                Server, Name, Container.ContainerUrl, sasToken, _writeCancellation.Begin());
+            await RefreshAsync();
+            Reported?.Invoke(change switch
+            {
+                CredentialChange.Created => "Credential created on server.",
+                _ when replaced == BlobCredentialIdentity.ManagedIdentity =>
+                    "Credential replaced on server: it authenticated as the instance's managed " +
+                    "identity and now holds the stored SAS token.",
+                _ => "Credential updated on server with the stored SAS token."
+            }, false);
+
+            if (replaced == BlobCredentialIdentity.ManagedIdentity)
+                _log.ServerChange(Server.ServerName,
+                    $"credential [{Name}] identity changed from Managed Identity to SAS");
+        }
+        catch (Exception ex)
+        {
+            Reported?.Invoke($"Failed to create credential: {ex.Message}", true);
+        }
+    }
+
+    // Deliberately available even when the credential is present and valid. SQL Server will not
+    // hand back a credential's secret, so "present and SAS" says nothing about whether the token
+    // inside it still works - a SAS that was rotated or has expired looks identical from here.
+    // Since Execute no longer rewrites the credential on every run, this button is the only way
+    // to push a fresh token, and hiding it left users with no route at all.
+    private bool CanCreate() => Server != null && Container != null;
+
+    partial void OnServerChanged(ServerConnection? value) => CreateOnServerCommand.NotifyCanExecuteChanged();
+    partial void OnContainerChanged(BlobContainerConfig? value) => CreateOnServerCommand.NotifyCanExecuteChanged();
+
+    /// <summary>
+    /// What the execute path should do about the credential before it starts, and everything it
+    /// should say about it. Writes to the server only when there is nothing of that name.
+    /// </summary>
+    public async Task<CredentialPreflight> PrepareForRestoreAsync(
+        ServerConnection server, Action<string> appendLog)
+    {
+        if (Container == null) return CredentialPreflight.Proceed;
+
+        // No stored token means nothing this app could write anyway - an Entra container has none
+        // by design. Whatever is on the server is what the restore will use, and it is not this
+        // app's to guess at.
+        var sasToken = _store.GetSasToken(Container);
+        if (string.IsNullOrEmpty(sasToken)) return CredentialPreflight.Proceed;
+
+        // Only write when the credential is genuinely missing. This used to drop and recreate on
+        // every single execute, regardless of the status the panel was displaying, which
+        // contradicted the UI's own "creating it is optional" wording and briefly removed a
+        // credential that other sessions may have been using (#10).
+        //
+        // A credential that exists and is SAS is left alone. Its secret could still be a rotated
+        // SAS that no longer works - unknowable from here, since the secret cannot be read back -
+        // so the fix for that case is the explicit button, not rewriting server state on every run.
+        //
+        // A managed identity is left alone for a stronger reason: it restores perfectly well, this
+        // app cannot create one, and ALTER would reset the identity. Reading "not SAS" as "broken"
+        // is what silently converted somebody's working managed identity into a SAS token here,
+        // taking every other job on that container with it, under the log line "Credential updated
+        // on the server" (#145).
+        var credential = await _sql.CredentialExistsAsync(server, Name);
+
+        if (credential.CanRestoreFromUrl)
+        {
+            appendLog(credential.Kind == BlobCredentialIdentity.ManagedIdentity
+                ? $"Using the existing SQL credential [{Name}] (Managed Identity). Server state not modified."
+                : $"Using the existing SQL credential [{Name}]. Server state not modified.");
+            return CredentialPreflight.Proceed;
+        }
+
+        if (credential.Exists)
+        {
+            // Neither usable nor ours to reinterpret. Converting it is a real option - it is what
+            // the button on the panel does - but it must be a decision somebody made, not a side
+            // effect of pressing Execute. Stopping costs a restore that was about to fail on blob
+            // access anyway.
+            var refusal =
+                $"Credential [{Name}] exists with identity '{credential.Identity}', which a " +
+                "restore from URL cannot use. Left untouched: replacing it with the stored SAS " +
+                "token is what \"Create credential on server\" does, so that it is a deliberate change.";
+            appendLog(refusal);
+            return CredentialPreflight.Stop(refusal);
+        }
+
+        appendLog($"Credential [{Name}] is missing - creating it...");
+
+        // This statement carries the SAS token to the server. It is the one moment in a restore
+        // where a secret crosses the wire, so if the connection is encrypted but unverified, say so
+        // here rather than only in settings (#17).
+        if (server.TrustServerCertificate)
+            appendLog(
+                "  Note: this connection trusts the server certificate without validating it, " +
+                "and the SAS token is sent over it.");
+
+        var written = await _sql.EnsureCredentialExistsAsync(
+            server, Name, Container.ContainerUrl, sasToken);
+
+        appendLog(written == CredentialChange.Created
+            ? "Credential created on the server."
+            : "Credential updated on the server.");
+
+        // Changing a credential is a change to shared state on someone's instance. It belongs in
+        // the file, not only in a console that closes with the app.
+        _log.ServerChange(server.ServerName,
+            $"credential [{Name}] {written.ToString().ToLowerInvariant()}");
+
+        return CredentialPreflight.Proceed;
+    }
+}
+
+/// <summary>
+/// Whether a restore may start, and what to say when it may not. A refusal here has touched
+/// nothing, so the caller has nothing to unwind.
+/// </summary>
+public readonly record struct CredentialPreflight(bool CanProceed, string? Refusal)
+{
+    public static CredentialPreflight Proceed => new(true, null);
+
+    public static CredentialPreflight Stop(string reason) => new(false, reason);
+}

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1075,7 +1075,7 @@
                                      Margin="0,0,0,16" />
 
                             <TextBlock Text="SQL CREDENTIAL NAME" Style="{StaticResource LabelText}" />
-                            <TextBox Text="{Binding SqlCredentialName, UpdateSourceTrigger=PropertyChanged}"
+                            <TextBox Text="{Binding Credential.Name, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,8"
                                      ToolTip="Defaults to the container URL. The credential on the server must match this name (container URL) for RESTORE FROM URL." />
@@ -1083,7 +1083,7 @@
                             <!-- Blob credential: when not connected, prompt to connect to verify; when connected, show status and optional Create -->
                             <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="12,10" Margin="0,0,0,16"
-                                    Visibility="{Binding CredentialSectionVisible, Converter={StaticResource BoolToVis}}">
+                                    Visibility="{Binding Credential.SectionVisible, Converter={StaticResource BoolToVis}}">
                                 <StackPanel>
                                     <TextBlock Text="BLOB CREDENTIAL ON SERVER" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
                                     <!-- Not connected: verify credential by connecting -->
@@ -1101,14 +1101,14 @@
                                                     <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
                                                     <Setter Property="BorderThickness" Value="0" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CredentialIsUsable}" Value="True">
+                                                        <DataTrigger Binding="{Binding Credential.IsUsable}" Value="True">
                                                             <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
                                                             <Setter Property="CornerRadius" Value="4" />
                                                             <Setter Property="Padding" Value="8,6,8,6" />
                                                         </DataTrigger>
-                                                        <DataTrigger Binding="{Binding CredentialExistsOnServer}" Value="False">
+                                                        <DataTrigger Binding="{Binding Credential.ExistsOnServer}" Value="False">
                                                             <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
@@ -1117,8 +1117,8 @@
                                                         </DataTrigger>
                                                         <MultiDataTrigger>
                                                             <MultiDataTrigger.Conditions>
-                                                                <Condition Binding="{Binding CredentialExistsOnServer}" Value="True" />
-                                                                <Condition Binding="{Binding CredentialIsUsable}" Value="False" />
+                                                                <Condition Binding="{Binding Credential.ExistsOnServer}" Value="True" />
+                                                                <Condition Binding="{Binding Credential.IsUsable}" Value="False" />
                                                             </MultiDataTrigger.Conditions>
                                                             <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource WarningBrush}" />
@@ -1129,11 +1129,11 @@
                                                     </Style.Triggers>
                                                 </Style>
                                             </Border.Style>
-                                            <TextBlock Text="{Binding CredentialStatusMessage}"
+                                            <TextBlock Text="{Binding Credential.StatusMessage}"
                                                        Style="{StaticResource SecondaryText}"
                                                        TextWrapping="Wrap" />
                                         </Border>
-                                        <TextBlock Visibility="{Binding CredentialIsUsable, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                        <TextBlock Visibility="{Binding Credential.IsUsable, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
                                             <Run Text="Restore from URL needs a SQL credential for the container, holding either a SHARED ACCESS SIGNATURE or - on SQL Server 2022 and later - the instance's Managed Identity. You can create the SAS kind from here, or create either on the server yourself before running the script. Execute will create one for you only if there is nothing of that name: a credential that already exists is never rewritten behind your back. The SAS token is never included in the generated script." />
                                         </TextBlock>
@@ -1141,18 +1141,18 @@
                                              credential of that name exists. SQL Server will not return its secret, so a
                                              rotated or expired token is indistinguishable from a working one, and this is
                                              the only way to push a fresh one. -->
-                                        <TextBlock Visibility="{Binding CredentialIsSharedAccessSignature, Converter={StaticResource BoolToVis}}"
+                                        <TextBlock Visibility="{Binding Credential.IsSharedAccessSignature, Converter={StaticResource BoolToVis}}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
                                             <Run Text="Execute will leave this credential alone. If the SAS token has been rotated or has expired since the credential was created, the restore will fail on blob access - refresh it below to push the token currently stored for this container." />
                                         </TextBlock>
                                         <!-- A managed identity is somebody else's deliberate setup: this app cannot create
                                              one, and the button below would ALTER it into a SAS credential, which is a
                                              change to how the whole instance authenticates to that container (#145). -->
-                                        <TextBlock Visibility="{Binding CredentialIsManagedIdentity, Converter={StaticResource BoolToVis}}"
+                                        <TextBlock Visibility="{Binding Credential.IsManagedIdentity, Converter={StaticResource BoolToVis}}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
                                             <Run Text="Execute will leave this credential alone and no SAS token is sent to the server. The instance authenticates to the container as itself, so the restore depends on its identity holding a role on the storage account rather than on anything stored here. The button below would replace that with a SAS credential - which would also change how anything else on this instance reaches the same container." />
                                         </TextBlock>
-                                        <Button Command="{Binding CreateCredentialOnServerCommand}"
+                                        <Button Command="{Binding Credential.CreateOnServerCommand}"
                                                 Margin="0,0,0,0" Padding="10,6"
                                                 ToolTip="Creates the SQL Server credential for this blob container URL, or updates an existing one with the SAS token currently stored for the container, so that RESTORE FROM URL can access the backups. An existing credential is altered in place, never dropped. The SAS token is not included in the generated script."
                                                 HorizontalAlignment="Left">
@@ -1160,13 +1160,13 @@
                                                 <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
                                                     <Setter Property="Content" Value="Create credential on server" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CredentialIsSharedAccessSignature}" Value="True">
+                                                        <DataTrigger Binding="{Binding Credential.IsSharedAccessSignature}" Value="True">
                                                             <Setter Property="Content" Value="Refresh credential with stored SAS token" />
                                                         </DataTrigger>
                                                         <!-- Says what the press would actually do. The same button under the
                                                              old label read as a harmless refresh while it converted the
                                                              instance's managed identity to a SAS token (#145). -->
-                                                        <DataTrigger Binding="{Binding CredentialIsManagedIdentity}" Value="True">
+                                                        <DataTrigger Binding="{Binding Credential.IsManagedIdentity}" Value="True">
                                                             <Setter Property="Content" Value="Replace Managed Identity with stored SAS token" />
                                                         </DataTrigger>
                                                     </Style.Triggers>


### PR DESCRIPTION
@
Fifth seam of #115. **2,157 → 1,956 lines**, and the credential is now one 340-line child rather than four places that had to agree with each other.

Those four were the panels status text, the buttons label, what Execute does before it runs, and the sequencing that keeps a slow check from answering for a container the user has already left. They did not agree - #145 was the panel calling a managed identity broken and Execute then acting on that, which is two of the four.

## What moved

`ServerCredentialViewModel` owns the state, the check, the create command, and `PrepareForRestoreAsync` - the answer to *may the restore start, and what should it say*. A refusal has written nothing to the server, so the execute path has nothing to unwind: it reports and returns, and nothing goes in the history because nothing was attempted.

The execute paths credential handling goes from ~65 lines of nested branching to four:

```csharp
var preflight = await Credential.PrepareForRestoreAsync(server, AppendLog);
if (!preflight.CanProceed) { attempted = false; SetError(preflight.Refusal!); return; }
```

Which also makes seam 6 (execution) smaller before it starts.

## Two things tightened on the way past

- **Setting `ConnectedServer` re-checks the credential itself.** `MainViewModel` used to set the property and then remember to call the refresh separately. Anything that forgot left the panel describing the credential on a server the user had just disconnected from - and that panel is what somebody reads before deciding whether to overwrite a credential.
- **The child reports through an event** rather than calling back into the parent, so it can be exercised without one. `PrepareForRestoreAsync` deliberately does not raise it: a refusal there is the execute paths to report alongside everything else it unwinds.

Cancellation keeps the split it had: its own source for the background check (not user-initiated, races itself), the parents for the write, so the Stop button still stops a credential write (#111).

## Tests

**929 passing, 24 skipped** (up 10). None of this had a test before, for the reason the earlier seams kept finding: reaching it meant standing up a container, a listing and a connection through `RestoreViewModel`, so the two things most worth pinning were the least reachable.

- **A superseded check does not get the last word.** Two overlapping checks, the first held open and released after the second finishes - the panel must show the second. Needed a fake that honours the cancellation token, since the real service turns a cancelled command into `OperationCanceledException` and a fake that ignored it would let a viewmodel with no sequencing at all pass.
- **A failed check leaves no stale verdict**, rather than the previous containers answer.
- **What Execute decides per identity**: an unusable one stops and names itself; a missing one is written; a container with no stored token proceeds without touching the server at all - which is the Entra case, where there is no token by design.
- **The certificate warning** when the SAS crosses an unvalidated connection (#17) now has a test.
- Creating with no stored token reports it and writes nothing; replacing a managed identity says that is what happened.

No CHANGELOG entry, matching the previous four seams: behaviour is unchanged.

## Remaining on #115

4 (container listing and discovery, ~250 lines) and 6 (execution, ~330).
@