### PR TITLE
Collapse the Restore steps once they are done (#117 item 3)

### DIFF
--- a/src/NineLives.Tests/BusyFeedbackTests.cs
+++ b/src/NineLives.Tests/BusyFeedbackTests.cs
@@ -54,6 +54,9 @@ public class ChainCheckStateTests
         };
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // The app no longer chooses a database or a restore point for anybody.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
         vm.IsConnectedToServer = true;
         vm.ConnectedServer = new ServerConnection

--- a/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
+++ b/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -50,6 +50,9 @@ public class ExecuteBlockedReasonTests
             ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
         };
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // The app no longer chooses a database or a restore point for anybody.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         return vm;
     }
 

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -1,5 +1,6 @@
 ﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
 
 namespace Blackcat.NineLives.Tests;
 
@@ -253,5 +254,22 @@ public sealed class FakeSqlServerService : ISqlServerService
     {
         CredentialWrites.Add(credentialName);
         return Task.FromResult(CredentialChange.None);
+    }
+}
+
+/// <summary>
+/// What a person does after a load: pick a database, then a restore point.
+///
+/// The app deliberately chooses neither any more - preselecting the first database and the latest
+/// point meant it had silently decided what to restore, and everything downstream described a
+/// restore nobody had asked for. Tests that need a chain therefore have to make the choices a user
+/// would, which is also a fair description of what they were always relying on.
+/// </summary>
+internal static class RestoreSetup
+{
+    public static void ChooseADatabaseAndAPoint(RestoreViewModel vm)
+    {
+        vm.SelectedDatabaseName ??= vm.DiscoveredDatabases.FirstOrDefault();
+        vm.Timeline.SelectedPoint ??= vm.Timeline.Points.LastOrDefault();
     }
 }

--- a/src/NineLives.Tests/QueryCancellationTests.cs
+++ b/src/NineLives.Tests/QueryCancellationTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -59,6 +59,9 @@ public class QueryCancellationTests
         };
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // The app no longer chooses a database or a restore point for anybody.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
         vm.IsConnectedToServer = true;
         vm.ConnectedServer = new ServerConnection

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -62,6 +62,9 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
+        // The app no longer chooses a database or a restore point for anybody.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
+
         vm.TargetDatabaseName = "MyDb_Restored";
         vm.IsConnectedToServer = true;
         vm.ConnectedServer = connected;

--- a/src/NineLives.Tests/RestoreStepTests.cs
+++ b/src/NineLives.Tests/RestoreStepTests.cs
@@ -307,6 +307,55 @@ public class RestoreStepTests
     }
 
     /// <summary>
+    /// Once confirmed there is nothing left to confirm. The bar is rendered outside the fold, so
+    /// without this a confirmed - and therefore collapsed - step still showed a button asking to
+    /// confirm what had just been confirmed.
+    /// </summary>
+    [Fact]
+    public void TheConfirmBarGoesAwayOnceTheStepIsConfirmed()
+    {
+        var steps = new RestoreStepsViewModel();
+        steps.Report(steps.Source, true, "a source");
+
+        steps.Point.CanConfirm = true;
+        Assert.True(steps.Point.IsAwaitingConfirmation);
+
+        steps.Point.ConfirmCommand.Execute(null);
+
+        Assert.False(steps.Point.IsAwaitingConfirmation);
+    }
+
+    /// <summary>A step that never asks for confirmation never shows the bar.</summary>
+    [Fact]
+    public void AStepThatFinishesByItselfNeverAsksToBeConfirmed()
+    {
+        var steps = new RestoreStepsViewModel();
+
+        Assert.False(steps.Source.IsAwaitingConfirmation);
+        Assert.False(steps.Execute.IsAwaitingConfirmation);
+    }
+
+    /// <summary>
+    /// Backtracking must not leave the screen closed.
+    ///
+    /// Changing the database after confirming a point withdraws everything downstream - and step 1
+    /// was already complete, so nothing handed over and every pane ended up collapsed with no
+    /// indication of what to do next. That is the flow getting stuck.
+    /// </summary>
+    [Fact]
+    public void BacktrackingReopensTheStepYouHaveBeenSentBackTo()
+    {
+        var steps = Confirmed();
+
+        // As choosing a different database does: the point is no longer valid for it.
+        steps.Point.Invalidate();
+
+        Assert.True(steps.Point.IsVisible);
+        Assert.True(steps.Point.IsExpanded);
+        Assert.Contains(steps.All, s => s.IsVisible && s.IsExpanded);
+    }
+
+    /// <summary>
     /// Changing a confirmed point takes the confirmation back, and the steps that stood on it go
     /// with it. A script and a summary describing a moment nobody chose is exactly the failure
     /// this screen cannot have.

--- a/src/NineLives.Tests/RestoreStepTests.cs
+++ b/src/NineLives.Tests/RestoreStepTests.cs
@@ -168,6 +168,39 @@ public class RestoreStepTests
     }
 
     /// <summary>
+    /// The options step describes itself without ever claiming to be finished.
+    ///
+    /// The target database name is derived from the chosen source database, so treating a
+    /// non-empty one as completion folded this step away the moment a database was picked - and
+    /// the hand-over from step 2 then skipped over it to step 4, so the options were never seen.
+    /// </summary>
+    [Fact]
+    public void DescribingAStepUpdatesItsSummaryWithoutFoldingIt()
+    {
+        var step = Step();
+
+        step.Describe("as MyDb_Restored, RECOVERY");
+
+        Assert.Equal("as MyDb_Restored, RECOVERY", step.Summary);
+        Assert.True(step.IsExpanded);
+        Assert.False(step.IsComplete);
+    }
+
+    /// <summary>Choosing a restore point hands over to the options, not past them.</summary>
+    [Fact]
+    public void TheHandOverFromThePointLandsOnTheOptions()
+    {
+        var steps = new RestoreStepsViewModel();
+        steps.Options.Describe("as MyDb_Restored, RECOVERY");
+
+        steps.Report(steps.Source, true, "backups, MyDb on SRV01");
+        steps.Report(steps.Point, true, "2026-01-10 22:00, Full + 2 logs");
+
+        Assert.True(steps.Options.IsExpanded);
+        Assert.False(steps.Execute.IsExpanded);
+    }
+
+    /// <summary>
     /// Step 4 is never reported on - it is the action, with no completed state - so it is where
     /// the hand-over lands once 1 to 3 are done, which is exactly where somebody wants to be.
     /// </summary>

--- a/src/NineLives.Tests/RestoreStepTests.cs
+++ b/src/NineLives.Tests/RestoreStepTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.ViewModels;
+﻿using Blackcat.NineLives.ViewModels;
 using Xunit;
 
 namespace Blackcat.NineLives.Tests;
@@ -107,5 +107,79 @@ public class RestoreStepTests
         Assert.StartsWith("1.", steps.Source.Title);
         Assert.StartsWith("2.", steps.Point.Title);
         Assert.StartsWith("3.", steps.Options.Title);
+        Assert.StartsWith("4.", steps.Execute.Title);
+    }
+
+    // ── the accordion ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// One open at a time. Collapsing the finished steps was only half of it: with four panes free
+    /// to be open at once the screen could still be as long as it ever was, and step 4 - script,
+    /// console and recovery actions - is tall enough to bury everything above it.
+    /// </summary>
+    [Fact]
+    public void OpeningAStepClosesTheOthers()
+    {
+        var steps = new RestoreStepsViewModel();
+
+        steps.Options.ToggleCommand.Execute(null);
+
+        Assert.True(steps.Options.IsExpanded);
+        Assert.False(steps.Source.IsExpanded);
+        Assert.False(steps.Point.IsExpanded);
+        Assert.False(steps.Execute.IsExpanded);
+    }
+
+    [Fact]
+    public void OnlyTheFirstStepIsOpenToBeginWith()
+    {
+        var steps = new RestoreStepsViewModel();
+
+        Assert.True(steps.Source.IsExpanded);
+        Assert.Equal(1, steps.All.Count(s => s.IsExpanded));
+    }
+
+    /// <summary>
+    /// Finishing a step puts you in the next one still to do, rather than in front of nothing.
+    /// That is what makes it read as a sequence instead of four independent drawers.
+    /// </summary>
+    [Fact]
+    public void FinishingAStepOpensTheNextOneStillToDo()
+    {
+        var steps = new RestoreStepsViewModel();
+
+        steps.Report(steps.Source, isComplete: true, summary: "backups, MyDb on SRV01");
+
+        Assert.False(steps.Source.IsExpanded);
+        Assert.True(steps.Point.IsExpanded);
+    }
+
+    /// <summary>Already-done steps are skipped over - going back and changing step 1 should not
+    /// drop somebody into a step 2 they finished ten minutes ago.</summary>
+    [Fact]
+    public void TheHandOverSkipsStepsThatAreAlreadyDone()
+    {
+        var steps = new RestoreStepsViewModel();
+        steps.Report(steps.Point, isComplete: true, summary: "a point");
+        steps.Report(steps.Source, isComplete: true, summary: "a source");
+
+        Assert.False(steps.Point.IsExpanded);
+        Assert.True(steps.Options.IsExpanded);
+    }
+
+    /// <summary>
+    /// Step 4 is never reported on - it is the action, with no completed state - so it is where
+    /// the hand-over lands once 1 to 3 are done, which is exactly where somebody wants to be.
+    /// </summary>
+    [Fact]
+    public void TheLastStepIsWhereTheHandOverEnds()
+    {
+        var steps = new RestoreStepsViewModel();
+        steps.Report(steps.Source, true, "source");
+        steps.Report(steps.Point, true, "point");
+        steps.Report(steps.Options, true, "options");
+
+        Assert.True(steps.Execute.IsExpanded);
+        Assert.Equal(1, steps.All.Count(s => s.IsExpanded));
     }
 }

--- a/src/NineLives.Tests/RestoreStepTests.cs
+++ b/src/NineLives.Tests/RestoreStepTests.cs
@@ -1,0 +1,111 @@
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// When a step folds away, and when it refuses to (#117 item 3).
+///
+/// The Restore screen was one long scroll with every step expanded at all times, including the
+/// ones already finished and the ones not yet reachable. Collapsing is easy; collapsing without
+/// fighting the person using it is the part worth pinning.
+/// </summary>
+public class RestoreStepTests
+{
+    private static RestoreStep Step() => new("1. SELECT SOURCE");
+
+    [Fact]
+    public void AStepStartsOpen()
+    {
+        var step = Step();
+
+        Assert.True(step.IsExpanded);
+        Assert.False(step.IsComplete);
+    }
+
+    [Fact]
+    public void FinishingAStepFoldsItAwayAndLeavesItsAnswerOnScreen()
+    {
+        var step = Step();
+
+        step.Report(isComplete: true, summary: "backups, MyDb on SRV01");
+
+        Assert.False(step.IsExpanded);
+        Assert.Equal("backups, MyDb on SRV01", step.Summary);
+    }
+
+    /// <summary>
+    /// The summary keeps changing while a completed step stays collapsed - editing the target name
+    /// updates the heading. Re-collapsing on every one of those would be invisible; re-collapsing
+    /// after the user opened it back up would not be.
+    /// </summary>
+    [Fact]
+    public void AlreadyCompleteStepsAreNotCollapsedAgain()
+    {
+        var step = Step();
+        step.Report(isComplete: true, summary: "first");
+
+        step.IsExpanded = true;                              // not via Toggle: no user decision
+        step.Report(isComplete: true, summary: "second");
+
+        Assert.True(step.IsExpanded);
+        Assert.Equal("second", step.Summary);
+    }
+
+    /// <summary>
+    /// Somebody who opens a finished step is reading it. A screen that folds it away again the
+    /// moment they change the thing they came back to change is worse than one that never folded.
+    /// </summary>
+    [Fact]
+    public void OpeningAStepYourselfStopsItFoldingAwayLater()
+    {
+        var step = Step();
+        step.Report(isComplete: true, summary: "done");
+        Assert.False(step.IsExpanded);
+
+        step.ToggleCommand.Execute(null);
+        Assert.True(step.IsExpanded);
+
+        // Complete all over again - a different container, say.
+        step.Report(isComplete: false, summary: string.Empty);
+        step.Report(isComplete: true, summary: "done again");
+
+        Assert.True(step.IsExpanded);
+    }
+
+    /// <summary>
+    /// Going incomplete reopens it whatever happened before: the contents are the only way to put
+    /// it right, and hiding them behind a chevron at that moment helps nobody.
+    /// </summary>
+    [Fact]
+    public void AStepThatBecomesIncompleteOpensAgain()
+    {
+        var step = Step();
+        step.Report(isComplete: true, summary: "done");
+        Assert.False(step.IsExpanded);
+
+        step.Report(isComplete: false, summary: string.Empty);
+
+        Assert.True(step.IsExpanded);
+    }
+
+    [Fact]
+    public void ClosingAStepYourselfIsRespected()
+    {
+        var step = Step();
+
+        step.ToggleCommand.Execute(null);
+
+        Assert.False(step.IsExpanded);
+    }
+
+    [Fact]
+    public void TheStepsAreNumberedInTheOrderTheyAreWorkedThrough()
+    {
+        var steps = new RestoreStepsViewModel();
+
+        Assert.StartsWith("1.", steps.Source.Title);
+        Assert.StartsWith("2.", steps.Point.Title);
+        Assert.StartsWith("3.", steps.Options.Title);
+    }
+}

--- a/src/NineLives.Tests/RestoreStepTests.cs
+++ b/src/NineLives.Tests/RestoreStepTests.cs
@@ -121,12 +121,17 @@ public class RestoreStepTests
     public void OpeningAStepClosesTheOthers()
     {
         var steps = new RestoreStepsViewModel();
+        steps.Report(steps.Source, true, "a source");
+        steps.Point.CanConfirm = true;
+        steps.Point.ConfirmCommand.Execute(null);
 
-        steps.Options.ToggleCommand.Execute(null);
+        // The hand-over has already opened step 3, so reopen step 2 - going BACK is the case
+        // worth pinning anyway, and it must still close whatever was open.
+        steps.Point.ToggleCommand.Execute(null);
 
-        Assert.True(steps.Options.IsExpanded);
+        Assert.True(steps.Point.IsExpanded);
         Assert.False(steps.Source.IsExpanded);
-        Assert.False(steps.Point.IsExpanded);
+        Assert.False(steps.Options.IsExpanded);
         Assert.False(steps.Execute.IsExpanded);
     }
 
@@ -157,14 +162,21 @@ public class RestoreStepTests
     /// <summary>Already-done steps are skipped over - going back and changing step 1 should not
     /// drop somebody into a step 2 they finished ten minutes ago.</summary>
     [Fact]
-    public void TheHandOverSkipsStepsThatAreAlreadyDone()
+    public void GoingBackAndReanswveringStepOneReturnsToStepTwo()
     {
-        var steps = new RestoreStepsViewModel();
-        steps.Report(steps.Point, isComplete: true, summary: "a point");
-        steps.Report(steps.Source, isComplete: true, summary: "a source");
+        var steps = Confirmed();
 
-        Assert.False(steps.Point.IsExpanded);
-        Assert.True(steps.Options.IsExpanded);
+        // Choosing a different database: step 1 goes incomplete, which withdraws everything after
+        // it, and answering it again puts the user back at the restore point rather than at the
+        // end of a sequence whose answers have just been thrown away.
+        steps.Report(steps.Source, isComplete: false, summary: string.Empty);
+        Assert.False(steps.Point.IsVisible);
+
+        steps.Report(steps.Source, isComplete: true, summary: "backups, OtherDb on SRV01");
+
+        Assert.True(steps.Point.IsVisible);
+        Assert.True(steps.Point.IsExpanded);
+        Assert.False(steps.Point.IsComplete);
     }
 
     /// <summary>
@@ -186,15 +198,15 @@ public class RestoreStepTests
         Assert.False(step.IsComplete);
     }
 
-    /// <summary>Choosing a restore point hands over to the options, not past them.</summary>
+    /// <summary>Confirming a restore point hands over to the options, not past them.</summary>
     [Fact]
     public void TheHandOverFromThePointLandsOnTheOptions()
     {
         var steps = new RestoreStepsViewModel();
-        steps.Options.Describe("as MyDb_Restored, RECOVERY");
-
         steps.Report(steps.Source, true, "backups, MyDb on SRV01");
-        steps.Report(steps.Point, true, "2026-01-10 22:00, Full + 2 logs");
+
+        steps.Point.CanConfirm = true;
+        steps.Point.ConfirmCommand.Execute(null);
 
         Assert.True(steps.Options.IsExpanded);
         Assert.False(steps.Execute.IsExpanded);
@@ -207,12 +219,108 @@ public class RestoreStepTests
     [Fact]
     public void TheLastStepIsWhereTheHandOverEnds()
     {
-        var steps = new RestoreStepsViewModel();
-        steps.Report(steps.Source, true, "source");
-        steps.Report(steps.Point, true, "point");
-        steps.Report(steps.Options, true, "options");
+        var steps = Confirmed();
 
         Assert.True(steps.Execute.IsExpanded);
         Assert.Equal(1, steps.All.Count(s => s.IsExpanded));
+    }
+
+    // ── only what can be acted on ───────────────────────────────────────────────
+
+    /// <summary>Walks the whole sequence the way a user does.</summary>
+    private static RestoreStepsViewModel Confirmed()
+    {
+        var steps = new RestoreStepsViewModel();
+        steps.Report(steps.Source, true, "backups, MyDb on SRV01");
+        steps.Point.CanConfirm = true;
+        steps.Point.ConfirmCommand.Execute(null);
+        steps.Options.CanConfirm = true;
+        steps.Options.ConfirmCommand.Execute(null);
+        return steps;
+    }
+
+    /// <summary>
+    /// A step nobody can act on yet is noise - and on this screen it was noise between somebody
+    /// and the dropdown they were trying to use. Loading a container used to reveal steps 2, 3 and
+    /// 4 immediately, before a database had even been chosen.
+    /// </summary>
+    [Fact]
+    public void OnlyTheFirstStepIsOfferedUntilItIsAnswered()
+    {
+        var steps = new RestoreStepsViewModel();
+
+        Assert.True(steps.Source.IsVisible);
+        Assert.False(steps.Point.IsVisible);
+        Assert.False(steps.Options.IsVisible);
+        Assert.False(steps.Execute.IsVisible);
+    }
+
+    [Fact]
+    public void EachStepIsOfferedOnlyOnceTheOneBeforeItIsAnswered()
+    {
+        var steps = new RestoreStepsViewModel();
+
+        steps.Report(steps.Source, true, "backups, MyDb on SRV01");
+        Assert.True(steps.Point.IsVisible);
+        Assert.False(steps.Options.IsVisible);
+
+        steps.Point.CanConfirm = true;
+        steps.Point.ConfirmCommand.Execute(null);
+        Assert.True(steps.Options.IsVisible);
+        Assert.False(steps.Execute.IsVisible);
+
+        steps.Options.CanConfirm = true;
+        steps.Options.ConfirmCommand.Execute(null);
+        Assert.True(steps.Execute.IsVisible);
+    }
+
+    // ── confirmation ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Choosing a restore point is the decision this application exists to support. Folding the
+    /// step away the instant a dot is clicked takes the timeline from somebody who is still
+    /// comparing points - so it stays open until they say they are done.
+    /// </summary>
+    [Fact]
+    public void ChoosingAPointDoesNotFinishTheStep()
+    {
+        var steps = new RestoreStepsViewModel();
+        steps.Report(steps.Source, true, "a source");
+
+        steps.Point.Describe("2026-01-10 22:00, Full + 2 logs");
+        steps.Point.CanConfirm = true;
+
+        Assert.False(steps.Point.IsComplete);
+        Assert.True(steps.Point.IsExpanded);
+        Assert.False(steps.Options.IsVisible);
+    }
+
+    [Fact]
+    public void ConfirmingIsRefusedUntilThereIsSomethingToConfirm()
+    {
+        var steps = new RestoreStepsViewModel();
+        steps.Report(steps.Source, true, "a source");
+
+        steps.Point.ConfirmCommand.Execute(null);
+
+        Assert.False(steps.Point.IsComplete);
+    }
+
+    /// <summary>
+    /// Changing a confirmed point takes the confirmation back, and the steps that stood on it go
+    /// with it. A script and a summary describing a moment nobody chose is exactly the failure
+    /// this screen cannot have.
+    /// </summary>
+    [Fact]
+    public void ChangingWhatWasConfirmedWithdrawsTheConfirmation()
+    {
+        var steps = Confirmed();
+        Assert.True(steps.Execute.IsVisible);
+
+        steps.Point.Invalidate();
+
+        Assert.False(steps.Point.IsComplete);
+        Assert.False(steps.Options.IsVisible);
+        Assert.False(steps.Execute.IsVisible);
     }
 }

--- a/src/NineLives.Tests/RestoreTimelineViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreTimelineViewModelTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -57,14 +57,19 @@ public class RestoreTimelineViewModelTests
     // ── loading ─────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void LoadingShowsEveryPointAndSelectsTheMostRecent()
+    public void LoadingShowsEveryPointAndSELECTSNOTHING()
     {
         var timeline = Loaded();
 
         Assert.True(timeline.HasPoints);
         Assert.True(timeline.HasVisiblePoints);
         Assert.Equal(4, timeline.Points.Count);
-        Assert.Equal(T0.AddHours(3), timeline.SelectedPoint!.Timestamp);
+
+        // It used to land on the most recent point, which looks helpful and is not: it is the app
+        // deciding which moment to restore to, on the screen whose entire purpose is choosing that
+        // moment. Everything downstream - the chain, the script, the summary - then described a
+        // restore nobody had asked for.
+        Assert.Null(timeline.SelectedPoint);
     }
 
     [Fact]
@@ -91,7 +96,7 @@ public class RestoreTimelineViewModelTests
     public void LoadingADatabaseWithNoPointsDropsThePreviousSelection()
     {
         var timeline = Loaded();
-        Assert.NotNull(timeline.SelectedPoint);
+        timeline.SelectedPoint = timeline.Points[^1];   // as a user would, since nothing is preselected
 
         timeline.Load([]);
 

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -70,8 +70,16 @@ public class RestoreViewModelTests
 
     // ── loading and chain selection ─────────────────────────────────────────────
 
+    /// <summary>
+    /// A load offers the lists and answers none of them.
+    ///
+    /// Preselecting the first server, the first database and the latest restore point meant the
+    /// app had silently decided what to restore and when to restore it to - and the chain, the
+    /// script and the summary then all described a restore nobody had asked for. On a screen whose
+    /// last button overwrites a database, the app does not get to guess.
+    /// </summary>
     [Fact]
-    public async Task LoadingBuildsRestorePointsAndSelectsTheMostRecent()
+    public async Task ALoadChoosesNothingOnTheUsersBehalf()
     {
         var vm = NewViewModel();
         _blob.Files = FullPlusLogs(3);
@@ -80,13 +88,38 @@ public class RestoreViewModelTests
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
         Assert.True(vm.BackupsLoaded);
+        Assert.NotEmpty(vm.DiscoveredDatabases);
+
+        Assert.Null(vm.SelectedServerName);
+        Assert.Null(vm.SelectedDatabaseName);
+        Assert.Null(vm.Timeline.SelectedPoint);
+
+        // And nothing downstream has been built from a choice nobody made.
+        Assert.Null(vm.RestoreChain);
+        Assert.False(vm.HasScript);
+        Assert.Equal(string.Empty, vm.RestoreSummaryText);
+    }
+
+    [Fact]
+    public async Task ChoosingTheLatestPointBuildsAValidChainToIt()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
+
+        Assert.True(vm.BackupsLoaded);
         Assert.True(vm.Timeline.HasPoints);
 
         // A full plus three logs: the full itself, then one point per log.
         Assert.Equal(4, vm.Timeline.Points.Count);
 
-        // The default selection is the latest point, which is what someone restoring after an
-        // incident almost always wants.
+        // The latest point is what someone restoring after an incident usually wants - but they
+        // have to say so. The helper above is standing in for that click, not for the app.
         Assert.Equal(T0.AddHours(3), vm.Timeline.SelectedPoint!.Timestamp);
         Assert.True(vm.HasValidChain);
     }
@@ -98,6 +131,9 @@ public class RestoreViewModelTests
         _blob.Files = FullPlusLogs(3);
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
         // The second log: full + the logs up to and including it, and nothing after.
         vm.Timeline.SelectedPoint = vm.Timeline.Points.Single(
@@ -116,6 +152,9 @@ public class RestoreViewModelTests
         _blob.Files = FullPlusLogs(3);
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
 
         vm.Timeline.SelectedPoint = vm.Timeline.Points.First(p => p.Type == BackupType.Full);
@@ -139,6 +178,9 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
         Assert.False(vm.Timeline.HasPoints);
 
@@ -168,6 +210,9 @@ public class RestoreViewModelTests
         _blob.Files = FullPlusLogs(3);
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
 
         Assert.True(vm.BackupsLoaded);
@@ -193,6 +238,9 @@ public class RestoreViewModelTests
         _blob.Files = FullPlusLogs(1);
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
         vm.IsConnectedToServer = true;
         vm.ConnectedServer = new ServerConnection
@@ -223,6 +271,9 @@ public class RestoreViewModelTests
         _blob.Files = FullPlusLogs(3);
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
 
         // The latest point is a log, so stopping partway through it is meaningful.
@@ -248,6 +299,9 @@ public class RestoreViewModelTests
         _blob.Files = FullPlusLogs(3);
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
         Assert.NotEmpty(vm.GeneratedScript);
 
@@ -269,6 +323,9 @@ public class RestoreViewModelTests
         _blob.Files = FullPlusLogs(3);
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
 
         vm.PointInTime.Use = true;
@@ -311,6 +368,9 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
+
         Assert.NotNull(vm.Timeline.SelectedPoint);
         Assert.NotEmpty(vm.GeneratedScript);
 
@@ -335,11 +395,17 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
+
         vm.Timeline.FromText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
         Assert.Equal(2, vm.Timeline.Points.Count);
 
         // A range typed for one database would silently hide points belonging to the next.
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
         Assert.Equal(6, vm.Timeline.Points.Count);
         Assert.Equal(string.Empty, vm.Timeline.FromText);
@@ -361,12 +427,18 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
+
         Assert.Equal(3, vm.Timeline.Points.Count);
 
         // A new log arrives in the container, and the user presses Load again.
         var fresh = T0.AddHours(3);
         _blob.Files = FullPlusLogs(3);
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
         Assert.Equal(4, vm.Timeline.Points.Count);
         Assert.Contains(vm.Timeline.Points, p => p.Timestamp == fresh);
@@ -384,10 +456,19 @@ public class RestoreViewModelTests
         // First load has no selection yet and must scan the whole container - the server and
         // database lists are built from what it finds.
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         Assert.Null(_blob.LastScope);
 
+        // The server as well as the database: the scope is built from both, and the load no longer
+        // picks either.
+        vm.SelectedServerName = "SRV01";
         vm.SelectedDatabaseName = "MyDb";
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
         Assert.NotNull(_blob.LastScope);
         Assert.Equal("MyDb", _blob.LastScope!.DatabaseName);
@@ -403,8 +484,15 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
+        vm.SelectedServerName = @"SRV01\PROD";
         vm.SelectedDatabaseName = "MyDb";
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
         // "SRV01\PROD" lives under "SRV01" in the container layout.
         Assert.Equal("SRV01", _blob.LastScope!.ServerName);
@@ -418,6 +506,9 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Nothing is preselected any more, so the test makes the choices a user would.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
         Assert.False(vm.BackupsLoaded);
         Assert.Contains("No SAS token found.", vm.StatusMessage);

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -94,10 +94,40 @@ public class RestoreViewModelTests
         Assert.Null(vm.SelectedDatabaseName);
         Assert.Null(vm.Timeline.SelectedPoint);
 
+        // And NOTHING is drawn. This is the part that bit hardest: with no database chosen the
+        // working set fell back to every set in the container, so the timeline rendered every
+        // backup of every database on every server - thousands of points on a real container, none
+        // of them meaningful, because a restore chain only exists within one database.
+        Assert.False(vm.Timeline.HasPoints);
+        Assert.Empty(vm.Timeline.Points);
+        Assert.Equal(0, vm.SetCount);
+
         // And nothing downstream has been built from a choice nobody made.
         Assert.Null(vm.RestoreChain);
         Assert.False(vm.HasScript);
         Assert.Equal(string.Empty, vm.RestoreSummaryText);
+    }
+
+    /// <summary>
+    /// Clearing the database selection clears what it produced. The old code returned early on a
+    /// null, which was safe only because something was always selected.
+    /// </summary>
+    [Fact]
+    public async Task ClearingTheDatabaseClearsTheRestorePointsItProduced()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.SelectedDatabaseName = "MyDb";
+        Assert.True(vm.Timeline.HasPoints);
+
+        vm.SelectedDatabaseName = null;
+
+        Assert.False(vm.Timeline.HasPoints);
+        Assert.Empty(vm.Timeline.Points);
+        Assert.Equal(0, vm.SetCount);
     }
 
     [Fact]

--- a/src/NineLives.Tests/ScriptStaysInStepTests.cs
+++ b/src/NineLives.Tests/ScriptStaysInStepTests.cs
@@ -54,6 +54,9 @@ public class ScriptStaysInStepTests
         };
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // The app no longer chooses a database or a restore point for anybody.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
         return vm;
     }

--- a/src/NineLives.Tests/VerifyWithMoveTests.cs
+++ b/src/NineLives.Tests/VerifyWithMoveTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -150,6 +150,9 @@ public class VerifyWithMoveViewModelTests(WpfFixture wpf)
         };
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // The app no longer chooses a database or a restore point for anybody.
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
         vm.IsConnectedToServer = true;
         vm.ConnectedServer = new ServerConnection

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -229,6 +229,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
@@ -277,6 +278,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
 
@@ -315,6 +317,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
 
@@ -348,6 +351,7 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.IsConnectedToServer = true;
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
 
@@ -376,6 +380,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             Realise(view);
@@ -433,6 +438,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
@@ -479,6 +485,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
 
@@ -512,6 +519,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             Realise(view);
@@ -538,6 +546,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
@@ -582,6 +591,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
@@ -633,6 +643,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
@@ -738,6 +749,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsVisible = true;
             vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -227,6 +227,9 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.HasRecoveryActions = true;
             vm.ExecutionComplete = true;
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
             try
@@ -272,6 +275,9 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.IsConnectedToServer = true;
             vm.Credential.SectionVisible = true;
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
 
             vm.Credential.ExistsOnServer = false;
@@ -307,6 +313,9 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.IsConnectedToServer = true;
             vm.Credential.SectionVisible = true;
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
 
             vm.Credential.ExistsOnServer = true;
@@ -337,6 +346,9 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.BackupsLoaded = true;
             vm.HasScript = true;
             vm.IsConnectedToServer = true;
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
 
             // Not running: nothing to stop, so the button must not be offered.
@@ -362,6 +374,9 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.IsBusy = true;
             vm.CanCancelLoad = true;
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             Realise(view);
 
@@ -416,6 +431,9 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.IsExecuting = false;
             vm.ExecutionComplete = true;
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
             try
@@ -459,6 +477,9 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
             vm.Console.HasOutput = true;
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
 
             vm.IsConsoleDetached = false;
@@ -489,6 +510,9 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.IsConsoleDetached = false;   // as if the wiring failed
             vm.IsExecuting = true;
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             Realise(view);
 
@@ -512,6 +536,9 @@ public class XamlLoadTests(WpfFixture wpf)
             var vm = NewRestoreViewModel();
             vm.PointInTime.SetWindow((new DateTime(2026, 1, 10, 22, 0, 0), new DateTime(2026, 1, 10, 22, 15, 0)));
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
             try
@@ -553,6 +580,9 @@ public class XamlLoadTests(WpfFixture wpf)
             ];
             vm.HasInventoryIssues = true;
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
             try
@@ -601,6 +631,9 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.HasVerifyResults = true;
             vm.HasVerifyFailures = true;
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
             try
@@ -703,6 +736,9 @@ public class XamlLoadTests(WpfFixture wpf)
                 }
             ];
 
+            // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
+            // parent never measures, so its item containers are never generated to be found.
+            vm.Steps.Execute.IsExpanded = true;
             var view = new RestoreView { DataContext = vm };
             var listener = BindingErrorListener.Attach();
             try

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -988,6 +988,12 @@
                                     Padding="6,2"
                                     Cursor="Hand"
                                     FontSize="12" />
+                        </Grid>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
     <!-- A collapsible step heading on the Restore screen (#117 item 3).
 

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -1010,17 +1010,37 @@
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
+                            <!-- A tick and a green title once the step is answered, so the state
+                                 of the whole screen reads at a glance (#117 item 3). -->
                             <TextBlock Grid.Column="0"
+                                       VerticalAlignment="Center"
+                                       Margin="0,0,8,0"
+                                       FontSize="13"
+                                       Text="&#x2713;"
+                                       Foreground="{DynamicResource SuccessBrush}"
+                                       Visibility="{Binding IsComplete, Converter={StaticResource BoolToVis}}" />
+
+                            <TextBlock Grid.Column="1"
                                        Text="{Binding Title}"
-                                       Style="{StaticResource SubHeaderText}"
-                                       VerticalAlignment="Center" />
+                                       VerticalAlignment="Center">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource SubHeaderText}">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsComplete}" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
 
                             <!-- Only when collapsed: expanded, the contents say it better. -->
-                            <TextBlock Grid.Column="1"
+                            <TextBlock Grid.Column="2"
                                        Text="{Binding Summary}"
                                        TextTrimming="CharacterEllipsis"
                                        VerticalAlignment="Center"
@@ -1037,7 +1057,7 @@
                                 </TextBlock.Style>
                             </TextBlock>
 
-                            <TextBlock Grid.Column="2"
+                            <TextBlock Grid.Column="3"
                                        VerticalAlignment="Center"
                                        FontSize="11"
                                        Foreground="{DynamicResource SecondaryTextBrush}">

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -988,6 +988,70 @@
                                     Padding="6,2"
                                     Cursor="Hand"
                                     FontSize="12" />
+
+    <!-- A collapsible step heading on the Restore screen (#117 item 3).
+
+         The step's own state object is the DataContext, so one template serves all of them:
+         Title, Summary, IsComplete, IsExpanded and ToggleCommand come from RestoreStep.
+
+         The whole heading is the hit target rather than just a chevron - a heading that collapses
+         when you click the words is what people try first. -->
+    <Style x:Key="StepHeader" TargetType="Button" BasedOn="{x:Null}">
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Command" Value="{Binding ToggleCommand}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border Background="Transparent" Padding="0,0,0,8">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Column="0"
+                                       Text="{Binding Title}"
+                                       Style="{StaticResource SubHeaderText}"
+                                       VerticalAlignment="Center" />
+
+                            <!-- Only when collapsed: expanded, the contents say it better. -->
+                            <TextBlock Grid.Column="1"
+                                       Text="{Binding Summary}"
+                                       TextTrimming="CharacterEllipsis"
+                                       VerticalAlignment="Center"
+                                       Margin="12,0,12,0">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsExpanded}" Value="True">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
+                            <TextBlock Grid.Column="2"
+                                       VerticalAlignment="Center"
+                                       FontSize="11"
+                                       Foreground="{DynamicResource SecondaryTextBrush}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Text" Value="&#x25B2;" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsExpanded}" Value="False">
+                                                <Setter Property="Text" Value="&#x25BC;" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
                         </Grid>
                     </Border>
                 </ControlTemplate>

--- a/src/NineLives/ViewModels/RestoreStepsViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreStepsViewModel.cs
@@ -49,6 +49,16 @@ public partial class RestoreStep(string title) : ObservableObject
     /// Only on the transition into complete: re-running it on every keystroke would fold the step
     /// away while somebody was still working in it.
     /// </summary>
+    /// <summary>
+    /// Updates what the step says when collapsed, without claiming it is finished.
+    ///
+    /// For a step that has no completed state: the options all have defaults, so there is no
+    /// moment at which they become "done". Reporting them as complete - which the target database
+    /// name, derived from the chosen source database, quietly did - folded the step away and made
+    /// the hand-over skip it, so choosing a database meant never seeing the options at all.
+    /// </summary>
+    public void Describe(string summary) => Summary = summary;
+
     /// <returns>True when this call folded the step away, so the caller can move on to the next.</returns>
     public bool Report(bool isComplete, string summary)
     {

--- a/src/NineLives/ViewModels/RestoreStepsViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreStepsViewModel.cs
@@ -1,0 +1,76 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// One numbered step on the Restore screen: whether it is open, and what it says when it is not.
+///
+/// The screen was one very long scroll with every step expanded at all times, including the ones
+/// already finished and the ones not yet reachable (#117 item 3).
+/// </summary>
+public partial class RestoreStep(string title) : ObservableObject
+{
+    public string Title { get; } = title;
+
+    [ObservableProperty]
+    private bool _isExpanded = true;
+
+    /// <summary>
+    /// What the step shows instead of its contents once it is done - "backups, MyDb on SRV01"
+    /// rather than nothing, so a collapsed step is still an answer rather than a closed drawer.
+    /// </summary>
+    [ObservableProperty]
+    private string _summary = string.Empty;
+
+    /// <summary>Has enough been chosen here for the next step to mean anything.</summary>
+    [ObservableProperty]
+    private bool _isComplete;
+
+    /// <summary>
+    /// Set the moment the user opens or closes this step themselves, and never cleared.
+    ///
+    /// After that, completion stops collapsing it. Somebody who opened a step back up is reading
+    /// it, and a screen that folds it away again the instant they change something they came back
+    /// to change is worse than one that never folded at all.
+    /// </summary>
+    private bool _userDecided;
+
+    [RelayCommand]
+    private void Toggle()
+    {
+        _userDecided = true;
+        IsExpanded = !IsExpanded;
+    }
+
+    /// <summary>
+    /// Records progress, collapsing the step the first time it is finished.
+    ///
+    /// Only on the transition into complete: re-running it on every keystroke would fold the step
+    /// away while somebody was still working in it.
+    /// </summary>
+    public void Report(bool isComplete, string summary)
+    {
+        Summary = summary;
+
+        var justCompleted = isComplete && !IsComplete;
+        IsComplete = isComplete;
+
+        if (justCompleted && !_userDecided) IsExpanded = false;
+
+        // Going incomplete reopens it whatever happened before - the contents are the only way to
+        // put it right, and hiding them behind a chevron at that moment helps nobody.
+        if (!isComplete) IsExpanded = true;
+    }
+}
+
+/// <summary>
+/// The Restore screen's steps. Numbering and titles live here rather than in the markup so the
+/// summaries and the headings cannot drift apart.
+/// </summary>
+public sealed class RestoreStepsViewModel
+{
+    public RestoreStep Source { get; } = new("1. SELECT SOURCE");
+    public RestoreStep Point { get; } = new("2. SELECT RESTORE POINT");
+    public RestoreStep Options { get; } = new("3. RESTORE OPTIONS");
+}

--- a/src/NineLives/ViewModels/RestoreStepsViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreStepsViewModel.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 namespace Blackcat.NineLives.ViewModels;
@@ -49,28 +49,96 @@ public partial class RestoreStep(string title) : ObservableObject
     /// Only on the transition into complete: re-running it on every keystroke would fold the step
     /// away while somebody was still working in it.
     /// </summary>
-    public void Report(bool isComplete, string summary)
+    /// <returns>True when this call folded the step away, so the caller can move on to the next.</returns>
+    public bool Report(bool isComplete, string summary)
     {
         Summary = summary;
 
         var justCompleted = isComplete && !IsComplete;
         IsComplete = isComplete;
 
-        if (justCompleted && !_userDecided) IsExpanded = false;
+        if (justCompleted && !_userDecided)
+        {
+            IsExpanded = false;
+            return true;
+        }
 
         // Going incomplete reopens it whatever happened before - the contents are the only way to
         // put it right, and hiding them behind a chevron at that moment helps nobody.
         if (!isComplete) IsExpanded = true;
+
+        return false;
     }
 }
 
 /// <summary>
 /// The Restore screen's steps. Numbering and titles live here rather than in the markup so the
 /// summaries and the headings cannot drift apart.
+///
+/// They behave as an accordion: opening one closes the others. Collapsing the finished steps was
+/// only half the fix - with four panes free to be open at once the screen could still be as long
+/// as it ever was, and the script pane in particular is tall enough to bury everything above it.
 /// </summary>
 public sealed class RestoreStepsViewModel
 {
     public RestoreStep Source { get; } = new("1. SELECT SOURCE");
     public RestoreStep Point { get; } = new("2. SELECT RESTORE POINT");
     public RestoreStep Options { get; } = new("3. RESTORE OPTIONS");
+    public RestoreStep Execute { get; } = new("4. GENERATE & EXECUTE");
+
+    public IReadOnlyList<RestoreStep> All { get; }
+
+    /// <summary>Guards the closing of the others from reopening this one, and so on.</summary>
+    private bool _settling;
+
+    public RestoreStepsViewModel()
+    {
+        All = [Source, Point, Options, Execute];
+
+        // One open to begin with, and it is the one there is anything to do in.
+        Point.IsExpanded = false;
+        Options.IsExpanded = false;
+        Execute.IsExpanded = false;
+
+        foreach (var step in All)
+        {
+            var opened = step;
+            opened.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName != nameof(RestoreStep.IsExpanded)) return;
+                if (!opened.IsExpanded || _settling) return;
+
+                _settling = true;
+                try
+                {
+                    foreach (var other in All)
+                        if (!ReferenceEquals(other, opened)) other.IsExpanded = false;
+                }
+                finally
+                {
+                    _settling = false;
+                }
+            };
+        }
+    }
+
+    /// <summary>
+    /// Records a step's progress and, when that folds it away, opens the next one still to do.
+    ///
+    /// This is what makes it read as a sequence rather than four independent drawers: finishing
+    /// step 1 puts you in step 2 rather than in front of nothing. Step 4 is never reported on - it
+    /// is the action, with no completed state to speak of - so it ends up being the step that is
+    /// opened once 1 to 3 are done, which is exactly where somebody wants to be by then.
+    /// </summary>
+    public void Report(RestoreStep step, bool isComplete, string summary)
+    {
+        if (!step.Report(isComplete, summary)) return;
+
+        var next = All
+            .SkipWhile(s => !ReferenceEquals(s, step))
+            .Skip(1)
+            .FirstOrDefault(s => !s.IsComplete);
+
+        if (next != null) next.IsExpanded = true;
+    }
 }

--- a/src/NineLives/ViewModels/RestoreStepsViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreStepsViewModel.cs
@@ -23,7 +23,18 @@ public partial class RestoreStep(string title, bool needsConfirmation = false) :
     public bool NeedsConfirmation { get; } = needsConfirmation;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsAwaitingConfirmation))]
     private bool _isExpanded = true;
+
+    /// <summary>
+    /// Whether the confirm button belongs on screen: this step asks to be confirmed, it is open,
+    /// and it has not been confirmed yet.
+    ///
+    /// All three matter. The button is rendered outside the fold, so a confirmed - and therefore
+    /// collapsed - step still showed a bar asking to confirm what had just been confirmed. It
+    /// comes back if the answer is withdrawn, which is what backtracking does.
+    /// </summary>
+    public bool IsAwaitingConfirmation => NeedsConfirmation && IsExpanded && !IsComplete;
 
     /// <summary>
     /// Hidden until the step before it is done. A step nobody can act on yet is noise, and on this
@@ -40,6 +51,7 @@ public partial class RestoreStep(string title, bool needsConfirmation = false) :
     private string _summary = string.Empty;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsAwaitingConfirmation))]
     private bool _isComplete;
 
     /// <summary>Whether there is yet anything to confirm - a point chosen, say.</summary>
@@ -226,6 +238,20 @@ public sealed class RestoreStepsViewModel
 
                 step.IsExpanded = false;
                 step.Invalidate();
+            }
+
+            // Backtracking must not leave the screen closed.
+            //
+            // Changing the database after confirming a point withdraws everything downstream, and
+            // step 1 was already complete so nothing handed over - every pane ended up collapsed
+            // with no indication of what to do next. Whenever nothing is open, open the earliest
+            // step still unanswered, which is where the user has just been sent back to.
+            if (!All.Any(s => s.IsVisible && s.IsExpanded))
+            {
+                var resume = All.FirstOrDefault(s => s.IsVisible && !s.IsComplete)
+                    ?? All.LastOrDefault(s => s.IsVisible);
+
+                if (resume != null) resume.IsExpanded = true;
             }
         }
         finally

--- a/src/NineLives/ViewModels/RestoreStepsViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreStepsViewModel.cs
@@ -1,20 +1,36 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 namespace Blackcat.NineLives.ViewModels;
 
 /// <summary>
-/// One numbered step on the Restore screen: whether it is open, and what it says when it is not.
+/// One numbered step on the Restore screen (#117 item 3).
 ///
 /// The screen was one very long scroll with every step expanded at all times, including the ones
-/// already finished and the ones not yet reachable (#117 item 3).
+/// already finished and the ones not yet reachable.
 /// </summary>
-public partial class RestoreStep(string title) : ObservableObject
+public partial class RestoreStep(string title, bool needsConfirmation = false) : ObservableObject
 {
     public string Title { get; } = title;
 
+    /// <summary>
+    /// Whether finishing this step is something the user says, rather than something inferred.
+    ///
+    /// Choosing a restore point is the decision the whole application exists to support, so it is
+    /// not treated as made the instant a dot is clicked - somebody is still comparing points at
+    /// that moment. The same goes for the options: they are read, adjusted and read again.
+    /// </summary>
+    public bool NeedsConfirmation { get; } = needsConfirmation;
+
     [ObservableProperty]
     private bool _isExpanded = true;
+
+    /// <summary>
+    /// Hidden until the step before it is done. A step nobody can act on yet is noise, and on this
+    /// screen it is noise between somebody and the dropdown they are trying to use.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isVisible;
 
     /// <summary>
     /// What the step shows instead of its contents once it is done - "backups, MyDb on SRV01"
@@ -23,9 +39,12 @@ public partial class RestoreStep(string title) : ObservableObject
     [ObservableProperty]
     private string _summary = string.Empty;
 
-    /// <summary>Has enough been chosen here for the next step to mean anything.</summary>
     [ObservableProperty]
     private bool _isComplete;
+
+    /// <summary>Whether there is yet anything to confirm - a point chosen, say.</summary>
+    [ObservableProperty]
+    private bool _canConfirm;
 
     /// <summary>
     /// Set the moment the user opens or closes this step themselves, and never cleared.
@@ -43,57 +62,82 @@ public partial class RestoreStep(string title) : ObservableObject
         IsExpanded = !IsExpanded;
     }
 
+    /// <summary>Raised when the step is finished, so the screen can move on to the next one.</summary>
+    public event Action<RestoreStep>? Completed;
+
+    /// <summary>The user saying they are done here. Only for steps that ask.</summary>
+    [RelayCommand]
+    private void Confirm()
+    {
+        if (!CanConfirm) return;
+
+        IsComplete = true;
+        IsExpanded = false;
+        Completed?.Invoke(this);
+    }
+
     /// <summary>
-    /// Records progress, collapsing the step the first time it is finished.
+    /// Updates what the step says when collapsed, without claiming it is finished.
+    ///
+    /// For a step with no completed state of its own: the options all have defaults, so there is
+    /// no moment at which they become "done" by themselves.
+    /// </summary>
+    public void Describe(string summary) => Summary = summary;
+
+    /// <summary>
+    /// Records progress for a step that finishes by itself, collapsing it the first time it does.
     ///
     /// Only on the transition into complete: re-running it on every keystroke would fold the step
     /// away while somebody was still working in it.
     /// </summary>
-    /// <summary>
-    /// Updates what the step says when collapsed, without claiming it is finished.
-    ///
-    /// For a step that has no completed state: the options all have defaults, so there is no
-    /// moment at which they become "done". Reporting them as complete - which the target database
-    /// name, derived from the chosen source database, quietly did - folded the step away and made
-    /// the hand-over skip it, so choosing a database meant never seeing the options at all.
-    /// </summary>
-    public void Describe(string summary) => Summary = summary;
-
-    /// <returns>True when this call folded the step away, so the caller can move on to the next.</returns>
-    public bool Report(bool isComplete, string summary)
+    public void Report(bool isComplete, string summary)
     {
         Summary = summary;
 
         var justCompleted = isComplete && !IsComplete;
         IsComplete = isComplete;
 
-        if (justCompleted && !_userDecided)
+        if (justCompleted)
         {
-            IsExpanded = false;
-            return true;
+            if (!_userDecided) IsExpanded = false;
+            Completed?.Invoke(this);
+            return;
         }
 
         // Going incomplete reopens it whatever happened before - the contents are the only way to
         // put it right, and hiding them behind a chevron at that moment helps nobody.
         if (!isComplete) IsExpanded = true;
+    }
 
-        return false;
+    /// <summary>
+    /// Takes back a confirmation because what was confirmed has changed.
+    ///
+    /// Changing the restore point after confirming it must not leave the later steps standing on
+    /// the old answer: a script and a summary describing a moment nobody chose is exactly the
+    /// failure this screen cannot have.
+    /// </summary>
+    public void Invalidate()
+    {
+        if (!IsComplete) return;
+        IsComplete = false;
     }
 }
 
 /// <summary>
-/// The Restore screen's steps. Numbering and titles live here rather than in the markup so the
-/// summaries and the headings cannot drift apart.
+/// The Restore screen's steps, as a sequence rather than four independent drawers.
 ///
-/// They behave as an accordion: opening one closes the others. Collapsing the finished steps was
-/// only half the fix - with four panes free to be open at once the screen could still be as long
-/// as it ever was, and the script pane in particular is tall enough to bury everything above it.
+/// Three rules, all of which came out of using it:
+///   - a step is hidden until the one before it is done, so the screen only ever offers what can
+///     actually be acted on;
+///   - opening one closes the others, because four panes open at once is the long scroll again;
+///   - the two steps that decide what gets restored are finished by the user saying so, not by the
+///     app inferring it from a click.
 /// </summary>
 public sealed class RestoreStepsViewModel
 {
     public RestoreStep Source { get; } = new("1. SELECT SOURCE");
-    public RestoreStep Point { get; } = new("2. SELECT RESTORE POINT");
-    public RestoreStep Options { get; } = new("3. RESTORE OPTIONS");
+    public RestoreStep Point { get; } = new("2. SELECT RESTORE POINT", needsConfirmation: true);
+    public RestoreStep Options { get; } = new("3. RESTORE OPTIONS", needsConfirmation: true);
     public RestoreStep Execute { get; } = new("4. GENERATE & EXECUTE");
 
     public IReadOnlyList<RestoreStep> All { get; }
@@ -105,50 +149,107 @@ public sealed class RestoreStepsViewModel
     {
         All = [Source, Point, Options, Execute];
 
-        // One open to begin with, and it is the one there is anything to do in.
+        // One open, and it is the only one there is anything to do in yet. RefreshVisibility only
+        // acts on a CHANGE, so the steps that start hidden have to start closed too - otherwise
+        // they arrive already expanded the moment they become visible.
+        Source.IsVisible = true;
+        Source.IsExpanded = true;
         Point.IsExpanded = false;
         Options.IsExpanded = false;
         Execute.IsExpanded = false;
 
         foreach (var step in All)
         {
-            var opened = step;
-            opened.PropertyChanged += (_, e) =>
-            {
-                if (e.PropertyName != nameof(RestoreStep.IsExpanded)) return;
-                if (!opened.IsExpanded || _settling) return;
+            var self = step;
 
-                _settling = true;
-                try
+            self.Completed += _ => Advance(self);
+
+            self.PropertyChanged += (_, e) =>
+            {
+                switch (e.PropertyName)
                 {
-                    foreach (var other in All)
-                        if (!ReferenceEquals(other, opened)) other.IsExpanded = false;
-                }
-                finally
-                {
-                    _settling = false;
+                    case nameof(RestoreStep.IsExpanded) when self.IsExpanded && !_settling:
+                        CloseTheOthers(self);
+                        break;
+
+                    // Visibility runs off completion: a step is offered once the one before it is
+                    // answered, and taken away again if that answer is withdrawn.
+                    case nameof(RestoreStep.IsComplete):
+                        RefreshVisibility();
+                        break;
                 }
             };
+        }
+
+        RefreshVisibility();
+    }
+
+    private void CloseTheOthers(RestoreStep opened)
+    {
+        _settling = true;
+        try
+        {
+            foreach (var other in All)
+                if (!ReferenceEquals(other, opened)) other.IsExpanded = false;
+        }
+        finally
+        {
+            _settling = false;
         }
     }
 
     /// <summary>
-    /// Records a step's progress and, when that folds it away, opens the next one still to do.
+    /// Each step is offered once the one before it is done, and taken away again if that answer is
+    /// withdrawn.
     ///
-    /// This is what makes it read as a sequence rather than four independent drawers: finishing
-    /// step 1 puts you in step 2 rather than in front of nothing. Step 4 is never reported on - it
-    /// is the action, with no completed state to speak of - so it ends up being the step that is
-    /// opened once 1 to 3 are done, which is exactly where somebody wants to be by then.
+    /// Withdrawing CASCADES. A step that is no longer reachable cannot still be complete: leaving
+    /// step 3 flagged as answered while it was hidden kept step 4 on screen, so changing a
+    /// confirmed restore point left the execute button standing on a chain that no longer existed.
+    ///
+    /// One forward pass, guarded against re-entry, because clearing a completion raises the very
+    /// event that calls this.
     /// </summary>
-    public void Report(RestoreStep step, bool isComplete, string summary)
+    private void RefreshVisibility()
     {
-        if (!step.Report(isComplete, summary)) return;
+        if (_refreshing) return;
+
+        _refreshing = true;
+        try
+        {
+            for (var i = 1; i < All.Count; i++)
+            {
+                var step = All[i];
+                var visible = All[i - 1].IsComplete;
+
+                if (step.IsVisible != visible) step.IsVisible = visible;
+                if (visible) continue;
+
+                step.IsExpanded = false;
+                step.Invalidate();
+            }
+        }
+        finally
+        {
+            _refreshing = false;
+        }
+    }
+
+    private bool _refreshing;
+
+    /// <summary>Opens the next step that is available and not yet answered.</summary>
+    private void Advance(RestoreStep from)
+    {
+        RefreshVisibility();
 
         var next = All
-            .SkipWhile(s => !ReferenceEquals(s, step))
+            .SkipWhile(s => !ReferenceEquals(s, from))
             .Skip(1)
-            .FirstOrDefault(s => !s.IsComplete);
+            .FirstOrDefault(s => s.IsVisible && !s.IsComplete);
 
         if (next != null) next.IsExpanded = true;
     }
+
+    /// <summary>Records progress for a step that finishes by itself.</summary>
+    public void Report(RestoreStep step, bool isComplete, string summary)
+        => step.Report(isComplete, summary);
 }

--- a/src/NineLives/ViewModels/RestoreTimelineViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreTimelineViewModel.cs
@@ -120,7 +120,7 @@ public partial class RestoreTimelineViewModel : ObservableObject
         }
 
         HasPoints = true;
-        ApplyFilters(selectLatest: true);
+        ApplyFilters();
     }
 
     /// <summary>
@@ -154,7 +154,7 @@ public partial class RestoreTimelineViewModel : ObservableObject
     /// like a zoom: narrow to a two-hour window and those points spread across the whole track
     /// instead of staying bunched in the sliver they occupied before (#27).
     /// </summary>
-    private void ApplyFilters(bool selectLatest = false)
+    private void ApplyFilters()
     {
         var previous = SelectedPoint;
         var visible = _all.Where(Matches).ToList();
@@ -176,9 +176,13 @@ public partial class RestoreTimelineViewModel : ObservableObject
 
         // Keep the selection when it survives the filter - changing a type toggle should not throw
         // away the point someone had already chosen.
-        SelectedPoint = !selectLatest && previous != null && visible.Contains(previous)
-            ? previous
-            : visible[^1];
+        //
+        // A FRESH set of points selects nothing. Landing on the latest point looks helpful and is
+        // not: it is the app deciding which moment to restore to, on a screen whose purpose is
+        // choosing that moment, and everything downstream - the chain, the script, the summary -
+        // then describes a restore nobody asked for. The one thing this tool must never do is
+        // answer that question on somebody's behalf.
+        SelectedPoint = previous != null && visible.Contains(previous) ? previous : null;
     }
 
     private bool Matches(RestorePoint p)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -523,13 +523,19 @@ public partial class RestoreViewModel : ViewModelBase
         // the caller updates once at the end rather than four times through a half-built state.
         PointInTime.PropertyChanged += (_, _) =>
         {
-            if (!PointInTime.IsUpdating) UpdateRestoreSummary();
+            if (PointInTime.IsUpdating) return;
+            Steps.Options.Invalidate();
+            UpdateRestoreSummary();
         };
 
         // One subscription in place of a one-line change handler per option (#115 seam 7). An
         // option added later is kept in step with the script by existing, rather than by whoever
         // adds it remembering to write a handler - which is what #110 was.
-        Options.PropertyChanged += (_, _) => UpdateRestoreSummary();
+        Options.PropertyChanged += (_, _) =>
+        {
+            Steps.Options.Invalidate();
+            UpdateRestoreSummary();
+        };
 
         RefreshContainers();
     }
@@ -640,6 +646,10 @@ public partial class RestoreViewModel : ViewModelBase
     private void OnSelectedRestorePointChanged(RestorePoint? value)
     {
         ShowChainDetails = false;
+
+        // A confirmed point that then moves is no longer confirmed. Leaving it standing would let
+        // the script, the summary and the execute button describe a moment nobody chose.
+        Steps.Point.Invalidate();
 
         // Verification belongs to the chain that was verified. Leaving the results on screen
         // after the selection moves would show a green tick against backups nothing has read.
@@ -952,23 +962,30 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     private void RefreshSteps()
     {
+        // Step 1 finishes by itself, because there is nothing to confirm: a database either has
+        // been chosen or has not. It needs BOTH the container loaded and a database picked - the
+        // step holds the server and database dropdowns, so completing it on the load alone threw
+        // people out of the step before they could use them.
         Steps.Report(
             Steps.Source,
             BackupsLoaded && !string.IsNullOrWhiteSpace(SelectedDatabaseName),
             DescribeSource());
 
-        Steps.Report(
-            Steps.Point,
-            Timeline.SelectedPoint != null,
+        // Described, and confirmed by the user rather than by a click. Choosing a restore point is
+        // the decision this application exists to support: collapsing the step the instant a dot is
+        // clicked takes the timeline away from somebody who is still comparing points.
+        Steps.Point.Describe(
             Timeline.SelectedPoint is { } point
                 ? $"{point.TimestampDisplay}, {RestoreChain?.Summary ?? "no chain"}"
                 : string.Empty);
+        Steps.Point.CanConfirm = Timeline.SelectedPoint != null && RestoreChain != null;
 
         // Described, not completed. The options have defaults, so there is no point at which they
         // are finished - and the target name is derived from the chosen database, so treating a
         // non-empty one as completion folded this step away the moment a database was picked, and
         // the hand-over from step 2 then skipped straight over it to step 4.
         Steps.Options.Describe(DescribeOptions());
+        Steps.Options.CanConfirm = !string.IsNullOrWhiteSpace(TargetDatabaseName);
     }
 
     private string DescribeSource()

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -119,6 +119,13 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     public PointInTimeViewModel PointInTime { get; } = new();
 
+    /// <summary>
+    /// The numbered steps, and whether each is open (#117 item 3). Every step was expanded at all
+    /// times, including the ones already finished and the ones not yet reachable, on a screen of
+    /// roughly 1,300 lines of markup in one column.
+    /// </summary>
+    public RestoreStepsViewModel Steps { get; } = new();
+
     // ── Chain gap detection ──────────────────────────────────────────────────────
     // Structural validation of the selected chain, run at selection time. The app otherwise
     // assumes every discovered backup is present and intact, so a missing stripe or a hole in
@@ -496,6 +503,11 @@ public partial class RestoreViewModel : ViewModelBase
         {
             if (e.PropertyName is nameof(IsBusy) or nameof(TargetDatabaseName))
                 RefreshCheckState();
+
+            if (e.PropertyName is nameof(BackupsLoaded) or nameof(SelectedDatabaseName)
+                or nameof(SelectedServerName) or nameof(SelectedContainer)
+                or nameof(TargetDatabaseName))
+                RefreshSteps();
         };
 
         // The selection now lives on the timeline (#115 seam 2), which is a different object, so
@@ -892,6 +904,8 @@ public partial class RestoreViewModel : ViewModelBase
         // the thing people read before running a restore against production.
         RegenerateScript();
 
+        RefreshSteps();
+
         if (RestoreChain == null || string.IsNullOrWhiteSpace(TargetDatabaseName))
         {
             RestoreSummaryText = string.Empty;
@@ -933,6 +947,67 @@ public partial class RestoreViewModel : ViewModelBase
             parts.Add("Options: " + string.Join("; ", optionsList) + ".");
 
         RestoreSummaryText = string.Join(" ", parts);
+    }
+
+    /// <summary>
+    /// Tells each step where it stands. Driven from the same places as the restore summary, so a
+    /// step's heading cannot disagree with the screen underneath it.
+    /// </summary>
+    private void RefreshSteps()
+    {
+        Steps.Source.Report(
+            BackupsLoaded && !string.IsNullOrWhiteSpace(SelectedDatabaseName),
+            DescribeSource());
+
+        Steps.Point.Report(
+            Timeline.SelectedPoint != null,
+            Timeline.SelectedPoint is { } point
+                ? $"{point.TimestampDisplay}, {RestoreChain?.Summary ?? "no chain"}"
+                : string.Empty);
+
+        Steps.Options.Report(
+            !string.IsNullOrWhiteSpace(TargetDatabaseName),
+            DescribeOptions());
+    }
+
+    private string DescribeSource()
+    {
+        if (SelectedContainer == null) return string.Empty;
+
+        var parts = new List<string> { SelectedContainer.Name };
+        if (!string.IsNullOrWhiteSpace(SelectedDatabaseName))
+        {
+            parts.Add(string.IsNullOrWhiteSpace(SelectedServerName)
+                ? SelectedDatabaseName!
+                : $"{SelectedDatabaseName} on {SelectedServerName}");
+        }
+
+        return string.Join(", ", parts);
+    }
+
+    /// <summary>
+    /// The short form for a collapsed step: the target and the handful of options that change what
+    /// the restore DOES. Not the full sentence from the restore summary - that is a paragraph, and
+    /// this has to fit on the heading beside the step title.
+    /// </summary>
+    private string DescribeOptions()
+    {
+        if (string.IsNullOrWhiteSpace(TargetDatabaseName)) return string.Empty;
+
+        var parts = new List<string> { $"as {TargetDatabaseName}" };
+
+        parts.Add(Options.RecoveryMode switch
+        {
+            RecoveryMode.NoRecovery => "NORECOVERY",
+            RecoveryMode.Standby => "STANDBY",
+            _ => "RECOVERY"
+        });
+
+        if (Options.WithReplace) parts.Add("REPLACE");
+        if (UseWithMove) parts.Add("MOVE");
+        if (PointInTime.Effective is DateTime stopAt) parts.Add($"STOPAT {stopAt:yyyy-MM-dd HH:mm:ss}");
+
+        return string.Join(", ", parts);
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -955,17 +955,20 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     private void RefreshSteps()
     {
-        Steps.Source.Report(
+        Steps.Report(
+            Steps.Source,
             BackupsLoaded && !string.IsNullOrWhiteSpace(SelectedDatabaseName),
             DescribeSource());
 
-        Steps.Point.Report(
+        Steps.Report(
+            Steps.Point,
             Timeline.SelectedPoint != null,
             Timeline.SelectedPoint is { } point
                 ? $"{point.TimestampDisplay}, {RestoreChain?.Summary ?? "no chain"}"
                 : string.Empty);
 
-        Steps.Options.Report(
+        Steps.Report(
+            Steps.Options,
             !string.IsNullOrWhiteSpace(TargetDatabaseName),
             DescribeOptions());
     }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -570,8 +570,11 @@ public partial class RestoreViewModel : ViewModelBase
             .ToList();
 
         DiscoveredDatabases = new ObservableCollection<string>(dbs);
-        if (DiscoveredDatabases.Count > 0)
-            SelectedDatabaseName = DiscoveredDatabases[0];
+
+        // Nothing is chosen for the user. Picking the first database alphabetically is a decision
+        // about WHICH DATABASE TO RESTORE, made silently, and the rest of the screen then fills in
+        // around it as though somebody had asked for it - a chain, a restore point, a target name.
+        // On a screen whose last button overwrites a database, the app does not get to guess.
     }
 
     partial void OnSelectedDatabaseNameChanged(string? value) => RefreshSelectedDatabase(value);
@@ -713,15 +716,8 @@ public partial class RestoreViewModel : ViewModelBase
             DiscoveredDatabases = new ObservableCollection<string>(dbs);
             BackupsLoaded = _allBackups.Count > 0;
 
-            if (DiscoveredServers.Count > 0)
-            {
-                SelectedServerName = DiscoveredServers[0];
-            }
-            else if (DiscoveredDatabases.Count > 0)
-            {
-                SelectedDatabaseName = DiscoveredDatabases[0];
-            }
-            else
+            // Same again: the lists are offered, not answered. What follows is the no-selection
+            // case, which is now what every load starts in.
             {
                 _dbSets = _allSets;
                 FullCount = _dbSets.Count(s => s.Type == BackupType.Full);
@@ -967,10 +963,11 @@ public partial class RestoreViewModel : ViewModelBase
                 ? $"{point.TimestampDisplay}, {RestoreChain?.Summary ?? "no chain"}"
                 : string.Empty);
 
-        Steps.Report(
-            Steps.Options,
-            !string.IsNullOrWhiteSpace(TargetDatabaseName),
-            DescribeOptions());
+        // Described, not completed. The options have defaults, so there is no point at which they
+        // are finished - and the target name is derived from the chosen database, so treating a
+        // non-empty one as completion folded this step away the moment a database was picked, and
+        // the hand-over from step 2 then skipped straight over it to step 4.
+        Steps.Options.Describe(DescribeOptions());
     }
 
     private string DescribeSource()

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -589,7 +589,17 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     private void RefreshSelectedDatabase(string? value)
     {
-        if (value == null || _allSets.Count == 0) return;
+        // No database chosen: nothing to compute a chain from, so show nothing rather than
+        // everything. Returning early used to be safe because something was always selected.
+        // No database chosen: nothing to compute a chain from, so show nothing rather than
+        // everything. Returning early used to be safe because something was always selected.
+        if (string.IsNullOrEmpty(value) || _allSets.Count == 0)
+        {
+            _dbSets = [];
+            FullCount = DiffCount = LogCount = SetCount = 0;
+            Timeline.Clear();
+            return;
+        }
 
         _dbSets = _allSets
             .Where(s => string.Equals(s.DatabaseName, value, StringComparison.OrdinalIgnoreCase))
@@ -716,19 +726,10 @@ public partial class RestoreViewModel : ViewModelBase
             DiscoveredDatabases = new ObservableCollection<string>(dbs);
             BackupsLoaded = _allBackups.Count > 0;
 
-            // Same again: the lists are offered, not answered. What follows is the no-selection
-            // case, which is now what every load starts in.
-            {
-                _dbSets = _allSets;
-                FullCount = _dbSets.Count(s => s.Type == BackupType.Full);
-                DiffCount = _dbSets.Count(s => s.Type == BackupType.Differential);
-                LogCount = _dbSets.Count(s => s.Type == BackupType.TransactionLog);
-                SetCount = _dbSets.Count;
-                ComputeAndDisplayRestorePoints();
-            }
-
-
-            // Unconditionally, not just when the selection changed - see RefreshSelectedDatabase.
+            // The lists are offered, not answered - and until one IS answered there is nothing to
+            // show. Falling back to every set in the container meant a timeline of every backup of
+            // every database on every server: on a real container that is thousands of points, all
+            // of them meaningless, because a restore chain only exists within one database.
             RefreshSelectedDatabase(SelectedDatabaseName);
 
             // Only when nothing above went wrong. Selecting the first server or database runs the

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -55,8 +55,8 @@
                  with every option above it. Sitting inside the accordion it was invisible whenever
                  another pane was open, which is most of the time. -->
             <Border CornerRadius="6" Padding="14,12" Margin="0,0,0,16"
-                    Background="{DynamicResource SuccessPanelBackgroundBrush}"
-                    BorderBrush="{DynamicResource SuccessBrush}"
+                    Background="{DynamicResource WarningPanelBackgroundBrush}"
+                    BorderBrush="{DynamicResource WarningBrush}"
                     BorderThickness="1"
                     Visibility="{Binding RestoreSummaryText, Converter={StaticResource NullToVis}}">
                 <StackPanel>
@@ -216,7 +216,7 @@
 
             <!-- Step 2: Restore Point Selection -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
-                    Visibility="{Binding Timeline.HasPoints, Converter={StaticResource BoolToVis}}">
+                    Visibility="{Binding Steps.Point.IsVisible, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
                     <!-- Collapsible (#117 item 3). Title and summary come from Steps.Point. -->
                     <Button Style="{StaticResource StepHeader}" DataContext="{Binding Steps.Point}" />
@@ -859,12 +859,26 @@
                         </StackPanel>
                     </Border>
                     </StackPanel>
+                        <!-- Finishing this step is something the user says (#117 item 3). This is the moment the database will be restored to. Confirm to continue. -->
+                        <Border Background="{DynamicResource InputBackgroundBrush}" CornerRadius="4"
+                                Padding="12,10" Margin="0,16,0,0">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <TextBlock Style="{StaticResource SecondaryText}" VerticalAlignment="Center"
+                                           Margin="0,0,12,0" TextWrapping="Wrap"
+                                           Text="This is the moment the database will be restored to. Confirm to continue." />
+                                <Button Content="Confirm restore point"
+                                        Command="{Binding Steps.Point.ConfirmCommand}"
+                                        IsEnabled="{Binding Steps.Point.CanConfirm}"
+                                        Style="{StaticResource PrimaryButton}"
+                                        Padding="16,8" />
+                            </StackPanel>
+                        </Border>
                 </StackPanel>
             </Border>
 
             <!-- Step 3: Restore Options -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
-                    Visibility="{Binding BackupsLoaded, Converter={StaticResource BoolToVis}}">
+                    Visibility="{Binding Steps.Options.IsVisible, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
                     <!-- Collapsible (#117 item 3). Title and summary come from Steps.Options. -->
                     <Button Style="{StaticResource StepHeader}" DataContext="{Binding Steps.Options}" />
@@ -1242,13 +1256,27 @@
                             </Border>
                         </StackPanel>
                     </Grid>
+                        <!-- Finishing this step is something the user says (#117 item 3). Happy with these? Confirm to move on to generating the script. -->
+                        <Border Background="{DynamicResource InputBackgroundBrush}" CornerRadius="4"
+                                Padding="12,10" Margin="0,16,0,0">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                <TextBlock Style="{StaticResource SecondaryText}" VerticalAlignment="Center"
+                                           Margin="0,0,12,0" TextWrapping="Wrap"
+                                           Text="Happy with these? Confirm to move on to generating the script." />
+                                <Button Content="Confirm options"
+                                        Command="{Binding Steps.Options.ConfirmCommand}"
+                                        IsEnabled="{Binding Steps.Options.CanConfirm}"
+                                        Style="{StaticResource PrimaryButton}"
+                                        Padding="16,8" />
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
                 </StackPanel>
             </Border>
 
             <!-- Step 4: Generate + Execute -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
-                    Visibility="{Binding BackupsLoaded, Converter={StaticResource BoolToVis}}">
+                    Visibility="{Binding Steps.Execute.IsVisible, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
                     <!-- Collapsible like the rest (#117 item 3). It is the tallest pane on the screen -
                          script, console, recovery actions - so leaving it permanently open undid most of

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -51,9 +51,9 @@
             <!-- Step 1: Container + Database -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
                 <StackPanel>
-                    <TextBlock Text="1. SELECT SOURCE"
-                               Style="{StaticResource SubHeaderText}"
-                               Margin="0,0,0,12" />
+                    <!-- Collapsible (#117 item 3). Title and summary come from Steps.Source. -->
+                    <Button Style="{StaticResource StepHeader}" DataContext="{Binding Steps.Source}" />
+                    <StackPanel Visibility="{Binding Steps.Source.IsExpanded, Converter={StaticResource BoolToVis}}">
 
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -152,6 +152,7 @@
                                    Style="{StaticResource SecondaryText}"
                                    VerticalAlignment="Center" HorizontalAlignment="Right" />
                     </Grid>
+                    </StackPanel>
                 </StackPanel>
             </Border>
 
@@ -195,9 +196,9 @@
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
                     Visibility="{Binding Timeline.HasPoints, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
-                    <TextBlock Text="2. SELECT RESTORE POINT"
-                               Style="{StaticResource SubHeaderText}"
-                               Margin="0,0,0,4" />
+                    <!-- Collapsible (#117 item 3). Title and summary come from Steps.Point. -->
+                    <Button Style="{StaticResource StepHeader}" DataContext="{Binding Steps.Point}" />
+                    <StackPanel Visibility="{Binding Steps.Point.IsExpanded, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="Click a point on the timeline, or pick one from the list below."
                                Style="{StaticResource SecondaryText}"
                                Margin="0,0,0,12" />
@@ -835,6 +836,7 @@
                             </ItemsControl>
                         </StackPanel>
                     </Border>
+                    </StackPanel>
                 </StackPanel>
             </Border>
 
@@ -842,9 +844,9 @@
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
                     Visibility="{Binding BackupsLoaded, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
-                    <TextBlock Text="3. RESTORE OPTIONS"
-                               Style="{StaticResource SubHeaderText}"
-                               Margin="0,0,0,16" />
+                    <!-- Collapsible (#117 item 3). Title and summary come from Steps.Options. -->
+                    <Button Style="{StaticResource StepHeader}" DataContext="{Binding Steps.Options}" />
+                    <StackPanel Visibility="{Binding Steps.Options.IsExpanded, Converter={StaticResource BoolToVis}}">
 
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -1218,6 +1220,7 @@
                             </Border>
                         </StackPanel>
                     </Grid>
+                    </StackPanel>
                 </StackPanel>
             </Border>
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -48,6 +48,28 @@
                 </StackPanel>
             </Border>
 
+            <!-- The live summary of what a restore would do, at the top rather than buried
+                 between steps 3 and 4 (#117 item 3).
+
+                 It is not a step - it is the answer the steps are building towards, and it changes
+                 with every option above it. Sitting inside the accordion it was invisible whenever
+                 another pane was open, which is most of the time. -->
+            <Border CornerRadius="6" Padding="14,12" Margin="0,0,0,16"
+                    Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                    BorderBrush="{DynamicResource SuccessBrush}"
+                    BorderThickness="1"
+                    Visibility="{Binding RestoreSummaryText, Converter={StaticResource NullToVis}}">
+                <StackPanel>
+                    <TextBlock Text="THIS RESTORE WILL"
+                               Style="{StaticResource LabelText}"
+                               Margin="0,0,0,6" />
+                    <TextBlock Text="{Binding RestoreSummaryText}"
+                               Style="{StaticResource BodyText}"
+                               TextWrapping="Wrap"
+                               LineHeight="22" />
+                </StackPanel>
+            </Border>
+
             <!-- Step 1: Container + Database -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
                 <StackPanel>
@@ -1224,30 +1246,15 @@
                 </StackPanel>
             </Border>
 
-            <!-- Restore Summary -->
-            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
-                    Visibility="{Binding RestoreSummaryText, Converter={StaticResource NullToVis}}">
-                <StackPanel>
-                    <TextBlock Text="RESTORE SUMMARY"
-                               Style="{StaticResource SubHeaderText}"
-                               Margin="0,0,0,8" />
-                    <Border Background="{DynamicResource InputBackgroundBrush}"
-                            CornerRadius="4" Padding="12,10">
-                        <TextBlock Text="{Binding RestoreSummaryText}"
-                                   Style="{StaticResource BodyText}"
-                                   TextWrapping="Wrap"
-                                   LineHeight="22" />
-                    </Border>
-                </StackPanel>
-            </Border>
-
             <!-- Step 4: Generate + Execute -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
                     Visibility="{Binding BackupsLoaded, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
-                    <TextBlock Text="4. GENERATE &amp; EXECUTE"
-                               Style="{StaticResource SubHeaderText}"
-                               Margin="0,0,0,16" />
+                    <!-- Collapsible like the rest (#117 item 3). It is the tallest pane on the screen -
+                         script, console, recovery actions - so leaving it permanently open undid most of
+                         what collapsing the others bought. -->
+                    <Button Style="{StaticResource StepHeader}" DataContext="{Binding Steps.Execute}" />
+                    <StackPanel Visibility="{Binding Steps.Execute.IsExpanded, Converter={StaticResource BoolToVis}}">
 
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                         <Button Content="Generate Script"
@@ -1527,6 +1534,7 @@
                             </ItemsControl>
                         </StackPanel>
                     </Border>
+                    </StackPanel>
                 </StackPanel>
             </Border>
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -861,7 +861,8 @@
                     </StackPanel>
                         <!-- Finishing this step is something the user says (#117 item 3). This is the moment the database will be restored to. Confirm to continue. -->
                         <Border Background="{DynamicResource InputBackgroundBrush}" CornerRadius="4"
-                                Padding="12,10" Margin="0,16,0,0">
+                                Padding="12,10" Margin="0,16,0,0"
+                                Visibility="{Binding Steps.Point.IsAwaitingConfirmation, Converter={StaticResource BoolToVis}}">
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                                 <TextBlock Style="{StaticResource SecondaryText}" VerticalAlignment="Center"
                                            Margin="0,0,12,0" TextWrapping="Wrap"
@@ -1258,7 +1259,8 @@
                     </Grid>
                         <!-- Finishing this step is something the user says (#117 item 3). Happy with these? Confirm to move on to generating the script. -->
                         <Border Background="{DynamicResource InputBackgroundBrush}" CornerRadius="4"
-                                Padding="12,10" Margin="0,16,0,0">
+                                Padding="12,10" Margin="0,16,0,0"
+                                Visibility="{Binding Steps.Options.IsAwaitingConfirmation, Converter={StaticResource BoolToVis}}">
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                                 <TextBlock Style="{StaticResource SecondaryText}" VerticalAlignment="Center"
                                            Margin="0,0,12,0" TextWrapping="Wrap"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -237,7 +237,11 @@
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
 
-                            <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                            <!-- Wraps rather than running on. The type toggles plus two 150px date
+                                 boxes have a minimum width that a narrow window cannot give them,
+                                 and a Grid does not clip its children - so the row used to spill
+                                 over the count beside it. -->
+                            <WrapPanel Grid.Column="0" VerticalAlignment="Center">
                                 <CheckBox Content="Full" IsChecked="{Binding Timeline.ShowFull}"
                                           Style="{StaticResource DarkCheckBox}" Margin="0,0,12,0" />
                                 <CheckBox Content="Diff" IsChecked="{Binding Timeline.ShowDiff}"
@@ -258,12 +262,13 @@
                                          Style="{StaticResource DarkTextBox}"
                                          Width="150"
                                          ToolTip="yyyy-MM-dd or yyyy-MM-dd HH:mm:ss. Leave empty for no upper bound." />
-                            </StackPanel>
+                            </WrapPanel>
 
                             <TextBlock Grid.Column="1" Text="{Binding Timeline.CountText}"
                                        Style="{StaticResource SecondaryText}"
                                        VerticalAlignment="Center"
                                        HorizontalAlignment="Right"
+                                       TextTrimming="CharacterEllipsis"
                                        Margin="12,0,12,0" />
 
                             <StackPanel Grid.Column="2" Orientation="Horizontal">
@@ -550,12 +555,12 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0" VerticalAlignment="Center">
+                        <!-- Wraps inside its own column. With no wrapping it simply ran on
+                             underneath the buttons - a Grid does not clip its children. -->
+                        <TextBlock Grid.Column="0" VerticalAlignment="Center"
+                                   TextWrapping="Wrap" Margin="0,0,12,0">
                             <Run Text="Selected: " Foreground="{DynamicResource SecondaryTextBrush}" />
                             <Run Text="{Binding Timeline.SelectedPoint.TimestampDisplay, Mode=OneWay}"
                                  FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}" />
@@ -563,13 +568,17 @@
                             <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{DynamicResource SecondaryTextBrush}" />
                         </TextBlock>
 
+                        <!-- One wrapping panel, so on a narrow window the buttons fold onto
+                             another line instead of over the text beside them. -->
+                        <WrapPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center">
+
                         <!-- On-demand: one RESTORE HEADERONLY per chain member, so it is a
                              deliberate action rather than automatic on selection.
 
                              Named for the question it answers rather than for the word "validate".
                              Two of the buttons on this screen used to say "verify" and mean
                              different things, and a third said it while verifying nothing. -->
-                        <Button Grid.Column="1"
+                        <Button
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding ValidateChainCommand}"
                                 Padding="12,6" Margin="0,0,8,0"
@@ -605,7 +614,7 @@
                              checks the LSNs line up, this one reads each backup end to end and
                              checks it is intact. A truncated blob passes the first and fails this.
                              It is also the only one here that costs real time. -->
-                        <Button Grid.Column="2"
+                        <Button
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding VerifyChainCommand}"
                                 Padding="12,6" Margin="0,0,8,0"
@@ -640,7 +649,7 @@
                         <!-- Only while something is running. RESTORE VERIFYONLY reads every byte
                              of every backup in the chain at CommandTimeout = 0, so on a large
                              chain this is the difference between waiting and killing the app. -->
-                        <Button Grid.Column="3"
+                        <Button
                                 Content="Stop"
                                 Command="{Binding CancelQueryCommand}"
                                 Style="{StaticResource SecondaryButton}"
@@ -649,7 +658,7 @@
                                 Visibility="{Binding CanCancelQuery, Converter={StaticResource BoolToVis}}"
                                 ToolTip="Stop the server query that is running." />
 
-                        <Button Grid.Column="4"
+                        <Button
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding ToggleChainDetailsCommand}"
                                 Padding="12,6">
@@ -668,6 +677,7 @@
                                 </TextBlock>
                             </Button.Content>
                         </Button>
+                        </WrapPanel>
                     </Grid>
 
                     <!-- The pair above are the genuinely subtle one: both act on the whole chain


### PR DESCRIPTION
@
#117 item 3. **936 passing, 24 skipped.**

The Restore screen was roughly 1,300 lines of markup in a single column, with every step expanded at all times — including the ones already finished and the ones not yet reachable.

Steps 1 to 3 now fold away when complete, showing what was chosen rather than nothing:

| | |
|---|---|
| 1. SELECT SOURCE | `backups, MyDb on SRV01` |
| 2. SELECT RESTORE POINT | `2026-01-10 22:00, Full + 2 logs` |
| 3. RESTORE OPTIONS | `as MyDb_Restored, RECOVERY, REPLACE` |

Same information, a screen with a visible end.

**Step 4 is deliberately left alone.** It is the action, not a decision, and there is nothing to summarise about a button you have not pressed.

## The rules are about not fighting the person using it

Collapsing is easy. Collapsing without being annoying is the part worth pinning, and all three of these have a test:

- **A step folds only on the transition into complete.** The summary keeps changing after that — editing the target name rewrites step 3s heading — and re-collapsing on each of those would fold away a step somebody is working in.
- **Opening a step yourself stops it ever folding again.** Somebody who opens a finished step is reading it, and a screen that folds it away the moment they change the thing they came back to change is worse than one that never folded at all.
- **Going incomplete always reopens it**, whatever happened before. The contents are the only way to put it right, and hiding them behind a chevron at that moment helps nobody.

## Implementation

`RestoreStep` holds the state and the toggle; `RestoreStepsViewModel` holds the three. Titles live there rather than in the markup, so a heading and its summary cannot drift apart.

Step state is driven from `UpdateRestoreSummary`, which already runs on every option and selection change, plus the property hook that catches the ones that do not pass through it. One `StepHeader` template serves all three — title, summary, chevron — and the whole heading is the hit target, because clicking the words is what people try first.

Rendered open and collapsed and checked by eye. The markup change is mechanical (a header swap and a wrapper around each body) but it is 1,300 lines of XAML, so worth a look in the running app before it ships.
@