### PR TITLE
Say what to do first on an empty screen (#117 item 7)

### DIFF
--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -147,15 +147,56 @@
                     <Border Style="{StaticResource CardBorder}"
                             Visibility="{Binding IsEditing, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                         <StackPanel>
-                            <!-- Empty state -->
+                            <!-- Empty state. Two of them: "nothing selected" and "nothing exists
+                                 yet" are different questions, and a fresh install only ever saw
+                                 the first, which answers a question nobody was asking (#117
+                                 item 7). -->
                             <StackPanel Visibility="{Binding SelectedContainer, Converter={StaticResource NullToVis}, ConverterParameter=Invert}">
-                                <TextBlock Text="No container selected"
-                                           Style="{StaticResource SecondaryText}"
-                                           HorizontalAlignment="Center"
-                                           Margin="0,40,0,8" />
-                                <TextBlock Text="Add a new container or select one from the list."
-                                           Style="{StaticResource SecondaryText}"
-                                           HorizontalAlignment="Center" />
+                                <StackPanel HorizontalAlignment="Center" MaxWidth="460" Margin="0,40,0,0">
+                                    <StackPanel.Style>
+                                        <Style TargetType="StackPanel">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Containers.Count}" Value="0">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </StackPanel.Style>
+
+                                    <TextBlock Text="Start here"
+                                               Style="{StaticResource SubHeaderText}"
+                                               HorizontalAlignment="Center"
+                                               Margin="0,0,0,8" />
+                                    <TextBlock Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap"
+                                               TextAlignment="Center">
+                                        <Run Text="Add the blob container holding your backups - the URL, and either a SAS token or Entra ID sign-in." />
+                                        <LineBreak /><LineBreak />
+                                        <Run Text="A restore needs two things: this container, and a SQL Server connection on the SQL Servers screen to restore onto. You can browse backups with just the container." />
+                                    </TextBlock>
+                                </StackPanel>
+
+                                <StackPanel HorizontalAlignment="Center">
+                                    <StackPanel.Style>
+                                        <Style TargetType="StackPanel">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Containers.Count}" Value="0">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </StackPanel.Style>
+
+                                    <TextBlock Text="No container selected"
+                                               Style="{StaticResource SecondaryText}"
+                                               HorizontalAlignment="Center"
+                                               Margin="0,40,0,8" />
+                                    <TextBlock Text="Add a new container or select one from the list."
+                                               Style="{StaticResource SecondaryText}"
+                                               HorizontalAlignment="Center" />
+                                </StackPanel>
                             </StackPanel>
 
                             <!-- Detail state -->

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -24,6 +24,30 @@
                            Margin="0,4,0,0" />
             </StackPanel>
 
+            <!-- Nothing to restore from yet. An empty dropdown on the first screen somebody
+                 opens says nothing about which screen fixes it (#117 item 7). -->
+            <Border Background="{DynamicResource InputBackgroundBrush}"
+                    CornerRadius="6" Padding="16,14" Margin="0,0,0,16">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Containers.Count}" Value="0">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <StackPanel>
+                    <TextBlock Text="No blob containers configured"
+                               Style="{StaticResource SubHeaderText}"
+                               Margin="0,0,0,6" />
+                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap">
+                        <Run Text="Add one on the Blob Storage screen and it will appear here. A restore also needs a SQL Server connection, on the SQL Servers screen, to run against." />
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+
             <!-- Step 1: Container + Database -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
                 <StackPanel>

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -185,13 +185,53 @@
                             Visibility="{Binding IsEditing, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                         <StackPanel>
                             <StackPanel Visibility="{Binding SelectedServer, Converter={StaticResource NullToVis}, ConverterParameter=Invert}">
-                                <TextBlock Text="No server selected"
-                                           Style="{StaticResource SecondaryText}"
-                                           HorizontalAlignment="Center"
-                                           Margin="0,40,0,8" />
-                                <TextBlock Text="Add a new server or select one from the list."
-                                           Style="{StaticResource SecondaryText}"
-                                           HorizontalAlignment="Center" />
+                                <!-- "Nothing selected" and "nothing exists yet" are different
+                                     questions; a fresh install only ever saw the first (#117 item 7). -->
+                                <StackPanel HorizontalAlignment="Center" MaxWidth="460" Margin="0,40,0,0">
+                                    <StackPanel.Style>
+                                        <Style TargetType="StackPanel">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Servers.Count}" Value="0">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </StackPanel.Style>
+
+                                    <TextBlock Text="Add the server you want to restore ONTO"
+                                               Style="{StaticResource SubHeaderText}"
+                                               HorizontalAlignment="Center"
+                                               Margin="0,0,0,8" />
+                                    <TextBlock Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap"
+                                               TextAlignment="Center">
+                                        <Run Text="This is the instance the RESTORE runs on, which is not necessarily the one the backups came from." />
+                                        <LineBreak /><LineBreak />
+                                        <Run Text="Without one you can still browse backups and generate a script to run yourself. With one, the app can execute the restore for you." />
+                                    </TextBlock>
+                                </StackPanel>
+
+                                <StackPanel HorizontalAlignment="Center">
+                                    <StackPanel.Style>
+                                        <Style TargetType="StackPanel">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Servers.Count}" Value="0">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </StackPanel.Style>
+
+                                    <TextBlock Text="No server selected"
+                                               Style="{StaticResource SecondaryText}"
+                                               HorizontalAlignment="Center"
+                                               Margin="0,40,0,8" />
+                                    <TextBlock Text="Add a new server or select one from the list."
+                                               Style="{StaticResource SecondaryText}"
+                                               HorizontalAlignment="Center" />
+                                </StackPanel>
                             </StackPanel>
 
                             <StackPanel Visibility="{Binding SelectedServer, Converter={StaticResource NullToVis}}">


### PR DESCRIPTION
@
#117 item 7. **929 passing, 24 skipped.**

A fresh install opens on Blob Storage with an empty list and the words *"No container selected"* — which answers a question nobody was asking. The Servers screen said *"No server selected"* the same way, and the Restore screen showed an empty dropdown that says nothing about which screen fixes it.

**"Nothing is selected" and "nothing exists yet" are different questions.** Both screens now tell them apart, and the existing wording stays for when there genuinely are entries to select — at that point it is the right answer.

| Screen | First run now says |
|---|---|
| Blob Storage | What a container is, and that a restore needs a SQL Server connection too — browsing needs only the container |
| SQL Servers | That this is the instance the RESTORE runs **on**, not necessarily the one the backups came from; and that without one you can still browse and generate a script to run yourself |
| Restore | Which screen to go to, instead of an empty dropdown |

The SQL Servers wording is the one Id most like a second opinion on. "The server you want to restore onto" is the distinction people get wrong, and the screen previously said nothing about it at all.

## One deliberate omission

No keyboard shortcuts named in the copy, even though "(Ctrl+1)" would be the natural thing to write. Those shortcuts are on the #117 item 5 branch and this has to read correctly whichever of the two lands first. Worth adding once both are on `dev`.

Rendered all three first-run states and checked them by eye.
@