### PR TITLE
UX cohesion: persistent errors, keyboard access, and a Settings screen (#117 items 6, 5, 2)

### DIFF
--- a/src/NineLives.Tests/KeyboardShortcutTests.cs
+++ b/src/NineLives.Tests/KeyboardShortcutTests.cs
@@ -1,0 +1,103 @@
+using System.Globalization;
+using System.Windows.Data;
+using Blackcat.NineLives.Converters;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The keyboard shortcuts (#117 item 5).
+///
+/// The key gestures themselves live in MainWindow's InputBindings and cannot be pressed from a
+/// test without a shown window. What can be tested is the part that would actually go wrong: what
+/// each one decides to do, given that a window-level key reaches every screen.
+/// </summary>
+// In the WPF collection for the Application these ViewModels expect to exist, but nothing here
+// needs to run on the dispatcher thread, so the fixture itself is never touched.
+[Collection(WpfCollection.Name)]
+public class KeyboardShortcutTests
+{
+    private static MainViewModel New() => new(new FakeCredentialStore());
+
+    [Fact]
+    public void TheSidebarStartsOnTheScreenTheAppOpens()
+    {
+        // The sidebar highlight is bound to this now, rather than a hardcoded IsChecked on the
+        // first button - so if it did not start on a real view name, nothing would look selected.
+        var vm = New();
+
+        Assert.Equal(MainViewModel.Nav.BlobStorage, vm.CurrentViewName);
+        Assert.Contains(vm.CurrentViewName, MainViewModel.Nav.Views);
+    }
+
+    /// <summary>
+    /// F5 on a screen that lists nothing must do nothing. Bound straight to the Restore screen's
+    /// loader it would have run a blob listing while somebody was reading About.
+    /// </summary>
+    [Fact]
+    public void ReloadDoesNothingOnAScreenWithNothingToReload()
+    {
+        var vm = New();
+        vm.NavigateToCommand.Execute(MainViewModel.Nav.About);
+
+        vm.ReloadCommand.Execute(null);
+
+        Assert.False(vm.Restore.IsBusy);
+        Assert.False(vm.Restore.BackupsLoaded);
+    }
+
+    [Fact]
+    public void GenerateIsIgnoredAwayFromTheRestoreScreen()
+    {
+        var vm = New();
+        vm.NavigateToCommand.Execute(MainViewModel.Nav.History);
+
+        vm.GenerateScriptCommand.Execute(null);
+
+        Assert.False(vm.Restore.HasScript);
+    }
+
+    /// <summary>
+    /// Esc with nothing running is a no-op rather than an exception. It is not gated on the
+    /// current screen - a restore keeps running while somebody navigates away, and a stop key that
+    /// only works on one page is not a stop key.
+    /// </summary>
+    [Fact]
+    public void EscapeWithNothingRunningIsHarmless()
+    {
+        var vm = New();
+        vm.NavigateToCommand.Execute(MainViewModel.Nav.About);
+
+        vm.CancelCurrentCommand.Execute(null);
+        vm.CancelCurrentCommand.Execute(null);
+    }
+
+    /// <summary>
+    /// The sidebar binds IsChecked through EnumToBoolConverter against a STRING view name, not an
+    /// enum. ConvertBack has to refuse in that case: a RadioButton sets IsChecked locally when it
+    /// is clicked, and anything other than Binding.DoNothing there would write back through the
+    /// binding and leave the selection out of step with the screen actually showing.
+    /// </summary>
+    [Fact]
+    public void ClickingASidebarButtonDoesNotWriteBackThroughTheBinding()
+    {
+        var converter = new EnumToBoolConverter();
+
+        Assert.Equal(
+            Binding.DoNothing,
+            converter.ConvertBack(true, typeof(string), "Restore", CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData("Restore", "Restore", true)]
+    [InlineData("Restore", "History", false)]
+    public void TheSidebarHighlightFollowsTheCurrentView(string current, string button, bool expected)
+    {
+        var converter = new EnumToBoolConverter();
+
+        Assert.Equal(
+            expected,
+            converter.Convert(current, typeof(bool), button, CultureInfo.InvariantCulture));
+    }
+}

--- a/src/NineLives.Tests/SettingsViewModelTests.cs
+++ b/src/NineLives.Tests/SettingsViewModelTests.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The Settings screen (#117 item 2).
+///
+/// Two of these settings had no UI at all: the update check was editable only by hand-editing
+/// config.json, and log retention was a constant in the source.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class SettingsViewModelTests
+{
+    private static OperationLog ThrowawayLog() => new(Path.Combine(
+        Path.GetTempPath(), "ninelives-settings-tests", Guid.NewGuid().ToString("n")));
+
+    [Fact]
+    public void TheScreenOpensOnWhatIsInTheConfig()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.CheckForUpdates = false;
+        store.Config.LogRetentionDays = 7;
+
+        var vm = new SettingsViewModel(store, ThrowawayLog());
+
+        Assert.False(vm.CheckForUpdates);
+        Assert.Equal(7, vm.LogRetentionDays);
+    }
+
+    /// <summary>
+    /// Loading must not write. Every property here saves when it changes, so a constructor that
+    /// set them without a guard would save the config as a side effect of opening the screen -
+    /// and on a config that failed to load, that is how the file gets overwritten with defaults.
+    /// </summary>
+    [Fact]
+    public void OpeningTheScreenSavesNothing()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.CheckForUpdates = false;
+
+        _ = new SettingsViewModel(store, ThrowawayLog());
+
+        Assert.Equal(0, store.SaveConfigCalls);
+    }
+
+    [Fact]
+    public void TurningTheUpdateCheckOffIsRemembered()
+    {
+        var store = new FakeCredentialStore();
+        var vm = new SettingsViewModel(store, ThrowawayLog());
+
+        vm.CheckForUpdates = false;
+
+        Assert.False(store.Config.CheckForUpdates);
+    }
+
+    [Fact]
+    public void ChangingRetentionIsRememberedAndAppliedToTheLiveLog()
+    {
+        var store = new FakeCredentialStore();
+        var log = ThrowawayLog();
+        var vm = new SettingsViewModel(store, log);
+
+        vm.LogRetentionDays = 90;
+
+        Assert.Equal(90, store.Config.LogRetentionDays);
+
+        // Applied now rather than at next startup: somebody shortening it on a shared machine
+        // means it, and "restart the app" is the kind of instruction that gets skipped.
+        Assert.Equal(90, log.RetentionDays);
+    }
+
+    /// <summary>
+    /// A retention of zero would delete today's log file - the one recording the restore that is
+    /// running while somebody fiddles with this box.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void RetentionCannotBeSetLowEnoughToDeleteTodaysLog(int typed)
+    {
+        var store = new FakeCredentialStore();
+        var log = ThrowawayLog();
+        var vm = new SettingsViewModel(store, log);
+
+        vm.LogRetentionDays = typed;
+
+        Assert.Equal(OperationLog.MinimumRetentionDays, log.RetentionDays);
+
+        // And the box shows what is actually in force, not what was typed.
+        Assert.Equal(OperationLog.MinimumRetentionDays, vm.LogRetentionDays);
+    }
+
+    /// <summary>
+    /// About is a credits page again. It carried the theme picker only because it was the one
+    /// screen that was not a workflow step.
+    /// </summary>
+    [Fact]
+    public void SettingsIsReachableFromTheSidebarAndAboutIsNotASettingsScreen()
+    {
+        Assert.Contains(MainViewModel.Nav.Settings, MainViewModel.Nav.Views);
+        Assert.Null(typeof(AboutViewModel).GetProperty("SelectedTheme"));
+        Assert.Null(typeof(AboutViewModel).GetProperty("LogFolder"));
+    }
+}

--- a/src/NineLives.Tests/StatusAndErrorTests.cs
+++ b/src/NineLives.Tests/StatusAndErrorTests.cs
@@ -1,0 +1,94 @@
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Status is transient, an error is sticky (#117 item 6).
+///
+/// The two used to share one line and one clearing rule, so the next thing that happened painted
+/// over the last thing that went wrong. That was noticed once - "no valid restore points"
+/// disappearing under "Loaded 1 files" - and fixed at that one call site, which left every other
+/// pairing of a failure and a following success with the same hole.
+/// </summary>
+public class StatusAndErrorTests
+{
+    /// <summary>The protected surface, reachable. Every ViewModel inherits exactly this.</summary>
+    private sealed class TestViewModel : ViewModelBase
+    {
+        public void Status(string message) => SetStatus(message);
+        public void Error(string message) => SetError(message);
+        public void Clear() => ClearStatus();
+    }
+
+    [Fact]
+    public void AStatusMessageDoesNotEraseAnError()
+    {
+        var vm = new TestViewModel();
+
+        vm.Error("No valid restore points for that database.");
+        vm.Status("Loaded 1 files.");
+
+        Assert.True(vm.HasError);
+        Assert.Contains("No valid restore points", vm.ErrorMessage);
+        Assert.Equal("Loaded 1 files.", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void ANewErrorSupersedesTheOldOne()
+    {
+        var vm = new TestViewModel();
+
+        vm.Error("First failure.");
+        vm.Error("Second failure.");
+
+        Assert.True(vm.HasError);
+        Assert.Equal("Second failure.", vm.ErrorMessage);
+    }
+
+    /// <summary>
+    /// The escape hatch for the case the persistence rule would otherwise get wrong: a failure
+    /// that gets fixed and retried successfully. Every long-running command calls this before it
+    /// starts, so the stale error goes with it.
+    /// </summary>
+    [Fact]
+    public void StartingTheNextOperationClearsBoth()
+    {
+        var vm = new TestViewModel();
+
+        vm.Error("Login failed for user.");
+        vm.Clear();
+
+        Assert.False(vm.HasError);
+        Assert.Equal(string.Empty, vm.ErrorMessage);
+        Assert.Equal(string.Empty, vm.StatusMessage);
+    }
+
+    [Fact]
+    public void DismissingAnErrorLeavesTheStatusLineAlone()
+    {
+        var vm = new TestViewModel();
+
+        vm.Error("Could not check credential.");
+        vm.Status("Connected to SRV01.");
+        vm.DismissErrorCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+        Assert.Equal(string.Empty, vm.ErrorMessage);
+        Assert.Equal("Connected to SRV01.", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Not every screen surfaces both. The History screen binds only the status line, so an error
+    /// that wrote only to the error surface would be invisible there.
+    /// </summary>
+    [Fact]
+    public void AnErrorAlsoReachesTheStatusLineForScreensThatOnlyShowThat()
+    {
+        var vm = new TestViewModel();
+
+        vm.Error("Could not read the saved log.");
+
+        Assert.Equal("Could not read the saved log.", vm.StatusMessage);
+    }
+}

--- a/src/NineLives.Tests/ThemeTests.cs
+++ b/src/NineLives.Tests/ThemeTests.cs
@@ -1,4 +1,4 @@
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Media;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
@@ -340,7 +340,7 @@ public class ThemeTests(WpfFixture wpf)
         {
             wpf.Invoke(() =>
             {
-                var vm = new AboutViewModel(store) { SelectedTheme = AppTheme.HighContrast };
+                var vm = new SettingsViewModel(store) { SelectedTheme = AppTheme.HighContrast };
                 Assert.Equal(AppTheme.HighContrast, ThemeManager.Current);
             });
 
@@ -366,7 +366,7 @@ public class ThemeTests(WpfFixture wpf)
         {
             wpf.Invoke(() =>
             {
-                var vm = new AboutViewModel(store) { SelectedTheme = AppTheme.Light };
+                var vm = new SettingsViewModel(store) { SelectedTheme = AppTheme.Light };
 
                 Assert.Equal(AppTheme.Light, ThemeManager.Current);
                 Assert.True(vm.HasError);

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -182,6 +182,13 @@ public class XamlLoadTests(WpfFixture wpf)
         });
     }
 
+    // The sidebar highlight is likewise not asserted here (#117 item 5). It is bound to
+    // CurrentViewName so that Ctrl+1..6 moves it, and the obvious test - navigate by command, then
+    // check which RadioButton is checked - finds no RadioButtons at all: an unshown Window has no
+    // visual tree, the same limitation as the banner above. What CAN break is covered elsewhere:
+    // MainWindowLoads traces a wrong binding path, and KeyboardShortcutTests pins the converter in
+    // both directions, including that ConvertBack refuses so a click cannot desync the selection.
+
     // The update banner is not asserted on beyond MainWindowLoads above, which does cover what
     // can break silently: it parses the banner's markup, its storyboard and its drop shadow, and
     // resolves every {StaticResource} it uses - a missing key would throw there.

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -138,6 +138,11 @@ public class XamlLoadTests(WpfFixture wpf)
             new BlobBrowserView { DataContext = new BlobBrowserViewModel(new BlobStorageService(Store()), Store()) });
 
     [Fact]
+    public void SettingsViewLoads()
+        => Check("SettingsView", () =>
+            new SettingsView { DataContext = new SettingsViewModel(Store()) });
+
+    [Fact]
     public void RestoreViewLoads()
         => Check("RestoreView", () => new RestoreView { DataContext = NewRestoreViewModel() });
 

--- a/src/NineLives/App.xaml.cs
+++ b/src/NineLives/App.xaml.cs
@@ -1,4 +1,4 @@
-using System.Windows;
+﻿using System.Windows;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.Views;
 
@@ -27,7 +27,9 @@ public partial class App : Application
         AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
         TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
 
-        Log.Prune();
+        // Prune moved to MainViewModel, after the config is read: retention is configurable now,
+        // and pruning here with the default would delete files the user had asked to keep before
+        // anything had read the setting (#117 item 2).
         Log.Info($"Nine Lives {AppVersion.Display} starting on {Environment.OSVersion}");
 
         // Explicit for the whole startup sequence: while the splash is briefly the only window,

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -15,9 +15,28 @@
          built a MainViewModel against the real %LOCALAPPDATA% config and ran the secret-key
          migration over it. -->
 
+    <!-- Keyboard shortcuts (#117 item 5). Every action needed the mouse: no menu bar, no
+         accelerators, nothing. Ctrl+1..6 follow the sidebar's own order, so the numbering is
+         readable off the screen rather than something to memorise.
+
+         What each one does is decided on MainViewModel, not bound straight to a screen's command -
+         see the comment there. -->
+    <Window.InputBindings>
+        <KeyBinding Modifiers="Ctrl" Key="D1" Command="{Binding NavigateToCommand}" CommandParameter="Blob Storage" />
+        <KeyBinding Modifiers="Ctrl" Key="D2" Command="{Binding NavigateToCommand}" CommandParameter="SQL Servers" />
+        <KeyBinding Modifiers="Ctrl" Key="D3" Command="{Binding NavigateToCommand}" CommandParameter="Browse Backups" />
+        <KeyBinding Modifiers="Ctrl" Key="D4" Command="{Binding NavigateToCommand}" CommandParameter="Restore" />
+        <KeyBinding Modifiers="Ctrl" Key="D5" Command="{Binding NavigateToCommand}" CommandParameter="History" />
+        <KeyBinding Modifiers="Ctrl" Key="D6" Command="{Binding NavigateToCommand}" CommandParameter="About" />
+        <KeyBinding Key="F5" Command="{Binding ReloadCommand}" />
+        <KeyBinding Modifiers="Ctrl" Key="G" Command="{Binding GenerateScriptCommand}" />
+        <KeyBinding Key="Escape" Command="{Binding CancelCurrentCommand}" />
+    </Window.InputBindings>
+
     <Window.Resources>
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
         <converters:NullToVisibilityConverter x:Key="NullToVis" />
+        <converters:EnumToBoolConverter x:Key="EnumToBool" />
 
         <DataTemplate DataType="{x:Type vm:BlobConfigViewModel}">
             <views:BlobConfigView />
@@ -140,6 +159,7 @@
                     <!-- About Button -->
                     <RadioButton DockPanel.Dock="Bottom"
                                  Style="{StaticResource SidebarButton}"
+                                 IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='About'}"
                                  Command="{Binding NavigateToCommand}"
                                  CommandParameter="About"
                                  Margin="0,0,0,4">
@@ -184,7 +204,7 @@
                                    FontFamily="Segoe UI" />
 
                         <RadioButton Style="{StaticResource SidebarButton}"
-                                     IsChecked="True"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Blob Storage'}"
                                      Command="{Binding NavigateToCommand}"
                                      CommandParameter="Blob Storage">
                             <StackPanel Orientation="Horizontal">
@@ -194,6 +214,7 @@
                         </RadioButton>
 
                         <RadioButton Style="{StaticResource SidebarButton}"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='SQL Servers'}"
                                      Command="{Binding NavigateToCommand}"
                                      CommandParameter="SQL Servers">
                             <StackPanel Orientation="Horizontal">
@@ -213,6 +234,7 @@
                                    FontFamily="Segoe UI" />
 
                         <RadioButton Style="{StaticResource SidebarButton}"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Browse Backups'}"
                                      Command="{Binding NavigateToCommand}"
                                      CommandParameter="Browse Backups">
                             <StackPanel Orientation="Horizontal">
@@ -222,6 +244,7 @@
                         </RadioButton>
 
                         <RadioButton Style="{StaticResource SidebarButton}"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Restore'}"
                                      Command="{Binding NavigateToCommand}"
                                      CommandParameter="Restore">
                             <StackPanel Orientation="Horizontal">
@@ -231,6 +254,7 @@
                         </RadioButton>
 
                         <RadioButton Style="{StaticResource SidebarButton}"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='History'}"
                                      Command="{Binding NavigateToCommand}"
                                      CommandParameter="History">
                             <StackPanel Orientation="Horizontal">

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -27,7 +27,8 @@
         <KeyBinding Modifiers="Ctrl" Key="D3" Command="{Binding NavigateToCommand}" CommandParameter="Browse Backups" />
         <KeyBinding Modifiers="Ctrl" Key="D4" Command="{Binding NavigateToCommand}" CommandParameter="Restore" />
         <KeyBinding Modifiers="Ctrl" Key="D5" Command="{Binding NavigateToCommand}" CommandParameter="History" />
-        <KeyBinding Modifiers="Ctrl" Key="D6" Command="{Binding NavigateToCommand}" CommandParameter="About" />
+        <KeyBinding Modifiers="Ctrl" Key="D6" Command="{Binding NavigateToCommand}" CommandParameter="Settings" />
+        <KeyBinding Modifiers="Ctrl" Key="D7" Command="{Binding NavigateToCommand}" CommandParameter="About" />
         <KeyBinding Key="F5" Command="{Binding ReloadCommand}" />
         <KeyBinding Modifiers="Ctrl" Key="G" Command="{Binding GenerateScriptCommand}" />
         <KeyBinding Key="Escape" Command="{Binding CancelCurrentCommand}" />
@@ -40,6 +41,9 @@
 
         <DataTemplate DataType="{x:Type vm:BlobConfigViewModel}">
             <views:BlobConfigView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:SettingsViewModel}">
+            <views:SettingsView />
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:ServerManagerViewModel}">
             <views:ServerManagerView />
@@ -155,6 +159,21 @@
                             Height="1"
                             Background="{DynamicResource CardBorderBrush}"
                             Margin="16,8,16,8" />
+
+                    <!-- Settings and About, pinned to the bottom. Settings is declared first so
+                         it docks BELOW About - DockPanel stacks bottom-docked children in
+                         declaration order, from the edge inwards. -->
+                    <RadioButton DockPanel.Dock="Bottom"
+                                 Style="{StaticResource SidebarButton}"
+                                 IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Settings'}"
+                                 Command="{Binding NavigateToCommand}"
+                                 CommandParameter="Settings"
+                                 Margin="0,0,0,4">
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="&#x2699;" FontSize="15" VerticalAlignment="Center" Width="24" />
+                            <TextBlock Text="Settings" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </RadioButton>
 
                     <!-- About Button -->
                     <RadioButton DockPanel.Dock="Bottom"

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -312,6 +312,16 @@ public class AppConfig
     public AppTheme Theme { get; set; } = AppTheme.Dark;
 
     /// <summary>
+    /// How many days of operation logs to keep. It was a hardcoded 30 with no way to change it,
+    /// which is the wrong answer in both directions: a change ticket may need the record kept for
+    /// longer, and a shared machine may want it kept for less (#117 item 2).
+    ///
+    /// Clamped where it is used rather than trusted from here - a hand-edited 0 would otherwise
+    /// delete today's log, which is the one recording the restore currently running.
+    /// </summary>
+    public int LogRetentionDays { get; set; } = OperationLog.DefaultRetentionDays;
+
+    /// <summary>
     /// Set when config.json existed but could not be read or parsed. Not persisted - it describes
     /// this load attempt, not the configuration. While it is set, this object holds empty defaults
     /// that do NOT reflect what is on disk, so <see cref="CredentialStore.SaveConfig"/> will

--- a/src/NineLives/Services/OperationLog.cs
+++ b/src/NineLives/Services/OperationLog.cs
@@ -19,8 +19,24 @@ namespace Blackcat.NineLives.Services;
 /// </summary>
 public sealed class OperationLog
 {
-    /// <summary>Files older than this are removed on startup.</summary>
-    private const int RetentionDays = 30;
+    /// <summary>What retention is when nobody has said otherwise.</summary>
+    public const int DefaultRetentionDays = 30;
+
+    /// <summary>The floor. A log the app deletes the moment it writes it is not a log.</summary>
+    public const int MinimumRetentionDays = 1;
+
+    private int _retentionDays = DefaultRetentionDays;
+
+    /// <summary>
+    /// Files older than this are removed by <see cref="Prune"/>. Settable from the Settings screen
+    /// (#117 item 2), and clamped: the value comes from config.json, which is hand-editable, and a
+    /// 0 there would delete today's file - the one recording the restore currently running.
+    /// </summary>
+    public int RetentionDays
+    {
+        get => _retentionDays;
+        set => _retentionDays = Math.Max(MinimumRetentionDays, value);
+    }
 
     /// <summary>A single day's file is rolled once it passes this, so one runaway loop cannot fill the disk.</summary>
     private const long MaxFileBytes = 5 * 1024 * 1024;

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -949,5 +949,50 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <!-- The error surface, one definition for every screen (#117 item 6).
+
+         Four views each had their own bare TextBlock bound to ErrorMessage, which is why an error
+         read as ordinary body text on some screens, and why none of them offered any way to clear
+         one. Now that an error persists until it is superseded or dismissed, it has to be both
+         visibly an error and closeable.
+
+         Usage: <ContentControl Style="{StaticResource ErrorBanner}" /> - it binds itself to the
+         ViewModelBase members on the inherited DataContext. -->
+    <Style x:Key="ErrorBanner" TargetType="ContentControl">
+        <Setter Property="Visibility" Value="{Binding HasError, Converter={StaticResource BoolToVis}}" />
+        <Setter Property="Margin" Value="0,0,0,12" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ContentControl">
+                    <Border Background="{DynamicResource DangerPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource ErrorBrush}"
+                            BorderThickness="1" CornerRadius="4" Padding="10,8">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="{Binding ErrorMessage}"
+                                       Foreground="{DynamicResource ErrorBrush}"
+                                       TextWrapping="Wrap"
+                                       VerticalAlignment="Center" />
+                            <Button Grid.Column="1"
+                                    Command="{Binding DismissErrorCommand}"
+                                    Content="&#x2715;"
+                                    ToolTip="Dismiss this error"
+                                    Margin="10,0,0,0"
+                                    VerticalAlignment="Top"
+                                    Foreground="{DynamicResource ErrorBrush}"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Padding="6,2"
+                                    Cursor="Hand"
+                                    FontSize="12" />
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
 </ResourceDictionary>

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -1,6 +1,4 @@
-using System.Diagnostics;
-using System.IO;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Services;
 
@@ -19,21 +17,20 @@ public sealed record ThemeOption(AppTheme Value, string Name)
     public override string ToString() => Name;
 }
 
+/// <summary>
+/// Credits. Nothing here changes anything.
+///
+/// It used to carry the theme picker and the log folder, because it was the only page that was not
+/// a workflow step - so the one screen with no settings on it became the settings screen. They are
+/// on Settings now (#117 item 2).
+/// </summary>
 public partial class AboutViewModel : ViewModelBase
 {
-    private readonly ICredentialStore? _credentialStore;
-
-    public AboutViewModel() : this(null) { }
-
     /// <summary>
-    /// Takes the store so the theme choice can be remembered. Optional, because About is otherwise
-    /// a static page and a test that only wants to render it should not need a store.
+    /// Takes an optional store purely so the existing construction sites do not all have to
+    /// change. Nothing is read from it.
     /// </summary>
-    public AboutViewModel(ICredentialStore? credentialStore)
-    {
-        _credentialStore = credentialStore;
-        _selectedTheme = ThemeManager.Current;
-    }
+    public AboutViewModel(ICredentialStore? credentialStore = null) { }
 
     public string AppName => "Nine Lives";
     public string Version => Services.AppVersion.Display;
@@ -43,66 +40,4 @@ public partial class AboutViewModel : ViewModelBase
     public string Website => "https://blackcat.wales";
     public string Description => "Every database deserves nine lives. A production-ready utility for restoring SQL Server databases from Azure Blob Storage backups with full support for point-in-time recovery using Full, Differential, and Transaction Log backup chains.";
 
-    /// <summary>Shown so the path can be read even if opening the folder fails.</summary>
-    public string LogFolder => App.Log.Directory;
-
-    // ── appearance ──────────────────────────────────────────────────────────────
-
-    /// <summary>One entry per theme, named for the picker.</summary>
-    public IReadOnlyList<ThemeOption> Themes { get; } =
-        ThemeManager.All.Select(t => new ThemeOption(t, ThemeManager.DisplayName(t))).ToList();
-
-    [ObservableProperty]
-    private AppTheme _selectedTheme;
-
-    /// <summary>
-    /// Applies the theme immediately and remembers it.
-    ///
-    /// Applying first: a theme that will not load is worth knowing about right away, and the
-    /// switch is instant because every colour is a DynamicResource. Saving is best-effort - a
-    /// config that refuses to write should not undo a change the user can already see.
-    /// </summary>
-    partial void OnSelectedThemeChanged(AppTheme value)
-    {
-        if (!ThemeManager.Apply(value))
-        {
-            SetError("The theme could not be applied.");
-            return;
-        }
-
-        ClearStatus();
-
-        if (_credentialStore == null) return;
-
-        try
-        {
-            var config = _credentialStore.LoadConfig();
-            config.Theme = value;
-            _credentialStore.SaveConfig(config);
-        }
-        catch (Exception ex)
-        {
-            SetError($"The theme was applied, but could not be saved for next time: {ex.Message}");
-        }
-    }
-
-    public static string ThemeName(AppTheme theme) => ThemeManager.DisplayName(theme);
-
-    /// <summary>
-    /// Opens the log folder in Explorer. The logs are what someone attaches to a bug report, so
-    /// there needs to be a way to find them that is not "know where LocalAppData is" (#40).
-    /// </summary>
-    [RelayCommand]
-    private void OpenLogFolder()
-    {
-        try
-        {
-            Directory.CreateDirectory(App.Log.Directory);
-            Process.Start(new ProcessStartInfo(App.Log.Directory) { UseShellExecute = true });
-        }
-        catch (Exception ex)
-        {
-            SetError($"Could not open the log folder: {ex.Message}. It is at {App.Log.Directory}");
-        }
-    }
 }

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -52,6 +52,7 @@ public partial class MainViewModel : ViewModelBase
     public BlobBrowserViewModel BlobBrowser { get; }
     public RestoreViewModel Restore { get; }
     public HistoryViewModel History { get; }
+    public SettingsViewModel Settings { get; }
     public AboutViewModel About { get; }
 
     /// <summary>
@@ -96,7 +97,14 @@ public partial class MainViewModel : ViewModelBase
             _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
             log: null, history: _historyStore);
         History = new HistoryViewModel(_historyStore);
-        About = new AboutViewModel(_credentialStore);
+        Settings = new SettingsViewModel(_credentialStore);
+        About = new AboutViewModel();
+
+        // After the config is loaded, not at startup in App: pruning first and reading the setting
+        // afterwards would delete files the user had asked to keep, using the default of 30 to
+        // decide (#117 item 2).
+        App.Log.RetentionDays = Settings.LogRetentionDays;
+        App.Log.Prune();
 
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
 
@@ -331,10 +339,11 @@ public partial class MainViewModel : ViewModelBase
         public const string BrowseBackups = "Browse Backups";
         public const string Restore = "Restore";
         public const string History = "History";
+        public const string Settings = "Settings";
         public const string About = "About";
 
         public static IReadOnlyList<string> Views =>
-            [BlobStorage, SqlServers, BrowseBackups, Restore, History, About];
+            [BlobStorage, SqlServers, BrowseBackups, Restore, History, Settings, About];
     }
 
     [RelayCommand]
@@ -348,6 +357,7 @@ public partial class MainViewModel : ViewModelBase
             Nav.BrowseBackups => BlobBrowser,
             Nav.Restore => Restore,
             Nav.History => History,
+            Nav.Settings => Settings,
             Nav.About => About,
             _ => BlobConfig
         };

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -19,7 +19,9 @@ public partial class MainViewModel : ViewModelBase
     private ViewModelBase? _currentView;
 
     [ObservableProperty]
-    private string _currentViewName = "Blob Storage";
+    // The sidebar's selection is bound to this, so it also decides which button is highlighted at
+    // startup - it used to be a hardcoded IsChecked="True" on the first one (#117 item 5).
+    private string _currentViewName = Nav.BlobStorage;
 
     [ObservableProperty]
     private string _globalStatus = "Ready";
@@ -260,6 +262,58 @@ public partial class MainViewModel : ViewModelBase
     private void DisconnectSql()
     {
         ServerManager.DisconnectCommand.Execute(null);
+    }
+
+    // ── keyboard (#117 item 5) ──────────────────────────────────────────────────
+    //
+    // The shortcuts are declared on the window, but what they DO is decided here, because a key
+    // that reaches the whole app has to mean something sensible on every screen. F5 bound straight
+    // to the Restore screen's loader would run a blob listing while somebody was reading About -
+    // no visible effect, real network traffic, and a status line changing on a page that has none.
+    //
+    // Each of these routes to the current screen and does nothing where it has no meaning, rather
+    // than being disabled globally because one screen cannot use it.
+
+    /// <summary>F5: reload whatever the current screen lists.</summary>
+    [RelayCommand]
+    private void Reload()
+    {
+        switch (CurrentViewName)
+        {
+            case Nav.Restore:
+                if (Restore.LoadBackupsCommand.CanExecute(null)) Restore.LoadBackupsCommand.Execute(null);
+                break;
+            case Nav.BrowseBackups:
+                BlobBrowser.RefreshContainers();
+                break;
+            case Nav.History:
+                History.Refresh();
+                break;
+        }
+    }
+
+    /// <summary>Ctrl+G: generate the restore script. Only the Restore screen generates anything.</summary>
+    [RelayCommand]
+    private void GenerateScript()
+    {
+        if (CurrentViewName != Nav.Restore) return;
+        if (Restore.GenerateScriptCommand.CanExecute(null)) Restore.GenerateScriptCommand.Execute(null);
+    }
+
+    /// <summary>
+    /// Esc: stop whatever is running.
+    ///
+    /// Not gated on the current screen. A restore or a verify keeps running while somebody
+    /// navigates away, and the whole point of a stop key is that it works when you reach for it.
+    /// Ordered by cost of letting it continue: an execute is writing to a database, a query is
+    /// only reading, a load is only listing.
+    /// </summary>
+    [RelayCommand]
+    private void CancelCurrent()
+    {
+        if (Restore.CancelExecuteCommand.CanExecute(null)) { Restore.CancelExecuteCommand.Execute(null); return; }
+        if (Restore.CancelQueryCommand.CanExecute(null)) { Restore.CancelQueryCommand.Execute(null); return; }
+        if (Restore.CancelLoadCommand.CanExecute(null)) Restore.CancelLoadCommand.Execute(null);
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,165 @@
+using System.Diagnostics;
+using System.IO;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The application's own settings, in one place (#117 item 2).
+///
+/// They were scattered or unreachable: the theme picker went into About because About was the only
+/// page that was not a workflow step, the update check existed only in config.json, and log
+/// retention was a constant in the source. About is a credits page again.
+///
+/// Everything here is global. The per-container backup server time zone (#102) is NOT here even
+/// though the issue listed it, because it is a property OF a container - one machine can hold
+/// backups from several servers on different clocks - so it stays on the container editor where
+/// the container it describes is.
+/// </summary>
+public partial class SettingsViewModel : ViewModelBase
+{
+    private readonly ICredentialStore _credentialStore;
+    private readonly OperationLog _log;
+
+    /// <summary>True while the constructor is filling the properties from config.</summary>
+    private readonly bool _loading;
+
+    public SettingsViewModel(ICredentialStore credentialStore, OperationLog? log = null)
+    {
+        _credentialStore = credentialStore;
+        _log = log ?? App.Log;
+
+        _loading = true;
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            _selectedTheme = ThemeManager.Current;
+            _checkForUpdates = config.CheckForUpdates;
+            _logRetentionDays = config.LogRetentionDays;
+        }
+        catch
+        {
+            // A config that will not load is reported where it is loaded for real. Here it just
+            // means the screen shows defaults rather than failing to open at all.
+            _selectedTheme = ThemeManager.Current;
+            _checkForUpdates = true;
+            _logRetentionDays = OperationLog.DefaultRetentionDays;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    // ── appearance ──────────────────────────────────────────────────────────────
+
+    /// <summary>One entry per theme, named for the picker.</summary>
+    public IReadOnlyList<ThemeOption> Themes { get; } =
+        ThemeManager.All.Select(t => new ThemeOption(t, ThemeManager.DisplayName(t))).ToList();
+
+    [ObservableProperty]
+    private AppTheme _selectedTheme;
+
+    /// <summary>
+    /// Applies the theme immediately and remembers it.
+    ///
+    /// Applying first: a theme that will not load is worth knowing about right away, and the
+    /// switch is instant because every colour is a DynamicResource. Saving is best-effort - a
+    /// config that refuses to write should not undo a change the user can already see.
+    /// </summary>
+    partial void OnSelectedThemeChanged(AppTheme value)
+    {
+        if (_loading) return;
+
+        if (!ThemeManager.Apply(value))
+        {
+            SetError("The theme could not be applied.");
+            return;
+        }
+
+        Save(config => config.Theme = value, "The theme was applied, but could not be saved for next time");
+    }
+
+    // ── updates ─────────────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private bool _checkForUpdates;
+
+    partial void OnCheckForUpdatesChanged(bool value)
+    {
+        if (_loading) return;
+        Save(config => config.CheckForUpdates = value, "The update setting could not be saved");
+    }
+
+    // ── logs ────────────────────────────────────────────────────────────────────
+
+    /// <summary>Shown so the path can be read even if opening the folder fails.</summary>
+    public string LogFolder => _log.Directory;
+
+    [ObservableProperty]
+    private int _logRetentionDays;
+
+    /// <summary>
+    /// Applied to the live log as well as saved, so a shortened retention takes effect now rather
+    /// than at next startup - somebody reducing it on a shared machine means it, and telling them
+    /// to restart the app for that is the kind of thing that gets skipped.
+    /// </summary>
+    partial void OnLogRetentionDaysChanged(int value)
+    {
+        if (_loading) return;
+
+        _log.RetentionDays = value;
+        _log.Prune();
+
+        // The clamped value, not the typed one: the box should show what is actually in force.
+        if (_log.RetentionDays != value)
+        {
+            LogRetentionDays = _log.RetentionDays;
+            return;
+        }
+
+        Save(config => config.LogRetentionDays = value, "The log retention could not be saved");
+    }
+
+    /// <summary>
+    /// Opens the log folder in Explorer. The logs are what someone attaches to a bug report, so
+    /// there needs to be a way to find them that is not "know where LocalAppData is" (#40).
+    /// </summary>
+    [RelayCommand]
+    private void OpenLogFolder()
+    {
+        try
+        {
+            Directory.CreateDirectory(_log.Directory);
+            Process.Start(new ProcessStartInfo(_log.Directory) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not open the log folder: {ex.Message}. It is at {_log.Directory}");
+        }
+    }
+
+    /// <summary>
+    /// Read, change, write - one setting at a time, on the config as it is on disk right now.
+    ///
+    /// Never holds a loaded config across edits. Two screens both writing settings from their own
+    /// stale copy is how one of them silently reverts the other's, and the container and server
+    /// lists live in the same file.
+    /// </summary>
+    private void Save(Action<AppConfig> change, string failureLead)
+    {
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            change(config);
+            _credentialStore.SaveConfig(config);
+            ClearStatus();
+        }
+        catch (Exception ex)
+        {
+            SetError($"{failureLead}: {ex.Message}");
+        }
+    }
+}

--- a/src/NineLives/ViewModels/ViewModelBase.cs
+++ b/src/NineLives/ViewModels/ViewModelBase.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Blackcat.NineLives.ViewModels;
 
@@ -33,13 +34,24 @@ public abstract partial class ViewModelBase : ObservableObject
     [ObservableProperty]
     private string _errorMessage = string.Empty;
 
-    protected void SetStatus(string message)
-    {
-        StatusMessage = message;
-        HasError = false;
-        ErrorMessage = string.Empty;
-    }
+    /// <summary>
+    /// Transient: what the app is doing, or has just done.
+    ///
+    /// Deliberately does NOT clear the error any more (#117 item 6). The two shared one line, so
+    /// the next thing that happened painted over the last thing that went wrong - "no valid
+    /// restore points" vanishing under "Loaded 1 files" was this, and it was fixed narrowly at
+    /// that one call site rather than here. An error now outlives the status messages that follow
+    /// it.
+    /// </summary>
+    protected void SetStatus(string message) => StatusMessage = message;
 
+    /// <summary>
+    /// Sticky: survives until another error supersedes it, the user dismisses it, or the next
+    /// operation starts and calls <see cref="ClearStatus"/>.
+    ///
+    /// Still writes the status line as well, because not every screen surfaces both - the History
+    /// screen binds only the status line, and an error there would otherwise be silent.
+    /// </summary>
     protected void SetError(string message)
     {
         HasError = true;
@@ -47,9 +59,21 @@ public abstract partial class ViewModelBase : ObservableObject
         StatusMessage = message;
     }
 
+    /// <summary>
+    /// Both surfaces, for the start of an operation. Called by every long-running command before
+    /// it does anything, which is what stops a fixed-and-retried failure leaving its error behind.
+    /// </summary>
     protected void ClearStatus()
     {
         StatusMessage = string.Empty;
+        HasError = false;
+        ErrorMessage = string.Empty;
+    }
+
+    /// <summary>Dismisses the error without touching the status line.</summary>
+    [RelayCommand]
+    private void DismissError()
+    {
         HasError = false;
         ErrorMessage = string.Empty;
     }

--- a/src/NineLives/Views/AboutView.xaml
+++ b/src/NineLives/Views/AboutView.xaml
@@ -54,34 +54,6 @@
                     </Hyperlink>
                 </TextBlock>
 
-                <Border Height="1" Background="{DynamicResource CardBorderBrush}" Margin="0,0,0,20" />
-
-                <TextBlock Text="APPEARANCE" Style="{StaticResource LabelText}" HorizontalAlignment="Center" />
-                <ComboBox ItemsSource="{Binding Themes}"
-                          DisplayMemberPath="Name"
-                          SelectedValuePath="Value"
-                          SelectedValue="{Binding SelectedTheme}"
-                          Style="{StaticResource DarkComboBox}"
-                          Width="200"
-                          HorizontalAlignment="Center"
-                          Margin="0,0,0,6"
-                          ToolTip="Dark is the default. High contrast is pure black and white with saturated status colours, for anyone who needs it." />
-                <TextBlock Text="Applies straight away, and is remembered."
-                           Style="{StaticResource SecondaryText}"
-                           FontSize="11"
-                           HorizontalAlignment="Center"
-                           Margin="0,0,0,20" />
-
-                <!-- The logs are what someone attaches to a bug report, so there has to be a way
-                     to find them that is not "know where LocalAppData lives" (#40). -->
-                <Button Content="Open log folder"
-                        Command="{Binding OpenLogFolderCommand}"
-                        Style="{StaticResource SecondaryButton}"
-                        Padding="10,6"
-                        HorizontalAlignment="Center"
-                        Margin="0,0,0,12"
-                        ToolTip="{Binding LogFolder}" />
-
                 <ContentControl Style="{StaticResource ErrorBanner}" />
 
                 <TextBlock HorizontalAlignment="Center"

--- a/src/NineLives/Views/AboutView.xaml
+++ b/src/NineLives/Views/AboutView.xaml
@@ -82,12 +82,7 @@
                         Margin="0,0,0,12"
                         ToolTip="{Binding LogFolder}" />
 
-                <TextBlock Text="{Binding ErrorMessage}"
-                           Style="{StaticResource SecondaryText}"
-                           TextWrapping="Wrap"
-                           HorizontalAlignment="Center"
-                           Margin="0,0,0,12"
-                           Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}" />
+                <ContentControl Style="{StaticResource ErrorBanner}" />
 
                 <TextBlock HorizontalAlignment="Center"
                            Style="{StaticResource SecondaryText}">

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -663,12 +663,7 @@
                                 </StackPanel>
                             </Border>
 
-                            <!-- Error display -->
-                            <TextBlock Text="{Binding ErrorMessage}"
-                                       Foreground="{DynamicResource ErrorBrush}"
-                                       Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
-                                       Margin="0,0,0,12"
-                                       TextWrapping="Wrap" />
+                            <ContentControl Style="{StaticResource ErrorBanner}" />
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                 <Button Content="Save"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1282,10 +1282,7 @@
                         </TextBlock>
                     </Border>
 
-                    <TextBlock Text="{Binding ErrorMessage}"
-                               Foreground="{DynamicResource ErrorBrush}"
-                               Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
-                               Margin="0,0,0,12" TextWrapping="Wrap" />
+                    <ContentControl Style="{StaticResource ErrorBanner}" />
 
                     <!-- The generated script. Stays visible during and after execution: it used to
                          be hidden the moment Execute was pressed, so the script and the console

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -366,11 +366,7 @@
                                      HorizontalAlignment="Left"
                                      Margin="0,0,0,16" />
 
-                            <TextBlock Text="{Binding ErrorMessage}"
-                                       Foreground="{DynamicResource ErrorBrush}"
-                                       Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
-                                       Margin="0,0,0,12"
-                                       TextWrapping="Wrap" />
+                            <ContentControl Style="{StaticResource ErrorBanner}" />
 
                             <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                                 <Button Content="Save"

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -1,0 +1,87 @@
+﻿<UserControl x:Class="Blackcat.NineLives.Views.SettingsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="24">
+        <StackPanel MaxWidth="640" HorizontalAlignment="Left">
+
+            <TextBlock Text="Settings" Style="{StaticResource HeaderText}" Margin="0,0,0,4" />
+            <TextBlock Text="Applies to the whole application. Anything that belongs to one container or one server is edited where that container or server is."
+                       Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,20" />
+
+            <ContentControl Style="{StaticResource ErrorBanner}" />
+
+            <!-- Appearance -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="APPEARANCE" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                    <ComboBox ItemsSource="{Binding Themes}"
+                              DisplayMemberPath="Name"
+                              SelectedValuePath="Value"
+                              SelectedValue="{Binding SelectedTheme}"
+                              Style="{StaticResource DarkComboBox}"
+                              Width="240"
+                              HorizontalAlignment="Left"
+                              Margin="0,0,0,6"
+                              ToolTip="Dark is the default. High contrast is pure black and white with saturated status colours, for anyone who needs it." />
+                    <TextBlock Text="Applies straight away, and is remembered."
+                               Style="{StaticResource SecondaryText}"
+                               FontSize="11" />
+                </StackPanel>
+            </Border>
+
+            <!-- Updates -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="UPDATES" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                    <CheckBox IsChecked="{Binding CheckForUpdates}"
+                              Content="Check GitHub for a newer release at startup"
+                              Style="{StaticResource DarkCheckBox}"
+                              Margin="0,0,0,6" />
+                    <TextBlock Text="Turn this off for an offline install, or where outbound access to github.com is not allowed. Nothing is ever downloaded or installed automatically - the check only shows a banner."
+                               Style="{StaticResource SecondaryText}"
+                               FontSize="11"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+
+            <!-- Logs -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="LOGS" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+
+                    <TextBlock Text="{Binding LogFolder}"
+                               Style="{StaticResource SecondaryText}"
+                               FontFamily="Cascadia Code, Consolas, Courier New"
+                               FontSize="11"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,8" />
+
+                    <!-- The logs are what someone attaches to a bug report, so there has to be a
+                         way to find them that is not "know where LocalAppData lives" (#40). -->
+                    <Button Content="Open log folder"
+                            Command="{Binding OpenLogFolderCommand}"
+                            Style="{StaticResource SecondaryButton}"
+                            Padding="10,6"
+                            HorizontalAlignment="Left"
+                            Margin="0,0,0,16"
+                            ToolTip="{Binding LogFolder}" />
+
+                    <TextBlock Text="KEEP LOGS FOR (DAYS)" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
+                    <TextBox Text="{Binding LogRetentionDays, UpdateSourceTrigger=LostFocus}"
+                             Style="{StaticResource DarkTextBox}"
+                             Width="100"
+                             HorizontalAlignment="Left"
+                             Margin="0,0,0,6" />
+                    <TextBlock Text="Older log files are deleted on startup, and when this is changed. A restore's own record lives here, so a change ticket that needs the evidence later needs this set high enough to keep it."
+                               Style="{StaticResource SecondaryText}"
+                               FontSize="11"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/NineLives/Views/SettingsView.xaml.cs
+++ b/src/NineLives/Views/SettingsView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class SettingsView : UserControl
+{
+    public SettingsView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
@
#117 item 6. **934 passing, 24 skipped.**

## The defect

`SetStatus` cleared `HasError` and `ErrorMessage`. Status and errors shared one line *and* one clearing rule, so the next thing that happened painted over the last thing that went wrong.

That was noticed once — "no valid restore points" disappearing under "Loaded 1 files" — and fixed at that one call site. Every other pairing of a failure with a following success behaved the same way, and there are 84 `SetStatus`/`SetError` calls across seven ViewModels.

## The rule now

- **`SetStatus` writes the status line and nothing else.** An error survives until another error supersedes it, the user dismisses it, or the next operation starts.
- **`ClearStatus` still clears both**, and every long-running command already called it before doing anything — so a failure that gets fixed and retried successfully still clears its own error. That existing habit is what makes the persistence rule safe rather than sticky-forever.
- **`SetError` still writes the status line too.** Not every screen surfaces both: the History screen binds only the status line, and an error there would otherwise be silent.
- **`DismissError`** on the base, because a persistent error needs a way out.

## One error surface instead of four

Each of RestoreView, BlobConfigView, ServerManagerView and AboutView had its own `TextBlock` bound to `ErrorMessage`. They had drifted — three red, Abouts in grey secondary text, so an error there read as ordinary body copy — and none could be dismissed.

One `ErrorBanner` style in `Controls.xaml`, used as `<ContentControl Style="{StaticResource ErrorBanner}" />`. Same reasoning as #39s one publish definition: four copies of a thing is four chances for one to be wrong.

**Rendered under all three themes and checked by eye** — the technique that caught the invisible History text and the theme picker binding. Red on the dark, light and high-contrast palettes all read, and the `✕` picks up no default button chrome. Worth doing because #126 was exactly this failure mode: a colour pairing that was unreadable in one palette only.

## Tests

Five, against a `ViewModelBase` subclass, since the surface is protected and had none: a status does not erase an error; a new error supersedes the old; `ClearStatus` clears both; dismissing leaves the status line alone; an error still reaches the status line for screens that only show that.
@