### PR TITLE
Show which container a restore is coming FROM (#117 item 8)

### DIFF
--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -39,10 +39,26 @@
 
                         <StackPanel Grid.Column="0" Margin="0,0,12,0">
                             <TextBlock Text="BLOB CONTAINER" Style="{StaticResource LabelText}" />
+                            <!-- Tag pills here too, not only on the containers screen. This is the
+                                 dropdown where "which of these is production" actually gets
+                                 decided, and it was the one place the tags did not follow (#117
+                                 item 8). DisplayMemberPath cannot coexist with an item template,
+                                 so the name is spelled out. -->
                             <ComboBox ItemsSource="{Binding Containers}"
                                       SelectedItem="{Binding SelectedContainer}"
-                                      DisplayMemberPath="Name"
-                                      Style="{StaticResource DarkComboBox}" />
+                                      Style="{StaticResource DarkComboBox}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{Binding Name}" VerticalAlignment="Center" />
+                                            <ItemsControl ItemsSource="{Binding TagChips}"
+                                                          Style="{StaticResource TagChipList}"
+                                                          Margin="8,0,0,0"
+                                                          VerticalAlignment="Center" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
                         </StackPanel>
 
                         <Button Grid.Column="1"
@@ -1267,7 +1283,16 @@
                                 <Run Text="{Binding TargetDatabaseName, Mode=OneWay}" FontWeight="SemiBold" />
                                 <Run Text="(" />
                                 <Run Text="{Binding ChainSummary, Mode=OneWay}" />
-                                <Run Text="). This operation cannot be undone." Foreground="{DynamicResource ErrorBrush}" />
+                                <Run Text=")." />
+                                <!-- The SOURCE, named on the last screen before an irreversible
+                                     write. Restoring the right chain from the wrong container is
+                                     as bad as restoring to the wrong server, and only one of the
+                                     two was on this banner (#117 item 8). -->
+                                <Run Text=" From:" />
+                                <Run Text="{Binding SelectedContainer.Name, Mode=OneWay}" FontWeight="SemiBold" />
+                                <Run Text="/" />
+                                <Run Text="{Binding SelectedDatabaseName, Mode=OneWay}" FontWeight="SemiBold" />
+                                <Run Text=". This operation cannot be undone." Foreground="{DynamicResource ErrorBrush}" />
                             </TextBlock>
                         </StackPanel>
                     </Border>


### PR DESCRIPTION
@
Two of #117 item 8s smaller points, both the same underlying thing: the screen showed where a restore was **going** without showing where it was **coming from**.

- **The arm-to-execute banner** named the server, the target database and the chain — but not the source container. Restoring the right chain from the wrong container is exactly as bad as restoring to the wrong server, and that banner is the last thing anybody reads before an irreversible write.
- **Tag pills on the Restore screens container dropdown**, not just on the containers screen. That dropdown is where "which of these is production" actually gets decided, and it was the one place the tags did not follow.

## A trap worth recording

The dropdown needed `DisplayMemberPath` replaced with an item template — which is precisely the shape that once rendered `ThemeOption { Value = Dark... }` in the theme picker, because this apps custom ComboBox template draws its selection through a `ContentPresenter`.

So I rendered the **closed** dropdown rather than assuming, and it shows the name and pills correctly. Worth checking every time, because the failure is invisible to the build, the tests and the binding listener.

## Still open in item 8

History keyboard navigation and opening a saved log directly, and the position of `+ Add Server` at the bottom of a tall empty list — though item 7s first-run panel now fills that space with something useful.

**929 passing, 24 skipped.**
@