### PR TITLE
Sign in to Entra off the UI thread (#152)

### DIFF
--- a/src/NineLives.Tests/EntraSignInThreadTests.cs
+++ b/src/NineLives.Tests/EntraSignInThreadTests.cs
@@ -36,14 +36,31 @@ public class EntraSignInThreadTests(WpfFixture wpf) : IDisposable
     {
         public List<int> CalledOnThreads { get; } = [];
 
+        /// <summary>Set by the dispatcher, proving the UI thread was still processing messages.</summary>
+        public ManualResetEventSlim UiPumped { get; } = new(false);
+
+        /// <summary>False when the sign-in gave up waiting for the UI thread to do anything.</summary>
+        public bool UiRespondedDuringSignIn { get; private set; }
+
         public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken ct)
         {
-            lock (CalledOnThreads) CalledOnThreads.Add(Environment.CurrentManagedThreadId);
+            var first = false;
+            lock (CalledOnThreads)
+            {
+                first = CalledOnThreads.Count == 0;
+                CalledOnThreads.Add(Environment.CurrentManagedThreadId);
+            }
 
-            // Stands in for somebody completing a sign-in in a browser. Short, but long enough that
-            // a blocked dispatcher would fail the pumping check below.
-            Thread.Sleep(300);
-            stopAfterFirst.Cancel();
+            // Stands in for somebody completing a sign-in in a browser: it does not finish until
+            // the UI thread has demonstrably pumped. That makes the check deterministic instead of
+            // a race - the operation cannot complete, and the frame cannot exit, before the probe
+            // has had its turn. If the sign-in were running ON the UI thread, nothing could set
+            // this and the wait times out, which is the failure being tested for.
+            if (first)
+            {
+                UiRespondedDuringSignIn = UiPumped.Wait(TimeSpan.FromSeconds(5));
+                stopAfterFirst.Cancel();
+            }
 
             return new AccessToken("token", DateTimeOffset.UtcNow.AddHours(1));
         }
@@ -71,7 +88,6 @@ public class EntraSignInThreadTests(WpfFixture wpf) : IDisposable
         BlobStorageService.CredentialFactoryForTests = _ => credential;
 
         var uiThreadId = 0;
-        var dispatcherKeptPumping = false;
 
         wpf.Invoke(() =>
         {
@@ -80,11 +96,10 @@ public class EntraSignInThreadTests(WpfFixture wpf) : IDisposable
             var service = new BlobStorageService(new FakeCredentialStore());
             var frame = new DispatcherFrame();
 
-            // Queued at a lower priority than the work: it can only run if the dispatcher is still
-            // processing messages, which is exactly what "the window is frozen" means it is not.
+            // The probe. A frozen window is one whose dispatcher never gets to this.
             _ = Dispatcher.CurrentDispatcher.BeginInvoke(
                 DispatcherPriority.Background,
-                new Action(() => dispatcherKeptPumping = true));
+                new Action(() => credential.UiPumped.Set()));
 
             _ = service.VerifyConnectionAsync(EntraContainer(), stop.Token)
                 .ContinueWith(_ => frame.Continue = false, TaskScheduler.FromCurrentSynchronizationContext());
@@ -95,7 +110,7 @@ public class EntraSignInThreadTests(WpfFixture wpf) : IDisposable
         Assert.NotEmpty(credential.CalledOnThreads);
         var signIn = credential.CalledOnThreads[0];
         Assert.NotEqual(uiThreadId, signIn);
-        Assert.True(dispatcherKeptPumping, "the dispatcher stopped processing while signing in");
+        Assert.True(credential.UiRespondedDuringSignIn, "the dispatcher stopped processing while signing in");
     }
 
     /// <summary>A SAS container has no sign-in to do, and must not be made to wait for one.</summary>

--- a/src/NineLives.Tests/EntraSignInThreadTests.cs
+++ b/src/NineLives.Tests/EntraSignInThreadTests.cs
@@ -1,0 +1,122 @@
+﻿using System.Windows.Threading;
+using Azure.Core;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The Entra sign-in must not happen on the UI thread (#152).
+///
+/// InteractiveBrowserCredential launches a browser and waits for the redirect to come back, on
+/// whatever thread asked for the token. Every blob operation starts from a command on the UI
+/// thread, so the window stopped painting for as long as the sign-in was open - the app asking
+/// somebody to go and authenticate while appearing, to them, to have crashed.
+///
+/// It went unnoticed because the path that had been exercised was the FAILING one: a 403 for a
+/// missing role comes back without any sign-in UI ever appearing.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class EntraSignInThreadTests(WpfFixture wpf) : IDisposable
+{
+    public void Dispose() => BlobStorageService.CredentialFactoryForTests = null;
+
+    /// <summary>
+    /// Records the thread of every token request, in order.
+    ///
+    /// There is more than one: the warm-up asks first, then the client's own pipeline asks again
+    /// for the request itself. Only the FIRST matters here - a real credential caches, so that is
+    /// the one that opens a browser and waits, and every later one is a cache read.
+    ///
+    /// It also cancels after answering, so the test does not sit through the Azure SDK retrying a
+    /// connection to a port nothing is listening on.
+    /// </summary>
+    private sealed class ThreadRecordingCredential(CancellationTokenSource stopAfterFirst) : TokenCredential
+    {
+        public List<int> CalledOnThreads { get; } = [];
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken ct)
+        {
+            lock (CalledOnThreads) CalledOnThreads.Add(Environment.CurrentManagedThreadId);
+
+            // Stands in for somebody completing a sign-in in a browser. Short, but long enough that
+            // a blocked dispatcher would fail the pumping check below.
+            Thread.Sleep(300);
+            stopAfterFirst.Cancel();
+
+            return new AccessToken("token", DateTimeOffset.UtcNow.AddHours(1));
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext, CancellationToken ct)
+            => new(GetToken(requestContext, ct));
+    }
+
+    private static BlobContainerConfig EntraContainer() => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        // Nothing listens here, so the operation fails immediately AFTER the sign-in - which is
+        // all this test needs, since the sign-in is what it is about.
+        ContainerUrl = "https://127.0.0.1:1/backups",
+        AuthMode = BlobAuthMode.EntraInteractive
+    };
+
+    [Fact]
+    public void TheSignInDoesNotRunOnTheUiThread()
+    {
+        using var stop = new CancellationTokenSource();
+        var credential = new ThreadRecordingCredential(stop);
+        BlobStorageService.CredentialFactoryForTests = _ => credential;
+
+        var uiThreadId = 0;
+        var dispatcherKeptPumping = false;
+
+        wpf.Invoke(() =>
+        {
+            uiThreadId = Environment.CurrentManagedThreadId;
+
+            var service = new BlobStorageService(new FakeCredentialStore());
+            var frame = new DispatcherFrame();
+
+            // Queued at a lower priority than the work: it can only run if the dispatcher is still
+            // processing messages, which is exactly what "the window is frozen" means it is not.
+            _ = Dispatcher.CurrentDispatcher.BeginInvoke(
+                DispatcherPriority.Background,
+                new Action(() => dispatcherKeptPumping = true));
+
+            _ = service.VerifyConnectionAsync(EntraContainer(), stop.Token)
+                .ContinueWith(_ => frame.Continue = false, TaskScheduler.FromCurrentSynchronizationContext());
+
+            Dispatcher.PushFrame(frame);
+        });
+
+        Assert.NotEmpty(credential.CalledOnThreads);
+        var signIn = credential.CalledOnThreads[0];
+        Assert.NotEqual(uiThreadId, signIn);
+        Assert.True(dispatcherKeptPumping, "the dispatcher stopped processing while signing in");
+    }
+
+    /// <summary>A SAS container has no sign-in to do, and must not be made to wait for one.</summary>
+    [Fact]
+    public async Task ASasContainerNeverAsksForAToken()
+    {
+        using var unused = new CancellationTokenSource();
+        var credential = new ThreadRecordingCredential(unused);
+        BlobStorageService.CredentialFactoryForTests = _ => credential;
+
+        var service = new BlobStorageService(new FakeCredentialStore());
+        var sas = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://127.0.0.1:1/backups",
+            AuthMode = BlobAuthMode.SasToken
+        };
+
+        await Assert.ThrowsAnyAsync<Exception>(() => service.VerifyConnectionAsync(sas));
+
+        Assert.Empty(credential.CalledOnThreads);
+    }
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -99,8 +99,13 @@ public class BlobStorageService : IBlobStorageService
 
         try
         {
-            var token = await CredentialFor(config.AuthMode).GetTokenAsync(
-                new TokenRequestContext([StorageScope]), ct);
+            // Off the UI thread for the same reason as the operations themselves (#152). Usually a
+            // cache read by the time this runs - it only happens after a failure - but "usually" is
+            // not a reason to block the window on a credential that might decide to prompt.
+            var token = await Task.Run(
+                () => CredentialFor(config.AuthMode)
+                    .GetTokenAsync(new TokenRequestContext([StorageScope]), ct).AsTask(),
+                ct);
 
             return EntraIdentity.Describe(token.Token);
         }

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -52,10 +52,19 @@ public class BlobStorageService : IBlobStorageService
     private static readonly Lock CredentialLock = new();
     private static readonly Dictionary<BlobAuthMode, TokenCredential> Credentials = [];
 
+    /// <summary>
+    /// Test seam. A real credential cannot be exercised offline, and the thing worth pinning about
+    /// #152 - that a sign-in never runs on the UI thread - is otherwise unobservable.
+    /// </summary>
+    internal static Func<BlobAuthMode, TokenCredential>? CredentialFactoryForTests { get; set; }
+
     private static TokenCredential CredentialFor(BlobAuthMode mode)
     {
         lock (CredentialLock)
         {
+            // Checked before the cache, so a test is never handed a credential a previous test made.
+            if (CredentialFactoryForTests != null) return CredentialFactoryForTests(mode);
+
             if (Credentials.TryGetValue(mode, out var existing)) return existing;
 
             TokenCredential created = mode == BlobAuthMode.EntraInteractive
@@ -106,8 +115,37 @@ public class BlobStorageService : IBlobStorageService
     /// itself; it is only spelled out here because the diagnostic asks directly.</summary>
     private const string StorageScope = "https://storage.azure.com/.default";
 
+    /// <summary>
+    /// Gets the Entra sign-in out of the way, on the thread pool, before anything touches the
+    /// container (#152).
+    ///
+    /// InteractiveBrowserCredential launches a browser and waits for the redirect to come back, and
+    /// it does that on whatever thread asked for the token. Every blob operation starts from a
+    /// command on the UI thread, so the window stopped painting for as long as the sign-in was open
+    /// - an application asking somebody to go and authenticate while looking, to them, like it had
+    /// crashed.
+    ///
+    /// Task.Run rather than ConfigureAwait: the blocking happens before the credential's first
+    /// await yields, so there is no continuation to redirect - the work has to start somewhere
+    /// other than the UI thread.
+    ///
+    /// Only the first operation pays for this. The credential caches the token, and it is shared
+    /// process-wide, so everything after is a cache read.
+    /// </summary>
+    private static async Task EnsureSignedInAsync(BlobContainerConfig config, CancellationToken ct)
+    {
+        if (!config.AuthMode.IsEntra()) return;
+
+        var credential = CredentialFor(config.AuthMode);
+
+        await Task.Run(
+            () => credential.GetTokenAsync(new TokenRequestContext([StorageScope]), ct).AsTask(),
+            ct);
+    }
+
     public async Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
     {
+        await EnsureSignedInAsync(config, ct);
         var client = CreateClient(config);
         await foreach (var _ in client.GetBlobsAsync(
             BlobTraits.None, BlobStates.None, prefix: null, cancellationToken: ct)
@@ -122,6 +160,7 @@ public class BlobStorageService : IBlobStorageService
     public async Task<List<string>> ListTopLevelFoldersAsync(
         BlobContainerConfig config, CancellationToken ct = default)
     {
+        await EnsureSignedInAsync(config, ct);
         var client = CreateClient(config);
         var folders = new List<string>();
 
@@ -154,6 +193,7 @@ public class BlobStorageService : IBlobStorageService
         IProgress<int>? progress,
         CancellationToken ct = default)
     {
+        await EnsureSignedInAsync(config, ct);
         var client = CreateClient(config);
         var files = new List<BackupFileInfo>();
 


### PR DESCRIPTION
@
Closes #152. **931 passing, 24 skipped.**

## The bug

Selecting a container that authenticates with Entra launches the browser for sign-in, and the application freezes until it finishes.

`InteractiveBrowserCredential` launches the browser and waits for the redirect to come back, and it does that **on whatever thread asked for the token**. Every blob operation starts from a command on the UI thread, so the window stopped painting for exactly as long as the sign-in was open — an app asking somebody to go and authenticate while appearing, to them, to have crashed.

**This survived #29 because the path that had been exercised was the failing one.** A 403 for a missing role comes back without any sign-in UI ever appearing, so the freeze only shows up once the account can actually read the container — which is precisely the change that made Entra "work".

## The fix

The token is acquired through `Task.Run` before anything touches the container.

`Task.Run` rather than `ConfigureAwait(false)`: the blocking happens *before* the credentials first await yields, so there is no continuation to redirect — the work has to **start** somewhere other than the UI thread. Only the first operation pays; the credential caches the token and is shared process-wide.

It also fixes the silence. The busy indicator from #128 is already set on these paths and simply never got a chance to paint — with the UI thread free, "Listing the container..." appears while the sign-in is open.

## What was ruled out

- **No sync-over-async in our code.** No `.Result`, `.Wait()` or `.GetAwaiter().GetResult()` anywhere in the app; the listings all use `GetBlobsAsync`/`GetBlobsByHierarchyAsync`.
- **Not a hang in Azure.Identity.** `DefaultAzureCredential` resolves against the real storage scope in **6.6s** on this machine — slow, but it answers.

## The test

Fails without the fix, passes with it — I checked by reverting the fix rather than assuming. A recording credential plus a `DispatcherFrame`, asserting both that the sign-in ran on another thread **and** that the dispatcher kept processing while it did.

It needed a credential seam (`CredentialFactoryForTests`), because a real credential cannot be exercised offline. Worth noting the first version of the test was wrong in an instructive way: it recorded the *last* token request rather than the first, and there are two — the warm-up, then the clients own acquisition for the request itself. The second lands on the UI thread even with the fix, but a real credential serves it from cache in microseconds. Only the first one opens a browser and waits.

## Still to verify

I cannot complete an interactive Entra sign-in here, so the proof that the window stays responsive through a **real** browser sign-in is yours to make. What is proven automatically is that the token request no longer originates on the UI thread, which is the mechanism behind the freeze.

## Not in this fix

Parenting the browser prompt to the main window needs `Azure.Identity.Broker` and WAM. If the prompt now appears *behind* the app rather than freezing it, that is a separate change — #30/#142 were the same problem on the SQL side.
@