### PR TITLE
Release 1.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Something Nine Lives did wrong
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this.
+
+        **Before you paste anything:** Nine Lives talks to real servers and real storage
+        accounts. Please replace server names, database names, storage account names and
+        container names with placeholders (`SRV01`, `MyDb`, `mystorageaccount`) — and never
+        paste a SAS token, a connection string or a password. The app strips secrets from its
+        own log, but it cannot strip them from a screenshot.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did the app do, and what did you expect instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Select container ...
+        2. Load backups
+        3. Pick the restore point at ...
+        4. Press Execute
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Nine Lives version
+      description: Shown at the bottom right of the window, and on the About screen.
+      placeholder: v1.2.0
+    validations:
+      required: true
+
+  - type: input
+    id: windows
+    attributes:
+      label: Windows version
+      placeholder: Windows 11 Pro 23H2
+    validations:
+      required: true
+
+  - type: input
+    id: sql
+    attributes:
+      label: SQL Server version
+      description: Only if the problem involves a server. The app shows this once connected.
+      placeholder: SQL Server 2022
+
+  - type: dropdown
+    id: layout
+    attributes:
+      label: Backup layout
+      description: How the backups are arranged in the container.
+      options:
+        - Standalone (BackupType/Server/Database/File)
+        - Availability Group (flat Ola Hallengren naming)
+        - Mixed
+        - Something else / not sure
+
+  - type: textarea
+    id: script
+    attributes:
+      label: Generated script
+      description: >
+        If the problem is with the restore itself, the generated T-SQL is the most useful thing
+        you can attach. It contains no credentials — but it does contain URLs, so sanitise the
+        storage account and database names first.
+      render: sql
+
+  - type: textarea
+    id: log
+    attributes:
+      label: Log
+      description: >
+        **Open log folder** on the About screen. Secrets are already stripped, but names are not,
+        so have a read before pasting.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/jakemorgangit/NineLives/security/advisories/new
+    about: >
+      Please report privately rather than opening an issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Something Nine Lives should be able to do
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please keep real server, database and storage account names out of the description -
+        `SRV01`, `MyDb` and `mystorageaccount` make the point just as well.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: >
+        The situation, rather than the feature. "I need to refresh a test database from
+        production every Monday" says more than "add a scheduler".
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: How do you do it today?
+      description: Including "I do it by hand in SSMS" - that is useful to know.
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like the app to do?
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Does this involve
+      options:
+        - label: Writing to a SQL Server (rather than reading from one)
+        - label: A storage provider other than Azure Blob
+        - label: Running without a user present (scheduled, scripted, CI)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,11 @@ jobs:
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
           Write-Host "Version: $version"
 
+      # Through the publish PROFILE, not a hand-repeated flag list. The two had drifted - the
+      # profile asked for ReadyToRun and this line did not - and nothing compares them, so the
+      # difference went unnoticed through three releases (#39).
       - name: Publish single-file exe
-        run: dotnet publish src/NineLives/NineLives.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o publish
+        run: dotnet publish src/NineLives/NineLives.csproj -p:PublishProfile=SingleFileExe -o publish
 
       - name: Package release assets
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to Nine Lives are recorded here.
 
@@ -9,6 +9,16 @@ Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/
 more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
+
+## [1.3.0] - 2026-08-06
+
+Authentication that does not need a SAS token, and the restore screen taken apart from the inside.
+Runs on **.NET 10**. **953 tests**, up from 587.
+
+Entra ID is the headline. Browsing a container and connecting to SQL Server no longer require a
+long-lived SAS token or a stored password, which is what kept the tool out of estates that prohibit
+them. The server-side credential a restore authenticates with is a separate thing, and this release
+also stops the app quietly rewriting one it did not create.
 
 ### Added
 
@@ -30,6 +40,13 @@ more detail on the user-facing changes; this file is the short history.
   refused and the role it is missing, which Azure's own error does not (#29)
 - **Entra MFA for SQL Server connections** (`ActiveDirectoryInteractive`), with the sign-in prompt
   parented to the app window (#30)
+- **A per-container backup server time zone**, so backups whose filenames carry no timestamp sort
+  correctly against the rest instead of being marked approximate. The conversion is from the
+  instant, so daylight saving is handled (#102)
+- **The app says when it is working** — spinners on the long actions, a completion tick, and a
+  global busy status (#128)
+- The saved servers list gained card edges and a marker for the connected one, and dropped the
+  auth line it repeated on every row (#127)
 
 ### Fixed
 
@@ -48,6 +65,13 @@ more detail on the user-facing changes; this file is the short history.
 - Saving now writes the config *before* the secret, so a refused save cannot leave Credential
   Manager holding a password the config file does not match (#113)
 - The credential check no longer races itself and reports the container you just left (#111)
+- **Verify Backups now passes the MOVE clauses**, so it verifies the restore that is actually going
+  to run rather than a different one (#129)
+- White text on the yellow accent was unreadable under high contrast (#126)
+- **The app no longer freezes while the Entra sign-in browser is open.** `InteractiveBrowserCredential`
+  waits for the sign-in on whatever thread asked for the token, and every blob operation starts on
+  the UI thread — so the window stopped painting for as long as the browser was open, which is to
+  say it asked you to go and authenticate while appearing to have crashed (#152)
 - **A Managed Identity blob credential is no longer converted to SAS by running a restore.** The
   check reduced every identity to "is it a SAS credential", so a credential authenticating as the
   instance's own identity was reported as broken and then altered into a SAS one — changing how
@@ -63,6 +87,13 @@ more detail on the user-facing changes; this file is the short history.
 - `RestoreOptions` no longer carries a SAS token it never used (#42)
 - One publish definition instead of three. The release workflow was missing `PublishReadyToRun`
   because it repeated the profile's flags rather than using it (#39)
+- The four verification actions are named for what they each do, rather than four variations on
+  "verify" (#117)
+- The update banner is styled to be noticed — it was dark on a dark app, so it read as chrome (#100)
+- **The restore screen is five smaller pieces rather than one 2,600-line class**: the console, the
+  timeline, the point-in-time target, the options, and the server-side credential. Behaviour is
+  unchanged; what changed is that each part can now be tested on its own, and most of the new tests
+  in this release cover behaviour that previously needed a whole restore to reach (#115)
 
 ## [1.2.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,117 @@
+# Changelog
+
+All notable changes to Nine Lives are recorded here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
+more detail on the user-facing changes; this file is the short history.
+
+## [Unreleased]
+
+### Added
+
+- **Light and high-contrast themes**, switchable from About and remembered between runs. The dark
+  theme is retuned to match the splash screen it always sat next to (#109)
+- **Verify Backups** — `RESTORE VERIFYONLY` over every backup in the chain, so an unreadable blob
+  is found in seconds rather than an hour into a restore (#26)
+- **`CHECKSUM` and `CONTINUE_AFTER_ERROR`** restore options, both off by default (#26)
+- **Restore history** — every execution recorded with its script, console log and outcome, plus a
+  **Save output** action for the console (#31)
+- **A sortable list of restore points** beside the timeline, with type filters and a date range
+  that zooms rather than just filters (#27)
+- Backup times now record which clock they came from; blob-derived ones are marked approximate (#47)
+- A **Stop** button for the server queries — verify, validate, the metadata reads and the
+  post-failure recovery actions (#111)
+- Execute now says *why* it is disabled instead of just being greyed out (#117)
+
+### Fixed
+
+- **The script on screen is the script that runs.** Four options — both WITH MOVE paths, the
+  STANDBY undo file and STATS — never regenerated it. Ticking WITH MOVE while connected could
+  produce a script with no `MOVE` clause at all, sending the restore to the file paths baked into
+  the backup (#110)
+- STANDBY with a blank undo path emitted `STANDBY = ''`, which fails as the last statement of the
+  chain — after the target has already been overwritten (#110)
+- Changing the container on the Restore screen left the previous container's chain and script
+  armed and executable (#112)
+- **Refresh Token silently deleted a container's tags** (#114)
+- Reloading with the same database selected never rebuilt the restore points, so a backup taken
+  since the last scan never appeared (#27)
+- A container with no full backup had its explanation overwritten by the load summary (#41)
+- Saving now writes the config *before* the secret, so a refused save cannot leave Credential
+  Manager holding a password the config file does not match (#113)
+- The credential check no longer races itself and reports the container you just left (#111)
+
+### Changed
+
+- The I/O services are behind interfaces, so the ViewModels can be tested. The first ViewModel
+  tests came with it (#41)
+- `null!` placeholders on the chain members replaced with `required` (#116)
+- `RestoreOptions` no longer carries a SAS token it never used (#42)
+- One publish definition instead of three. The release workflow was missing `PublishReadyToRun`
+  because it repeated the profile's flags rather than using it (#39)
+
+## [1.2.0] - 2026-08-05
+
+The biggest release so far, and mostly about correctness. Runs on **.NET 10**. **587 tests**, up
+from 345.
+
+### Fixed
+
+- The restore could run against a different server than the one you connected with (#11)
+- Every Execute dropped and recreated the blob credential, whether or not anything needed
+  changing — removing it out from under anything else using it (#10)
+- A database whose name contained "diff" had its full backups classified as differentials, and
+  could end up with no restore points at all (#45)
+- A transaction log written as `.bak` became the root of a chain and truncated earlier log chains (#44)
+- A briefly locked `config.json` wiped every saved server and container (#7)
+- Renaming a container stranded its SAS token (#8)
+- Test Connection saved secrets before you did (#12)
+- An unexpected error no longer closes the app and takes the execution log with it (#13)
+
+### Added
+
+- Cancellation for a running restore and a long container listing (#25)
+- Post-failure recovery guidance, with the statements that put the database right (#14)
+- A proper terminal for the execution console — its own window, live progress, SQL syntax
+  highlighting, and a script that updates as options change
+- An operation log at `%LOCALAPPDATA%\NineLives\logs`, with secrets stripped on the way in (#40)
+- Unreachable log backups are reported rather than quietly disappearing (#46)
+
+### Security
+
+- SQL passwords are passed out-of-band and never appear in a connection string (#20)
+- Test Connection reports whether certificate validation would actually succeed (#17)
+- A SAS expiry that cannot be read counts as expired rather than valid (#21)
+- Copied blob URLs no longer carry the SAS token (#18)
+- Every dependency pinned and locked, verified on every build (#16)
+- Releases carry a Sigstore build provenance attestation (#33)
+
+## [1.1.0] - 2026-08-05
+
+345 tests.
+
+### Fixed
+
+- Every log backup reachable from a chain is now offered (#24)
+- Backup sets are identified per server and per instance, so two instances no longer merge (#43, #48)
+- Copy-only fulls are no longer used as differential bases (#49)
+
+### Added
+
+- Structural and LSN chain validation (#62, #23)
+- Tags on servers and containers (#67)
+- An update check against the releases page (#65)
+- The paw logo and the splash screen
+
+## [1.0.0] - 2026-08-05
+
+First release. Restore SQL Server databases from Azure Blob Storage with full, differential and
+transaction log chains.
+
+[Unreleased]: https://github.com/jakemorgangit/NineLives/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/jakemorgangit/NineLives/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/jakemorgangit/NineLives/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/jakemorgangit/NineLives/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ more detail on the user-facing changes; this file is the short history.
 - A **Stop** button for the server queries — verify, validate, the metadata reads and the
   post-failure recovery actions (#111)
 - Execute now says *why* it is disabled instead of just being greyed out (#117)
+- **Entra ID authentication for blob containers**, as an alternative to a SAS token, for
+  organisations that do not allow long-lived SAS. A permission failure names the account that was
+  refused and the role it is missing, which Azure's own error does not (#29)
+- **Entra MFA for SQL Server connections** (`ActiveDirectoryInteractive`), with the sign-in prompt
+  parented to the app window (#30)
 
 ### Fixed
 
@@ -43,6 +48,12 @@ more detail on the user-facing changes; this file is the short history.
 - Saving now writes the config *before* the secret, so a refused save cannot leave Credential
   Manager holding a password the config file does not match (#113)
 - The credential check no longer races itself and reports the container you just left (#111)
+- **A Managed Identity blob credential is no longer converted to SAS by running a restore.** The
+  check reduced every identity to "is it a SAS credential", so a credential authenticating as the
+  instance's own identity was reported as broken and then altered into a SAS one — changing how
+  anything else on that instance reached the same container. Execute now leaves any usable
+  credential alone, and never converts one it did not create: replacing an identity is what the
+  button on the panel is for, and it says so before it is pressed (#145)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,9 @@ Your SAS token needs the following minimum permissions:
 - **List (l)** - To enumerate blobs in the container
 - **Read (r)** - To read backup files
 
-For restore execution, the SQL Server instance must have a credential for the blob container URL (identity `SHARED ACCESS SIGNATURE`). You can create or update this credential from the app using "Create credential on server" in the Restore options; the SAS token is never included in generated scripts.
+For restore execution, the SQL Server instance must have a credential for the blob container URL. Two identities work: `SHARED ACCESS SIGNATURE`, and — on SQL Server 2022 and later or Azure SQL MI — `Managed Identity`. You can create the SAS kind from the app using "Create credential on server" in the Restore options; the SAS token is never included in generated scripts.
+
+A credential that already exists is never rewritten by running a restore. If it holds a managed identity the app reports it as valid and leaves it alone, since replacing it would change how the whole instance reaches that container. Replacing one is a deliberate press of the button on the credential panel, which says exactly what it would do.
 
 Example SAS token permissions: `sp=rl` (read + list)
 
@@ -409,8 +411,10 @@ NineLives/
 
 - Windows only (WPF application)
 - x64 architecture only
-- SAS token authentication only (no Azure AD/Managed Identity yet)
 - Single container per restore operation
+- Browsing a container works with a SAS token or Entra ID. The **server-side** credential that
+  `RESTORE FROM URL` needs can only be created from here as a SAS credential — a Managed Identity
+  credential is recognised and left alone, but has to be created on the instance itself
 
 ## Troubleshooting
 
@@ -418,6 +422,9 @@ NineLives/
 - Verify your SAS token has `list` permission
 - Check the token hasn't expired
 - Ensure the container URL is correct (no trailing slash)
+- On Entra ID, the account needs **Storage Blob Data Reader** on the container. Owner or
+  Contributor is not enough — see [Entra ID for Blob Storage](#entra-id-for-blob-storage) above.
+  Test Connection names the account it signed in as
 
 ### "File cannot be restored to..." error
 - Enable **WITH MOVE** option

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nine Lives 🐈‍⬛
+﻿# Nine Lives 🐈‍⬛
 
 [![Build](https://github.com/jakemorgangit/NineLives/actions/workflows/build.yml/badge.svg)](https://github.com/jakemorgangit/NineLives/actions/workflows/build.yml)
 
@@ -28,7 +28,7 @@ Nine Lives points at a container, discovers every backup, groups striped sets, c
 ## Features
 
 ### Azure Blob Storage Integration
-- Connect to Azure Blob Storage containers using SAS tokens
+- Connect to Azure Blob Storage containers using SAS tokens, or Entra ID for organisations that prohibit long-lived SAS ([see the caveat](#entra-id-for-blob-storage))
 - Automatic discovery of backup files (Full, Differential, Transaction Log)
 - Intelligent parsing of blob path structures with customisable patterns
 - Support for striped backup sets (multiple files per backup)
@@ -186,7 +186,9 @@ The executable will be created at `./publish/NineLives.exe`.
 2. Click **+ Add Container**
 3. Enter a display name for the container
 4. Enter the full container URL (e.g., `https://mystorageaccount.blob.core.windows.net/sqlbackups`)
-5. Enter your SAS token (with at least `list` and `read` permissions)
+5. Choose how to authenticate:
+   - **SAS token** — paste one with at least `list` and `read` permissions
+   - **Entra ID** — nothing to paste, and nothing is stored ([caveat below](#entra-id-for-blob-storage))
 6. Configure the **Blob Path Structure** to match your backup folder layout:
    - Default: `{BackupType}/{ServerName}/{DatabaseName}/{FileName}`
    - Drag and drop components to rearrange
@@ -194,6 +196,30 @@ The executable will be created at `./publish/NineLives.exe`.
    - For Availability Group backups, select the AG source type (supports Ola Hallengren default AG naming and cluster/AG path tokens)
 7. Click **Test Connection** to verify access
 8. Click **Save**
+
+#### Entra ID for Blob Storage
+
+> **Untested against a real tenant.** There is no Entra-enabled storage account to develop this
+> against, so what is verified is which credential the app uses and what it stops storing — not that
+> a token is accepted. **Test Connection** will tell you honestly whether it works; please open an
+> issue either way.
+
+| Mode | What it does | When to pick it |
+| --- | --- | --- |
+| **Interactive (MFA)** | Opens a browser to sign in. The sign-in lasts as long as the app is running and is written nowhere | Any Entra-enabled account, including MFA |
+| **Default** | Environment, then managed identity, then Azure CLI / Visual Studio sign-in, then a prompt | Running the app on an Azure VM with a managed identity |
+
+Your account needs **Storage Blob Data Reader** on the container. Owner or Contributor on the
+subscription is not enough on its own — the data-plane roles are separate from the management-plane
+ones, which is the usual first surprise.
+
+Switching a container from SAS to Entra deletes its stored token from Windows Credential Manager. An
+organisation that has banned long-lived SAS has banned it wherever it is sitting.
+
+**This covers browsing only.** The RESTORE itself runs on SQL Server, which needs its own credential
+for the container URL — for Entra that is `CREATE CREDENTIAL ... WITH IDENTITY = 'Managed Identity'`
+on SQL Server 2022+ or Azure SQL MI. Entra on the client and a SAS credential on the server is a
+perfectly valid combination.
 
 ### 2. Configure SQL Server (Optional - for direct execution)
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Three modes, all of which store nothing:
 
 | Mode | What it does | When to pick it |
 | --- | --- | --- |
-| **Interactive (MFA)** | Opens a browser to sign in | The mode that satisfies multi-factor authentication. Optionally give a username to pre-select the account |
+| **Interactive (MFA)** | Signs in through the Windows account broker, parented to the app window | The mode that satisfies multi-factor authentication. Optionally give a username to pre-select the account |
 | **Integrated** | Uses the Windows account you are already signed in with, no prompt | Machine joined to the directory |
 | **Default** | Environment, then managed identity, then the signed-in account, then a prompt | SQL Server on an Azure VM, where the managed identity should be used |
 

--- a/README.md
+++ b/README.md
@@ -233,11 +233,6 @@ perfectly valid combination.
 
 #### Entra ID authentication
 
-> **Untested against a real tenant.** There is no Entra-enabled instance to develop this against, so
-> what is verified is the connection string handed to the driver, not that a sign-in succeeds. The
-> token flow itself belongs to `Microsoft.Data.SqlClient`. **Test Connection** will tell you honestly
-> whether it works — please open an issue either way.
-
 Three modes, all of which store nothing:
 
 | Mode | What it does | When to pick it |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Nine Lives points at a container, discovers every backup, groups striped sets, c
 
 ### SQL Server Connectivity
 - Windows Authentication and SQL Server Authentication support
+- Entra ID authentication — interactive (MFA), integrated, and default — for Azure SQL Managed Instance and Entra-enabled estates ([see the caveat](#entra-id-authentication))
 - Configurable connection options (Encrypt, Trust Server Certificate, Timeout)
 - Persistent server configurations with secure password storage
 - Real-time connection status visible across all views
@@ -203,6 +204,28 @@ The executable will be created at `./publish/NineLives.exe`.
 5. Click **Test Connection** to verify
 6. Click **Save**
 7. Select the server and click **Connect** to establish a session
+
+#### Entra ID authentication
+
+> **Untested against a real tenant.** There is no Entra-enabled instance to develop this against, so
+> what is verified is the connection string handed to the driver, not that a sign-in succeeds. The
+> token flow itself belongs to `Microsoft.Data.SqlClient`. **Test Connection** will tell you honestly
+> whether it works — please open an issue either way.
+
+Three modes, all of which store nothing:
+
+| Mode | What it does | When to pick it |
+| --- | --- | --- |
+| **Interactive (MFA)** | Opens a browser to sign in | The mode that satisfies multi-factor authentication. Optionally give a username to pre-select the account |
+| **Integrated** | Uses the Windows account you are already signed in with, no prompt | Machine joined to the directory |
+| **Default** | Environment, then managed identity, then the signed-in account, then a prompt | SQL Server on an Azure VM, where the managed identity should be used |
+
+Switching a saved connection from SQL Authentication to any other mode deletes its stored password
+from Windows Credential Manager — a secret nothing uses any more should not outlive the reason it
+was stored.
+
+Note that this covers **the app's own connection to SQL Server**. Restoring `FROM URL` still needs a
+credential on the *instance* for the blob container, which is separate and configured on the server.
 
 ### 3. Browse Backups
 

--- a/README.md
+++ b/README.md
@@ -199,19 +199,22 @@ The executable will be created at `./publish/NineLives.exe`.
 
 #### Entra ID for Blob Storage
 
-> **Untested against a real tenant.** There is no Entra-enabled storage account to develop this
-> against, so what is verified is which credential the app uses and what it stops storing — not that
-> a token is accepted. **Test Connection** will tell you honestly whether it works; please open an
-> issue either way.
-
 | Mode | What it does | When to pick it |
 | --- | --- | --- |
 | **Interactive (MFA)** | Opens a browser to sign in. The sign-in lasts as long as the app is running and is written nowhere | Any Entra-enabled account, including MFA |
 | **Default** | Environment, then managed identity, then Azure CLI / Visual Studio sign-in, then a prompt | Running the app on an Azure VM with a managed identity |
 
-Your account needs **Storage Blob Data Reader** on the container. Owner or Contributor on the
-subscription is not enough on its own — the data-plane roles are separate from the management-plane
-ones, which is the usual first surprise.
+Your account needs **Storage Blob Data Reader** on the container. Owner or Contributor is **not**
+enough — blob *data* access is a separate set of roles from the ones that administer the account,
+which is the usual first surprise.
+
+If another tool works with the same account, that is not a contradiction. Azure Storage Explorer
+commonly falls back to the storage **account key**, which Owner *can* fetch through the management
+plane, so it never exercises the role at all.
+
+When a permission error does appear, **Test Connection names the account it signed in as**. Checking
+that first is worth doing — a 403 against an account that demonstrably has access usually means a
+different account or tenant was used than the one being thought about.
 
 Switching a container from SAS to Entra deletes its stored token from Windows Credential Manager. An
 organisation that has banned long-lived SAS has banned it wherever it is sitting.

--- a/build_standalone.cmd
+++ b/build_standalone.cmd
@@ -6,8 +6,11 @@ set "PUBLISH_OUT=%SCRIPT_DIR%publish"
 echo Close Nine Lives (NineLives.exe) if it is running, then press any key to publish...
 pause >nul
 
+REM Through the publish profile, so this produces the same binary the release workflow does.
+REM The flags used to be repeated here and in release.yml, and they had already drifted apart
+REM from the profile - see the note in Properties\PublishProfiles\SingleFileExe.pubxml (#39).
 cd /d "%SCRIPT_DIR%src\NineLives"
-dotnet publish -c Release -o "%PUBLISH_OUT%" -r win-x64 --self-contained -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish -p:PublishProfile=SingleFileExe -o "%PUBLISH_OUT%"
 
 set "EXIT_CODE=%ERRORLEVEL%"
 if %EXIT_CODE% equ 0 (

--- a/src/NineLives.Tests/BackupChainBuilderTests.cs
+++ b/src/NineLives.Tests/BackupChainBuilderTests.cs
@@ -373,34 +373,9 @@ public class BackupChainBuilderTests
         Assert.Equal(T(3), window.Value.latest);
     }
 
-    // ---- GetRestoreWindow (BackupFileInfo overload) ----------------------
-
-    [Fact]
-    public void GetRestoreWindow_Files_NoFulls_ReturnsNull()
-    {
-        var files = new List<BackupFileInfo>
-        {
-            File(BackupType.TransactionLog, T(1)),
-            File(BackupType.Unknown, T(2))
-        };
-
-        Assert.Null(_builder.GetRestoreWindow(files));
-    }
-
-    [Fact]
-    public void GetRestoreWindow_Files_UsesBackupStartDateWhenPresentOtherwiseLastModified()
-    {
-        // The full's EffectiveDate comes from BackupStartDate (not LastModified);
-        // the log has no header metadata so its LastModified wins for the latest bound.
-        var full = File(BackupType.Full, lastModified: T(9), backupStartDate: T(1));
-        var log = File(BackupType.TransactionLog, lastModified: T(12));
-
-        var window = _builder.GetRestoreWindow(new List<BackupFileInfo> { full, log });
-
-        Assert.NotNull(window);
-        Assert.Equal(T(1), window.Value.earliest);
-        Assert.Equal(T(12), window.Value.latest);
-    }
+    // The file-level GetRestoreWindow overload and its two tests are gone (#42). It had no
+    // production caller and compared BackupStartDate against LastModified - two different clocks
+    // (#47) - so its tests were pinning behaviour nothing depended on and nobody should copy.
 
     // ---- BuildChainFromRestorePoint --------------------------------------
 

--- a/src/NineLives.Tests/BackupServerTimeZoneTests.cs
+++ b/src/NineLives.Tests/BackupServerTimeZoneTests.cs
@@ -1,0 +1,233 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Putting both clocks on one clock (#102).
+///
+/// #47 made the app honest about the fact that a filename timestamp reads the backup server's
+/// local clock while a blob's LastModified reads UTC - it labelled the second as approximate and
+/// left it there. That is all it could do: nothing in a container says what zone the server is in.
+///
+/// Told the zone, the UTC reading converts and the two become comparable rather than merely
+/// labelled. What no zone can fix is that LastModified is when the UPLOAD finished, not when the
+/// backup was taken, so it stays marked approximate.
+/// </summary>
+public class BackupServerTimeZoneTests
+{
+    private readonly BlobStorageService _service = new(new FakeCredentialStore());
+
+    /// <summary>UTC+10 in winter, UTC+11 in summer - so DST is actually exercised.</summary>
+    private const string Sydney = "AUS Eastern Standard Time";
+
+    private static BackupFileInfo File(string blobName, DateTimeOffset lastModified)
+        => new()
+        {
+            BlobName = blobName,
+            Type = BackupType.Full,
+            InferredServerName = "SRV01",
+            InferredDatabaseName = "MyDb",
+            SizeBytes = 100,
+            LastModified = lastModified
+        };
+
+    [Fact]
+    public void WithoutAZoneTheReadingStaysOnTheBlobsClock()
+    {
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/adhoc.bak", new DateTimeOffset(2026, 6, 15, 22, 30, 0, TimeSpan.Zero))]);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.BlobLastModified, set.TimestampSource);
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 30, 0), set.Timestamp);
+        Assert.True(set.IsTimestampOnAnotherClock);
+    }
+
+    [Fact]
+    public void WithAZoneTheReadingMovesOntoTheBackupServersClock()
+    {
+        // 22:30 UTC on 15 June is 08:30 the next morning in Sydney (UTC+10, no DST in June).
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/adhoc.bak", new DateTimeOffset(2026, 6, 15, 22, 30, 0, TimeSpan.Zero))],
+            Sydney);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.BlobLastModifiedConverted, set.TimestampSource);
+        Assert.Equal(new DateTime(2026, 6, 16, 8, 30, 0), set.Timestamp);
+
+        // On the right clock now, so it sorts correctly - but still the upload time.
+        Assert.False(set.IsTimestampOnAnotherClock);
+        Assert.True(set.IsTimestampApproximate);
+    }
+
+    /// <summary>
+    /// The reason a zone is stored rather than a fixed offset. A container spanning a DST
+    /// transition needs the rule, not one number.
+    /// </summary>
+    [Fact]
+    public void TheOffsetFollowsDaylightSaving()
+    {
+        var winter = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/winter.bak", new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero))],
+            Sydney).Single();
+
+        var summer = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/summer.bak", new DateTimeOffset(2026, 12, 15, 12, 0, 0, TimeSpan.Zero))],
+            Sydney).Single();
+
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 0, 0), winter.Timestamp);   // UTC+10
+        Assert.Equal(new DateTime(2026, 12, 15, 23, 0, 0), summer.Timestamp);  // UTC+11
+    }
+
+    /// <summary>
+    /// The whole point: a database with both kinds of naming sorts in the right order once the
+    /// zone is known. Unconverted, the ad-hoc backup lands ten hours out of position.
+    /// </summary>
+    [Fact]
+    public void AMixedDatabaseSortsCorrectlyOnceTheZoneIsKnown()
+    {
+        // The scheduled backup ran at 09:00 Sydney time; the ad-hoc one an hour later, which is
+        // 00:00 UTC.
+        List<BackupFileInfo> files =
+        [
+            File("FULL/SRV01/MyDb/20260616_090000.bak", new DateTimeOffset(2026, 6, 15, 23, 0, 0, TimeSpan.Zero)),
+            File("FULL/SRV01/MyDb/adhoc.bak", new DateTimeOffset(2026, 6, 16, 0, 0, 0, TimeSpan.Zero)),
+        ];
+
+        var unconverted = _service.GroupIntoBackupSets(files);
+        var adhocUnconverted = unconverted.Single(s => s.SetId == "adhoc");
+        var scheduled = unconverted.Single(s => s.SetId == "20260616_090000");
+
+        // 00:00 against 09:00 - the ad-hoc one looks nine hours EARLIER than the backup it
+        // actually followed.
+        Assert.True(adhocUnconverted.Timestamp < scheduled.Timestamp);
+
+        var converted = _service.GroupIntoBackupSets(files, Sydney);
+        var adhocConverted = converted.Single(s => s.SetId == "adhoc");
+
+        Assert.Equal(new DateTime(2026, 6, 16, 10, 0, 0), adhocConverted.Timestamp);
+        Assert.True(adhocConverted.Timestamp > scheduled.Timestamp);
+        Assert.Equal("adhoc", converted[^1].SetId);
+    }
+
+    [Fact]
+    public void AFileNameTimestampIsNeverConverted()
+    {
+        // It is already on the backup server's clock. Converting it would move it by the offset
+        // for no reason - the exact bug in reverse.
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/20260615_220000.bak", new DateTimeOffset(2026, 6, 15, 22, 0, 0, TimeSpan.Zero))],
+            Sydney);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.FileName, set.TimestampSource);
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 0, 0), set.Timestamp);
+    }
+
+    [Theory]
+    [InlineData("Not A Real Zone")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AZoneThisMachineDoesNotKnowFallsBackRatherThanThrowing(string id)
+    {
+        // A config carried from another machine, or hand-edited. Browsing a container must not be
+        // stopped by a setting that only affects how a few timestamps are displayed.
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/adhoc.bak", new DateTimeOffset(2026, 6, 15, 22, 30, 0, TimeSpan.Zero))],
+            id);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.BlobLastModified, set.TimestampSource);
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 30, 0), set.Timestamp);
+    }
+
+    [Fact]
+    public void AConvertedReadingExplainsItselfDifferently()
+    {
+        var converted = new BackupSet { TimestampSource = BackupTimestampSource.BlobLastModifiedConverted };
+        var unconverted = new BackupSet { TimestampSource = BackupTimestampSource.BlobLastModified };
+
+        Assert.Contains("time zone", converted.TimestampNote);
+        Assert.DoesNotContain("time zone", unconverted.TimestampNote);
+        Assert.Contains("hours away", unconverted.TimestampNote);
+    }
+
+    // ── the setting itself ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheZoneIsSavedAndReadBack()
+    {
+        var store = new FakeCredentialStore();
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2026-01-01&sig=x";
+        vm.EditBackupServerTimeZone = BlobConfigViewModel.TimeZones.First(z => z.Id == Sydney);
+        vm.SaveCommand.Execute(null);
+
+        var saved = Assert.Single(store.Config.BlobContainers);
+        Assert.Equal(Sydney, saved.BackupServerTimeZoneId);
+
+        // And it comes back into the form when the container is edited again.
+        var reopened = new BlobConfigViewModel(store, new FakeBlobStorageService())
+        {
+            SelectedContainer = null
+        };
+        reopened.SelectedContainer = reopened.Containers.Single();
+        reopened.EditCommand.Execute(null);
+
+        Assert.Equal(Sydney, reopened.EditBackupServerTimeZone?.Id);
+    }
+
+    [Fact]
+    public void NotKnownIsTheDefaultAndStoresNothing()
+    {
+        var store = new FakeCredentialStore();
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2026-01-01&sig=x";
+        vm.SaveCommand.Execute(null);
+
+        Assert.Null(Assert.Single(store.Config.BlobContainers).BackupServerTimeZoneId);
+    }
+
+    [Fact]
+    public void AStoredZoneThisMachineDoesNotKnowShowsAsNotKnown()
+    {
+        // Otherwise the picker claims a setting the app is not actually applying.
+        var option = TimeZoneOption.For("Mars Standard Time", BlobConfigViewModel.TimeZones);
+
+        Assert.Null(option.Id);
+        Assert.Same(TimeZoneOption.Unknown, option);
+    }
+
+    [Fact]
+    public void ChangingOnlyTheZoneCountsAsAnUnsavedChange()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        });
+
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        Assert.False(vm.HasUnsavedChanges);
+
+        vm.EditBackupServerTimeZone = BlobConfigViewModel.TimeZones.First(z => z.Id == Sydney);
+
+        Assert.True(vm.HasUnsavedChanges);
+    }
+}

--- a/src/NineLives.Tests/BackupTimestampSourceTests.cs
+++ b/src/NineLives.Tests/BackupTimestampSourceTests.cs
@@ -1,0 +1,187 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A backup's time can come from two places that are NOT on the same clock: the filename, which
+/// the backup job wrote in the SERVER's local time, and the blob's LastModified, which is UTC.
+/// Nothing in a container reconciles them.
+///
+/// The skew cannot be removed without knowing the backup server's zone, so what these tests pin
+/// is that the app knows which clock each reading came from and says so, rather than presenting
+/// a mixed set as one exact timeline.
+/// </summary>
+public class BackupTimestampSourceTests
+{
+    private readonly BlobStorageService _service = new(new CredentialStore());
+
+    private static BackupFileInfo File(string blobName, DateTimeOffset? lastModified = null)
+        => new()
+        {
+            BlobName = blobName,
+            Type = BackupType.Full,
+            InferredDatabaseName = "MyDb",
+            InferredServerName = "SRV01",
+            SizeBytes = 100,
+            LastModified = lastModified ?? new DateTimeOffset(2026, 6, 15, 22, 30, 0, TimeSpan.Zero)
+        };
+
+    [Fact]
+    public void ATimestampParsedFromTheFileNameIsRecordedAsSuch()
+    {
+        var sets = _service.GroupIntoBackupSets([File("FULL/SRV01/MyDb/20260615_220000.bak")]);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.FileName, set.TimestampSource);
+        Assert.False(set.IsTimestampApproximate);
+        Assert.Null(set.TimestampNote);
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 0, 0), set.Timestamp);
+    }
+
+    [Fact]
+    public void AFileNameWithNoTimestampFallsBackToTheBlobAndIsMarkedApproximate()
+    {
+        // Plausible before a change window: an ad-hoc backup dropped alongside the scheduled ones.
+        var sets = _service.GroupIntoBackupSets([File("FULL/SRV01/MyDb/MyDb_preupgrade.bak")]);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(BackupTimestampSource.BlobLastModified, set.TimestampSource);
+        Assert.True(set.IsTimestampApproximate);
+        Assert.NotNull(set.TimestampNote);
+    }
+
+    [Fact]
+    public void AMaintenancePlanNameIsAlsoApproximate()
+    {
+        // Maintenance-plan naming carries a date, but not in a shape ParseTimestamp reads - so it
+        // takes the fallback like any other unparsable name.
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/MyDb/MyDb_backup_2026_01_28_114441_1234567.bak")]);
+
+        Assert.True(Assert.Single(sets).IsTimestampApproximate);
+    }
+
+    [Fact]
+    public void OneDatabaseCanHoldBothKindsAtOnce()
+    {
+        // This is the case that actually bites: homogeneous naming is consistent either way, but a
+        // mixed database renders one set hours out of position against the rest.
+        var sets = _service.GroupIntoBackupSets(
+        [
+            File("FULL/SRV01/MyDb/20260615_220000.bak"),
+            File("FULL/SRV01/MyDb/MyDb_preupgrade.bak"),
+        ]);
+
+        Assert.Equal(2, sets.Count);
+        Assert.Single(sets, s => s.TimestampSource == BackupTimestampSource.FileName);
+        Assert.Single(sets, s => s.TimestampSource == BackupTimestampSource.BlobLastModified);
+    }
+
+    [Fact]
+    public void TheFallbackReadsTheBlobsUtcClockNotTheOffsetItArrivedWith()
+    {
+        // Azure sends +00:00, but DateTimeOffset.DateTime returns the wall clock OF THE OFFSET,
+        // so anything that ever supplies a non-zero offset silently shifted the reading. Taking
+        // UTC explicitly means the fallback is always on one known clock.
+        var sets = _service.GroupIntoBackupSets(
+        [
+            File("FULL/SRV01/MyDb/adhoc.bak",
+                 new DateTimeOffset(2026, 6, 15, 23, 30, 0, TimeSpan.FromHours(1))),
+        ]);
+
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 30, 0), Assert.Single(sets).Timestamp);
+    }
+
+    [Fact]
+    public void AWallClockCarriesNoKindSoNothingCanSilentlyConvertIt()
+    {
+        // Kind=Utc would invite ToLocalTime() and DateTimeOffset conversions that reinterpret the
+        // value against the WORKSTATION's zone - which is neither clock in play.
+        var sets = _service.GroupIntoBackupSets([File("FULL/SRV01/MyDb/adhoc.bak")]);
+
+        Assert.Equal(DateTimeKind.Unspecified, Assert.Single(sets).Timestamp.Kind);
+    }
+
+    [Fact]
+    public void AnApproximateTimeIsMarkedInWhatTheUserSees()
+    {
+        var approximate = new BackupSet
+        {
+            Timestamp = new DateTime(2026, 6, 15, 22, 30, 0),
+            TimestampSource = BackupTimestampSource.BlobLastModified
+        };
+        var exact = new BackupSet
+        {
+            Timestamp = new DateTime(2026, 6, 15, 22, 30, 0),
+            TimestampSource = BackupTimestampSource.FileName
+        };
+
+        Assert.Equal("~2026-06-15 22:30:00", approximate.TimestampDisplay);
+        Assert.Equal("2026-06-15 22:30:00", exact.TimestampDisplay);
+    }
+
+    [Fact]
+    public void ARestorePointInheritsTheMarkFromTheSetThatPlacesIt()
+    {
+        var set = new BackupSet
+        {
+            Timestamp = new DateTime(2026, 6, 15, 22, 30, 0),
+            TimestampSource = BackupTimestampSource.BlobLastModified
+        };
+        var point = new RestorePoint
+        {
+            Timestamp = set.Timestamp,
+            Type = BackupType.Full,
+            PrimarySet = set,
+            RequiredFullSet = set
+        };
+
+        Assert.True(point.IsTimestampApproximate);
+        Assert.Equal("~2026-06-15 22:30:00", point.TimestampDisplay);
+        Assert.NotNull(point.TimestampNote);
+    }
+
+    [Fact]
+    public void AFilesEffectiveDatePrefersTheHeaderAndSaysWhenItDidNot()
+    {
+        var withHeader = File("FULL/SRV01/MyDb/20260615_220000.bak");
+        withHeader.BackupStartDate = new DateTime(2026, 6, 15, 22, 0, 0);
+
+        var withoutHeader = File("FULL/SRV01/MyDb/20260615_220000.bak");
+
+        Assert.Equal(BackupTimestampSource.BackupHeader, withHeader.EffectiveDateSource);
+        Assert.False(withHeader.IsEffectiveDateApproximate);
+        Assert.Null(withHeader.EffectiveDateNote);
+        Assert.Equal("2026-06-15 22:00:00", withHeader.EffectiveDateDisplay);
+
+        Assert.Equal(BackupTimestampSource.BlobLastModified, withoutHeader.EffectiveDateSource);
+        Assert.True(withoutHeader.IsEffectiveDateApproximate);
+        Assert.NotNull(withoutHeader.EffectiveDateNote);
+        Assert.Equal("~2026-06-15 22:30:00", withoutHeader.EffectiveDateDisplay);
+    }
+
+    [Fact]
+    public void AFilesFallbackDateAlsoReadsUtc()
+    {
+        var file = File("FULL/SRV01/MyDb/adhoc.bak",
+                        new DateTimeOffset(2026, 6, 15, 23, 30, 0, TimeSpan.FromHours(1)));
+
+        Assert.Equal(new DateTime(2026, 6, 15, 22, 30, 0), file.EffectiveDate);
+        Assert.Equal(DateTimeKind.Unspecified, file.EffectiveDate.Kind);
+    }
+
+    [Fact]
+    public void TheSetSummaryCountsHowManyTimesItHadToGuess()
+    {
+        var sets = _service.GroupIntoBackupSets(
+        [
+            File("FULL/SRV01/MyDb/20260615_220000.bak"),
+            File("FULL/SRV01/MyDb/adhoc.bak"),
+            File("FULL/SRV01/MyDb/preupgrade.bak"),
+        ]);
+
+        Assert.Equal(2, _service.GetSetBasedSummary(sets).ApproximateSets);
+    }
+}

--- a/src/NineLives.Tests/BlobStorageServiceTests.cs
+++ b/src/NineLives.Tests/BlobStorageServiceTests.cs
@@ -194,8 +194,24 @@ public class BlobStorageServiceTests
         Assert.Equal(1, summary.FullBackups);
         Assert.Equal(1, summary.LogBackups);
         Assert.Equal(210, summary.TotalSizeBytes);
-        Assert.Equal(new DateTime(2026, 1, 10, 22, 0, 0), summary.EarliestBackup!.Value.DateTime);
-        Assert.Equal(new DateTime(2026, 1, 10, 23, 0, 0), summary.LatestBackup!.Value.DateTime);
+        Assert.Equal(new DateTime(2026, 1, 10, 22, 0, 0), summary.EarliestSetTimestamp);
+        Assert.Equal(new DateTime(2026, 1, 10, 23, 0, 0), summary.LatestSetTimestamp);
+        Assert.Equal(0, summary.ApproximateSets);
+    }
+
+    [Fact]
+    public void GetSetBasedSummary_DoesNotPopulateTheFileLevelRange()
+    {
+        // The set range and the file range are different kinds of value - wall clocks against
+        // instants - and were previously served through the same two properties, which is what
+        // let a wall clock get stamped with the workstation's offset.
+        var sets = _service.GroupIntoBackupSets(
+            [File("FULL/SRV01/Db/20260110_220000.bak", db: "Db")]);
+
+        var summary = _service.GetSetBasedSummary(sets);
+
+        Assert.Null(summary.EarliestBackup);
+        Assert.Null(summary.LatestBackup);
     }
 
     [Fact]

--- a/src/NineLives.Tests/BusyFeedbackTests.cs
+++ b/src/NineLives.Tests/BusyFeedbackTests.cs
@@ -150,7 +150,7 @@ public class ChainCheckStateTests
         Assert.True(vm.VerifyPassed);
 
         // The result belongs to the chain that was checked.
-        vm.SelectedRestorePoint = vm.RestorePoints.First();
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.First();
 
         Assert.False(vm.ChainCheckPassed);
         Assert.False(vm.VerifyPassed);

--- a/src/NineLives.Tests/BusyFeedbackTests.cs
+++ b/src/NineLives.Tests/BusyFeedbackTests.cs
@@ -1,0 +1,249 @@
+﻿using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Feedback that the app is doing something (#128).
+///
+/// Check chain and Verify backups only changed their own label, and verify can run as long as the
+/// restore - so on a large chain the app looked hung. Once one has passed for the selected chain
+/// there is also no reason to run it again, and re-running VERIFYONLY by accident is expensive.
+/// </summary>
+public class ChainCheckStateTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+        new FakeRestoreHistoryStore());
+
+    private static BackupFileInfo File(string blobName, BackupType type, DateTime stamp) => new()
+    {
+        BlobName = blobName,
+        BlobUrl = $"https://mystorageaccount.blob.core.windows.net/backups/{blobName}",
+        Type = type,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = "MyDb",
+        SizeBytes = 1000,
+        LastModified = new DateTimeOffset(stamp, TimeSpan.Zero)
+    };
+
+    private async Task<RestoreViewModel> Loaded()
+    {
+        _blob.Files =
+        [
+            File("FULL/SRV01/MyDb/20260110_220000.bak", BackupType.Full, T0),
+            File("LOG/SRV01/MyDb/20260110_230000.trn", BackupType.TransactionLog, T0.AddHours(1)),
+        ];
+
+        var vm = NewViewModel();
+        vm.SelectedContainer = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        return vm;
+    }
+
+    [Fact]
+    public async Task AChainThatPassedItsCheckDoesNotOfferToCheckItAgain()
+    {
+        var vm = await Loaded();
+
+        Assert.False(vm.ChainCheckPassed);
+        Assert.True(vm.ValidateChainCommand.CanExecute(null));
+
+        // The outcome the real check produces when the headers line up.
+        vm.ChainLsnVerified = true;
+        vm.HasChainIssues = false;
+
+        Assert.True(vm.ChainCheckPassed);
+        Assert.False(vm.ValidateChainCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task AChainWithProblemsStaysCheckable()
+    {
+        var vm = await Loaded();
+
+        // A check that found something is worth re-running once the problem is dealt with.
+        vm.ChainLsnVerified = true;
+        vm.HasChainIssues = true;
+
+        Assert.False(vm.ChainCheckPassed);
+        Assert.True(vm.ValidateChainCommand.CanExecute(null));
+    }
+
+    /// <summary>
+    /// Running the real command against headers it cannot read leaves the button enabled - the
+    /// check did not pass, so offering it again is right.
+    /// </summary>
+    [Fact]
+    public async Task RunningTheCheckAndFindingProblemsLeavesItEnabled()
+    {
+        var vm = await Loaded();
+
+        await vm.ValidateChainCommand.ExecuteAsync(null);
+
+        Assert.True(vm.ChainLsnVerified);
+        Assert.True(vm.HasChainIssues);
+        Assert.False(vm.ChainCheckPassed);
+        Assert.True(vm.ValidateChainCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task VerifyingTwiceOnTheSameChainIsNotOffered()
+    {
+        var vm = await Loaded();
+
+        Assert.True(vm.VerifyChainCommand.CanExecute(null));
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.True(vm.VerifyPassed);
+        Assert.False(vm.VerifyChainCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task AVerifyThatFoundMissingDirectoriesHasNotPassed()
+    {
+        var vm = await Loaded();
+        _sql.VerifyResult = new VerifyOnlyResult(true, "Directory lookup failed.", TargetPathsMissing: true);
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        // The backups read back, but the restore cannot land - not a pass.
+        Assert.False(vm.VerifyPassed);
+        Assert.True(vm.VerifyChainCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task ChangingTheSelectedPointMakesBothCheckableAgain()
+    {
+        var vm = await Loaded();
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+        vm.ChainLsnVerified = true;
+        vm.HasChainIssues = false;
+
+        Assert.True(vm.ChainCheckPassed);
+        Assert.True(vm.VerifyPassed);
+
+        // The result belongs to the chain that was checked.
+        vm.SelectedRestorePoint = vm.RestorePoints.First();
+
+        Assert.False(vm.ChainCheckPassed);
+        Assert.False(vm.VerifyPassed);
+        Assert.True(vm.ValidateChainCommand.CanExecute(null));
+        Assert.True(vm.VerifyChainCommand.CanExecute(null));
+    }
+
+    // ── what the screen says it is doing ────────────────────────────────────────
+
+    [Fact]
+    public async Task TheScreenNamesWhatItIsDoing()
+    {
+        var vm = await Loaded();
+
+        Assert.Empty(vm.BusyDescription);
+        Assert.False(vm.IsBusyWithAnything);
+
+        vm.IsValidatingChain = true;
+        Assert.Equal("Checking the chain...", vm.BusyDescription);
+
+        vm.IsValidatingChain = false;
+        vm.IsVerifyingChain = true;
+        Assert.Equal("Verifying backups...", vm.BusyDescription);
+
+        vm.IsVerifyingChain = false;
+        vm.IsExecuting = true;
+        Assert.Contains("MyDb_Restored", vm.BusyDescription);
+
+        vm.IsExecuting = false;
+        Assert.Empty(vm.BusyDescription);
+    }
+
+    [Fact]
+    public async Task ARestoreOutranksTheOtherWork()
+    {
+        var vm = await Loaded();
+
+        vm.IsBusy = true;
+        vm.IsExecuting = true;
+
+        // The one that matters is the one writing to a database.
+        Assert.Contains("Restoring", vm.BusyDescription);
+    }
+}
+
+/// <summary>
+/// The window says what the app is doing, wherever the user has scrolled to.
+/// </summary>
+public class GlobalBusyTests
+{
+    [Fact]
+    public void TheWindowIsIdleUntilAChildIsBusy()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        Assert.False(vm.IsBusy);
+        Assert.Empty(vm.BusyText);
+    }
+
+    [Fact]
+    public void AChildStartingWorkReachesTheWindow()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.BlobBrowser.IsBusy = true;
+        Assert.True(vm.IsBusy);
+        Assert.Equal("Listing the container...", vm.BusyText);
+
+        vm.BlobBrowser.IsBusy = false;
+        Assert.False(vm.IsBusy);
+        Assert.Empty(vm.BusyText);
+    }
+
+    [Fact]
+    public void TheRestoreScreenNamesItsOwnWork()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.Restore.IsVerifyingChain = true;
+
+        Assert.True(vm.IsBusy);
+        Assert.Equal("Verifying backups...", vm.BusyText);
+    }
+
+    [Fact]
+    public void ARestoreOutranksAnythingElseRunning()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.ServerManager.IsBusy = true;
+        vm.Restore.TargetDatabaseName = "MyDb_Restored";
+        vm.Restore.IsExecuting = true;
+
+        Assert.Contains("Restoring", vm.BusyText);
+    }
+}

--- a/src/NineLives.Tests/ConsoleBufferTests.cs
+++ b/src/NineLives.Tests/ConsoleBufferTests.cs
@@ -1,0 +1,196 @@
+﻿using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The console's line handling and batching, now that it is its own type rather than 90 lines in
+/// the middle of a 2,400-line viewmodel (#115).
+///
+/// None of this needed a restore, a server or a container to exercise - it just could not be
+/// reached without one.
+/// </summary>
+public class ConsoleBufferTests
+{
+    private static ConsoleBuffer New(Action<string>? alsoLog = null) => new(alsoLog);
+
+    [Fact]
+    public void AMessageBecomesALine()
+    {
+        var console = New();
+
+        console.Append("Beginning restore execution...");
+
+        var line = Assert.Single(console.Lines);
+        Assert.Equal("Beginning restore execution...", line.Text);
+        Assert.True(console.HasOutput);
+    }
+
+    [Fact]
+    public void AMultiLineMessageIsSplit()
+    {
+        var console = New();
+
+        console.Append("first\nsecond\nthird");
+
+        Assert.Equal(["first", "second", "third"], console.Lines.Select(l => l.Text));
+    }
+
+    [Fact]
+    public void CarriageReturnsAreNotLeftOnTheEndOfLines()
+    {
+        var console = New();
+
+        console.Append("first\r\nsecond");
+
+        Assert.Equal(["first", "second"], console.Lines.Select(l => l.Text));
+    }
+
+    /// <summary>
+    /// Messages routinely arrive with a leading or trailing newline for spacing, and SQL Server's
+    /// own output has its own blank lines. Left alone that put a gap between almost every line.
+    /// </summary>
+    [Fact]
+    public void RunsOfBlankLinesCollapseToOne()
+    {
+        var console = New();
+
+        console.Append("first\n\n\n\nsecond");
+
+        Assert.Equal(["first", "", "second"], console.Lines.Select(l => l.Text));
+    }
+
+    [Fact]
+    public void ABlankLineIsNotAddedAtTheVeryStart()
+    {
+        var console = New();
+
+        console.Append("\nfirst");
+
+        Assert.Equal(["first"], console.Lines.Select(l => l.Text));
+    }
+
+    [Fact]
+    public void ABlankAcrossTwoSeparateMessagesStillCollapses()
+    {
+        // The buffer has to look at what is already on screen, not just what is pending - the
+        // messages that end and begin with a newline arrive separately.
+        var console = New();
+
+        console.Append("first\n");
+        console.Append("\nsecond");
+
+        Assert.Equal(["first", "", "second"], console.Lines.Select(l => l.Text));
+    }
+
+    [Fact]
+    public void LinesAreClassifiedAsTheyArrive()
+    {
+        var console = New();
+
+        console.Append("ERROR: could not open backup device");
+        console.Append("50 percent processed.");
+
+        Assert.Equal(ConsoleLineKind.Error, console.Lines[0].Kind);
+        Assert.NotEqual(ConsoleLineKind.Error, console.Lines[1].Kind);
+    }
+
+    [Fact]
+    public void EveryMessageAlsoGoesToTheLog()
+    {
+        // The file must not drift from what was on screen, so both are written from one place.
+        var logged = new List<string>();
+        var console = New(logged.Add);
+
+        console.Append("first");
+        console.Append("second");
+
+        Assert.Equal(["first", "second"], logged);
+    }
+
+    [Fact]
+    public void TextIsTheWholeConsoleForCopying()
+    {
+        var console = New();
+
+        console.Append("first\nsecond");
+
+        Assert.Equal($"first{Environment.NewLine}second", console.Text);
+    }
+
+    [Fact]
+    public void ClearingEmptiesEverything()
+    {
+        var console = New();
+        console.Append("first");
+
+        console.Clear();
+
+        Assert.Empty(console.Lines);
+        Assert.False(console.HasOutput);
+        Assert.Empty(console.Text);
+    }
+
+    [Fact]
+    public void ClearingDropsAnythingStillBuffered()
+    {
+        // A run that starts while the previous one's tail is still pending must not inherit it.
+        var console = New();
+        console.IsRunning = true;
+        console.Append("from the last run");
+        console.Clear();
+        console.Flush();
+
+        Assert.Empty(console.Lines);
+    }
+}
+
+/// <summary>
+/// The batching itself, which needs a dispatcher to tick.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class ConsoleBufferBatchingTests(WpfFixture wpf)
+{
+    /// <summary>
+    /// On a dispatcher thread lines wait for the timer rather than landing one at a time.
+    ///
+    /// SQL Server emits progress in clusters - several messages within a millisecond, then nothing
+    /// for a second. Adding each individually meant a layout pass and a scroll per message, which
+    /// is what made the console judder.
+    /// </summary>
+    [Fact]
+    public void LinesAreBatchedRatherThanAppliedImmediately()
+    {
+        wpf.Invoke(() =>
+        {
+            var console = new ConsoleBuffer { IsRunning = true };
+
+            console.Append("first");
+            console.Append("second");
+
+            // Still buffered - the timer has not ticked.
+            Assert.Empty(console.Lines);
+            Assert.True(console.HasPending);
+
+            console.Flush();
+
+            Assert.Equal(2, console.Lines.Count);
+            Assert.False(console.HasPending);
+        });
+    }
+
+    /// <summary>
+    /// Off a dispatcher there is nothing to drain the buffer, so it applies inline instead of
+    /// holding lines forever - which is what a plain unit test or a background thread gets.
+    /// </summary>
+    [Fact]
+    public async Task WithNoDispatcherTheLinesApplyImmediately()
+    {
+        var console = new ConsoleBuffer { IsRunning = true };
+
+        await Task.Run(() => console.Append("from a thread with no dispatcher"));
+
+        Assert.Single(console.Lines);
+    }
+}

--- a/src/NineLives.Tests/ConsoleBufferTests.cs
+++ b/src/NineLives.Tests/ConsoleBufferTests.cs
@@ -13,7 +13,16 @@ namespace Blackcat.NineLives.Tests;
 /// </summary>
 public class ConsoleBufferTests
 {
-    private static ConsoleBuffer New(Action<string>? alsoLog = null) => new(alsoLog);
+    /// <summary>
+    /// No dispatcher, said outright rather than inferred from the thread.
+    ///
+    /// These used to construct the plain way and rely on an xUnit worker thread having no
+    /// dispatcher on it. That is not something a test can assume: a worker that had already run
+    /// something which left a dispatcher behind made the buffer wait for a timer nothing was
+    /// pumping, and every assertion here saw an empty console. It reproduced only on CI, because
+    /// fewer cores means more thread reuse.
+    /// </summary>
+    private static ConsoleBuffer New(Action<string>? alsoLog = null) => new(alsoLog, dispatcher: null);
 
     [Fact]
     public void AMessageBecomesALine()
@@ -132,6 +141,29 @@ public class ConsoleBufferTests
         Assert.Empty(console.Text);
     }
 
+    /// <summary>
+    /// The CI failure, reproduced deterministically.
+    ///
+    /// Eight tests in this class went red on CI and nowhere else. The cause was not the console at
+    /// all: a worker thread had been used for something that left a Dispatcher on it, and the
+    /// buffer used to ask the CURRENT thread whether one existed. It found one, waited for a timer
+    /// nothing was pumping, and every assertion here saw an empty console. Fewer cores on CI meant
+    /// more thread reuse, which is why a local run never showed it.
+    ///
+    /// The buffer now takes its dispatcher at construction instead of sniffing for one, so what the
+    /// thread happens to be carrying no longer decides anything.
+    /// </summary>
+    [Fact]
+    public void AThreadThatAlreadyCarriesADispatcherChangesNothing()
+    {
+        _ = System.Windows.Threading.Dispatcher.CurrentDispatcher;
+
+        var console = New();
+        console.Append("first\nsecond");
+
+        Assert.Equal(["first", "second"], console.Lines.Select(l => l.Text));
+    }
+
     [Fact]
     public void ClearingDropsAnythingStillBuffered()
     {
@@ -164,7 +196,9 @@ public class ConsoleBufferBatchingTests(WpfFixture wpf)
     {
         wpf.Invoke(() =>
         {
+            // Constructed on the dispatcher thread, so it picks one up the ordinary way.
             var console = new ConsoleBuffer { IsRunning = true };
+            Assert.True(console.HasDispatcher, "the batching test needs a real dispatcher to batch on");
 
             console.Append("first");
             console.Append("second");
@@ -187,7 +221,7 @@ public class ConsoleBufferBatchingTests(WpfFixture wpf)
     [Fact]
     public async Task WithNoDispatcherTheLinesApplyImmediately()
     {
-        var console = new ConsoleBuffer { IsRunning = true };
+        var console = new ConsoleBuffer(null, dispatcher: null) { IsRunning = true };
 
         await Task.Run(() => console.Append("from a thread with no dispatcher"));
 

--- a/src/NineLives.Tests/ContainerEditingTests.cs
+++ b/src/NineLives.Tests/ContainerEditingTests.cs
@@ -1,0 +1,96 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Editing a saved container without losing anything that was already on it.
+/// </summary>
+public class ContainerEditingTests
+{
+    private readonly FakeCredentialStore _store = new();
+
+    private BlobConfigViewModel NewViewModel()
+        => new(_store, new FakeBlobStorageService());
+
+    private BlobContainerConfig Tagged()
+    {
+        var container = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups",
+            PathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}"
+        };
+        container.Tags.Add("prod");
+        container.Tags.Add("uk-south");
+
+        _store.Config.BlobContainers.Add(container);
+        return container;
+    }
+
+    /// <summary>
+    /// Refresh Token is a separate button from Edit, so replacing an expired SAS is the natural
+    /// way to reach it - and it repopulated every field of the edit form EXCEPT the tags, which
+    /// Save then wrote back as empty. Silent, persisted, no undo.
+    /// </summary>
+    [Fact]
+    public void RefreshingTheTokenKeepsTheTags()
+    {
+        var container = Tagged();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+
+        vm.RefreshTokenCommand.Execute(null);
+        vm.EditSasToken = "sv=2026-01-01&sig=replacement";
+        vm.SaveCommand.Execute(null);
+
+        var saved = Assert.Single(_store.Config.BlobContainers);
+        Assert.Equal(["prod", "uk-south"], saved.Tags.OrderBy(t => t));
+    }
+
+    [Fact]
+    public void RefreshingTheTokenShowsTheExistingTagsInTheBox()
+    {
+        Tagged();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+
+        vm.RefreshTokenCommand.Execute(null);
+
+        Assert.Contains("prod", vm.EditTags);
+        Assert.Contains("uk-south", vm.EditTags);
+    }
+
+    [Fact]
+    public void ChangingOnlyTheTagsCountsAsAnUnsavedChange()
+    {
+        Tagged();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        Assert.False(vm.HasUnsavedChanges);
+
+        vm.EditTags = "prod, uk-south, restored-here";
+
+        Assert.True(vm.HasUnsavedChanges);
+    }
+
+    [Fact]
+    public void EditingTheTagsSavesThem()
+    {
+        Tagged();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        vm.EditTags = "staging";
+        vm.SaveCommand.Execute(null);
+
+        var saved = Assert.Single(_store.Config.BlobContainers);
+        Assert.Equal(["staging"], saved.Tags);
+    }
+}

--- a/src/NineLives.Tests/CredentialIdentityTests.cs
+++ b/src/NineLives.Tests/CredentialIdentityTests.cs
@@ -1,0 +1,97 @@
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Reading a credential's identity, and saying what was found (#145).
+///
+/// This used to be one bool - "is the identity SHARED ACCESS SIGNATURE" - which put a managed
+/// identity, a Windows account and a typo in the same bucket. The restore path then acted on that
+/// bucket by overwriting it, so the classification is what the destructive decision hangs off.
+/// </summary>
+public class CredentialIdentityTests
+{
+    [Theory]
+    [InlineData("SHARED ACCESS SIGNATURE")]
+    [InlineData("shared access signature")]
+    public void ASasIdentityIsRecognisedWhateverItsCase(string identity)
+        => Assert.Equal(
+            BlobCredentialIdentity.SharedAccessSignature,
+            SqlServerService.ClassifyIdentity(identity));
+
+    /// <summary>
+    /// Case is not guaranteed here either: the docs write it both ways, and whoever created the
+    /// credential typed one of them. Getting this wrong is not a cosmetic miss - an unrecognised
+    /// managed identity is exactly the input that used to be overwritten.
+    /// </summary>
+    [Theory]
+    [InlineData("Managed Identity")]
+    [InlineData("MANAGED IDENTITY")]
+    [InlineData("managed identity")]
+    public void AManagedIdentityIsRecognisedWhateverItsCase(string identity)
+        => Assert.Equal(
+            BlobCredentialIdentity.ManagedIdentity,
+            SqlServerService.ClassifyIdentity(identity));
+
+    [Theory]
+    [InlineData("MYDOMAIN\\svc_sql")]
+    [InlineData("mystorageaccount")]
+    [InlineData("")]
+    public void AnythingElseIsOther(string identity)
+        => Assert.Equal(BlobCredentialIdentity.Other, SqlServerService.ClassifyIdentity(identity));
+
+    [Theory]
+    [InlineData(BlobCredentialIdentity.SharedAccessSignature, true)]
+    [InlineData(BlobCredentialIdentity.ManagedIdentity, true)]
+    [InlineData(BlobCredentialIdentity.Other, false)]
+    [InlineData(BlobCredentialIdentity.Missing, false)]
+    public void OnlyTheTwoIdentitiesARestoreCanUseCountAsUsable(
+        BlobCredentialIdentity kind, bool expected)
+        => Assert.Equal(expected, new BlobCredentialStatus(kind, "x").CanRestoreFromUrl);
+
+    [Fact]
+    public void OnlyAMissingCredentialReportsThatItIsAbsent()
+    {
+        Assert.False(BlobCredentialStatus.Missing.Exists);
+        Assert.True(new BlobCredentialStatus(BlobCredentialIdentity.Other, "x").Exists);
+    }
+
+    /// <summary>
+    /// The panel's wording. A managed identity must not be described as a problem: the old message
+    /// said "restore may fail" about a credential that would have worked, which is the sentence
+    /// that invited somebody to press the button and convert it.
+    /// </summary>
+    [Fact]
+    public void AManagedIdentityIsDescribedAsValid()
+    {
+        var message = RestoreViewModel.DescribeCredential(
+            new BlobCredentialStatus(BlobCredentialIdentity.ManagedIdentity, "Managed Identity"));
+
+        Assert.Contains("valid", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Managed Identity", message);
+        Assert.DoesNotContain("may fail", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// An unusable one is named. "Not a SAS credential" was true of every identity that is not a
+    /// SAS credential, which left no way to tell a mistake from somebody's deliberate arrangement.
+    /// </summary>
+    [Fact]
+    public void AnUnusableCredentialIsNamedRatherThanJustRejected()
+    {
+        var message = RestoreViewModel.DescribeCredential(
+            new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql"));
+
+        Assert.Contains("MYDOMAIN\\svc_sql", message);
+    }
+
+    [Fact]
+    public void AMissingCredentialSaysSo()
+    {
+        var message = RestoreViewModel.DescribeCredential(BlobCredentialStatus.Missing);
+
+        Assert.Contains("not present", message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/NineLives.Tests/CredentialIdentityTests.cs
+++ b/src/NineLives.Tests/CredentialIdentityTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Services;
+﻿using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
 
@@ -66,7 +66,7 @@ public class CredentialIdentityTests
     [Fact]
     public void AManagedIdentityIsDescribedAsValid()
     {
-        var message = RestoreViewModel.DescribeCredential(
+        var message = ServerCredentialViewModel.Describe(
             new BlobCredentialStatus(BlobCredentialIdentity.ManagedIdentity, "Managed Identity"));
 
         Assert.Contains("valid", message, StringComparison.OrdinalIgnoreCase);
@@ -81,7 +81,7 @@ public class CredentialIdentityTests
     [Fact]
     public void AnUnusableCredentialIsNamedRatherThanJustRejected()
     {
-        var message = RestoreViewModel.DescribeCredential(
+        var message = ServerCredentialViewModel.Describe(
             new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql"));
 
         Assert.Contains("MYDOMAIN\\svc_sql", message);
@@ -90,7 +90,7 @@ public class CredentialIdentityTests
     [Fact]
     public void AMissingCredentialSaysSo()
     {
-        var message = RestoreViewModel.DescribeCredential(BlobCredentialStatus.Missing);
+        var message = ServerCredentialViewModel.Describe(BlobCredentialStatus.Missing);
 
         Assert.Contains("not present", message, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/NineLives.Tests/CredentialLifecycleTests.cs
+++ b/src/NineLives.Tests/CredentialLifecycleTests.cs
@@ -93,6 +93,9 @@ public class CredentialLifecycleTests
     /// <summary>
     /// A credential sitting there under some other identity cannot serve a RESTORE FROM URL, so
     /// ALTER resets IDENTITY too rather than leaving a broken credential to fail the restore.
+    ///
+    /// This is the service doing what it is told. Since #145 only the explicit button asks for it -
+    /// the execute path stops rather than converting an identity it did not create.
     /// </summary>
     [RequiresSqlFact]
     public async Task NonSasCredential_IsConvertedToSharedAccessSignature()
@@ -103,14 +106,48 @@ public class CredentialLifecycleTests
             await DropCredentialIfExists(name);
             await CreateNonSasCredential(name);
 
-            Assert.False((await Service().CredentialExistsAsync(TestServer(), name)).IsSharedAccessSignature);
+            var before = await Service().CredentialExistsAsync(TestServer(), name);
+            Assert.Equal(BlobCredentialIdentity.Other, before.Kind);
+            Assert.False(before.CanRestoreFromUrl);
 
             var change = await Service().EnsureCredentialExistsAsync(TestServer(), name, Url, FirstSas);
 
             Assert.Equal(CredentialChange.Updated, change);
-            var (exists, isSas) = await Service().CredentialExistsAsync(TestServer(), name);
-            Assert.True(exists);
-            Assert.True(isSas);
+            var after = await Service().CredentialExistsAsync(TestServer(), name);
+            Assert.True(after.Exists);
+            Assert.Equal(BlobCredentialIdentity.SharedAccessSignature, after.Kind);
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    /// <summary>
+    /// A managed-identity credential read back off a real instance (#145).
+    ///
+    /// The classification is a string comparison against what sys.credentials returns, and this is
+    /// the only way to know that is the text SQL Server actually stores rather than the text the
+    /// documentation prints. It proves the read, not the restore: authenticating with a managed
+    /// identity needs an Azure VM, an Arc-enabled instance or SQL MI, and CREATE CREDENTIAL takes
+    /// the identity as free text on any of them, so this runs anywhere.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ManagedIdentityCredential_IsRecognisedRatherThanTreatedAsBroken()
+    {
+        const string name = "ninelives-test-lifecycle-managed-identity";
+        try
+        {
+            await DropCredentialIfExists(name);
+            await CreateManagedIdentityCredential(name);
+
+            var credential = await Service().CredentialExistsAsync(TestServer(), name);
+
+            Assert.True(credential.Exists);
+            Assert.Equal(BlobCredentialIdentity.ManagedIdentity, credential.Kind);
+
+            // The bit that matters: the execute path reads this and leaves the credential alone.
+            Assert.True(credential.CanRestoreFromUrl);
         }
         finally
         {
@@ -126,10 +163,10 @@ public class CredentialLifecycleTests
         const string name = "ninelives-test-lifecycle-absent";
         await DropCredentialIfExists(name);
 
-        var (exists, isSas) = await Service().CredentialExistsAsync(TestServer(), name);
+        var credential = await Service().CredentialExistsAsync(TestServer(), name);
 
-        Assert.False(exists);
-        Assert.False(isSas);
+        Assert.False(credential.Exists);
+        Assert.Equal(BlobCredentialIdentity.Missing, credential.Kind);
         Assert.False(await CredentialExists(name));
     }
 
@@ -171,6 +208,19 @@ public class CredentialLifecycleTests
         await using var conn = await OpenAsync();
         await using var cmd = conn.CreateCommand();
         cmd.CommandText = $"CREATE CREDENTIAL {TSql.QuoteName(name)} WITH IDENTITY = 'ninelives-test-identity', SECRET = 'not-a-sas'";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// No SECRET, which is how a managed-identity credential is written. SQL Server takes the
+    /// identity as free text, so this creates on any edition - it only fails when something tries
+    /// to authenticate with it.
+    /// </summary>
+    private static async Task CreateManagedIdentityCredential(string name)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"CREATE CREDENTIAL {TSql.QuoteName(name)} WITH IDENTITY = 'Managed Identity'";
         await cmd.ExecuteNonQueryAsync();
     }
 

--- a/src/NineLives.Tests/EntraBlobAuthTests.cs
+++ b/src/NineLives.Tests/EntraBlobAuthTests.cs
@@ -234,6 +234,81 @@ public class EntraBlobAuthTests
         Assert.True(vm.HasUnsavedChanges);
     }
 
+    // ── Test Connection ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The regression. Test Connection builds its own config from the form rather than using the
+    /// saved one, and it was not carrying the authentication mode - so an Entra container fell
+    /// through to the SAS path and was refused with "No SAS token found. Please configure the SAS
+    /// token for this container" for a container that is never going to have one.
+    ///
+    /// The Save path had tests. This one did not, and it is the button people press first.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public async Task TestingANewEntraContainerUsesEntraRatherThanLookingForASasToken(BlobAuthMode mode)
+    {
+        var blob = new FakeBlobStorageService();
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditAuthMode = mode;
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.False(vm.HasError, vm.ErrorMessage);
+        Assert.NotNull(blob.LastConfig);
+        Assert.Equal(mode, blob.LastConfig.AuthMode);
+        Assert.Equal("https://mystorageaccount.blob.core.windows.net/backups", blob.LastConfig.ContainerUrl);
+    }
+
+    /// <summary>
+    /// And switching an existing SAS container to Entra tests as Entra, before it is saved -
+    /// otherwise Test Connection answers for the mode the container used to be in.
+    /// </summary>
+    [Fact]
+    public async Task TestingAfterSwitchingAnExistingContainerUsesTheNewMode()
+    {
+        var store = new FakeCredentialStore();
+        var existing = Container(BlobAuthMode.SasToken);
+        store.Config.BlobContainers.Add(existing);
+        store.SaveSasToken(existing, "sv=2024-01-01&sig=old");
+
+        var blob = new FakeBlobStorageService();
+        var vm = new BlobConfigViewModel(store, blob);
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.Equal(BlobAuthMode.EntraInteractive, blob.LastConfig!.AuthMode);
+    }
+
+    /// <summary>
+    /// A SAS container still tests with the token being typed, unsaved - the #12 behaviour, which
+    /// the Entra branch must not have disturbed.
+    /// </summary>
+    [Fact]
+    public async Task TestingASasContainerStillUsesTheUnsavedToken()
+    {
+        var blob = new FakeBlobStorageService();
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2024-01-01&sig=being-typed";
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.Equal(BlobAuthMode.SasToken, blob.LastConfig!.AuthMode);
+        Assert.Equal("sv=2024-01-01&sig=being-typed", blob.LastConfig.UnsavedSasToken);
+    }
+
     /// <summary>
     /// The stored values are what config.json holds. Reordering would silently repoint every saved
     /// container at a different authentication mode, and a container written before this existed

--- a/src/NineLives.Tests/EntraBlobAuthTests.cs
+++ b/src/NineLives.Tests/EntraBlobAuthTests.cs
@@ -1,0 +1,260 @@
+﻿using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Entra ID authentication to Blob Storage (#29).
+///
+/// **Untested against a real tenant.** There is no Entra-enabled storage account to develop
+/// against, so what is pinned here is the decision the app makes - which credential, and what it
+/// stops storing - not that a token is accepted. The token flow belongs to Azure.Identity.
+///
+/// The reason it matters: many organisations now prohibit long-lived SAS tokens outright, which
+/// made the tool unusable for them regardless of its merits.
+/// </summary>
+public class EntraBlobAuthTests
+{
+    private static BlobContainerConfig Container(BlobAuthMode mode) => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups",
+        AuthMode = mode
+    };
+
+    // ── no secret of ours ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The SAS path refuses to work without a token, which is right - but that refusal must not
+    /// apply to a mode that has no token by design. This is the whole feature in one assertion.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void AnEntraContainerNeedsNoStoredToken(BlobAuthMode mode)
+    {
+        var store = new FakeCredentialStore();
+        var config = Container(mode);
+
+        // No token stored anywhere, and no exception: the client is built from a credential.
+        Assert.Null(store.GetSasToken(config));
+        var ex = Record.Exception(() => new BlobStorageService(store).CreateClientForTests(config));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ASasContainerStillSaysSoWhenItHasNoToken()
+    {
+        var store = new FakeCredentialStore();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => new BlobStorageService(store).CreateClientForTests(Container(BlobAuthMode.SasToken)));
+
+        Assert.Contains("No SAS token", ex.Message);
+    }
+
+    /// <summary>
+    /// The container URL is used as-is under Entra - no query string is appended, because there is
+    /// no signature to append. A stray "?" would be sent to Azure as an empty SAS.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void TheContainerUrlIsUsedUntouched(BlobAuthMode mode)
+    {
+        var client = new BlobStorageService(new FakeCredentialStore())
+            .CreateClientForTests(Container(mode));
+
+        Assert.Equal(
+            "https://mystorageaccount.blob.core.windows.net/backups", client.Uri.ToString());
+        Assert.Empty(client.Uri.Query);
+    }
+
+    /// <summary>
+    /// One credential per mode for the life of the process. A fresh one per operation means a fresh
+    /// sign-in per operation - for interactive mode, a browser window every time the container is
+    /// listed.
+    /// </summary>
+    [Fact]
+    public void TheSignInIsReusedRatherThanRepeatedPerOperation()
+    {
+        // Static, so it is shared across service instances too - the token cache belongs to the
+        // signed-in user, not to whichever service happened to ask for it first.
+        Assert.Same(
+            BlobStorageService.CredentialForTests(BlobAuthMode.EntraInteractive),
+            BlobStorageService.CredentialForTests(BlobAuthMode.EntraInteractive));
+    }
+
+    [Fact]
+    public void EachModeGetsItsOwnCredential()
+    {
+        Assert.NotSame(
+            BlobStorageService.CredentialForTests(BlobAuthMode.EntraInteractive),
+            BlobStorageService.CredentialForTests(BlobAuthMode.EntraDefault));
+    }
+
+    // ── expiry does not apply ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// An Entra container has no token of ours to expire, so it must never report itself expired -
+    /// otherwise the list shows a warning and a Refresh Token button for something that does not
+    /// exist.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void AnEntraContainerIsNeverExpired(BlobAuthMode mode)
+    {
+        var config = Container(mode);
+
+        // Even carrying a long-expired SAS from a previous life.
+        config.CacheSasToken("sv=2024-01-01&se=2020-01-01T00%3A00%3A00Z&sig=x");
+
+        Assert.False(config.IsExpired);
+    }
+
+    [Fact]
+    public void ASasContainerStillReportsExpiry()
+    {
+        var config = Container(BlobAuthMode.SasToken);
+        config.CacheSasToken("sv=2024-01-01&se=2020-01-01T00%3A00%3A00Z&sig=x");
+
+        Assert.True(config.IsExpired);
+    }
+
+    // ── the config screen ───────────────────────────────────────────────────────
+
+    private static BlobConfigViewModel NewVm(FakeCredentialStore store) =>
+        new(store, new FakeBlobStorageService());
+
+    [Fact]
+    public void ANewEntraContainerSavesWithoutASasToken()
+    {
+        var store = new FakeCredentialStore();
+        var vm = NewVm(store);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+        var saved = Assert.Single(store.Config.BlobContainers);
+        Assert.Equal(BlobAuthMode.EntraInteractive, saved.AuthMode);
+        Assert.Null(store.GetSasToken(saved));
+    }
+
+    [Fact]
+    public void ANewSasContainerStillDemandsAToken()
+    {
+        var store = new FakeCredentialStore();
+        var vm = NewVm(store);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Contains("SAS Token is required", vm.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Switching a container to Entra destroys its stored SAS token. An organisation that has
+    /// banned long-lived SAS has banned it wherever it is sitting, including in this machine's
+    /// Credential Manager - and the token is no longer used for anything.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void SwitchingToEntraDestroysTheStoredSasToken(BlobAuthMode to)
+    {
+        var store = new FakeCredentialStore();
+        var existing = Container(BlobAuthMode.SasToken);
+        store.Config.BlobContainers.Add(existing);
+        store.SaveSasToken(existing, "sv=2024-01-01&sig=no-longer-needed");
+
+        var vm = NewVm(store);
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        vm.EditAuthMode = to;
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+        Assert.Null(store.GetSasToken(vm.Containers.Single()));
+    }
+
+    /// <summary>
+    /// And only once the mode change has reached the disk - the same ordering rule the rest of the
+    /// save path follows. A refused save that had already destroyed the token would leave a SAS
+    /// container in config.json with nothing behind it.
+    /// </summary>
+    [Fact]
+    public void ARefusedSwitchToEntraKeepsTheToken()
+    {
+        var store = new FakeCredentialStore();
+        var existing = Container(BlobAuthMode.SasToken);
+        store.Config.BlobContainers.Add(existing);
+        store.SaveSasToken(existing, "sv=2024-01-01&sig=still-needed");
+
+        var vm = NewVm(store);
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        store.SaveConfigThrows = new InvalidOperationException("config.json is in use by another process");
+
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Equal(BlobAuthMode.SasToken, vm.Containers.Single().AuthMode);
+        Assert.Equal("sv=2024-01-01&sig=still-needed", store.GetSasToken(vm.Containers.Single()));
+    }
+
+    [Fact]
+    public void ChangingTheModeCountsAsAnUnsavedChange()
+    {
+        var store = new FakeCredentialStore();
+        var existing = Container(BlobAuthMode.SasToken);
+        store.Config.BlobContainers.Add(existing);
+
+        var vm = NewVm(store);
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+        Assert.False(vm.HasUnsavedChanges);
+
+        vm.EditAuthMode = BlobAuthMode.EntraDefault;
+
+        Assert.True(vm.HasUnsavedChanges);
+    }
+
+    /// <summary>
+    /// The stored values are what config.json holds. Reordering would silently repoint every saved
+    /// container at a different authentication mode, and a container written before this existed
+    /// has no value at all - which must land on SAS, the behaviour it already had.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.SasToken, 0)]
+    [InlineData(BlobAuthMode.EntraInteractive, 1)]
+    [InlineData(BlobAuthMode.EntraDefault, 2)]
+    public void TheStoredValuesArePinned(BlobAuthMode mode, int expected)
+    {
+        Assert.Equal(expected, (int)mode);
+    }
+
+    [Fact]
+    public void AContainerFromBeforeThisExistedIsASasContainer()
+    {
+        var legacy = System.Text.Json.JsonSerializer.Deserialize<BlobContainerConfig>(
+            """{"Name":"backups","ContainerUrl":"https://mystorageaccount.blob.core.windows.net/backups"}""");
+
+        Assert.NotNull(legacy);
+        Assert.Equal(BlobAuthMode.SasToken, legacy.AuthMode);
+    }
+}

--- a/src/NineLives.Tests/EntraDiagnosticsTests.cs
+++ b/src/NineLives.Tests/EntraDiagnosticsTests.cs
@@ -1,0 +1,267 @@
+using System.Text;
+using System.Text.Json;
+using Azure;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Making an Azure permission failure answerable (#29).
+///
+/// Azure refuses a data-plane request with 403 AuthorizationPermissionMismatch and nothing else -
+/// one message covering "the role is on the management plane", "the role is on the wrong scope" and
+/// "this is not the account you think it is". The response carries a request id, the original XML
+/// and eleven headers, and says nothing about what to change.
+///
+/// Same instinct as the recovery guidance after a failed restore (#14): the moment it fails is the
+/// moment to say what to do about it.
+/// </summary>
+public class EntraDiagnosticsTests
+{
+    private static BlobContainerConfig Container(BlobAuthMode mode = BlobAuthMode.EntraInteractive) => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/sqlbackups",
+        AuthMode = mode
+    };
+
+    private static RequestFailedException Failure(string errorCode, int status = 403) =>
+        new(status, "This request is not authorized to perform this operation using this permission.\n"
+            + "RequestId:d0733940-001e-000f-16ae-255e25000000\n"
+            + "Time:2026-08-06T14:20:06.5131329Z", errorCode, innerException: null);
+
+    // ── who was refused ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A token is a JWT: three base64url segments, the middle one a JSON claims object. Reading the
+    /// account out of it is the only way the app can say WHICH identity Azure turned down.
+    /// </summary>
+    private static string Jwt(object payload)
+    {
+        static string Segment(string json) =>
+            Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
+                .TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+        return $"{Segment("{\"alg\":\"RS256\"}")}.{Segment(JsonSerializer.Serialize(payload))}.signature";
+    }
+
+    [Fact]
+    public void AUserTokenIsDescribedByTheAccountAndTenant()
+    {
+        var token = Jwt(new { upn = "dba@example.com", tid = "11111111-2222-3333-4444-555555555555" });
+
+        Assert.Equal(
+            "dba@example.com (tenant 11111111-2222-3333-4444-555555555555)",
+            EntraIdentity.Describe(token));
+    }
+
+    /// <summary>Not every token carries upn - a guest or a personal account often has only this.</summary>
+    [Fact]
+    public void PreferredUsernameIsUsedWhenThereIsNoUpn()
+    {
+        var token = Jwt(new { preferred_username = "guest@other.com", tid = "abc" });
+
+        Assert.Equal("guest@other.com (tenant abc)", EntraIdentity.Describe(token));
+    }
+
+    /// <summary>
+    /// A managed identity or service principal has no user at all. Its object id is still the thing
+    /// a role assignment is checked against, so it is worth naming.
+    /// </summary>
+    [Fact]
+    public void AManagedIdentityIsDescribedByItsObjectId()
+    {
+        var token = Jwt(new { oid = "99999999-0000-0000-0000-000000000000", tid = "abc" });
+
+        Assert.Equal("99999999-0000-0000-0000-000000000000 (tenant abc)", EntraIdentity.Describe(token));
+    }
+
+    /// <summary>
+    /// A bearer token is a live credential for as long as it lasts, and this text goes on screen
+    /// and into the log. None of it may come back.
+    /// </summary>
+    [Fact]
+    public void NoPartOfTheTokenIsEverReturned()
+    {
+        var token = Jwt(new { upn = "dba@example.com", tid = "abc" });
+
+        var described = EntraIdentity.Describe(token);
+
+        Assert.NotNull(described);
+        foreach (var segment in token.Split('.'))
+            Assert.DoesNotContain(segment, described);
+    }
+
+    /// <summary>
+    /// This only ever runs to improve an error message. Failing to improve one must not replace it
+    /// with a different error.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-token")]
+    [InlineData("only.two")]
+    [InlineData("aaa.!!!not-base64!!!.ccc")]
+    [InlineData("aaa.eyJub3QiOiJhbiBvYmplY3QifQ.ccc")]
+    public void AnUnreadableTokenIsNotAnError(string token)
+    {
+        var ex = Record.Exception(() => EntraIdentity.Describe(token));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ATokenWithNothingIdentifyingGivesNothing()
+    {
+        Assert.Null(EntraIdentity.Describe(Jwt(new { aud = "https://storage.azure.com" })));
+    }
+
+    // ── what to do about it ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The one worth spelling out. Blob DATA access is a separate set of roles from the ones that
+    /// administer the account, so the reflex of "but I'm Owner" is exactly the wrong fix.
+    /// </summary>
+    [Fact]
+    public void APermissionMismatchUnderEntraNamesTheRoleThatIsMissing()
+    {
+        var guidance = BlobFailureExplainer.Explain(
+            Failure("AuthorizationPermissionMismatch"), Container());
+
+        Assert.NotNull(guidance);
+        Assert.Contains("Storage Blob Data Reader", guidance);
+        Assert.Contains("Owner and Contributor do not include it", guidance);
+        // Names the container, so it is clear what scope the assignment goes on.
+        Assert.Contains("sqlbackups", guidance);
+    }
+
+    /// <summary>
+    /// The other tool "working" is the most misleading evidence there is, and it comes up first.
+    /// Storage Explorer commonly falls back to the account key - which Owner CAN fetch - so it
+    /// never exercises the role at all.
+    /// </summary>
+    [Fact]
+    public void ItExplainsWhyStorageExplorerDisagrees()
+    {
+        var guidance = BlobFailureExplainer.Explain(
+            Failure("AuthorizationPermissionMismatch"), Container());
+
+        Assert.Contains("Storage Explorer", guidance);
+        Assert.Contains("account key", guidance);
+    }
+
+    /// <summary>The same code under SAS means something completely different.</summary>
+    [Fact]
+    public void APermissionMismatchUnderSasTalksAboutTheToken()
+    {
+        var guidance = BlobFailureExplainer.Explain(
+            Failure("AuthorizationPermissionMismatch"), Container(BlobAuthMode.SasToken));
+
+        Assert.NotNull(guidance);
+        Assert.Contains("List and Read", guidance);
+        Assert.DoesNotContain("Storage Blob Data Reader", guidance);
+    }
+
+    [Theory]
+    [InlineData("ContainerNotFound", "case-sensitive")]
+    [InlineData("AccountIsDisabled", "disabled")]
+    [InlineData("InvalidResourceName", "legal Azure container name")]
+    public void TheOtherCommonFailuresAreExplainedToo(string code, string expected)
+    {
+        Assert.Contains(expected, BlobFailureExplainer.Explain(Failure(code, 404), Container()));
+    }
+
+    /// <summary>
+    /// Only where there is something worth adding. Inventing guidance for an unrecognised failure
+    /// would bury Azure's own message under a guess.
+    /// </summary>
+    [Fact]
+    public void AnUnrecognisedFailureGetsNoGuidance()
+    {
+        Assert.Null(BlobFailureExplainer.Explain(Failure("SomethingNewFromAzure", 500), Container()));
+    }
+
+    [Fact]
+    public void ANonAzureFailureGetsNoGuidance()
+    {
+        Assert.Null(BlobFailureExplainer.Explain(
+            new InvalidOperationException("No SAS token found."), Container()));
+    }
+
+    // ── what the user ends up reading ───────────────────────────────────────────
+
+    /// <summary>
+    /// All three parts, in the order that answers the question fastest: what failed, who was
+    /// refused, then what to change. The identity comes before the guidance because it settles the
+    /// most common confusion - a permission error against an account that demonstrably has access
+    /// usually means a different account was used than the one being thought about.
+    /// </summary>
+    [Fact]
+    public async Task TheTestResultSaysWhatFailedWhoWasRefusedAndWhatToChange()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            ListThrows = Failure("AuthorizationPermissionMismatch"),
+            SignedInIdentity = "someone.else@example.com (tenant abc)"
+        };
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/sqlbackups";
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.False(vm.TestSuccess);
+        Assert.Contains("Connection failed", vm.TestResult);
+        Assert.Contains("someone.else@example.com", vm.TestResult);
+        Assert.Contains("Storage Blob Data Reader", vm.TestResult);
+    }
+
+    /// <summary>
+    /// Azure appends the request id, the timestamp, the original XML and every response header to
+    /// its exception message. Only the first line is worth putting at the top.
+    /// </summary>
+    [Fact]
+    public async Task TheHeadersAndRequestIdDoNotGetInTheWay()
+    {
+        var blob = new FakeBlobStorageService { ListThrows = Failure("AuthorizationPermissionMismatch") };
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/sqlbackups";
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.DoesNotContain("RequestId:", vm.TestResult);
+        Assert.DoesNotContain("Time:2026", vm.TestResult);
+    }
+
+    /// <summary>A SAS container has no signed-in account, so nothing is claimed about one.</summary>
+    [Fact]
+    public async Task ASasFailureDoesNotClaimAnIdentity()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            ListThrows = Failure("AuthorizationPermissionMismatch"),
+            SignedInIdentity = "should-not-be-used@example.com"
+        };
+        var vm = new BlobConfigViewModel(new FakeCredentialStore(), blob);
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/sqlbackups";
+        vm.EditSasToken = "sv=2024-01-01&sig=x";
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.DoesNotContain("Signed in as", vm.TestResult);
+        Assert.DoesNotContain("should-not-be-used", vm.TestResult);
+    }
+}

--- a/src/NineLives.Tests/EntraSignInThreadTests.cs
+++ b/src/NineLives.Tests/EntraSignInThreadTests.cs
@@ -1,0 +1,137 @@
+﻿using System.Windows.Threading;
+using Azure.Core;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The Entra sign-in must not happen on the UI thread (#152).
+///
+/// InteractiveBrowserCredential launches a browser and waits for the redirect to come back, on
+/// whatever thread asked for the token. Every blob operation starts from a command on the UI
+/// thread, so the window stopped painting for as long as the sign-in was open - the app asking
+/// somebody to go and authenticate while appearing, to them, to have crashed.
+///
+/// It went unnoticed because the path that had been exercised was the FAILING one: a 403 for a
+/// missing role comes back without any sign-in UI ever appearing.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class EntraSignInThreadTests(WpfFixture wpf) : IDisposable
+{
+    public void Dispose() => BlobStorageService.CredentialFactoryForTests = null;
+
+    /// <summary>
+    /// Records the thread of every token request, in order.
+    ///
+    /// There is more than one: the warm-up asks first, then the client's own pipeline asks again
+    /// for the request itself. Only the FIRST matters here - a real credential caches, so that is
+    /// the one that opens a browser and waits, and every later one is a cache read.
+    ///
+    /// It also cancels after answering, so the test does not sit through the Azure SDK retrying a
+    /// connection to a port nothing is listening on.
+    /// </summary>
+    private sealed class ThreadRecordingCredential(CancellationTokenSource stopAfterFirst) : TokenCredential
+    {
+        public List<int> CalledOnThreads { get; } = [];
+
+        /// <summary>Set by the dispatcher, proving the UI thread was still processing messages.</summary>
+        public ManualResetEventSlim UiPumped { get; } = new(false);
+
+        /// <summary>False when the sign-in gave up waiting for the UI thread to do anything.</summary>
+        public bool UiRespondedDuringSignIn { get; private set; }
+
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken ct)
+        {
+            var first = false;
+            lock (CalledOnThreads)
+            {
+                first = CalledOnThreads.Count == 0;
+                CalledOnThreads.Add(Environment.CurrentManagedThreadId);
+            }
+
+            // Stands in for somebody completing a sign-in in a browser: it does not finish until
+            // the UI thread has demonstrably pumped. That makes the check deterministic instead of
+            // a race - the operation cannot complete, and the frame cannot exit, before the probe
+            // has had its turn. If the sign-in were running ON the UI thread, nothing could set
+            // this and the wait times out, which is the failure being tested for.
+            if (first)
+            {
+                UiRespondedDuringSignIn = UiPumped.Wait(TimeSpan.FromSeconds(5));
+                stopAfterFirst.Cancel();
+            }
+
+            return new AccessToken("token", DateTimeOffset.UtcNow.AddHours(1));
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext, CancellationToken ct)
+            => new(GetToken(requestContext, ct));
+    }
+
+    private static BlobContainerConfig EntraContainer() => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        // Nothing listens here, so the operation fails immediately AFTER the sign-in - which is
+        // all this test needs, since the sign-in is what it is about.
+        ContainerUrl = "https://127.0.0.1:1/backups",
+        AuthMode = BlobAuthMode.EntraInteractive
+    };
+
+    [Fact]
+    public void TheSignInDoesNotRunOnTheUiThread()
+    {
+        using var stop = new CancellationTokenSource();
+        var credential = new ThreadRecordingCredential(stop);
+        BlobStorageService.CredentialFactoryForTests = _ => credential;
+
+        var uiThreadId = 0;
+
+        wpf.Invoke(() =>
+        {
+            uiThreadId = Environment.CurrentManagedThreadId;
+
+            var service = new BlobStorageService(new FakeCredentialStore());
+            var frame = new DispatcherFrame();
+
+            // The probe. A frozen window is one whose dispatcher never gets to this.
+            _ = Dispatcher.CurrentDispatcher.BeginInvoke(
+                DispatcherPriority.Background,
+                new Action(() => credential.UiPumped.Set()));
+
+            _ = service.VerifyConnectionAsync(EntraContainer(), stop.Token)
+                .ContinueWith(_ => frame.Continue = false, TaskScheduler.FromCurrentSynchronizationContext());
+
+            Dispatcher.PushFrame(frame);
+        });
+
+        Assert.NotEmpty(credential.CalledOnThreads);
+        var signIn = credential.CalledOnThreads[0];
+        Assert.NotEqual(uiThreadId, signIn);
+        Assert.True(credential.UiRespondedDuringSignIn, "the dispatcher stopped processing while signing in");
+    }
+
+    /// <summary>A SAS container has no sign-in to do, and must not be made to wait for one.</summary>
+    [Fact]
+    public async Task ASasContainerNeverAsksForAToken()
+    {
+        using var unused = new CancellationTokenSource();
+        var credential = new ThreadRecordingCredential(unused);
+        BlobStorageService.CredentialFactoryForTests = _ => credential;
+
+        var service = new BlobStorageService(new FakeCredentialStore());
+        var sas = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://127.0.0.1:1/backups",
+            AuthMode = BlobAuthMode.SasToken
+        };
+
+        await Assert.ThrowsAnyAsync<Exception>(() => service.VerifyConnectionAsync(sas));
+
+        Assert.Empty(credential.CalledOnThreads);
+    }
+}

--- a/src/NineLives.Tests/EntraSqlAuthTests.cs
+++ b/src/NineLives.Tests/EntraSqlAuthTests.cs
@@ -1,0 +1,186 @@
+using Microsoft.Data.SqlClient;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Entra ID authentication to SQL Server (#30).
+///
+/// **Untested against a real tenant.** There is no Entra-enabled instance to develop against, so
+/// what is pinned here is the connection string the driver is handed and the promise that nothing
+/// is stored - not that a sign-in succeeds. The token flow itself belongs to
+/// Microsoft.Data.SqlClient and is Microsoft's to get right; what this project can get wrong is the
+/// string it hands over, and that is exactly what these tests cover.
+///
+/// The reason it matters is the estate that needs it: Azure SQL Managed Instance and Azure-VM SQL
+/// increasingly mandate Entra with MFA, which neither Windows nor SQL auth can satisfy.
+/// </summary>
+public class EntraSqlAuthTests
+{
+    private static SqlServerService Service() => new(new FakeCredentialStore());
+
+    private static ServerConnection Server(AuthMode mode, string? username = null) => new()
+    {
+        Id = ServerConnection.NewId(),
+        Name = "SRV01",
+        ServerName = "srv01.database.windows.net",
+        AuthMode = mode,
+        Username = username
+    };
+
+    private static SqlConnectionStringBuilder Built(AuthMode mode, string? username = null) =>
+        new(Service().BuildConnectionString(Server(mode, username)));
+
+    // ── the connection string ───────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive, SqlAuthenticationMethod.ActiveDirectoryInteractive)]
+    [InlineData(AuthMode.EntraIntegrated, SqlAuthenticationMethod.ActiveDirectoryIntegrated)]
+    [InlineData(AuthMode.EntraDefault, SqlAuthenticationMethod.ActiveDirectoryDefault)]
+    public void EachEntraModeMapsToItsDriverAuthenticationMethod(
+        AuthMode mode, SqlAuthenticationMethod expected)
+    {
+        Assert.Equal(expected, Built(mode).Authentication);
+    }
+
+    /// <summary>
+    /// Integrated Security and Authentication are mutually exclusive - the driver rejects a
+    /// connection string carrying both, so this is the difference between working and not opening
+    /// at all.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive)]
+    [InlineData(AuthMode.EntraIntegrated)]
+    [InlineData(AuthMode.EntraDefault)]
+    public void EntraNeverAlsoAsksForIntegratedSecurity(AuthMode mode)
+    {
+        Assert.False(Built(mode).IntegratedSecurity);
+    }
+
+    [Theory]
+    [InlineData(AuthMode.WindowsAuth)]
+    [InlineData(AuthMode.SqlAuth)]
+    public void TheExistingModesAskForNoAuthenticationMethod(AuthMode mode)
+    {
+        Assert.Equal(SqlAuthenticationMethod.NotSpecified, Built(mode).Authentication);
+    }
+
+    [Fact]
+    public void WindowsAuthStillUsesIntegratedSecurity()
+    {
+        Assert.True(Built(AuthMode.WindowsAuth).IntegratedSecurity);
+    }
+
+    // ── the username ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Interactive sign-in takes a username as a hint that pre-selects the account, which is worth
+    /// having on a machine signed in to several. It is not a credential - there is no password to
+    /// pair it with - so unlike the SQL auth username it is safe in the connection string.
+    /// </summary>
+    [Fact]
+    public void AnInteractiveHintIsPassedThroughToPreSelectTheAccount()
+    {
+        Assert.Equal("dba@example.com", Built(AuthMode.EntraInteractive, "dba@example.com").UserID);
+    }
+
+    [Fact]
+    public void InteractiveWithNoHintAsksForNoParticularAccount()
+    {
+        Assert.Empty(Built(AuthMode.EntraInteractive).UserID);
+    }
+
+    /// <summary>
+    /// The other two modes choose the account themselves - integrated from the signed-in Windows
+    /// account, default from the environment or a managed identity. Passing a username would either
+    /// be ignored or contradict what the mode is for.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraIntegrated)]
+    [InlineData(AuthMode.EntraDefault)]
+    public void TheNonInteractiveModesIgnoreAUsername(AuthMode mode)
+    {
+        Assert.Empty(Built(mode, "dba@example.com").UserID);
+    }
+
+    // ── nothing is stored ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The whole reason an organisation mandates Entra is to stop tools holding passwords. A
+    /// SqlCredential attached to an Entra connection would also make the driver reject it.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive)]
+    [InlineData(AuthMode.EntraIntegrated)]
+    [InlineData(AuthMode.EntraDefault)]
+    public void NoPasswordIsEverAttachedForAnEntraConnection(AuthMode mode)
+    {
+        var store = new FakeCredentialStore();
+        var server = Server(mode, "dba@example.com");
+
+        // Even with a password sitting in the vault from a previous SQL auth life.
+        store.SaveSqlPassword(server, "left-over-password");
+
+        using var conn = new SqlServerService(store).CreateConnection(server);
+
+        Assert.Null(conn.Credential);
+        Assert.DoesNotContain("left-over-password", conn.ConnectionString);
+    }
+
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive, false)]
+    [InlineData(AuthMode.EntraIntegrated, false)]
+    [InlineData(AuthMode.EntraDefault, false)]
+    [InlineData(AuthMode.WindowsAuth, false)]
+    [InlineData(AuthMode.SqlAuth, true)]
+    public void OnlySqlAuthNeedsAStoredPassword(AuthMode mode, bool expected)
+    {
+        Assert.Equal(expected, mode.NeedsStoredPassword());
+    }
+
+    // ── how it reads ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The list shows the username only when it identifies the login connecting. For interactive
+    /// Entra it is a hint for the account picker, not necessarily the account that ends up
+    /// connecting, so showing it would misstate who is connected to a production instance.
+    /// </summary>
+    [Fact]
+    public void TheListNamesTheModeRatherThanTheHint()
+    {
+        Assert.Equal(
+            "srv01.database.windows.net (Entra ID (interactive))",
+            Server(AuthMode.EntraInteractive, "dba@example.com").DisplayText);
+    }
+
+    [Fact]
+    public void SqlAuthStillShowsWhoIsConnecting()
+    {
+        Assert.Equal("srv01.database.windows.net (sa)", Server(AuthMode.SqlAuth, "sa").DisplayText);
+    }
+
+    [Fact]
+    public void WindowsAuthStillSaysSo()
+    {
+        Assert.Equal(
+            "srv01.database.windows.net (Windows Auth)", Server(AuthMode.WindowsAuth).DisplayText);
+    }
+
+    /// <summary>
+    /// The stored values are what config.json holds. Reordering the enum would silently repoint
+    /// every saved connection at a different authentication mode - a Windows auth entry quietly
+    /// becoming an Entra one is the kind of change nobody notices until a restore fails.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.WindowsAuth, 0)]
+    [InlineData(AuthMode.SqlAuth, 1)]
+    [InlineData(AuthMode.EntraInteractive, 2)]
+    [InlineData(AuthMode.EntraIntegrated, 3)]
+    [InlineData(AuthMode.EntraDefault, 4)]
+    public void TheStoredValuesArePinned(AuthMode mode, int expected)
+    {
+        Assert.Equal(expected, (int)mode);
+    }
+}

--- a/src/NineLives.Tests/EntraSqlAuthTests.cs
+++ b/src/NineLives.Tests/EntraSqlAuthTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Data.SqlClient;
+﻿using Microsoft.Data.SqlClient;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Xunit;
@@ -182,5 +182,46 @@ public class EntraSqlAuthTests
     public void TheStoredValuesArePinned(AuthMode mode, int expected)
     {
         Assert.Equal(expected, (int)mode);
+    }
+
+    // ── the provider has to exist ───────────────────────────────────────────────
+
+    /// <summary>
+    /// The regression, and the one thing about Entra that IS checkable without a tenant.
+    ///
+    /// Microsoft.Data.SqlClient 7.0 moved the Entra providers out of the main package and into
+    /// Microsoft.Data.SqlClient.Extensions.Azure. Without that package every Entra connection fails
+    /// at open with "Cannot find an authentication provider for 'ActiveDirectoryInteractive'" -
+    /// which is what the first person to try it hit.
+    ///
+    /// MSAL being present transitively is necessary but not sufficient, and checking for MSAL is
+    /// what was done instead of checking for this. Reverting the package reference fails all three.
+    /// </summary>
+    [Theory]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryInteractive)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryIntegrated)]
+    [InlineData(SqlAuthenticationMethod.ActiveDirectoryDefault)]
+    public void SomethingCanActuallyServiceTheAuthenticationMethod(SqlAuthenticationMethod method)
+    {
+        Assert.NotNull(SqlAuthenticationProvider.GetProvider(method));
+    }
+
+    /// <summary>
+    /// And it is the real provider from the Azure extension package, not some placeholder that
+    /// would fail later with a less helpful message.
+    ///
+    /// The driver discovers this at runtime. Discovery was checked against an actual single-file
+    /// self-contained publish - the shape this app ships in, where an assembly nothing references
+    /// from code could plausibly have been left behind - and it resolves there too.
+    /// </summary>
+    [Fact]
+    public void TheProviderIsTheOneFromTheAzureExtensionPackage()
+    {
+        var provider = SqlAuthenticationProvider.GetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive);
+
+        Assert.Equal(
+            "Microsoft.Data.SqlClient.ActiveDirectoryAuthenticationProvider",
+            provider!.GetType().FullName);
     }
 }

--- a/src/NineLives.Tests/EntraWindowHandleTests.cs
+++ b/src/NineLives.Tests/EntraWindowHandleTests.cs
@@ -1,0 +1,225 @@
+﻿using System.Reflection;
+using System.Windows;
+using System.Windows.Interop;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Parenting the Entra sign-in prompt to a window (#30).
+///
+/// On Windows, MSAL signs in through the Web Account Manager broker rather than a plain browser
+/// window, and the broker refuses to show a dialog it cannot parent - which is the second thing
+/// the first real sign-in attempt hit, after the missing provider package:
+///
+///   A window handle must be configured. (window_handle_required)
+///
+/// Nothing here proves a token is issued. What it proves is that the app answers the question the
+/// broker asks, which is the part the app is responsible for.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class EntraWindowHandleTests(WpfFixture wpf)
+{
+    /// <summary>
+    /// The regression. Building an Entra connection string has to leave a provider in place that
+    /// can be asked for a window - the driver's own discovered provider has none, because nothing
+    /// in a library can know what the application's window is.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive, SqlAuthenticationMethod.ActiveDirectoryInteractive)]
+    [InlineData(AuthMode.EntraIntegrated, SqlAuthenticationMethod.ActiveDirectoryIntegrated)]
+    [InlineData(AuthMode.EntraDefault, SqlAuthenticationMethod.ActiveDirectoryDefault)]
+    public void BuildingAnEntraConnectionRegistersAProviderThatCanBeGivenAWindow(
+        AuthMode mode, SqlAuthenticationMethod method)
+    {
+        EntraAuthentication.ResetForTests();
+
+        new SqlServerService(new FakeCredentialStore()).BuildConnectionString(new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "srv01.database.windows.net",
+            AuthMode = mode
+        });
+
+        var provider = SqlAuthenticationProvider.GetProvider(method);
+
+        Assert.NotNull(provider);
+        // Ours, registered with a window func - not whatever the driver discovered on its own.
+        Assert.Equal(
+            "Microsoft.Data.SqlClient.ActiveDirectoryAuthenticationProvider",
+            provider.GetType().FullName);
+        Assert.True(provider.IsSupported(method));
+    }
+
+    /// <summary>
+    /// The link that actually broke, and the one nothing else here covers: a provider IS registered
+    /// and a handle CAN be resolved, but if the two are never connected the broker still gets
+    /// nothing and the sign-in still fails with window_handle_required.
+    ///
+    /// Reaches into the provider's private field to do it. That is a deliberate trade: it is the
+    /// only way to see what the driver was told without standing in front of a real sign-in, and
+    /// this is precisely the wiring that shipped broken. If Microsoft.Data.SqlClient renames the
+    /// field this test fails loudly, which is the right outcome - it means checking the API again,
+    /// not assuming the wiring survived.
+    /// </summary>
+    [Fact]
+    public void TheRegisteredProviderIsWiredToTheWindowLookup()
+    {
+        EntraAuthentication.ResetForTests();
+        EntraAuthentication.Register(() => 4242);
+
+        var provider = SqlAuthenticationProvider.GetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive);
+
+        var field = provider!.GetType().GetField(
+            "_parentActivityOrWindowFunc",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.True(field != null,
+            "Microsoft.Data.SqlClient no longer stores the parent window func in "
+            + "_parentActivityOrWindowFunc - check SetParentActivityOrWindowFunc is still how a "
+            + "window is supplied before assuming Entra sign-in still works.");
+
+        var func = Assert.IsType<Func<object>>(field!.GetValue(provider), exactMatch: false);
+        Assert.Equal((nint)4242, func());
+    }
+
+    /// <summary>
+    /// Registration is process-wide global state. Doing it twice would replace a provider that may
+    /// already be mid-sign-in, so it happens once and later calls are no-ops.
+    /// </summary>
+    [Fact]
+    public void RegisteringIsIdempotent()
+    {
+        EntraAuthentication.ResetForTests();
+        EntraAuthentication.Register(() => 1);
+        var first = SqlAuthenticationProvider.GetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive);
+
+        EntraAuthentication.Register(() => 2);
+        var second = SqlAuthenticationProvider.GetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive);
+
+        Assert.Same(first, second);
+    }
+
+    // ── which window ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A real HWND for a shown window. Zero is what the broker rejects, so "not zero" is the whole
+    /// point - and it has to be a window that actually exists, since a handle is only created when
+    /// the window is shown.
+    /// </summary>
+    [Fact]
+    public void AShownWindowGivesARealHandle()
+    {
+        wpf.Invoke(() =>
+        {
+            var window = new Window { Width = 100, Height = 100, ShowInTaskbar = false };
+            try
+            {
+                window.Show();
+                Application.Current.MainWindow = window;
+
+                var handle = EntraAuthentication.ActiveWindowHandle();
+
+                Assert.NotEqual(nint.Zero, handle);
+                Assert.Equal(new WindowInteropHelper(window).Handle, handle);
+            }
+            finally
+            {
+                Application.Current.MainWindow = null;
+                window.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// With a modal open the prompt must parent to THAT, not to the main window - a dialog parented
+    /// behind a modal is invisible, and a sign-in nobody can see reads as a hang.
+    /// </summary>
+    [Fact]
+    public void TheActiveWindowWinsOverTheMainWindow()
+    {
+        wpf.Invoke(() =>
+        {
+            var main = new Window { Width = 100, Height = 100, ShowInTaskbar = false };
+            var onTop = new Window { Width = 80, Height = 80, ShowInTaskbar = false };
+            try
+            {
+                main.Show();
+                Application.Current.MainWindow = main;
+                onTop.Owner = main;
+                onTop.Show();
+                onTop.Activate();
+
+                // Only assert the preference when the test machine actually gave it focus -
+                // an unfocused desktop session would otherwise fail this for the wrong reason.
+                if (!onTop.IsActive) return;
+
+                Assert.Equal(new WindowInteropHelper(onTop).Handle,
+                    EntraAuthentication.ActiveWindowHandle());
+            }
+            finally
+            {
+                Application.Current.MainWindow = null;
+                onTop.Close();
+                main.Close();
+            }
+        });
+    }
+
+    /// <summary>
+    /// No window yet means zero rather than a crash. The broker turns that into the
+    /// window_handle_required message, which is a far better outcome than an exception out of a
+    /// background token acquisition.
+    /// </summary>
+    [Fact]
+    public void NoWindowIsZeroRatherThanAThrow()
+    {
+        wpf.Invoke(() =>
+        {
+            Application.Current.MainWindow = null;
+
+            var ex = Record.Exception(() => EntraAuthentication.ActiveWindowHandle());
+
+            Assert.Null(ex);
+        });
+    }
+
+    /// <summary>
+    /// MSAL acquires the token on whatever thread it likes, and WPF's window collection can only be
+    /// touched on the UI thread. Resolving from a background thread has to marshal rather than
+    /// throw - this is the call that happens for real, on the thread it really happens on.
+    /// </summary>
+    [Fact]
+    public async Task TheHandleCanBeAskedForFromABackgroundThread()
+    {
+        Window? window = null;
+        wpf.Invoke(() =>
+        {
+            window = new Window { Width = 100, Height = 100, ShowInTaskbar = false };
+            window.Show();
+            Application.Current.MainWindow = window;
+        });
+
+        try
+        {
+            var handle = await Task.Run(EntraAuthentication.ActiveWindowHandle);
+
+            Assert.NotEqual(nint.Zero, handle);
+        }
+        finally
+        {
+            wpf.Invoke(() =>
+            {
+                Application.Current.MainWindow = null;
+                window!.Close();
+            });
+        }
+    }
+}

--- a/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
+++ b/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
@@ -1,0 +1,128 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Saying why Execute cannot be pressed (#117).
+///
+/// It was disabled identically whether the user was not connected, had no script, or had a chain
+/// the app already knew would not restore. Three different problems, one greyed-out button, and
+/// the answer sitting in properties nobody displayed.
+/// </summary>
+public class ExecuteBlockedReasonTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+        new FakeRestoreHistoryStore());
+
+    private async Task<RestoreViewModel> Loaded()
+    {
+        _blob.Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = "FULL/SRV01/MyDb/20260110_220000.bak",
+                BlobUrl = "https://mystorageaccount.blob.core.windows.net/backups/FULL/SRV01/MyDb/20260110_220000.bak",
+                Type = BackupType.Full,
+                InferredServerName = "SRV01",
+                InferredDatabaseName = "MyDb",
+                SizeBytes = 1000,
+                LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+            }
+        ];
+
+        var vm = NewViewModel();
+        vm.SelectedContainer = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        return vm;
+    }
+
+    [Fact]
+    public async Task NotConnectedSaysSo()
+    {
+        var vm = await Loaded();
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        Assert.False(vm.CanPressExecute);
+        Assert.Contains("Connect", vm.ExecuteBlockedReason);
+    }
+
+    [Fact]
+    public async Task ConnectedButWithNoScriptSaysThatInstead()
+    {
+        var vm = await Loaded();
+        vm.IsConnectedToServer = true;
+        vm.TargetDatabaseName = string.Empty;   // no target, so no script
+
+        Assert.False(vm.CanPressExecute);
+        Assert.Contains("No script", vm.ExecuteBlockedReason);
+    }
+
+    [Fact]
+    public async Task AChainThatCannotRestoreSaysThatInstead()
+    {
+        var vm = await Loaded();
+        vm.IsConnectedToServer = true;
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.HasChainErrors = true;
+
+        Assert.False(vm.CanPressExecute);
+        Assert.Contains("cannot restore", vm.ExecuteBlockedReason);
+    }
+
+    [Fact]
+    public async Task NothingIsSaidWhenExecuteIsAvailable()
+    {
+        var vm = await Loaded();
+        vm.IsConnectedToServer = true;
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        Assert.True(vm.CanPressExecute);
+        Assert.False(vm.IsExecuteBlocked);
+        Assert.Empty(vm.ExecuteBlockedReason);
+    }
+
+    /// <summary>The reason has to keep up, or it explains a state the button is no longer in.</summary>
+    [Fact]
+    public async Task TheReasonFollowsTheStateThatCausedIt()
+    {
+        var vm = await Loaded();
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        Assert.Contains("Connect", vm.ExecuteBlockedReason);
+
+        vm.IsConnectedToServer = true;
+        Assert.Empty(vm.ExecuteBlockedReason);
+
+        vm.HasChainErrors = true;
+        Assert.Contains("cannot restore", vm.ExecuteBlockedReason);
+    }
+
+    [Fact]
+    public async Task NothingIsSaidWhileTheRestoreIsRunning()
+    {
+        var vm = await Loaded();
+        vm.IsConnectedToServer = true;
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsExecuting = true;
+
+        // The button is doing its other job here; a "why not" line would be noise.
+        Assert.Empty(vm.ExecuteBlockedReason);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -78,8 +78,17 @@ public sealed class FakeBlobStorageService : IBlobStorageService
 
     public int ListCalls { get; private set; }
 
+    /// <summary>
+    /// The config the ViewModel actually handed over. What is on the form has to reach the service
+    /// intact - the authentication mode failing to make that trip is what shipped broken in #29.
+    /// </summary>
+    public BlobContainerConfig? LastConfig { get; private set; }
+
     public Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
-        => Task.FromResult(true);
+    {
+        LastConfig = config;
+        return Task.FromResult(true);
+    }
 
     public Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default)
         => Task.FromResult(new List<string>());

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -180,10 +180,15 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Every token handed to a verify call, so a test can prove one was passed at all.</summary>
     public List<CancellationToken> VerifyTokens { get; } = [];
 
+    /// <summary>The MOVE clauses the last verification was given (#129).</summary>
+    public List<FileMoveOption> VerifiedWithMoves { get; private set; } = [];
+
     public Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
-        ServerConnection server, IReadOnlyList<string> blobUrls, bool withChecksum = false, CancellationToken ct = default)
+        ServerConnection server, IReadOnlyList<string> blobUrls, bool withChecksum = false,
+        IReadOnlyList<FileMoveOption>? fileMoves = null, CancellationToken ct = default)
     {
         VerifiedUrls.AddRange(blobUrls);
+        VerifiedWithMoves = fileMoves?.ToList() ?? [];
         VerifyTokens.Add(ct);
         OnVerify?.Invoke(ct);
 

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -237,9 +237,15 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Lets a test hold a credential check open, or fail one. Without it the check completes
+    /// synchronously, so the sequencing between two overlapping checks cannot be reached.
+    /// </summary>
+    public Func<string, CancellationToken, Task<BlobCredentialStatus>>? OnCredentialCheck { get; set; }
+
     public Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default)
-        => Task.FromResult(Credential);
+        => OnCredentialCheck?.Invoke(credentialName, ct) ?? Task.FromResult(Credential);
 
     public Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -1,0 +1,195 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// An in-memory <see cref="ICredentialStore"/>. Nothing here reaches the Windows Credential
+/// Manager or the user's config file, which is the whole reason the interface exists (#41).
+/// </summary>
+public sealed class FakeCredentialStore : ICredentialStore
+{
+    private readonly Dictionary<string, (string username, string secret)> _secrets = [];
+
+    public AppConfig Config { get; set; } = new();
+
+    /// <summary>Set to make SaveConfig throw, standing in for a refused or locked config file.</summary>
+    public Exception? SaveConfigThrows { get; set; }
+
+    public int SaveConfigCalls { get; private set; }
+
+    public void SaveSecret(string key, string username, string secret) => _secrets[key] = (username, secret);
+
+    public (string? username, string? secret) ReadSecret(string key)
+        => _secrets.TryGetValue(key, out var v) ? (v.username, v.secret) : (null, null);
+
+    public bool DeleteSecret(string key) => _secrets.Remove(key);
+
+    public List<string> ListCredentialKeys(string prefix)
+        => _secrets.Keys.Where(k => k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    public void SaveSasToken(BlobContainerConfig config, string sasToken)
+        => SaveSecret(BlobKey(config), "sas", sasToken);
+
+    public string? GetSasToken(BlobContainerConfig config)
+        => config.UnsavedSasToken ?? ReadSecret(BlobKey(config)).secret;
+
+    public bool IsSasTokenExpired(BlobContainerConfig config) => false;
+
+    public DateTime? GetSasTokenExpiry(BlobContainerConfig config) => null;
+
+    public SasExpiryInfo ReadSasTokenExpiry(BlobContainerConfig config)
+        => config.ReadSasExpiry(GetSasToken(config));
+
+    public void SaveSqlPassword(ServerConnection connection, string password)
+        => SaveSecret(SqlKey(connection), connection.Username ?? string.Empty, password);
+
+    public string? GetSqlPassword(ServerConnection connection)
+        => connection.UnsavedPassword ?? ReadSecret(SqlKey(connection)).secret;
+
+    public AppConfig LoadConfig() => Config;
+
+    public void SaveConfig(AppConfig config)
+    {
+        SaveConfigCalls++;
+        if (SaveConfigThrows != null) throw SaveConfigThrows;
+        Config = config;
+    }
+
+    private static string BlobKey(BlobContainerConfig c) => $"NineLives:Blob:{c.Id ?? c.Name}";
+    private static string SqlKey(ServerConnection s) => $"NineLives:SQL:{s.Id ?? s.Name}";
+}
+
+/// <summary>
+/// A blob container that exists only in the test. The grouping and summary methods delegate to the
+/// real service - they are pure, and faking them would test the fake rather than the app.
+/// </summary>
+public sealed class FakeBlobStorageService : IBlobStorageService
+{
+    private readonly BlobStorageService _real = new(new FakeCredentialStore());
+
+    public List<BackupFileInfo> Files { get; set; } = [];
+
+    /// <summary>Throw instead of listing, for the failure paths.</summary>
+    public Exception? ListThrows { get; set; }
+
+    /// <summary>The scope the ViewModel pushed down on the last listing.</summary>
+    public BlobListingScope? LastScope { get; private set; }
+
+    public int ListCalls { get; private set; }
+
+    public Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
+        => Task.FromResult(true);
+
+    public Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default)
+        => Task.FromResult(new List<string>());
+
+    public Task<List<BackupFileInfo>> ListBackupFilesAsync(BlobContainerConfig config, CancellationToken ct = default)
+        => ListBackupFilesAsync(config, null, null, ct);
+
+    public Task<List<BackupFileInfo>> ListBackupFilesAsync(
+        BlobContainerConfig config, BlobListingScope? scope, IProgress<int>? progress, CancellationToken ct = default)
+    {
+        ListCalls++;
+        LastScope = scope;
+        ct.ThrowIfCancellationRequested();
+        if (ListThrows != null) throw ListThrows;
+
+        progress?.Report(Files.Count);
+        return Task.FromResult(Files.ToList());
+    }
+
+    public ContainerSummary GetContainerSummary(List<BackupFileInfo> files) => _real.GetContainerSummary(files);
+    public ContainerSummary GetSetBasedSummary(List<BackupSet> sets) => _real.GetSetBasedSummary(sets);
+    public List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files) => _real.GroupIntoBackupSets(files);
+    public List<string> GetDiscoveredDatabases(List<BackupFileInfo> files) => _real.GetDiscoveredDatabases(files);
+    public List<string> GetDiscoveredServers(List<BackupFileInfo> files) => _real.GetDiscoveredServers(files);
+}
+
+/// <summary>
+/// A SQL Server that records what it was asked to do. Nothing opens a connection.
+/// </summary>
+public sealed class FakeSqlServerService : ISqlServerService
+{
+    /// <summary>Every server instance handed to an execute call, in order.</summary>
+    public List<ServerConnection> ExecutedAgainst { get; } = [];
+
+    /// <summary>Every script handed to an execute call, in order.</summary>
+    public List<string> ExecutedScripts { get; } = [];
+
+    public List<string> VerifiedUrls { get; } = [];
+
+    public bool CredentialExists { get; set; } = true;
+    public bool CredentialIsSas { get; set; } = true;
+
+    public VerifyOnlyResult VerifyResult { get; set; } = new(true, "The backup set is valid.");
+
+    public DatabaseRecoveryState RecoveryState { get; set; } = DatabaseRecoveryState.Missing;
+
+    /// <summary>Set to make the restore fail the way a real one does.</summary>
+    public Exception? ExecuteThrows { get; set; }
+
+    public Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult(true);
+
+    public Task<bool?> WouldConnectWithCertificateValidationAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult<bool?>(true);
+
+    public Task<string> GetServerVersionAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult("Microsoft SQL Server 2022");
+
+    public Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult(new List<string>());
+
+    public Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult((@"D:\Data", @"D:\Logs"));
+
+    public Task<DatabaseRecoveryState> GetDatabaseRecoveryStateAsync(
+        ServerConnection server, string databaseName, CancellationToken ct = default)
+        => Task.FromResult(RecoveryState);
+
+    public Task ExecuteRecoveryActionAsync(ServerConnection server, string sql, CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
+        => Task.FromResult(new List<FileMoveOption>());
+
+    public Task<BackupFileInfo?> RestoreHeaderOnlyMultiAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
+        => Task.FromResult<BackupFileInfo?>(null);
+
+    public Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, bool withChecksum = false, CancellationToken ct = default)
+    {
+        VerifiedUrls.AddRange(blobUrls);
+        return Task.FromResult(VerifyResult);
+    }
+
+    public Task ExecuteNonQueryAsync(
+        ServerConnection server, string sql, Action<string>? messageCallback = null, CancellationToken ct = default)
+    {
+        ExecutedAgainst.Add(server);
+        ExecutedScripts.Add(sql);
+        return Task.CompletedTask;
+    }
+
+    public Task ExecuteRestoreWithProgressAsync(
+        ServerConnection server, string sql, Action<string>? messageCallback = null, CancellationToken ct = default)
+    {
+        ExecutedAgainst.Add(server);
+        ExecutedScripts.Add(sql);
+        messageCallback?.Invoke("100 percent processed.");
+        if (ExecuteThrows != null) throw ExecuteThrows;
+        return Task.CompletedTask;
+    }
+
+    public Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+        ServerConnection server, string credentialName, CancellationToken ct = default)
+        => Task.FromResult((CredentialExists, CredentialIsSas));
+
+    public Task<CredentialChange> EnsureCredentialExistsAsync(
+        ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
+        CancellationToken ct = default)
+        => Task.FromResult(CredentialChange.None);
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.Tests;
@@ -101,7 +101,8 @@ public sealed class FakeBlobStorageService : IBlobStorageService
 
     public ContainerSummary GetContainerSummary(List<BackupFileInfo> files) => _real.GetContainerSummary(files);
     public ContainerSummary GetSetBasedSummary(List<BackupSet> sets) => _real.GetSetBasedSummary(sets);
-    public List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files) => _real.GroupIntoBackupSets(files);
+    public List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files, string? backupServerTimeZoneId = null)
+        => _real.GroupIntoBackupSets(files, backupServerTimeZoneId);
     public List<string> GetDiscoveredDatabases(List<BackupFileInfo> files) => _real.GetDiscoveredDatabases(files);
     public List<string> GetDiscoveredServers(List<BackupFileInfo> files) => _real.GetDiscoveredServers(files);
 }

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -106,6 +106,20 @@ public sealed class FakeBlobStorageService : IBlobStorageService
     public List<string> GetDiscoveredServers(List<BackupFileInfo> files) => _real.GetDiscoveredServers(files);
 }
 
+/// <summary>An in-memory restore history, so the tests never touch the real one.</summary>
+public sealed class FakeRestoreHistoryStore : IRestoreHistoryStore
+{
+    public List<RestoreHistoryEntry> Entries { get; } = [];
+
+    public string FilePath => "(in memory)";
+
+    public List<RestoreHistoryEntry> Load() => Entries.ToList();
+
+    public void Append(RestoreHistoryEntry entry) => Entries.Insert(0, entry);
+
+    public void Clear() => Entries.Clear();
+}
+
 /// <summary>
 /// A SQL Server that records what it was asked to do. Nothing opens a connection.
 /// </summary>

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -173,10 +173,23 @@ public sealed class FakeSqlServerService : ISqlServerService
         ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
         => Task.FromResult<BackupFileInfo?>(null);
 
+    /// <summary>Called with the token the viewmodel supplied, so a test can see it was cancellable.</summary>
+    public Action<CancellationToken>? OnVerify { get; set; }
+
+    /// <summary>Every token handed to a verify call, so a test can prove one was passed at all.</summary>
+    public List<CancellationToken> VerifyTokens { get; } = [];
+
     public Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
         ServerConnection server, IReadOnlyList<string> blobUrls, bool withChecksum = false, CancellationToken ct = default)
     {
         VerifiedUrls.AddRange(blobUrls);
+        VerifyTokens.Add(ct);
+        OnVerify?.Invoke(ct);
+
+        // The real service translates a cancelled command into this; the fake has to as well, or a
+        // test would pass against a viewmodel that ignores the token entirely.
+        ct.ThrowIfCancellationRequested();
+
         return Task.FromResult(VerifyResult);
     }
 

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -90,6 +90,13 @@ public sealed class FakeBlobStorageService : IBlobStorageService
         return Task.FromResult(true);
     }
 
+    /// <summary>What DescribeSignedInIdentityAsync should answer.</summary>
+    public string? SignedInIdentity { get; set; }
+
+    public Task<string?> DescribeSignedInIdentityAsync(
+        BlobContainerConfig config, CancellationToken ct = default)
+        => Task.FromResult(config.AuthMode.IsEntra() ? SignedInIdentity : null);
+
     public Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default)
         => Task.FromResult(new List<string>());
 

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -150,8 +150,12 @@ public sealed class FakeSqlServerService : ISqlServerService
 
     public List<string> VerifiedUrls { get; } = [];
 
-    public bool CredentialExists { get; set; } = true;
-    public bool CredentialIsSas { get; set; } = true;
+    /// <summary>What a credential lookup finds. Defaults to the happy path: a SAS credential.</summary>
+    public BlobCredentialStatus Credential { get; set; } =
+        new(BlobCredentialIdentity.SharedAccessSignature, "SHARED ACCESS SIGNATURE");
+
+    /// <summary>Every name a credential write was asked for, so a test can prove none happened.</summary>
+    public List<string> CredentialWrites { get; } = [];
 
     public VerifyOnlyResult VerifyResult { get; set; } = new(true, "The backup set is valid.");
 
@@ -233,12 +237,15 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.CompletedTask;
     }
 
-    public Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+    public Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default)
-        => Task.FromResult((CredentialExists, CredentialIsSas));
+        => Task.FromResult(Credential);
 
     public Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
         CancellationToken ct = default)
-        => Task.FromResult(CredentialChange.None);
+    {
+        CredentialWrites.Add(credentialName);
+        return Task.FromResult(CredentialChange.None);
+    }
 }

--- a/src/NineLives.Tests/NavigationTests.cs
+++ b/src/NineLives.Tests/NavigationTests.cs
@@ -1,0 +1,102 @@
+using System.Windows.Controls.Primitives;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The sidebar (#42).
+///
+/// Navigation is by string, and an unrecognised name falls back to Blob Storage rather than
+/// failing - so a typo in the markup or a name missing from the switch shows up as a button that
+/// quietly goes to the wrong screen. Nothing throws and nothing logs.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class NavigationTests(WpfFixture wpf)
+{
+    [Fact]
+    public void EveryNameInTheListReachesItsOwnView()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+        var reached = new List<object>();
+
+        foreach (var name in MainViewModel.Nav.Views)
+        {
+            vm.NavigateToCommand.Execute(name);
+            Assert.NotNull(vm.CurrentView);
+            Assert.Equal(name, vm.CurrentViewName);
+            reached.Add(vm.CurrentView!);
+        }
+
+        // Distinct, so a name missing from the switch - which silently lands on Blob Storage -
+        // cannot pass by looking like a successful navigation.
+        Assert.Equal(MainViewModel.Nav.Views.Count, reached.Distinct().Count());
+    }
+
+    [Fact]
+    public void AnUnknownNameFallsBackRatherThanCrashing()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.NavigateToCommand.Execute("Not A View");
+
+        Assert.NotNull(vm.CurrentView);
+    }
+
+    /// <summary>
+    /// Every navigation button in the window passes a name the switch actually knows. This is the
+    /// half that a ViewModel test cannot reach: the strings live in XAML, and a mistyped one is
+    /// invisible at build time and silent at runtime.
+    /// </summary>
+    [Fact]
+    public void EverySidebarButtonPassesAKnownName()
+    {
+        wpf.Invoke(() =>
+        {
+            var window = new MainWindow(new MainViewModel(new FakeCredentialStore()));
+            window.ApplyTemplate();
+            window.Measure(new System.Windows.Size(1600, 1200));
+            window.Arrange(new System.Windows.Rect(0, 0, 1600, 1200));
+            window.UpdateLayout();
+
+            var all = FindAll<ButtonBase>(window).ToList();
+
+            // Matched by CommandParameter rather than by Command. The window has never been shown,
+            // so its bindings have not been evaluated and every Command is still null - but a
+            // CommandParameter is a literal set at parse time, and it is the half that can be
+            // mistyped. Nothing else in this window passes a string parameter.
+            var parameters = all
+                .Select(b => b.CommandParameter as string)
+                .Where(p => p != null)
+                .ToList();
+
+            Assert.True(parameters.Count > 0,
+                $"No navigation buttons found. ButtonBase elements in the tree: {all.Count}.");
+            Assert.All(parameters, p => Assert.Contains(p, MainViewModel.Nav.Views));
+
+            // And every view is actually reachable from the sidebar, so adding one to the switch
+            // without adding a button does not go unnoticed either.
+            Assert.Equal(
+                MainViewModel.Nav.Views.OrderBy(n => n),
+                parameters.Distinct().OrderBy(n => n));
+        });
+    }
+
+    /// <summary>
+    /// Walks the LOGICAL tree, not the visual one.
+    ///
+    /// A Window that has never been shown has no visual tree at all - the content is parsed and
+    /// the elements exist, but nothing has been rendered, so VisualTreeHelper finds precisely
+    /// nothing. The logical tree is built at parse time and is what these buttons live in.
+    /// </summary>
+    private static IEnumerable<T> FindAll<T>(System.Windows.DependencyObject root)
+        where T : System.Windows.DependencyObject
+    {
+        foreach (var child in System.Windows.LogicalTreeHelper.GetChildren(root))
+        {
+            if (child is not System.Windows.DependencyObject node) continue;
+            if (node is T match) yield return match;
+            foreach (var descendant in FindAll<T>(node)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives.Tests/PointInTimeViewModelTests.cs
+++ b/src/NineLives.Tests/PointInTimeViewModelTests.cs
@@ -1,0 +1,289 @@
+using System.Globalization;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The point-in-time (STOPAT) target, extracted from RestoreViewModel in #115 seam 3.
+///
+/// None of this had a test. It was ~130 lines in the middle of a 2,500-line class and reaching it
+/// meant a container, a listing, a chain and a selected log restore point - so the rules that decide
+/// whether a restore stops at 14:23:41 or discards the afternoon were only ever checked by hand.
+///
+/// The bounds matter: the target is constrained to the LAST log's window because every earlier log
+/// then applies in full. A target inside an earlier log would need the chain truncated to that log,
+/// or the later logs restore across a gap and fail with error 4305.
+/// </summary>
+public class PointInTimeViewModelTests
+{
+    private static readonly DateTime Earliest = new(2026, 1, 10, 22, 0, 0);
+    private static readonly DateTime Latest = new(2026, 1, 10, 22, 15, 0);
+
+    private static PointInTimeViewModel WithWindow()
+    {
+        var vm = new PointInTimeViewModel();
+        vm.SetWindow((Earliest, Latest));
+        return vm;
+    }
+
+    // ── the window ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AWindowOffersTheTargetPrefilledWithTheLatestUsableTime()
+    {
+        var vm = WithWindow();
+
+        Assert.True(vm.CanUse);
+        Assert.Equal(Earliest, vm.Earliest);
+        Assert.Equal(Latest, vm.Latest);
+        Assert.Equal("2026-01-10 22:15:00", vm.StopAtText);
+
+        // Prefilled but not ticked - showing the bounds is not the same as committing to them.
+        Assert.False(vm.Use);
+        Assert.Contains("Valid range", vm.Message);
+    }
+
+    [Fact]
+    public void NoWindowTurnsTheWholeThingOff()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        // A full or differential restore point: stopping partway through means nothing.
+        vm.SetWindow(null);
+
+        Assert.False(vm.CanUse);
+        Assert.False(vm.Use);
+        Assert.Null(vm.Earliest);
+        Assert.Null(vm.Latest);
+        Assert.Empty(vm.StopAtText);
+        Assert.Null(vm.StopAt);
+        Assert.Empty(vm.Message);
+        Assert.False(vm.HasError);
+        Assert.Null(vm.Effective);
+    }
+
+    /// <summary>
+    /// Moving to a different log has to drop the previous one's tick as well as its bounds. A
+    /// target carried across would be validated against the new window and, if it happened to fall
+    /// inside it, would silently discard transactions nobody asked to discard.
+    /// </summary>
+    [Fact]
+    public void ANewWindowStartsUnticked()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.SetWindow((Earliest.AddHours(1), Latest.AddHours(1)));
+
+        Assert.False(vm.Use);
+        Assert.Null(vm.Effective);
+        Assert.Equal("2026-01-10 23:15:00", vm.StopAtText);
+    }
+
+    // ── bounds ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Exclusive: at exactly the previous set's time nothing from this log has been applied yet,
+    /// which is the EARLIER restore point, not this one.
+    /// </summary>
+    [Fact]
+    public void TheLowerBoundIsExclusive()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:00:00";
+
+        Assert.Null(vm.StopAt);
+        Assert.True(vm.HasError);
+        Assert.Contains("Must be after", vm.Message);
+        Assert.Contains("select an earlier restore point", vm.Message);
+    }
+
+    [Fact]
+    public void OneSecondIntoTheLogIsAccepted()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:00:01";
+
+        Assert.Equal(new DateTime(2026, 1, 10, 22, 0, 1), vm.StopAt);
+        Assert.False(vm.HasError);
+    }
+
+    /// <summary>Inclusive: the end of the log is exactly what restoring the whole log gives.</summary>
+    [Fact]
+    public void TheUpperBoundIsInclusive()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:15:00";
+
+        Assert.Equal(Latest, vm.StopAt);
+        Assert.False(vm.HasError);
+    }
+
+    [Fact]
+    public void OneSecondPastTheEndOfTheLogIsRejected()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:15:01";
+
+        Assert.Null(vm.StopAt);
+        Assert.True(vm.HasError);
+        Assert.Contains("Must be at or before", vm.Message);
+        Assert.Contains("select a later restore point", vm.Message);
+    }
+
+    // ── what was typed ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("2026-01-10 22:10:30")]
+    [InlineData("2026-01-10T22:10:30")]
+    [InlineData("2026-01-10 22:10")]
+    [InlineData("2026-01-10T22:10")]
+    [InlineData("  2026-01-10 22:10:30  ")]
+    public void TheAcceptedShapesAllParse(string text)
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = text;
+
+        Assert.NotNull(vm.StopAt);
+        Assert.False(vm.HasError);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("2026-01-")]
+    [InlineData("10/01/2026 22:10")]
+    [InlineData("yesterday")]
+    public void AnythingElseIsRejectedWithTheShapeItWants(string text)
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = text;
+
+        Assert.Null(vm.StopAt);
+        Assert.True(vm.HasError);
+        Assert.Contains("yyyy-MM-dd HH:mm:ss", vm.Message);
+    }
+
+    /// <summary>
+    /// Parsed invariantly and exactly. A target read as 3 February when the user meant 3 March is a
+    /// month of transactions silently discarded - and 10/01/2026 is a different day in en-US and
+    /// en-GB, so an ambiguous shape is refused outright rather than guessed at.
+    /// </summary>
+    [Fact]
+    public void ADateIsReadTheSameWayWhateverTheMachinesCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+
+            var vm = WithWindow();
+            vm.Use = true;
+            vm.StopAtText = "2026-01-10 22:10:30";
+
+            Assert.Equal(new DateTime(2026, 1, 10, 22, 10, 30), vm.StopAt);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    // ── when it counts as an error ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Half-typed input in a box nobody has ticked is not a reason to block the restore - the box
+    /// is prefilled and editable whether or not STOPAT is being used.
+    /// </summary>
+    [Fact]
+    public void ABadValueIsNotAnErrorUntilItIsBeingUsed()
+    {
+        var vm = WithWindow();
+
+        vm.StopAtText = "2026-01-";
+
+        Assert.Null(vm.StopAt);
+        Assert.False(vm.HasError);
+        Assert.Null(vm.Effective);
+    }
+
+    [Fact]
+    public void TickingTheBoxOverABadValueRaisesTheError()
+    {
+        var vm = WithWindow();
+        vm.StopAtText = "2026-01-";
+        Assert.False(vm.HasError);
+
+        vm.Use = true;
+
+        Assert.True(vm.HasError);
+    }
+
+    [Fact]
+    public void TheMessageSaysWhatWillHappenOnceItIsBeingUsed()
+    {
+        var vm = WithWindow();
+        vm.StopAtText = "2026-01-10 22:10:30";
+        Assert.Contains("Valid range", vm.Message);
+
+        vm.Use = true;
+
+        Assert.Contains("Recovery will stop at 2026-01-10 22:10:30", vm.Message);
+        Assert.Contains("discarded", vm.Message);
+    }
+
+    // ── what reaches the script ─────────────────────────────────────────────────
+
+    [Fact]
+    public void NothingIsGeneratedUntilTheBoxIsTicked()
+    {
+        var vm = WithWindow();
+
+        // A perfectly valid target, sitting in an unticked box.
+        vm.StopAtText = "2026-01-10 22:10:30";
+
+        Assert.NotNull(vm.StopAt);
+        Assert.Null(vm.Effective);
+    }
+
+    [Fact]
+    public void ATickedValidTargetIsWhatGetsGenerated()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 22:10:30";
+
+        Assert.Equal(new DateTime(2026, 1, 10, 22, 10, 30), vm.Effective);
+    }
+
+    /// <summary>
+    /// A ticked box over a rejected target must generate nothing rather than fall back to the whole
+    /// log: the user asked to stop somewhere and silently restoring past it is the failure that
+    /// matters here.
+    /// </summary>
+    [Fact]
+    public void ATickedInvalidTargetGeneratesNothing()
+    {
+        var vm = WithWindow();
+        vm.Use = true;
+
+        vm.StopAtText = "2026-01-10 23:59:59";
+
+        Assert.True(vm.HasError);
+        Assert.Null(vm.Effective);
+    }
+}

--- a/src/NineLives.Tests/QueryCancellationTests.cs
+++ b/src/NineLives.Tests/QueryCancellationTests.cs
@@ -1,0 +1,144 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Stopping a server query that is already running (#111).
+///
+/// `RESTORE VERIFYONLY` reads every byte of every backup in the chain at `CommandTimeout = 0`.
+/// Before this there was no token, no Stop button and no timeout: on a large chain the app was
+/// unresponsive for hours and the only way out was killing the process, which left the reads
+/// running server-side.
+/// </summary>
+public class QueryCancellationTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+        new FakeRestoreHistoryStore());
+
+    private static BackupFileInfo File(string blobName, BackupType type, DateTime stamp)
+        => new()
+        {
+            BlobName = blobName,
+            BlobUrl = $"https://mystorageaccount.blob.core.windows.net/backups/{blobName}",
+            Type = type,
+            InferredServerName = "SRV01",
+            InferredDatabaseName = "MyDb",
+            SizeBytes = 1000,
+            LastModified = new DateTimeOffset(stamp, TimeSpan.Zero)
+        };
+
+    /// <summary>A full plus three logs, so the chain has four sets to verify one at a time.</summary>
+    private async Task<RestoreViewModel> Connected()
+    {
+        _blob.Files =
+        [
+            File("FULL/SRV01/MyDb/20260110_220000.bak", BackupType.Full, T0),
+            File("LOG/SRV01/MyDb/20260110_230000.trn", BackupType.TransactionLog, T0.AddHours(1)),
+            File("LOG/SRV01/MyDb/20260111_000000.trn", BackupType.TransactionLog, T0.AddHours(2)),
+            File("LOG/SRV01/MyDb/20260111_010000.trn", BackupType.TransactionLog, T0.AddHours(3)),
+        ];
+
+        var vm = NewViewModel();
+        vm.SelectedContainer = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        return vm;
+    }
+
+    [Fact]
+    public async Task VerifyIsGivenARealTokenRatherThanNone()
+    {
+        var vm = await Connected();
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.NotEmpty(_sql.VerifyTokens);
+        Assert.All(_sql.VerifyTokens, t => Assert.True(t.CanBeCanceled,
+            "The viewmodel passed CancellationToken.None, so there is nothing a Stop button could do."));
+    }
+
+    [Fact]
+    public async Task StoppingMidVerifyLeavesTheRestUnread()
+    {
+        var vm = await Connected();
+
+        // Stop as soon as the first backup is being read, the way pressing the button would.
+        _sql.OnVerify = _ => vm.CancelQueryCommand.Execute(null);
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        // Four sets in the chain; the first raises the cancel, so nothing after it runs.
+        Assert.Single(_sql.VerifyTokens);
+        Assert.Contains("cancel", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Cancelling is not a failure. Reporting it as one would tell the user their backups are bad
+    /// when all they did was press Stop - the same trap the restore path already guards against.
+    /// </summary>
+    [Fact]
+    public async Task StoppingIsNotReportedAsAVerificationFailure()
+    {
+        var vm = await Connected();
+        _sql.OnVerify = _ => vm.CancelQueryCommand.Execute(null);
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.False(vm.HasError);
+        Assert.False(vm.HasVerifyFailures);
+    }
+
+    [Fact]
+    public async Task TheStopButtonIsOfferedOnlyWhileSomethingIsRunning()
+    {
+        var vm = await Connected();
+
+        Assert.False(vm.CanCancelQuery);
+
+        bool offeredDuring = false;
+        _sql.OnVerify = _ => offeredDuring = vm.CanCancelQuery;
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.True(offeredDuring, "No Stop was offered while the verify was running.");
+        Assert.False(vm.CanCancelQuery);
+    }
+
+    [Fact]
+    public async Task AFinishedVerifyLeavesNothingToCancel()
+    {
+        var vm = await Connected();
+
+        await vm.VerifyChainCommand.ExecuteAsync(null);
+
+        Assert.False(vm.CanCancelQuery);
+        Assert.False(vm.IsCancelling);
+        Assert.Equal(4, _sql.VerifyTokens.Count);
+    }
+}

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -140,8 +140,8 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
         RunOnUi(async () =>
         {
             var (vm, sql) = await ReadyToExecute(server, store);
-            sql.CredentialExists = true;
-            sql.CredentialIsSas = true;
+            sql.Credential = new BlobCredentialStatus(
+                BlobCredentialIdentity.SharedAccessSignature, "SHARED ACCESS SIGNATURE");
             store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
 
             await vm.ExecuteScriptCommand.ExecuteAsync(null);
@@ -149,6 +149,137 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
         });
 
         Assert.Contains("Server state not modified", log);
+    }
+
+    /// <summary>
+    /// The #145 regression, and the reason it mattered.
+    ///
+    /// A managed-identity credential restores perfectly well, but the old check reduced every
+    /// identity to "is it SAS", so this arrived at the same branch as a broken one and was ALTERed -
+    /// which resets IDENTITY. The instance stopped authenticating to that container as itself, and
+    /// so did every other job pointed at the same URL, under the log line "Credential updated on
+    /// the server".
+    /// </summary>
+    [Fact]
+    public void AManagedIdentityCredentialIsLeftAloneRatherThanConvertedToSas()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var store = new FakeCredentialStore();
+        string log = string.Empty;
+        List<string> writes = [];
+        List<string> executed = [];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, store);
+            sql.Credential = new BlobCredentialStatus(
+                BlobCredentialIdentity.ManagedIdentity, "Managed Identity");
+
+            // A SAS token IS stored for the container - that is what made this reachable. Browsing
+            // with one and restoring with the instance's identity is an ordinary pairing.
+            store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+
+            log = vm.Console.Text;
+            writes = sql.CredentialWrites;
+            executed = sql.ExecutedScripts;
+        });
+
+        Assert.Empty(writes);
+        Assert.Contains("Managed Identity", log);
+        Assert.Contains("Server state not modified", log);
+
+        // Left alone, not skipped: the restore still ran.
+        Assert.Single(executed);
+    }
+
+    /// <summary>
+    /// An identity that genuinely cannot serve a restore is still not this app's to overwrite on
+    /// the way past. Converting it is a real option - it is what the button on the panel does -
+    /// but it changes shared state on someone's instance, so it takes a decision rather than a
+    /// side effect of pressing Execute (#145).
+    /// </summary>
+    [Fact]
+    public void AnUnusableCredentialStopsTheRestoreInsteadOfBeingOverwritten()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var store = new FakeCredentialStore();
+        var history = new FakeRestoreHistoryStore();
+        string log = string.Empty;
+        string error = string.Empty;
+        List<string> writes = [];
+        List<string> executed = [];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, store, history);
+            sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql");
+            store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+
+            log = vm.Console.Text;
+            error = vm.ErrorMessage;
+            writes = sql.CredentialWrites;
+            executed = sql.ExecutedScripts;
+        });
+
+        Assert.Empty(writes);
+        Assert.Empty(executed);
+
+        // Named, so it is obvious whether the credential is a mistake or somebody's arrangement.
+        Assert.Contains("MYDOMAIN\\svc_sql", error);
+        Assert.Contains("MYDOMAIN\\svc_sql", log);
+
+        // Nothing was attempted, so this is not an execution to file.
+        Assert.Empty(history.Entries);
+    }
+
+    /// <summary>
+    /// The one case that does still write: nothing of that name exists, so there is nothing to
+    /// destroy and the restore cannot proceed without it.
+    /// </summary>
+    [Fact]
+    public void AMissingCredentialIsStillCreated()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var store = new FakeCredentialStore();
+        List<string> writes = [];
+        List<string> executed = [];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, store);
+            sql.Credential = BlobCredentialStatus.Missing;
+            store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+
+            writes = sql.CredentialWrites;
+            executed = sql.ExecutedScripts;
+        });
+
+        Assert.Single(writes);
+        Assert.Single(executed);
     }
 
     /// <summary>The script that runs is the one on screen, not one rebuilt on the way out.</summary>

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -47,13 +47,15 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
 
     /// <summary>Loads one full backup and arms the execute button, ready to fire.</summary>
     private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> ReadyToExecute(
-        ServerConnection connected, FakeCredentialStore store)
+        ServerConnection connected, FakeCredentialStore store,
+        FakeRestoreHistoryStore? history = null)
     {
         var blob = new FakeBlobStorageService { Files = [FullBackup()] };
         var sql = new FakeSqlServerService();
 
         var vm = new RestoreViewModel(
-            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store, ThrowawayLog())
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            ThrowawayLog(), history ?? new FakeRestoreHistoryStore())
         {
             SelectedContainer = Container()
         };
@@ -202,6 +204,87 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
         });
 
         Assert.True(hasError, "A restore that threw was not reported as a failure.");
+    }
+
+    /// <summary>
+    /// Every execution is filed, so the record exists after the app closes (#31).
+    /// </summary>
+    [Fact]
+    public void ASuccessfulRestoreIsRecordedWithEnoughToPutInATicket()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var history = new FakeRestoreHistoryStore();
+
+        RunOnUi(async () =>
+        {
+            var (vm, _) = await ReadyToExecute(server, new FakeCredentialStore(), history);
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+        });
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(RestoreOutcome.Succeeded, entry.Outcome);
+        Assert.Equal("SRV01", entry.ServerName);
+        Assert.Equal("MyDb_Restored", entry.TargetDatabase);
+        Assert.Contains("RESTORE DATABASE [MyDb_Restored]", entry.Script);
+
+        // The log is captured AFTER the console flush, so it is the whole thing rather than
+        // whatever had escaped the batching buffer at the moment the run ended.
+        Assert.Contains("Restore completed successfully", entry.Log);
+        Assert.True(entry.CompletedAt >= entry.StartedAt);
+    }
+
+    [Fact]
+    public void AFailedRestoreIsRecordedAsFailedWithTheReason()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var history = new FakeRestoreHistoryStore();
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, new FakeCredentialStore(), history);
+            sql.ExecuteThrows = new InvalidOperationException("RESTORE terminating abnormally.");
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+        });
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(RestoreOutcome.Failed, entry.Outcome);
+        Assert.Contains("terminating abnormally", entry.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Pressing Execute once only arms the button. Nothing ran, so nothing belongs in the history -
+    /// otherwise it fills with entries for restores that never happened.
+    /// </summary>
+    [Fact]
+    public void ArmingTheButtonRecordsNothing()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var history = new FakeRestoreHistoryStore();
+
+        RunOnUi(async () =>
+        {
+            await ReadyToExecute(server, new FakeCredentialStore(), history);
+        });
+
+        Assert.Empty(history.Entries);
     }
 
     /// <summary>

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -1,0 +1,235 @@
+using System.Runtime.ExceptionServices;
+using System.Windows.Threading;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The execute path, which needs a WPF Application because it marshals progress onto the
+/// dispatcher and batches console output through a DispatcherTimer.
+///
+/// This is the path where getting it wrong is most expensive - it runs RESTORE against someone's
+/// server - and until the services were behind interfaces (#41) none of it could be tested at all.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class RestoreExecutionViewModelTests(WpfFixture wpf)
+{
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+    };
+
+    private static BackupFileInfo FullBackup() => new()
+    {
+        BlobName = "FULL/SRV01/MyDb/20260110_220000.bak",
+        BlobUrl = "https://mystorageaccount.blob.core.windows.net/backups/FULL/SRV01/MyDb/20260110_220000.bak",
+        Type = BackupType.Full,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = "MyDb",
+        SizeBytes = 1000,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    /// <summary>
+    /// A log in a temp directory. Without this the execute path appends real restore lines to the
+    /// user's actual %LOCALAPPDATA% log - a test writing into the thing someone attaches to a bug
+    /// report.
+    /// </summary>
+    private static OperationLog ThrowawayLog() => new(System.IO.Path.Combine(
+        System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n")));
+
+    /// <summary>Loads one full backup and arms the execute button, ready to fire.</summary>
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> ReadyToExecute(
+        ServerConnection connected, FakeCredentialStore store)
+    {
+        var blob = new FakeBlobStorageService { Files = [FullBackup()] };
+        var sql = new FakeSqlServerService();
+
+        var vm = new RestoreViewModel(
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store, ThrowawayLog())
+        {
+            SelectedContainer = Container()
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = connected;
+
+        // The button arms on the first press and fires on the second.
+        await vm.ExecuteScriptCommand.ExecuteAsync(null);
+        Assert.True(vm.IsExecuteArmed);
+
+        return (vm, sql);
+    }
+
+    /// <summary>
+    /// The #11 regression, now checkable by CI.
+    ///
+    /// Execute used to re-read config.json and take the first entry whose ServerName matched,
+    /// rather than the connection in use. Two entries for one host that differ in authentication -
+    /// a Windows-auth entry and a SQL-auth entry for the same box - is an ordinary setup, and the
+    /// restore would then run under credentials the user never connected with or tested.
+    /// </summary>
+    [Fact]
+    public void TheRestoreRunsAgainstTheConnectionInUseNotOneLookedUpByName()
+    {
+        ServerConnection? executedAgainst = null;
+
+        var windowsAuthEntry = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01 (Windows)",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.WindowsAuth
+        };
+        var sqlAuthEntry = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01 (SQL)",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "restoreadmin"
+        };
+
+        var store = new FakeCredentialStore();
+        // Both entries in the config, the Windows one first - which is what a name lookup returns.
+        store.Config.Servers.Add(windowsAuthEntry);
+        store.Config.Servers.Add(sqlAuthEntry);
+
+        RunOnUi(async () =>
+        {
+            // Connected as the SECOND entry.
+            var (vm, sql) = await ReadyToExecute(sqlAuthEntry, store);
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+            executedAgainst = Assert.Single(sql.ExecutedAgainst);
+        });
+
+        Assert.Same(sqlAuthEntry, executedAgainst);
+        Assert.NotSame(windowsAuthEntry, executedAgainst);
+    }
+
+    /// <summary>
+    /// The #10 regression. A credential is server-scoped, so dropping and recreating it on every
+    /// run removed it out from under anything else relying on it - a backup job writing to the
+    /// same container being the obvious casualty.
+    /// </summary>
+    [Fact]
+    public void AnExistingSasCredentialIsLeftAloneRatherThanRecreated()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        var store = new FakeCredentialStore();
+        string log = string.Empty;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, store);
+            sql.CredentialExists = true;
+            sql.CredentialIsSas = true;
+            store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+            log = vm.ConsoleText;
+        });
+
+        Assert.Contains("Server state not modified", log);
+    }
+
+    /// <summary>The script that runs is the one on screen, not one rebuilt on the way out.</summary>
+    [Fact]
+    public void TheScriptExecutedIsTheScriptThatWasShown()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        string shown = string.Empty, executed = string.Empty;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, new FakeCredentialStore());
+            shown = vm.GeneratedScript;
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+            executed = Assert.Single(sql.ExecutedScripts);
+        });
+
+        Assert.Equal(shown, executed);
+        Assert.Contains("RESTORE DATABASE [MyDb_Restored]", executed);
+    }
+
+    /// <summary>
+    /// A failed restore has to report failure. The FireInfoMessageEventOnUserErrors defect (#6)
+    /// meant the app said "completed successfully" over a total failure; this pins the ViewModel
+    /// half of that contract, which the live SQL tests cannot reach.
+    /// </summary>
+    [Fact]
+    public void AFailedRestoreIsReportedAsAFailure()
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        bool hasError = false;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await ReadyToExecute(server, new FakeCredentialStore());
+            sql.ExecuteThrows = new InvalidOperationException("RESTORE terminating abnormally.");
+
+            await vm.ExecuteScriptCommand.ExecuteAsync(null);
+            hasError = vm.HasError;
+        });
+
+        Assert.True(hasError, "A restore that threw was not reported as a failure.");
+    }
+
+    /// <summary>
+    /// Runs an async body on the WPF thread and waits for it.
+    ///
+    /// Blocking the dispatcher thread with .GetAwaiter().GetResult() would deadlock: the
+    /// ViewModel's awaits resume on that same thread, and it would be sitting in the wait. Pumping
+    /// a DispatcherFrame keeps it processing until the body completes.
+    /// </summary>
+    private void RunOnUi(Func<Task> body)
+    {
+        Exception? captured = null;
+
+        wpf.Invoke(() =>
+        {
+            var frame = new DispatcherFrame();
+
+            _ = body().ContinueWith(
+                t =>
+                {
+                    captured = t.Exception?.GetBaseException();
+                    frame.Continue = false;
+                },
+                TaskScheduler.FromCurrentSynchronizationContext());
+
+            Dispatcher.PushFrame(frame);
+        });
+
+        if (captured != null) ExceptionDispatchInfo.Capture(captured).Throw();
+    }
+}

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -1,4 +1,4 @@
-using System.Runtime.ExceptionServices;
+﻿using System.Runtime.ExceptionServices;
 using System.Windows.Threading;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
@@ -145,7 +145,7 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
             store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
 
             await vm.ExecuteScriptCommand.ExecuteAsync(null);
-            log = vm.ConsoleText;
+            log = vm.Console.Text;
         });
 
         Assert.Contains("Server state not modified", log);

--- a/src/NineLives.Tests/RestoreHistoryTests.cs
+++ b/src/NineLives.Tests/RestoreHistoryTests.cs
@@ -1,0 +1,232 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The record of what was restored, kept so it survives the app closing (#31).
+///
+/// Two properties matter more than the rest: it must never lose entries it already holds, and
+/// recording must never be able to fail the restore it is recording.
+/// </summary>
+public class RestoreHistoryTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-history-tests", Guid.NewGuid().ToString("n"));
+
+    private RestoreHistoryStore Store() => new(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private static RestoreHistoryEntry Entry(string target = "MyDb", RestoreOutcome outcome = RestoreOutcome.Succeeded)
+        => new()
+        {
+            StartedAt = new DateTime(2026, 1, 10, 22, 0, 0),
+            CompletedAt = new DateTime(2026, 1, 10, 22, 4, 30),
+            ServerName = "SRV01",
+            TargetDatabase = target,
+            ChainSummary = "1 Full + 2 Log(s)",
+            Outcome = outcome,
+            Script = "RESTORE DATABASE [MyDb] FROM URL = N'https://mystorageaccount.blob.core.windows.net/backups/x.bak'",
+            Log = "Beginning restore execution..."
+        };
+
+    [Fact]
+    public void NoHistoryYetReadsAsEmptyRatherThanFailing()
+    {
+        Assert.Empty(Store().Load());
+    }
+
+    [Fact]
+    public void AnEntrySurvivesBeingWrittenAndReadBack()
+    {
+        Store().Append(Entry());
+
+        var loaded = Assert.Single(Store().Load());
+        Assert.Equal("MyDb", loaded.TargetDatabase);
+        Assert.Equal("SRV01", loaded.ServerName);
+        Assert.Equal(RestoreOutcome.Succeeded, loaded.Outcome);
+        Assert.Contains("RESTORE DATABASE", loaded.Script);
+    }
+
+    [Fact]
+    public void TheNewestIsFirst()
+    {
+        var store = Store();
+        store.Append(Entry("First"));
+        store.Append(Entry("Second"));
+        store.Append(Entry("Third"));
+
+        var loaded = store.Load();
+        Assert.Equal(["Third", "Second", "First"], loaded.Select(e => e.TargetDatabase));
+    }
+
+    [Fact]
+    public void AnUnreadableHistoryIsLeftAloneRatherThanOverwritten()
+    {
+        // The config-loss shape (#7): read fails, the caller carries on with an empty list, and the
+        // next save writes that over everything. Here the file is left exactly as it was.
+        Directory.CreateDirectory(_dir);
+        var path = Path.Combine(_dir, "restore-history.json");
+        File.WriteAllText(path, "{ this is not the history file }");
+
+        var store = Store();
+        Assert.Empty(store.Load());
+
+        store.Append(Entry());
+
+        Assert.Equal("{ this is not the history file }", File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void AFailureToRecordCannotFailTheRestore()
+    {
+        // A directory where the file should be: every write fails. Append must still return.
+        Directory.CreateDirectory(Path.Combine(_dir, "restore-history.json"));
+
+        var ex = Record.Exception(() => Store().Append(Entry()));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void SecretsAreStrippedOnTheWayIn()
+    {
+        // Redaction happens at the writing boundary, so a future caller cannot leak a token by
+        // forgetting to redact - the same rule OperationLog follows.
+        var entry = Entry();
+        entry.Log = "Using URL https://mystorageaccount.blob.core.windows.net/backups/x.bak?sv=2024-01-01&sig=SECRETVALUE";
+
+        Store().Append(entry);
+
+        var loaded = Assert.Single(Store().Load());
+        Assert.DoesNotContain("SECRETVALUE", loaded.Log);
+    }
+
+    [Fact]
+    public void ClearingRemovesEverything()
+    {
+        var store = Store();
+        store.Append(Entry());
+        store.Clear();
+
+        Assert.Empty(store.Load());
+    }
+
+    [Fact]
+    public void OldEntriesFallOffTheEnd()
+    {
+        var store = Store();
+        for (int i = 0; i < 205; i++) store.Append(Entry($"Db{i}"));
+
+        var loaded = store.Load();
+        Assert.Equal(200, loaded.Count);
+
+        // The ones kept are the recent ones.
+        Assert.Equal("Db204", loaded[0].TargetDatabase);
+        Assert.DoesNotContain(loaded, e => e.TargetDatabase == "Db0");
+    }
+
+    // ── display ─────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0, "<1s")]
+    [InlineData(45, "45s")]
+    [InlineData(90, "1m 30s")]
+    [InlineData(3700, "1h 1m")]
+    public void DurationReadsAtHumanScale(int seconds, string expected)
+    {
+        var entry = Entry();
+        entry.CompletedAt = entry.StartedAt.AddSeconds(seconds);
+
+        Assert.Equal(expected, entry.DurationDisplay);
+    }
+
+    [Fact]
+    public void ARecordFormatsAsASelfContainedDocument()
+    {
+        var text = HistoryViewModel.Format(Entry(outcome: RestoreOutcome.Failed));
+
+        // Everything needed to read it a week later without the app open.
+        Assert.Contains("SRV01", text);
+        Assert.Contains("MyDb", text);
+        Assert.Contains("Failed", text);
+        Assert.Contains("1 Full + 2 Log(s)", text);
+        Assert.Contains("RESTORE DATABASE", text);
+        Assert.Contains("Beginning restore execution", text);
+    }
+
+    // ── the view model over it ──────────────────────────────────────────────────
+
+    [Fact]
+    public void TheViewSelectsTheMostRecentSoItIsWhatYouJustRan()
+    {
+        var store = Store();
+        store.Append(Entry("Older"));
+        store.Append(Entry("Newer"));
+
+        var vm = new HistoryViewModel(store);
+
+        Assert.True(vm.HasEntries);
+        Assert.Equal("Newer", vm.SelectedEntry!.TargetDatabase);
+    }
+
+    [Fact]
+    public void FilteringMatchesDatabaseServerAndOutcome()
+    {
+        var store = Store();
+        store.Append(Entry("Sales"));
+        store.Append(Entry("Payroll", RestoreOutcome.Failed));
+
+        var vm = new HistoryViewModel(store);
+
+        vm.FilterText = "payroll";
+        Assert.Equal("Payroll", Assert.Single(vm.Entries).TargetDatabase);
+
+        vm.FilterText = "failed";
+        Assert.Equal("Payroll", Assert.Single(vm.Entries).TargetDatabase);
+
+        vm.FilterText = "SRV01";
+        Assert.Equal(2, vm.Entries.Count);
+
+        vm.FilterText = "";
+        Assert.Equal(2, vm.Entries.Count);
+    }
+
+    [Fact]
+    public void ClearingTakesTwoPresses()
+    {
+        var store = Store();
+        store.Append(Entry());
+        var vm = new HistoryViewModel(store);
+
+        vm.ClearHistoryCommand.Execute(null);
+        Assert.True(vm.IsClearArmed);
+        Assert.True(vm.HasEntries);            // still there after one press
+
+        vm.ClearHistoryCommand.Execute(null);
+        Assert.False(vm.HasEntries);
+        Assert.Empty(store.Load());
+    }
+
+    [Fact]
+    public void BackingOutOfAClearLeavesTheHistoryAlone()
+    {
+        var store = Store();
+        store.Append(Entry());
+        var vm = new HistoryViewModel(store);
+
+        vm.ClearHistoryCommand.Execute(null);
+        vm.CancelClearCommand.Execute(null);
+
+        Assert.False(vm.IsClearArmed);
+        Assert.Single(store.Load());
+    }
+}

--- a/src/NineLives.Tests/RestoreOptionsViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreOptionsViewModelTests.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The RESTORE options, extracted from RestoreViewModel in #115 seam 7.
+///
+/// The point of the seam is that #110 cannot happen again. Four options - both WITH MOVE paths,
+/// the STANDBY undo file and STATS - reached a release with no change handler at all, so editing
+/// them moved the box on screen and left the generated script alone. People read that script before
+/// running it against production.
+///
+/// Both halves of that bug were "someone has to remember": remember to write a change handler, and
+/// remember to copy the field into the options object three hundred lines away. The subscription
+/// side is structural now - one handler covers every option. The copy side is what
+/// <see cref="EveryOptionOnTheViewModelReachesTheGeneratedOptions"/> pins.
+/// </summary>
+public class RestoreOptionsViewModelTests
+{
+    /// <summary>The options a user can set - the ones Build has to copy.</summary>
+    private static List<PropertyInfo> Settable() =>
+        typeof(RestoreOptionsViewModel)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p is { CanRead: true, CanWrite: true })
+            .ToList();
+
+    /// <summary>Something this property is definitely not already set to.</summary>
+    private static object DistinctFrom(PropertyInfo property, object? current) => current switch
+    {
+        bool b => !b,
+        int i => i + 7,
+        string => $"set-{property.Name}",
+        RecoveryMode m => m == RecoveryMode.Recovery ? RecoveryMode.NoRecovery : RecoveryMode.Recovery,
+        _ => throw new NotSupportedException(
+            $"{property.Name} is a {property.PropertyType.Name}, which this test does not know how " +
+            "to vary. Add a case above so the option is still covered.")
+    };
+
+    /// <summary>
+    /// Every option the user can set has to arrive in the object the script generator reads.
+    ///
+    /// This is the #110 guard, and it is deliberately written by reflection rather than as a list:
+    /// a hand-written list of options is one more thing to remember to update, which is the failure
+    /// it is guarding against. An option added to the ViewModel and not to Build fails here.
+    /// </summary>
+    [Fact]
+    public void EveryOptionOnTheViewModelReachesTheGeneratedOptions()
+    {
+        var vm = new RestoreOptionsViewModel();
+        var options = Settable();
+
+        Assert.NotEmpty(options);
+
+        // Move every option off its default, so a field Build never copies shows up as the
+        // RestoreOptions default rather than what was set.
+        foreach (var p in options)
+            p.SetValue(vm, DistinctFrom(p, p.GetValue(vm)));
+
+        var built = vm.Build("MyDb_Restored", null, []);
+
+        foreach (var p in options)
+        {
+            var onOptions = typeof(RestoreOptions).GetProperty(p.Name);
+            Assert.True(onOptions != null,
+                $"{p.Name} is set on the options screen but has no matching field on " +
+                "RestoreOptions, so nothing can carry it into the generated script.");
+
+            Assert.True(
+                Equals(p.GetValue(vm), onOptions.GetValue(built)),
+                $"{p.Name} never reaches the generated script - RestoreOptionsViewModel.Build " +
+                "does not copy it. This is #110: the box on screen moves and the script does not.");
+        }
+    }
+
+    /// <summary>
+    /// The three things Build takes as arguments are the ones that are NOT options - each is worked
+    /// out somewhere that knows about the chain or the server.
+    /// </summary>
+    [Fact]
+    public void TheTargetTheStopAtAndTheFileMovesComeFromTheCaller()
+    {
+        var moves = new List<FileMoveOption>
+        {
+            new() { LogicalName = "MyDb", PhysicalName = @"C:\Data\MyDb.mdf", NewPhysicalName = @"E:\Data\MyDb.mdf" }
+        };
+        var stopAt = new DateTime(2026, 1, 10, 22, 10, 30);
+
+        var built = new RestoreOptionsViewModel().Build("MyDb_Restored", stopAt, moves);
+
+        Assert.Equal("MyDb_Restored", built.TargetDatabaseName);
+        Assert.Equal(stopAt, built.StopAt);
+        Assert.Same(moves, built.FileMoves);
+    }
+
+    // ── STANDBY ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Blank produced <c>STANDBY = ''</c>, which SQL Server rejects - as the LAST statement of the
+    /// chain, so it failed after SET SINGLE_USER and WITH REPLACE had already dropped and
+    /// overwritten the target.
+    /// </summary>
+    [Fact]
+    public void StandbyWithNoUndoFileIsNotUsable()
+    {
+        var vm = new RestoreOptionsViewModel { RecoveryMode = RecoveryMode.Standby };
+
+        Assert.True(vm.IsStandbyMode);
+        Assert.False(vm.HasStandbyFileIfNeeded);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WhitespaceIsNotAnUndoFile(string path)
+    {
+        var vm = new RestoreOptionsViewModel
+        {
+            RecoveryMode = RecoveryMode.Standby,
+            StandbyFilePath = path
+        };
+
+        Assert.False(vm.HasStandbyFileIfNeeded);
+        Assert.Null(vm.Build("MyDb", null, []).StandbyFilePath);
+    }
+
+    [Fact]
+    public void StandbyWithAnUndoFileIsUsable()
+    {
+        var vm = new RestoreOptionsViewModel
+        {
+            RecoveryMode = RecoveryMode.Standby,
+            StandbyFilePath = @"E:\Standby\MyDb.undo"
+        };
+
+        Assert.True(vm.HasStandbyFileIfNeeded);
+        Assert.Equal(@"E:\Standby\MyDb.undo", vm.Build("MyDb", null, []).StandbyFilePath);
+    }
+
+    /// <summary>The undo file only applies to STANDBY, so the other modes are never blocked by it.</summary>
+    [Theory]
+    [InlineData(RecoveryMode.Recovery)]
+    [InlineData(RecoveryMode.NoRecovery)]
+    public void TheOtherRecoveryModesNeedNoUndoFile(RecoveryMode mode)
+    {
+        var vm = new RestoreOptionsViewModel { RecoveryMode = mode };
+
+        Assert.False(vm.IsStandbyMode);
+        Assert.True(vm.HasStandbyFileIfNeeded);
+    }
+
+    /// <summary>
+    /// Both are computed, so the view needs telling when the things they are computed from move -
+    /// otherwise the undo-file box does not appear when STANDBY is picked.
+    /// </summary>
+    [Fact]
+    public void TheComputedStandbyStateIsAnnouncedWhenItChanges()
+    {
+        var vm = new RestoreOptionsViewModel();
+        var raised = new List<string?>();
+        vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        vm.RecoveryMode = RecoveryMode.Standby;
+
+        Assert.Contains(nameof(RestoreOptionsViewModel.IsStandbyMode), raised);
+        Assert.Contains(nameof(RestoreOptionsViewModel.HasStandbyFileIfNeeded), raised);
+
+        raised.Clear();
+        vm.StandbyFilePath = @"E:\Standby\MyDb.undo";
+
+        Assert.Contains(nameof(RestoreOptionsViewModel.HasStandbyFileIfNeeded), raised);
+    }
+
+    /// <summary>
+    /// One subscription keeps the script in step with every option, so each one has to announce
+    /// itself. An [ObservableProperty] does this for free - this is here so that an option added
+    /// later as a plain property, which would not, is caught.
+    /// </summary>
+    [Fact]
+    public void EveryOptionAnnouncesItsOwnChange()
+    {
+        foreach (var p in Settable())
+        {
+            var vm = new RestoreOptionsViewModel();
+            var raised = new List<string?>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+            p.SetValue(vm, DistinctFrom(p, p.GetValue(vm)));
+
+            Assert.True(raised.Contains(p.Name),
+                $"Changing {p.Name} raised no PropertyChanged for it, so the generated script " +
+                "would not follow it.");
+        }
+    }
+}

--- a/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
+++ b/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
@@ -443,15 +443,15 @@ public class RestoreScriptGeneratorTests
     [Fact]
     public void Generate_NeverEmbedsCredentials()
     {
-        var script = _generator.Generate(FullDiffLogChain(), Options(o =>
-        {
-            o.SasToken = "sv=2026&sig=SECRET";
-            o.CredentialName = "MyCred";
-        }));
+        // The options object no longer carries a SAS token or a credential name at all (#42), so
+        // the strongest thing left to assert is the contract itself: nothing that could carry a
+        // secret reaches the script. WITH CREDENTIAL is separately wrong for a SAS credential -
+        // SQL Server rejects it with Msg 3225 and matches by URL instead (#60).
+        var script = _generator.Generate(FullDiffLogChain(), Options());
 
-        // The generator's contract: no credential or SAS material in the script, ever.
-        Assert.DoesNotContain("SECRET", script);
         Assert.DoesNotContain("CREDENTIAL", script);
+        Assert.DoesNotContain("sig=", script);
+        Assert.DoesNotContain("sv=", script);
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
+++ b/src/NineLives.Tests/RestoreScriptGeneratorTests.cs
@@ -382,6 +382,43 @@ public class RestoreScriptGeneratorTests
     }
 
     [Fact]
+    public void Generate_ChecksumAndContinueAfterError_OffByDefault()
+    {
+        // CONTINUE_AFTER_ERROR produces a database SQL Server has already reported as damaged, and
+        // CHECKSUM fails outright against a backup that was taken without checksums. Neither is a
+        // safe default for a restore that runs unattended.
+        var script = _generator.Generate(FullOnlyChain(), Options());
+
+        Assert.DoesNotContain("CHECKSUM", script);
+        Assert.DoesNotContain("CONTINUE_AFTER_ERROR", script);
+    }
+
+    [Fact]
+    public void Generate_ChecksumAndContinueAfterError_EmittedOnEveryStatementWhenSet()
+    {
+        var script = _generator.Generate(FullDiffLogChain(), Options(o =>
+        {
+            o.WithChecksum = true;
+            o.ContinueAfterError = true;
+        }));
+
+        // Full + diff + two logs. An option applied to only the first statement would leave the
+        // rest of the chain restoring under different rules from the one the user chose.
+        Assert.Equal(4, CountOccurrences(script, "         CHECKSUM,"));
+        Assert.Equal(4, CountOccurrences(script, "         CONTINUE_AFTER_ERROR,"));
+    }
+
+    [Fact]
+    public void Generate_ContinueAfterError_WarnsInTheScriptItself()
+    {
+        // The script gets pasted into SSMS and run by someone who never saw the checkbox.
+        var script = _generator.Generate(FullOnlyChain(), Options(o => o.ContinueAfterError = true));
+
+        Assert.Contains("WARNING: CONTINUE_AFTER_ERROR", script);
+        Assert.Contains("DBCC CHECKDB", script);
+    }
+
+    [Fact]
     public void Generate_HeaderAndFooter_DescribeTheRestore()
     {
         var script = _generator.Generate(FullDiffLogChain(), Options());

--- a/src/NineLives.Tests/RestoreTimelineViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreTimelineViewModelTests.cs
@@ -1,0 +1,439 @@
+using System.Globalization;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The timeline's layout, filters and selection, now that they are their own type rather than 300
+/// lines in the middle of RestoreViewModel (#115 seam 2).
+///
+/// Most of these tests moved here from RestoreViewModelTests, where each one stood up a ViewModel,
+/// a fake blob service and a fake credential store, and awaited a container listing - to assert
+/// where a dot sits on a track. None of that is needed: the timeline is handed restore points and
+/// decides how to show them.
+/// </summary>
+public class RestoreTimelineViewModelTests
+{
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private static BackupSet Set(BackupType type, DateTime timestamp) => new()
+    {
+        Type = type,
+        Timestamp = timestamp,
+        SetId = $"{type}-{timestamp:yyyyMMddHHmmss}",
+        DatabaseName = "MyDb",
+        Files = [new BackupFileInfo { BlobName = "backup.bak", SizeBytes = 1024, Type = type }]
+    };
+
+    private static RestorePoint Point(DateTime timestamp, BackupType type = BackupType.TransactionLog)
+    {
+        var own = Set(type, timestamp);
+        return new RestorePoint
+        {
+            Timestamp = timestamp,
+            Type = type,
+            PrimarySet = own,
+            RequiredFullSet = type == BackupType.Full ? own : Set(BackupType.Full, T0)
+        };
+    }
+
+    /// <summary>A full at T0 plus <paramref name="logCount"/> logs at hourly intervals after it.</summary>
+    private static List<RestorePoint> FullPlusLogs(int logCount)
+    {
+        var points = new List<RestorePoint> { Point(T0, BackupType.Full) };
+        for (int i = 1; i <= logCount; i++) points.Add(Point(T0.AddHours(i)));
+        return points;
+    }
+
+    private static RestoreTimelineViewModel Loaded(int logCount = 3)
+    {
+        var timeline = new RestoreTimelineViewModel();
+        timeline.Load(FullPlusLogs(logCount));
+        return timeline;
+    }
+
+    // ── loading ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void LoadingShowsEveryPointAndSelectsTheMostRecent()
+    {
+        var timeline = Loaded();
+
+        Assert.True(timeline.HasPoints);
+        Assert.True(timeline.HasVisiblePoints);
+        Assert.Equal(4, timeline.Points.Count);
+        Assert.Equal(T0.AddHours(3), timeline.SelectedPoint!.Timestamp);
+    }
+
+    [Fact]
+    public void LoadingNothingLeavesTheTimelineEmpty()
+    {
+        var timeline = new RestoreTimelineViewModel();
+
+        timeline.Load([]);
+
+        Assert.False(timeline.HasPoints);
+        Assert.False(timeline.HasVisiblePoints);
+        Assert.Empty(timeline.Points);
+        Assert.Empty(timeline.CountText);
+    }
+
+    /// <summary>
+    /// Loading a database with no restore points has to drop the selection, not just the points.
+    ///
+    /// Everything downstream hangs off the selected point - the chain, the generated script, the
+    /// verification results. Keeping one belonging to the previous database leaves a complete,
+    /// authoritative-looking RESTORE on screen underneath a timeline that has nothing on it.
+    /// </summary>
+    [Fact]
+    public void LoadingADatabaseWithNoPointsDropsThePreviousSelection()
+    {
+        var timeline = Loaded();
+        Assert.NotNull(timeline.SelectedPoint);
+
+        timeline.Load([]);
+
+        Assert.Null(timeline.SelectedPoint);
+    }
+
+    [Fact]
+    public void ClearingEmptiesEverything()
+    {
+        var timeline = Loaded();
+
+        timeline.Clear();
+
+        Assert.False(timeline.HasPoints);
+        Assert.False(timeline.HasVisiblePoints);
+        Assert.Empty(timeline.Points);
+        Assert.Empty(timeline.Ticks);
+        Assert.Empty(timeline.WindowText);
+        Assert.Empty(timeline.StartText);
+        Assert.Empty(timeline.EndText);
+        Assert.Null(timeline.SelectedPoint);
+    }
+
+    /// <summary>
+    /// A clear has to forget the points as well as hide them, otherwise a filter change afterwards
+    /// brings the previous container's points back.
+    /// </summary>
+    [Fact]
+    public void AFilterChangeAfterAClearBringsNothingBack()
+    {
+        var timeline = Loaded();
+
+        timeline.Clear();
+        timeline.ShowLog = false;
+        timeline.ShowLog = true;
+
+        Assert.Empty(timeline.Points);
+        Assert.Null(timeline.SelectedPoint);
+    }
+
+    // ── layout ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PositionsSpanTheWholeTrack()
+    {
+        var timeline = Loaded();
+
+        var ordered = timeline.Points.OrderBy(p => p.Timestamp).ToList();
+        Assert.Equal(0.0, ordered.First().TimelinePosition, 6);
+        Assert.Equal(1.0, ordered.Last().TimelinePosition, 6);
+
+        // Evenly spaced points must stay evenly spaced, and monotonic.
+        Assert.All(ordered, p => Assert.InRange(p.TimelinePosition, 0.0, 1.0));
+        for (int i = 1; i < ordered.Count; i++)
+            Assert.True(ordered[i].TimelinePosition >= ordered[i - 1].TimelinePosition);
+    }
+
+    [Fact]
+    public void ASinglePointSitsInTheMiddleRatherThanAtZero()
+    {
+        var timeline = Loaded(logCount: 0);
+
+        var only = Assert.Single(timeline.Points);
+        Assert.Equal(0.5, only.TimelinePosition, 6);
+    }
+
+    [Fact]
+    public void PointsTooCloseToDrawSideBySideAreStackedIntoRows()
+    {
+        // 60 hourly logs over a fixed track: the gap between neighbours falls below the separation
+        // the row packer allows, so they cannot all sit on one row.
+        var timeline = Loaded(logCount: 60);
+
+        Assert.True(timeline.Points.Max(p => p.Row) > 0,
+            "Every point was placed on row 0, so they would be drawn on top of each other.");
+
+        // The track grows to fit however many rows were needed, otherwise the upper rows are drawn
+        // outside the control.
+        Assert.True(timeline.TrackHeight > 50);
+    }
+
+    /// <summary>
+    /// The two labels sit at each END of the track, so each one names one end. The right-hand one
+    /// was bound to the whole range - "start to end" - which put the start time at both ends and
+    /// buried the end time in the middle of a label nobody read as a label.
+    /// </summary>
+    [Fact]
+    public void EachEndOfTheTrackIsLabelledWithItsOwnTime()
+    {
+        var timeline = Loaded();
+
+        Assert.Equal("2026-01-10 22:00", timeline.StartText);
+        Assert.Equal("2026-01-11 01:00", timeline.EndText);
+
+        // The whole range, for the header above the track.
+        Assert.Equal("2026-01-10 22:00 to 2026-01-11 01:00", timeline.WindowText);
+    }
+
+    /// <summary>
+    /// Tick marks sit strictly inside the track, so a label does not overprint the start and end
+    /// labels drawn at the ends.
+    /// </summary>
+    [Fact]
+    public void TicksAreLabelledAndSitInsideTheTrack()
+    {
+        var timeline = Loaded();
+
+        Assert.NotEmpty(timeline.Ticks);
+        Assert.All(timeline.Ticks, t =>
+        {
+            Assert.InRange(t.Position, 0.02, 0.98);
+            Assert.NotEmpty(t.Label);
+        });
+    }
+
+    /// <summary>
+    /// The interval suits the span - hours across an afternoon, dates across a month - otherwise a
+    /// year of backups gets an hourly tick every few pixels.
+    /// </summary>
+    [Theory]
+    [InlineData(3, "HH:mm")]      // three hourly logs: within the day
+    [InlineData(24 * 20, "MMM")]  // twenty days: dates
+    public void TheTickIntervalSuitsTheSpan(int logCount, string expectedFormatMarker)
+    {
+        var timeline = Loaded(logCount);
+
+        var label = timeline.Ticks.First().Label;
+        bool looksLikeATime = label.Contains(':');
+
+        Assert.Equal(expectedFormatMarker == "HH:mm", looksLikeATime);
+    }
+
+    [Fact]
+    public void ASinglePointHasNoTicksToDraw()
+    {
+        var timeline = Loaded(logCount: 0);
+
+        Assert.Empty(timeline.Ticks);
+    }
+
+    // ── narrowing the points (#27) ──────────────────────────────────────────────
+
+    [Fact]
+    public void TurningOffATypeRemovesThosePointsFromBothSelectors()
+    {
+        var timeline = Loaded();
+        Assert.Equal(4, timeline.Points.Count);
+
+        timeline.ShowLog = false;
+
+        // The list and the timeline are the same collection, so this is both.
+        var only = Assert.Single(timeline.Points);
+        Assert.Equal(BackupType.Full, only.Type);
+        Assert.Contains("Showing 1 of 4", timeline.CountText);
+    }
+
+    [Fact]
+    public void ADateRangeNarrowsToTheWindowAsked()
+    {
+        var timeline = Loaded(logCount: 5);
+
+        timeline.FromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
+        timeline.ToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Equal(3, timeline.Points.Count);
+        Assert.All(timeline.Points, p => Assert.InRange(p.Timestamp, T0.AddHours(2), T0.AddHours(4)));
+    }
+
+    /// <summary>
+    /// The point of the range: the surviving points spread across the whole track rather than
+    /// staying bunched in the sliver they occupied before. Without this it filters but does not
+    /// zoom, and picking one of them is no easier than it was.
+    /// </summary>
+    [Fact]
+    public void NarrowingTheRangeSpreadsTheRemainingPointsAcrossTheTrack()
+    {
+        var timeline = Loaded(logCount: 20);
+
+        var before = timeline.Points
+            .Where(p => p.Timestamp >= T0.AddHours(2) && p.Timestamp <= T0.AddHours(4))
+            .Select(p => p.TimelinePosition)
+            .ToList();
+
+        // Before narrowing, three of twenty-one points sit inside a tenth of the track.
+        Assert.True(before.Max() - before.Min() < 0.2);
+
+        timeline.FromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
+        timeline.ToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+
+        var after = timeline.Points.Select(p => p.TimelinePosition).ToList();
+        Assert.Equal(0.0, after.Min(), 6);
+        Assert.Equal(1.0, after.Max(), 6);
+    }
+
+    [Fact]
+    public void AHalfTypedDateDoesNotBlankTheTimeline()
+    {
+        var timeline = Loaded();
+
+        // Mid-keystroke. Unparsable means no bound rather than an error.
+        timeline.FromText = "2026-01-";
+
+        Assert.Equal(4, timeline.Points.Count);
+        Assert.Null(timeline.From);
+    }
+
+    [Fact]
+    public void ADateIsReadTheSameWayWhateverTheMachinesCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            // en-US would read 02/03 as February; en-GB as March. The box is documented as
+            // yyyy-MM-dd, which is unambiguous, and it is parsed invariantly so it stays that way.
+            CultureInfo.CurrentCulture = new CultureInfo("en-US");
+
+            var timeline = Loaded();
+            timeline.FromText = "2026-01-10 23:30:00";
+
+            Assert.Equal(new DateTime(2026, 1, 10, 23, 30, 0), timeline.From);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void AFilterThatMatchesNothingSaysSoRatherThanLookingEmpty()
+    {
+        var timeline = Loaded();
+
+        timeline.ShowFull = false;
+        timeline.ShowLog = false;
+        timeline.ShowDiff = false;
+
+        Assert.Empty(timeline.Points);
+        Assert.False(timeline.HasVisiblePoints);
+
+        // Still true - the database HAS restore points, they are just all filtered out. The two are
+        // different states and the view shows different things for them.
+        Assert.True(timeline.HasPoints);
+    }
+
+    [Fact]
+    public void AnExistingSelectionSurvivesAFilterThatStillIncludesIt()
+    {
+        var timeline = Loaded(logCount: 5);
+
+        var chosen = timeline.Points.First(p => p.Timestamp == T0.AddHours(2));
+        timeline.SelectedPoint = chosen;
+
+        // Narrow to a window that still contains it.
+        timeline.FromText = T0.AddHours(1).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Same(chosen, timeline.SelectedPoint);
+    }
+
+    [Fact]
+    public void ZoomToDayNarrowsToTheSelectedPointsDay()
+    {
+        // Two days of hourly logs. T0 is 22:00, so they cross midnight - the day being zoomed to is
+        // the selected point's, not the first point's.
+        var timeline = Loaded(logCount: 30);
+
+        var chosen = timeline.Points.First(p => p.Timestamp == T0.AddHours(5));
+        timeline.SelectedPoint = chosen;
+        timeline.ZoomToSelectedDayCommand.Execute(null);
+
+        Assert.All(timeline.Points, p => Assert.Equal(chosen.Timestamp.Date, p.Timestamp.Date));
+        Assert.True(timeline.Points.Count < 31);
+        Assert.Contains(timeline.Points, p => p.Timestamp == chosen.Timestamp);
+    }
+
+    [Fact]
+    public void ZoomToDayWithNothingSelectedChangesNothing()
+    {
+        var timeline = Loaded();
+        timeline.SelectedPoint = null;
+
+        timeline.ZoomToSelectedDayCommand.Execute(null);
+
+        Assert.Equal(4, timeline.Points.Count);
+        Assert.Empty(timeline.FromText);
+    }
+
+    [Fact]
+    public void ResetPutsEveryPointBack()
+    {
+        var timeline = Loaded(logCount: 5);
+
+        // Logs off leaves only the full, which sits before the range - so nothing at all.
+        timeline.ShowLog = false;
+        timeline.FromText = T0.AddHours(3).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Empty(timeline.Points);
+
+        timeline.ResetFiltersCommand.Execute(null);
+
+        Assert.Equal(6, timeline.Points.Count);
+        Assert.Equal(string.Empty, timeline.FromText);
+        Assert.True(timeline.ShowLog);
+    }
+
+    [Fact]
+    public void LoadingAgainDoesNotInheritThePreviousFilters()
+    {
+        // A range typed for one database would silently hide points belonging to the next.
+        var timeline = Loaded(logCount: 5);
+        timeline.FromText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Equal(2, timeline.Points.Count);
+
+        timeline.Load(FullPlusLogs(5));
+
+        Assert.Equal(6, timeline.Points.Count);
+        Assert.Equal(string.Empty, timeline.FromText);
+    }
+
+    // ── selection ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ClickingADotSelectsIt()
+    {
+        var timeline = Loaded();
+        var chosen = timeline.Points.First();
+
+        timeline.SelectPointCommand.Execute(chosen);
+
+        Assert.Same(chosen, timeline.SelectedPoint);
+    }
+
+    /// <summary>
+    /// The dot command is bound to every item in an ItemsControl, so it is worth being sure a null
+    /// parameter cannot clear the selection out from under the chain that was built for it.
+    /// </summary>
+    [Fact]
+    public void SelectingNothingLeavesTheSelectionAlone()
+    {
+        var timeline = Loaded();
+        var before = timeline.SelectedPoint;
+
+        timeline.SelectPointCommand.Execute(null);
+
+        Assert.Same(before, timeline.SelectedPoint);
+    }
+}

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -210,6 +210,80 @@ public class RestoreViewModelTests
         Assert.False(vm.IsExecuteArmed);
     }
 
+    // ── point in time (#115 seam 3) ─────────────────────────────────────────────
+
+    /// <summary>
+    /// The wiring between the STOPAT box and the script. The rules themselves are pinned in
+    /// PointInTimeViewModelTests; this is the part that has to reach the RESTORE that runs.
+    /// </summary>
+    [Fact]
+    public async Task ATickedPointInTimeTargetReachesTheGeneratedScript()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        // The latest point is a log, so stopping partway through it is meaningful.
+        Assert.True(vm.PointInTime.CanUse);
+        Assert.DoesNotContain("STOPAT", vm.GeneratedScript);
+
+        vm.PointInTime.Use = true;
+        vm.PointInTime.StopAtText = T0.AddHours(2).AddMinutes(30).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Contains("STOPAT = '2026-01-11T00:30:00'", vm.GeneratedScript);
+    }
+
+    /// <summary>
+    /// A ticked box over a rejected target leaves no script at all. Falling back to the whole log
+    /// would restore past the moment someone explicitly asked to stop at, which is the failure that
+    /// matters - and a script that quietly ignores the box above it is exactly the stale-script
+    /// problem.
+    /// </summary>
+    [Fact]
+    public async Task ATickedButInvalidPointInTimeTargetLeavesNoScript()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        Assert.NotEmpty(vm.GeneratedScript);
+
+        vm.PointInTime.Use = true;
+        vm.PointInTime.StopAtText = "well after the end of the log";
+
+        Assert.Empty(vm.GeneratedScript);
+        Assert.False(vm.HasScript);
+    }
+
+    /// <summary>
+    /// Selecting a full or differential point takes the STOPAT box away with it - there is no log
+    /// to stop partway through - and the script must lose the STOPAT too.
+    /// </summary>
+    [Fact]
+    public async Task MovingToANonLogPointDropsThePointInTimeTarget()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        vm.PointInTime.Use = true;
+        vm.PointInTime.StopAtText = T0.AddHours(2).AddMinutes(30).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Contains("STOPAT", vm.GeneratedScript);
+
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.First(p => p.Type == BackupType.Full);
+
+        Assert.False(vm.PointInTime.CanUse);
+        Assert.False(vm.PointInTime.Use);
+        Assert.Null(vm.PointInTime.Effective);
+        Assert.NotEmpty(vm.GeneratedScript);
+        Assert.DoesNotContain("STOPAT", vm.GeneratedScript);
+    }
+
     // ── changing database ───────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -1,0 +1,258 @@
+﻿using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The first tests of a ViewModel rather than a service (#41).
+///
+/// Everything here used to be unreachable from a test: the ViewModels built their own
+/// <c>BlobStorageService</c>, <c>SqlServerService</c> and <c>CredentialStore</c>, so exercising any
+/// of it meant a real container, a real instance and the user's own credential vault. That is why
+/// the restore executing against a name-resolved server, and the credential being recreated on
+/// every run, both reached a release unnoticed.
+///
+/// Nothing in this file touches the network, a SQL Server, the credential vault or the config file.
+/// </summary>
+public class RestoreViewModelTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))));
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private static BackupFileInfo File(string blobName, BackupType type, DateTime lastModified)
+        => new()
+        {
+            BlobName = blobName,
+            BlobUrl = $"https://mystorageaccount.blob.core.windows.net/backups/{blobName}",
+            Type = type,
+            InferredServerName = "SRV01",
+            InferredDatabaseName = "MyDb",
+            SizeBytes = 1000,
+            LastModified = new DateTimeOffset(lastModified, TimeSpan.Zero)
+        };
+
+    /// <summary>A full at T0 plus <paramref name="logCount"/> logs at hourly intervals after it.</summary>
+    private static List<BackupFileInfo> FullPlusLogs(int logCount)
+    {
+        var files = new List<BackupFileInfo>
+        {
+            File("FULL/SRV01/MyDb/20260110_220000.bak", BackupType.Full, T0)
+        };
+
+        for (int i = 1; i <= logCount; i++)
+        {
+            var stamp = T0.AddHours(i);
+            files.Add(File(
+                $"LOG/SRV01/MyDb/{stamp:yyyyMMdd_HHmmss}.trn",
+                BackupType.TransactionLog,
+                stamp));
+        }
+
+        return files;
+    }
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+    };
+
+    // ── loading and chain selection ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task LoadingBuildsRestorePointsAndSelectsTheMostRecent()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.True(vm.BackupsLoaded);
+        Assert.True(vm.HasRestorePoints);
+
+        // A full plus three logs: the full itself, then one point per log.
+        Assert.Equal(4, vm.RestorePoints.Count);
+
+        // The default selection is the latest point, which is what someone restoring after an
+        // incident almost always wants.
+        Assert.Equal(T0.AddHours(3), vm.SelectedRestorePoint!.Timestamp);
+        Assert.True(vm.HasValidChain);
+    }
+
+    [Fact]
+    public async Task SelectingAPointBuildsTheChainThatReachesIt()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // The second log: full + the logs up to and including it, and nothing after.
+        vm.SelectedRestorePoint = vm.RestorePoints.Single(
+            p => p.Timestamp == T0.AddHours(2) && p.Type == BackupType.TransactionLog);
+
+        Assert.NotNull(vm.RestoreChain);
+        Assert.Equal(BackupType.Full, vm.RestoreChain!.FullSet.Type);
+        Assert.Equal(2, vm.RestoreChain.LogSets.Count);
+        Assert.DoesNotContain(vm.RestoreChain.LogSets, s => s.Timestamp > T0.AddHours(2));
+    }
+
+    [Fact]
+    public async Task ChangingTheSelectionRegeneratesTheScriptForTheNewChain()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        vm.SelectedRestorePoint = vm.RestorePoints.First(p => p.Type == BackupType.Full);
+        var fullOnly = vm.GeneratedScript;
+
+        vm.SelectedRestorePoint = vm.RestorePoints.Last();
+        var withLogs = vm.GeneratedScript;
+
+        Assert.DoesNotContain("RESTORE LOG", fullOnly);
+        Assert.Contains("RESTORE LOG", withLogs);
+    }
+
+    [Fact]
+    public async Task AContainerWithNoFullBackupOffersNoRestorePointAndSaysWhy()
+    {
+        var vm = NewViewModel();
+        _blob.Files =
+        [
+            File("LOG/SRV01/MyDb/20260110_230000.trn", BackupType.TransactionLog, T0.AddHours(1))
+        ];
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.False(vm.HasRestorePoints);
+
+        // The explanation has to survive the rest of the load. It used to be overwritten by
+        // "Loaded 1 files in 1 backup set(s)...", leaving an empty timeline and a status bar
+        // reporting success.
+        Assert.True(vm.HasError);
+        Assert.Contains("full backup", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+
+        // And the inventory panel says the same thing in the place that persists.
+        Assert.True(vm.HasInventoryIssues);
+    }
+
+    // ── timeline maths ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TimelinePositionsSpanTheWholeTrack()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        var ordered = vm.RestorePoints.OrderBy(p => p.Timestamp).ToList();
+        Assert.Equal(0.0, ordered.First().TimelinePosition, 6);
+        Assert.Equal(1.0, ordered.Last().TimelinePosition, 6);
+
+        // Evenly spaced points must stay evenly spaced, and monotonic.
+        Assert.All(ordered, p => Assert.InRange(p.TimelinePosition, 0.0, 1.0));
+        for (int i = 1; i < ordered.Count; i++)
+            Assert.True(ordered[i].TimelinePosition >= ordered[i - 1].TimelinePosition);
+    }
+
+    [Fact]
+    public async Task ASinglePointSitsInTheMiddleRatherThanAtZero()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(0);
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        var only = Assert.Single(vm.RestorePoints);
+        Assert.Equal(0.5, only.TimelinePosition, 6);
+    }
+
+    [Fact]
+    public async Task PointsTooCloseToDrawSideBySideAreStackedIntoRows()
+    {
+        var vm = NewViewModel();
+
+        // 60 hourly logs over a fixed track: the gap between neighbours falls below the
+        // separation the row packer allows, so they cannot all sit on one row.
+        _blob.Files = FullPlusLogs(60);
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.True(vm.RestorePoints.Max(p => p.Row) > 0,
+            "Every point was placed on row 0, so they would be drawn on top of each other.");
+
+        // The track grows to fit however many rows were needed, otherwise the upper rows are
+        // drawn outside the control.
+        Assert.True(vm.TimelineHeight > 50);
+    }
+
+    // ── filtering ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PickingADatabaseNarrowsTheNextListingToItRatherThanRescanningEverything()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(1);
+        vm.SelectedContainer = Container();
+
+        // First load has no selection yet and must scan the whole container - the server and
+        // database lists are built from what it finds.
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        Assert.Null(_blob.LastScope);
+
+        vm.SelectedDatabaseName = "MyDb";
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.NotNull(_blob.LastScope);
+        Assert.Equal("MyDb", _blob.LastScope!.DatabaseName);
+        Assert.Equal("SRV01", _blob.LastScope.ServerName);
+    }
+
+    [Fact]
+    public async Task AnInstanceScopesToItsHostBecauseThatIsWhatThePathHolds()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(1);
+        foreach (var f in _blob.Files) f.InferredInstanceName = "PROD";
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.SelectedDatabaseName = "MyDb";
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // "SRV01\PROD" lives under "SRV01" in the container layout.
+        Assert.Equal("SRV01", _blob.LastScope!.ServerName);
+    }
+
+    [Fact]
+    public async Task AFailedListingSaysSoAndLeavesNothingLoaded()
+    {
+        var vm = NewViewModel();
+        _blob.ListThrows = new InvalidOperationException("No SAS token found.");
+        vm.SelectedContainer = Container();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.False(vm.BackupsLoaded);
+        Assert.Contains("No SAS token found.", vm.StatusMessage);
+    }
+}

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -28,14 +28,15 @@ public class RestoreViewModelTests
 
     private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
 
-    private static BackupFileInfo File(string blobName, BackupType type, DateTime lastModified)
+    private static BackupFileInfo File(
+        string blobName, BackupType type, DateTime lastModified, string database = "MyDb")
         => new()
         {
             BlobName = blobName,
             BlobUrl = $"https://mystorageaccount.blob.core.windows.net/backups/{blobName}",
             Type = type,
             InferredServerName = "SRV01",
-            InferredDatabaseName = "MyDb",
+            InferredDatabaseName = database,
             SizeBytes = 1000,
             LastModified = new DateTimeOffset(lastModified, TimeSpan.Zero)
         };
@@ -79,14 +80,14 @@ public class RestoreViewModelTests
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
         Assert.True(vm.BackupsLoaded);
-        Assert.True(vm.HasRestorePoints);
+        Assert.True(vm.Timeline.HasPoints);
 
         // A full plus three logs: the full itself, then one point per log.
-        Assert.Equal(4, vm.RestorePoints.Count);
+        Assert.Equal(4, vm.Timeline.Points.Count);
 
         // The default selection is the latest point, which is what someone restoring after an
         // incident almost always wants.
-        Assert.Equal(T0.AddHours(3), vm.SelectedRestorePoint!.Timestamp);
+        Assert.Equal(T0.AddHours(3), vm.Timeline.SelectedPoint!.Timestamp);
         Assert.True(vm.HasValidChain);
     }
 
@@ -99,7 +100,7 @@ public class RestoreViewModelTests
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
         // The second log: full + the logs up to and including it, and nothing after.
-        vm.SelectedRestorePoint = vm.RestorePoints.Single(
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Single(
             p => p.Timestamp == T0.AddHours(2) && p.Type == BackupType.TransactionLog);
 
         Assert.NotNull(vm.RestoreChain);
@@ -117,10 +118,10 @@ public class RestoreViewModelTests
         await vm.LoadBackupsCommand.ExecuteAsync(null);
         vm.TargetDatabaseName = "MyDb_Restored";
 
-        vm.SelectedRestorePoint = vm.RestorePoints.First(p => p.Type == BackupType.Full);
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.First(p => p.Type == BackupType.Full);
         var fullOnly = vm.GeneratedScript;
 
-        vm.SelectedRestorePoint = vm.RestorePoints.Last();
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Last();
         var withLogs = vm.GeneratedScript;
 
         Assert.DoesNotContain("RESTORE LOG", fullOnly);
@@ -139,7 +140,7 @@ public class RestoreViewModelTests
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        Assert.False(vm.HasRestorePoints);
+        Assert.False(vm.Timeline.HasPoints);
 
         // The explanation has to survive the rest of the load. It used to be overwritten by
         // "Loaded 1 files in 1 backup set(s)...", leaving an empty timeline and a status bar
@@ -149,60 +150,6 @@ public class RestoreViewModelTests
 
         // And the inventory panel says the same thing in the place that persists.
         Assert.True(vm.HasInventoryIssues);
-    }
-
-    // ── timeline maths ──────────────────────────────────────────────────────────
-
-    [Fact]
-    public async Task TimelinePositionsSpanTheWholeTrack()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(3);
-        vm.SelectedContainer = Container();
-
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        var ordered = vm.RestorePoints.OrderBy(p => p.Timestamp).ToList();
-        Assert.Equal(0.0, ordered.First().TimelinePosition, 6);
-        Assert.Equal(1.0, ordered.Last().TimelinePosition, 6);
-
-        // Evenly spaced points must stay evenly spaced, and monotonic.
-        Assert.All(ordered, p => Assert.InRange(p.TimelinePosition, 0.0, 1.0));
-        for (int i = 1; i < ordered.Count; i++)
-            Assert.True(ordered[i].TimelinePosition >= ordered[i - 1].TimelinePosition);
-    }
-
-    [Fact]
-    public async Task ASinglePointSitsInTheMiddleRatherThanAtZero()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(0);
-        vm.SelectedContainer = Container();
-
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        var only = Assert.Single(vm.RestorePoints);
-        Assert.Equal(0.5, only.TimelinePosition, 6);
-    }
-
-    [Fact]
-    public async Task PointsTooCloseToDrawSideBySideAreStackedIntoRows()
-    {
-        var vm = NewViewModel();
-
-        // 60 hourly logs over a fixed track: the gap between neighbours falls below the
-        // separation the row packer allows, so they cannot all sit on one row.
-        _blob.Files = FullPlusLogs(60);
-        vm.SelectedContainer = Container();
-
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        Assert.True(vm.RestorePoints.Max(p => p.Row) > 0,
-            "Every point was placed on row 0, so they would be drawn on top of each other.");
-
-        // The track grows to fit however many rows were needed, otherwise the upper rows are
-        // drawn outside the control.
-        Assert.True(vm.TimelineHeight > 50);
     }
 
     // ── changing container ──────────────────────────────────────────────────────
@@ -224,15 +171,15 @@ public class RestoreViewModelTests
         vm.TargetDatabaseName = "MyDb_Restored";
 
         Assert.True(vm.BackupsLoaded);
-        Assert.NotEmpty(vm.RestorePoints);
+        Assert.NotEmpty(vm.Timeline.Points);
         Assert.NotEmpty(vm.GeneratedScript);
 
         vm.SelectedContainer = Container();   // a different container
 
         Assert.False(vm.BackupsLoaded);
-        Assert.Empty(vm.RestorePoints);
-        Assert.False(vm.HasRestorePoints);
-        Assert.Null(vm.SelectedRestorePoint);
+        Assert.Empty(vm.Timeline.Points);
+        Assert.False(vm.Timeline.HasPoints);
+        Assert.Null(vm.Timeline.SelectedPoint);
         Assert.Null(vm.RestoreChain);
         Assert.Empty(vm.GeneratedScript);
         Assert.False(vm.HasScript);
@@ -263,187 +210,48 @@ public class RestoreViewModelTests
         Assert.False(vm.IsExecuteArmed);
     }
 
-    // ── narrowing the restore points (#27) ──────────────────────────────────────
-
-    [Fact]
-    public async Task TurningOffATypeRemovesThosePointsFromBothSelectors()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(3);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        Assert.Equal(4, vm.RestorePoints.Count);
-
-        vm.ShowLogPoints = false;
-
-        // The list and the timeline are the same collection, so this is both.
-        var only = Assert.Single(vm.RestorePoints);
-        Assert.Equal(BackupType.Full, only.Type);
-        Assert.Contains("Showing 1 of 4", vm.PointCountText);
-    }
-
-    [Fact]
-    public async Task ADateRangeNarrowsToTheWindowAsked()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(5);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        vm.PointsFromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
-        vm.PointsToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
-
-        Assert.Equal(3, vm.RestorePoints.Count);
-        Assert.All(vm.RestorePoints, p => Assert.InRange(p.Timestamp, T0.AddHours(2), T0.AddHours(4)));
-    }
+    // ── changing database ───────────────────────────────────────────────────────
 
     /// <summary>
-    /// The point of the range: the surviving points spread across the whole track rather than
-    /// staying bunched in the sliver they occupied before. Without this it filters but does not
-    /// zoom, and picking one of them is no easier than it was.
+    /// Switching to a database with no restore points has to take the chain and the script with it.
+    ///
+    /// It did not. The timeline emptied and the error appeared, but the selected point belonged to
+    /// the previous database and nothing cleared it - so a complete RESTORE stayed on screen,
+    /// naming the previous database's backups, underneath a timeline with nothing on it and a
+    /// message saying there was nothing to restore to. Found while splitting the timeline out
+    /// (#115 seam 2).
+    ///
+    /// A database with logs but no full is not a contrived setup: it is what a container looks like
+    /// when the fulls have aged out of the retention window.
     /// </summary>
     [Fact]
-    public async Task NarrowingTheRangeSpreadsTheRemainingPointsAcrossTheTrack()
+    public async Task SwitchingToADatabaseWithNoRestorePointsClearsTheChainAndTheScript()
     {
         var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(20);
+        _blob.Files =
+        [
+            .. FullPlusLogs(3),
+            File("LOG/SRV01/OtherDb/20260110_230000.trn", BackupType.TransactionLog, T0.AddHours(1), "OtherDb"),
+            File("LOG/SRV01/OtherDb/20260111_000000.trn", BackupType.TransactionLog, T0.AddHours(2), "OtherDb")
+        ];
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        var before = vm.RestorePoints
-            .Where(p => p.Timestamp >= T0.AddHours(2) && p.Timestamp <= T0.AddHours(4))
-            .Select(p => p.TimelinePosition)
-            .ToList();
+        Assert.NotNull(vm.Timeline.SelectedPoint);
+        Assert.NotEmpty(vm.GeneratedScript);
 
-        // Before narrowing, three of twenty-one points sit inside a tenth of the track.
-        Assert.True(before.Max() - before.Min() < 0.2);
+        // OtherDb has logs but no full, so there is nothing it can be restored to.
+        vm.SelectedDatabaseName = "OtherDb";
 
-        vm.PointsFromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
-        vm.PointsToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
-
-        var after = vm.RestorePoints.Select(p => p.TimelinePosition).ToList();
-        Assert.Equal(0.0, after.Min(), 6);
-        Assert.Equal(1.0, after.Max(), 6);
+        Assert.Empty(vm.Timeline.Points);
+        Assert.Null(vm.Timeline.SelectedPoint);
+        Assert.Null(vm.RestoreChain);
+        Assert.Empty(vm.GeneratedScript);
+        Assert.False(vm.HasScript);
+        Assert.True(vm.HasError);
     }
 
-    [Fact]
-    public async Task AHalfTypedDateDoesNotBlankTheTimeline()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(3);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        // Mid-keystroke. Unparsable means no bound rather than an error.
-        vm.PointsFromText = "2026-01-";
-
-        Assert.Equal(4, vm.RestorePoints.Count);
-        Assert.Null(vm.PointsFrom);
-    }
-
-    [Fact]
-    public async Task ADateIsReadTheSameWayWhateverTheMachinesCulture()
-    {
-        var original = System.Globalization.CultureInfo.CurrentCulture;
-        try
-        {
-            // en-US would read 02/03 as February; en-GB as March. The box is documented as
-            // yyyy-MM-dd, which is unambiguous, and it is parsed invariantly so it stays that way.
-            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("en-US");
-
-            var vm = NewViewModel();
-            _blob.Files = FullPlusLogs(3);
-            vm.SelectedContainer = Container();
-            await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-            vm.PointsFromText = "2026-01-10 23:30:00";
-
-            Assert.Equal(new DateTime(2026, 1, 10, 23, 30, 0), vm.PointsFrom);
-        }
-        finally
-        {
-            System.Globalization.CultureInfo.CurrentCulture = original;
-        }
-    }
-
-    [Fact]
-    public async Task AFilterThatMatchesNothingSaysSoRatherThanLookingEmpty()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(3);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        vm.ShowFullPoints = false;
-        vm.ShowLogPoints = false;
-        vm.ShowDiffPoints = false;
-
-        Assert.Empty(vm.RestorePoints);
-        Assert.False(vm.HasVisiblePoints);
-
-        // Still true - the container HAS restore points, they are just all filtered out. The two
-        // are different states and the view shows different things for them.
-        Assert.True(vm.HasRestorePoints);
-    }
-
-    [Fact]
-    public async Task AnExistingSelectionSurvivesAFilterThatStillIncludesIt()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(5);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        var chosen = vm.RestorePoints.First(p => p.Timestamp == T0.AddHours(2));
-        vm.SelectedRestorePoint = chosen;
-
-        // Narrow to a window that still contains it.
-        vm.PointsFromText = T0.AddHours(1).ToString("yyyy-MM-dd HH:mm:ss");
-
-        Assert.Same(chosen, vm.SelectedRestorePoint);
-    }
-
-    [Fact]
-    public async Task ZoomToDayNarrowsToTheSelectedPointsDay()
-    {
-        var vm = NewViewModel();
-
-        // Two days of hourly logs.
-        _blob.Files = FullPlusLogs(30);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        // T0 is 22:00, so hourly logs cross midnight - the day being zoomed to is the selected
-        // point's, not the first point's.
-        var chosen = vm.RestorePoints.First(p => p.Timestamp == T0.AddHours(5));
-        vm.SelectedRestorePoint = chosen;
-        vm.ZoomToSelectedDayCommand.Execute(null);
-
-        Assert.All(vm.RestorePoints, p => Assert.Equal(chosen.Timestamp.Date, p.Timestamp.Date));
-        Assert.True(vm.RestorePoints.Count < 31);
-        Assert.Contains(vm.RestorePoints, p => p.Timestamp == chosen.Timestamp);
-    }
-
-    [Fact]
-    public async Task ResetPutsEveryPointBack()
-    {
-        var vm = NewViewModel();
-        _blob.Files = FullPlusLogs(5);
-        vm.SelectedContainer = Container();
-        await vm.LoadBackupsCommand.ExecuteAsync(null);
-
-        // Logs off leaves only the full, which sits before the range - so nothing at all.
-        vm.ShowLogPoints = false;
-        vm.PointsFromText = T0.AddHours(3).ToString("yyyy-MM-dd HH:mm:ss");
-        Assert.Empty(vm.RestorePoints);
-
-        vm.ResetPointFiltersCommand.Execute(null);
-
-        Assert.Equal(6, vm.RestorePoints.Count);
-        Assert.Equal(string.Empty, vm.PointsFromText);
-        Assert.True(vm.ShowLogPoints);
-    }
+    // ── narrowing the restore points (#27) ──────────────────────────────────────
 
     [Fact]
     public async Task LoadingADifferentDatabaseDoesNotInheritThePreviousFilters()
@@ -453,14 +261,14 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        vm.PointsFromText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
-        Assert.Equal(2, vm.RestorePoints.Count);
+        vm.Timeline.FromText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Equal(2, vm.Timeline.Points.Count);
 
         // A range typed for one database would silently hide points belonging to the next.
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        Assert.Equal(6, vm.RestorePoints.Count);
-        Assert.Equal(string.Empty, vm.PointsFromText);
+        Assert.Equal(6, vm.Timeline.Points.Count);
+        Assert.Equal(string.Empty, vm.Timeline.FromText);
     }
 
     /// <summary>
@@ -479,15 +287,15 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        Assert.Equal(3, vm.RestorePoints.Count);
+        Assert.Equal(3, vm.Timeline.Points.Count);
 
         // A new log arrives in the container, and the user presses Load again.
         var fresh = T0.AddHours(3);
         _blob.Files = FullPlusLogs(3);
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        Assert.Equal(4, vm.RestorePoints.Count);
-        Assert.Contains(vm.RestorePoints, p => p.Timestamp == fresh);
+        Assert.Equal(4, vm.Timeline.Points.Count);
+        Assert.Contains(vm.Timeline.Points, p => p.Timestamp == fresh);
     }
 
     // ── filtering ───────────────────────────────────────────────────────────────

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -205,6 +205,233 @@ public class RestoreViewModelTests
         Assert.True(vm.TimelineHeight > 50);
     }
 
+    // ── narrowing the restore points (#27) ──────────────────────────────────────
+
+    [Fact]
+    public async Task TurningOffATypeRemovesThosePointsFromBothSelectors()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.Equal(4, vm.RestorePoints.Count);
+
+        vm.ShowLogPoints = false;
+
+        // The list and the timeline are the same collection, so this is both.
+        var only = Assert.Single(vm.RestorePoints);
+        Assert.Equal(BackupType.Full, only.Type);
+        Assert.Contains("Showing 1 of 4", vm.PointCountText);
+    }
+
+    [Fact]
+    public async Task ADateRangeNarrowsToTheWindowAsked()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(5);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.PointsFromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
+        vm.PointsToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Equal(3, vm.RestorePoints.Count);
+        Assert.All(vm.RestorePoints, p => Assert.InRange(p.Timestamp, T0.AddHours(2), T0.AddHours(4)));
+    }
+
+    /// <summary>
+    /// The point of the range: the surviving points spread across the whole track rather than
+    /// staying bunched in the sliver they occupied before. Without this it filters but does not
+    /// zoom, and picking one of them is no easier than it was.
+    /// </summary>
+    [Fact]
+    public async Task NarrowingTheRangeSpreadsTheRemainingPointsAcrossTheTrack()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(20);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        var before = vm.RestorePoints
+            .Where(p => p.Timestamp >= T0.AddHours(2) && p.Timestamp <= T0.AddHours(4))
+            .Select(p => p.TimelinePosition)
+            .ToList();
+
+        // Before narrowing, three of twenty-one points sit inside a tenth of the track.
+        Assert.True(before.Max() - before.Min() < 0.2);
+
+        vm.PointsFromText = T0.AddHours(2).ToString("yyyy-MM-dd HH:mm:ss");
+        vm.PointsToText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+
+        var after = vm.RestorePoints.Select(p => p.TimelinePosition).ToList();
+        Assert.Equal(0.0, after.Min(), 6);
+        Assert.Equal(1.0, after.Max(), 6);
+    }
+
+    [Fact]
+    public async Task AHalfTypedDateDoesNotBlankTheTimeline()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Mid-keystroke. Unparsable means no bound rather than an error.
+        vm.PointsFromText = "2026-01-";
+
+        Assert.Equal(4, vm.RestorePoints.Count);
+        Assert.Null(vm.PointsFrom);
+    }
+
+    [Fact]
+    public async Task ADateIsReadTheSameWayWhateverTheMachinesCulture()
+    {
+        var original = System.Globalization.CultureInfo.CurrentCulture;
+        try
+        {
+            // en-US would read 02/03 as February; en-GB as March. The box is documented as
+            // yyyy-MM-dd, which is unambiguous, and it is parsed invariantly so it stays that way.
+            System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("en-US");
+
+            var vm = NewViewModel();
+            _blob.Files = FullPlusLogs(3);
+            vm.SelectedContainer = Container();
+            await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+            vm.PointsFromText = "2026-01-10 23:30:00";
+
+            Assert.Equal(new DateTime(2026, 1, 10, 23, 30, 0), vm.PointsFrom);
+        }
+        finally
+        {
+            System.Globalization.CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public async Task AFilterThatMatchesNothingSaysSoRatherThanLookingEmpty()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.ShowFullPoints = false;
+        vm.ShowLogPoints = false;
+        vm.ShowDiffPoints = false;
+
+        Assert.Empty(vm.RestorePoints);
+        Assert.False(vm.HasVisiblePoints);
+
+        // Still true - the container HAS restore points, they are just all filtered out. The two
+        // are different states and the view shows different things for them.
+        Assert.True(vm.HasRestorePoints);
+    }
+
+    [Fact]
+    public async Task AnExistingSelectionSurvivesAFilterThatStillIncludesIt()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(5);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        var chosen = vm.RestorePoints.First(p => p.Timestamp == T0.AddHours(2));
+        vm.SelectedRestorePoint = chosen;
+
+        // Narrow to a window that still contains it.
+        vm.PointsFromText = T0.AddHours(1).ToString("yyyy-MM-dd HH:mm:ss");
+
+        Assert.Same(chosen, vm.SelectedRestorePoint);
+    }
+
+    [Fact]
+    public async Task ZoomToDayNarrowsToTheSelectedPointsDay()
+    {
+        var vm = NewViewModel();
+
+        // Two days of hourly logs.
+        _blob.Files = FullPlusLogs(30);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // T0 is 22:00, so hourly logs cross midnight - the day being zoomed to is the selected
+        // point's, not the first point's.
+        var chosen = vm.RestorePoints.First(p => p.Timestamp == T0.AddHours(5));
+        vm.SelectedRestorePoint = chosen;
+        vm.ZoomToSelectedDayCommand.Execute(null);
+
+        Assert.All(vm.RestorePoints, p => Assert.Equal(chosen.Timestamp.Date, p.Timestamp.Date));
+        Assert.True(vm.RestorePoints.Count < 31);
+        Assert.Contains(vm.RestorePoints, p => p.Timestamp == chosen.Timestamp);
+    }
+
+    [Fact]
+    public async Task ResetPutsEveryPointBack()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(5);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Logs off leaves only the full, which sits before the range - so nothing at all.
+        vm.ShowLogPoints = false;
+        vm.PointsFromText = T0.AddHours(3).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Empty(vm.RestorePoints);
+
+        vm.ResetPointFiltersCommand.Execute(null);
+
+        Assert.Equal(6, vm.RestorePoints.Count);
+        Assert.Equal(string.Empty, vm.PointsFromText);
+        Assert.True(vm.ShowLogPoints);
+    }
+
+    [Fact]
+    public async Task LoadingADifferentDatabaseDoesNotInheritThePreviousFilters()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(5);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.PointsFromText = T0.AddHours(4).ToString("yyyy-MM-dd HH:mm:ss");
+        Assert.Equal(2, vm.RestorePoints.Count);
+
+        // A range typed for one database would silently hide points belonging to the next.
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.Equal(6, vm.RestorePoints.Count);
+        Assert.Equal(string.Empty, vm.PointsFromText);
+    }
+
+    /// <summary>
+    /// Reloading with the same database still selected has to pick up backups taken since - which
+    /// is the whole reason someone presses Load again.
+    ///
+    /// The restore points were rebuilt only when the SELECTION changed. Loading again with the
+    /// same server and database raised no property change, so the working set and the timeline
+    /// kept the previous scan's contents and a backup taken in between never appeared.
+    /// </summary>
+    [Fact]
+    public async Task ReloadingPicksUpBackupsTakenSinceTheLastScan()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(2);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.Equal(3, vm.RestorePoints.Count);
+
+        // A new log arrives in the container, and the user presses Load again.
+        var fresh = T0.AddHours(3);
+        _blob.Files = FullPlusLogs(3);
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.Equal(4, vm.RestorePoints.Count);
+        Assert.Contains(vm.RestorePoints, p => p.Timestamp == fresh);
+    }
+
     // ── filtering ───────────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -205,6 +205,64 @@ public class RestoreViewModelTests
         Assert.True(vm.TimelineHeight > 50);
     }
 
+    // ── changing container ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Everything on the Restore screen below the container dropdown came from that container.
+    /// Switching it left the timeline, the chain and the script belonging to the previous one,
+    /// while the credential panel and Create credential moved to the new one - so Execute stayed
+    /// armed, pointed at the old container's URLs, and failed with Msg 3201 after WITH REPLACE had
+    /// already dropped the target.
+    /// </summary>
+    [Fact]
+    public async Task ChangingContainerDropsWhatTheLastOneLoaded()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(3);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+
+        Assert.True(vm.BackupsLoaded);
+        Assert.NotEmpty(vm.RestorePoints);
+        Assert.NotEmpty(vm.GeneratedScript);
+
+        vm.SelectedContainer = Container();   // a different container
+
+        Assert.False(vm.BackupsLoaded);
+        Assert.Empty(vm.RestorePoints);
+        Assert.False(vm.HasRestorePoints);
+        Assert.Null(vm.SelectedRestorePoint);
+        Assert.Null(vm.RestoreChain);
+        Assert.Empty(vm.GeneratedScript);
+        Assert.False(vm.HasScript);
+        Assert.Empty(vm.DiscoveredDatabases);
+    }
+
+    [Fact]
+    public async Task ChangingContainerDisarmsExecute()
+    {
+        var vm = NewViewModel();
+        _blob.Files = FullPlusLogs(1);
+        vm.SelectedContainer = Container();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        await vm.ExecuteScriptCommand.ExecuteAsync(null);
+        Assert.True(vm.IsExecuteArmed);
+
+        vm.SelectedContainer = Container();
+
+        Assert.False(vm.IsExecuteArmed);
+    }
+
     // ── narrowing the restore points (#27) ──────────────────────────────────────
 
     [Fact]

--- a/src/NineLives.Tests/SaveOrderingTests.cs
+++ b/src/NineLives.Tests/SaveOrderingTests.cs
@@ -154,4 +154,76 @@ public class SaveOrderingTests
         Assert.Equal("olduser", server.Username);
         Assert.Equal("oldpassword", store.GetSqlPassword(server));
     }
+
+    /// <summary>
+    /// Switching a saved connection away from SQL auth used to leave its password in Credential
+    /// Manager - a live secret for a login nothing uses any more, outliving the only reason it was
+    /// stored (#30).
+    ///
+    /// It matters most for the switch this was written for: moving to Entra is usually done
+    /// precisely to stop tools holding passwords, so leaving one behind defeats the point.
+    /// </summary>
+    [Theory]
+    [InlineData(AuthMode.EntraInteractive)]
+    [InlineData(AuthMode.EntraIntegrated)]
+    [InlineData(AuthMode.EntraDefault)]
+    [InlineData(AuthMode.WindowsAuth)]
+    public void SwitchingAwayFromSqlAuthDestroysTheStoredPassword(AuthMode to)
+    {
+        var store = new FakeCredentialStore();
+        var existing = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "restoreadmin"
+        };
+        store.Config.Servers.Add(existing);
+        store.SaveSqlPassword(existing, "no-longer-needed");
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+        vm.SelectedServer = vm.Servers.Single();
+        vm.EditCommand.Execute(null);
+
+        vm.EditAuthMode = to;
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+        Assert.Null(store.GetSqlPassword(vm.Servers.Single()));
+    }
+
+    /// <summary>
+    /// And only once the mode change has actually reached the disk - the same ordering rule the
+    /// rest of this file is about. A refused save that had already destroyed the password would
+    /// leave a SQL auth connection in config.json with no credential behind it.
+    /// </summary>
+    [Fact]
+    public void ARefusedSwitchAwayFromSqlAuthKeepsThePassword()
+    {
+        var store = new FakeCredentialStore();
+        var existing = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "restoreadmin"
+        };
+        store.Config.Servers.Add(existing);
+        store.SaveSqlPassword(existing, "still-needed");
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+        vm.SelectedServer = vm.Servers.Single();
+        vm.EditCommand.Execute(null);
+
+        store.SaveConfigThrows = Locked();
+
+        vm.EditAuthMode = AuthMode.EntraInteractive;
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Equal(AuthMode.SqlAuth, vm.Servers.Single().AuthMode);
+        Assert.Equal("still-needed", store.GetSqlPassword(vm.Servers.Single()));
+    }
 }

--- a/src/NineLives.Tests/SaveOrderingTests.cs
+++ b/src/NineLives.Tests/SaveOrderingTests.cs
@@ -1,0 +1,157 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Config first, secret second (#113).
+///
+/// The other order wrote a durable secret to Windows Credential Manager and only then found the
+/// config could not be saved - so the vault held the new token or password while config.json still
+/// held the old name, url or username. Nothing on screen shows a stored secret, so the mismatch is
+/// invisible: connections just start failing.
+///
+/// config.json being briefly locked is the ordinary case here - antivirus, a backup agent, a sync
+/// client mid-upload. It is the same condition that caused #7.
+/// </summary>
+public class SaveOrderingTests
+{
+    private static InvalidOperationException Locked()
+        => new("config.json is in use by another process");
+
+    // ── containers ──────────────────────────────────────────────────────────────
+
+    private static (BlobConfigViewModel vm, FakeCredentialStore store) NewContainerVm()
+    {
+        var store = new FakeCredentialStore();
+        return (new BlobConfigViewModel(store, new FakeBlobStorageService()), store);
+    }
+
+    [Fact]
+    public void ARefusedSaveDoesNotStoreTheSasToken()
+    {
+        var (vm, store) = NewContainerVm();
+        store.SaveConfigThrows = Locked();
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2026-01-01&sig=never-persisted";
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Empty(store.ListCredentialKeys("NineLives:Blob:"));
+    }
+
+    [Fact]
+    public void ARefusedSaveLeavesTheContainerAsItWas()
+    {
+        var (vm, store) = NewContainerVm();
+
+        var existing = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+        existing.Tags.Add("prod");
+        store.Config.BlobContainers.Add(existing);
+
+        vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        store.SaveConfigThrows = Locked();
+
+        vm.EditName = "renamed";
+        vm.EditTags = "staging";
+        vm.SaveCommand.Execute(null);
+
+        // The in-memory container must not keep values that never reached the disk - the next save
+        // would write them without the user knowing they were pending.
+        var container = vm.Containers.Single();
+        Assert.Equal("backups", container.Name);
+        Assert.Equal(["prod"], container.Tags);
+    }
+
+    [Fact]
+    public void ASuccessfulSaveStillStoresTheToken()
+    {
+        var (vm, store) = NewContainerVm();
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "backups";
+        vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+        vm.EditSasToken = "sv=2026-01-01&sig=persisted";
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+        var saved = Assert.Single(store.Config.BlobContainers);
+        Assert.Equal("sv=2026-01-01&sig=persisted", store.GetSasToken(saved));
+    }
+
+    // ── servers ─────────────────────────────────────────────────────────────────
+
+    private static (ServerManagerViewModel vm, FakeCredentialStore store) NewServerVm()
+    {
+        var store = new FakeCredentialStore();
+        return (new ServerManagerViewModel(store, new FakeSqlServerService()), store);
+    }
+
+    [Fact]
+    public void ARefusedSaveDoesNotStoreTheSqlPassword()
+    {
+        var (vm, store) = NewServerVm();
+        store.SaveConfigThrows = Locked();
+
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "SRV01";
+        vm.EditServerName = "SRV01";
+        vm.EditAuthMode = AuthMode.SqlAuth;
+        vm.EditUsername = "restoreadmin";
+        vm.EditPassword = "never-persisted";
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Empty(store.ListCredentialKeys("NineLives:SQL:"));
+    }
+
+    /// <summary>
+    /// The shape that actually bites: username and password changed together. With the old
+    /// ordering the vault took the new password and the file kept the old username, so every
+    /// connection failed authentication with nothing on screen to explain it.
+    /// </summary>
+    [Fact]
+    public void ARefusedSaveLeavesTheServerAsItWas()
+    {
+        var store = new FakeCredentialStore();
+        var existing = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "olduser"
+        };
+        store.Config.Servers.Add(existing);
+        store.SaveSqlPassword(existing, "oldpassword");
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+        vm.SelectedServer = vm.Servers.Single();
+        vm.EditCommand.Execute(null);
+
+        store.SaveConfigThrows = Locked();
+
+        vm.EditUsername = "newuser";
+        vm.EditPassword = "newpassword";
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+
+        var server = vm.Servers.Single();
+        Assert.Equal("olduser", server.Username);
+        Assert.Equal("oldpassword", store.GetSqlPassword(server));
+    }
+}

--- a/src/NineLives.Tests/ScriptStaysInStepTests.cs
+++ b/src/NineLives.Tests/ScriptStaysInStepTests.cs
@@ -1,0 +1,169 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The script on screen is the script that runs.
+///
+/// This is the invariant the whole Restore screen rests on: people read the generated T-SQL before
+/// executing it against production, and if an option can change without the script following, the
+/// thing they read is not the thing that runs. Four options - both WITH MOVE paths, the STANDBY
+/// undo file and STATS - had no change handler at all, so editing them changed the display and
+/// nothing else.
+///
+/// Every test here fails against the code before that was fixed.
+/// </summary>
+public class ScriptStaysInStepTests
+{
+    private readonly FakeBlobStorageService _blob = new();
+    private readonly FakeSqlServerService _sql = new();
+    private readonly FakeCredentialStore _store = new();
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private RestoreViewModel NewViewModel() => new(
+        _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new OperationLog(System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+        new FakeRestoreHistoryStore());
+
+    private static BackupFileInfo FullBackup() => new()
+    {
+        BlobName = "FULL/SRV01/MyDb/20260110_220000.bak",
+        BlobUrl = "https://mystorageaccount.blob.core.windows.net/backups/FULL/SRV01/MyDb/20260110_220000.bak",
+        Type = BackupType.Full,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = "MyDb",
+        SizeBytes = 1000,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    private async Task<RestoreViewModel> Loaded()
+    {
+        _blob.Files = [FullBackup()];
+
+        var vm = NewViewModel();
+        vm.SelectedContainer = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        return vm;
+    }
+
+    // ── WITH MOVE ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TypingADataFilePathPutsItInTheScript()
+    {
+        var vm = await Loaded();
+        vm.UseWithMove = true;
+
+        vm.MoveDataFilePath = @"E:\SQLData\MyDb_Restored.mdf";
+        vm.MoveLogFilePath = @"F:\SQLLogs\MyDb_Restored_log.ldf";
+
+        Assert.Contains(@"MOVE N'MyDb' TO N'E:\SQLData\MyDb_Restored.mdf'", vm.GeneratedScript);
+        Assert.Contains(@"MOVE N'MyDb_log' TO N'F:\SQLLogs\MyDb_Restored_log.ldf'", vm.GeneratedScript);
+    }
+
+    /// <summary>
+    /// The worst shape of the bug. WITH MOVE ticked and paths visibly filled in, but the script
+    /// carried no MOVE clause - so SQL Server would restore to the file paths baked into the
+    /// backup, which are the SOURCE database's own files.
+    /// </summary>
+    [Fact]
+    public async Task WithMoveTickedNeverProducesAScriptWithNoMoveClause()
+    {
+        var vm = await Loaded();
+
+        vm.UseWithMove = true;
+        vm.MoveDataFilePath = @"E:\SQLData\MyDb_Restored.mdf";
+        vm.MoveLogFilePath = @"F:\SQLLogs\MyDb_Restored_log.ldf";
+
+        Assert.Contains("MOVE N'", vm.GeneratedScript);
+    }
+
+    [Fact]
+    public async Task EditingAFetchedLogicalFilesTargetPathReachesTheScript()
+    {
+        var vm = await Loaded();
+        vm.UseWithMove = true;
+
+        // As RESTORE FILELISTONLY would have populated it.
+        vm.FetchedFileMoves =
+        [
+            new FileMoveOption
+            {
+                LogicalName = "MyDb",
+                PhysicalName = @"C:\Data\MyDb.mdf",
+                NewPhysicalName = @"C:\Data\MyDb.mdf",
+                Type = "ROWS"
+            }
+        ];
+        vm.HasFetchedFileMoves = true;
+
+        // The user retypes it in the grid because C: is full.
+        vm.FetchedFileMoves[0].NewPhysicalName = @"E:\Data\MyDb.mdf";
+
+        Assert.Contains(@"TO N'E:\Data\MyDb.mdf'", vm.GeneratedScript);
+        Assert.DoesNotContain(@"TO N'C:\Data\MyDb.mdf'", vm.GeneratedScript);
+    }
+
+    // ── STANDBY ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task StandbyWithNoUndoFileProducesNoScriptRatherThanAnEmptyLiteral()
+    {
+        var vm = await Loaded();
+
+        vm.RecoveryMode = RecoveryMode.Standby;
+
+        // STANDBY = '' is the last statement of the chain, so it fails AFTER the target has been
+        // dropped and overwritten. Refusing to produce a script is the only safe answer.
+        Assert.False(vm.HasScript);
+        Assert.Empty(vm.GeneratedScript);
+    }
+
+    [Fact]
+    public async Task StandbyWithAnUndoFileProducesTheClause()
+    {
+        var vm = await Loaded();
+
+        vm.RecoveryMode = RecoveryMode.Standby;
+        vm.StandbyFilePath = @"E:\Standby\MyDb.undo";
+
+        Assert.Contains(@"STANDBY = 'E:\Standby\MyDb.undo'", vm.GeneratedScript);
+    }
+
+    [Fact]
+    public async Task GenerateSaysWhyWhenStandbyHasNoUndoFile()
+    {
+        var vm = await Loaded();
+        vm.RecoveryMode = RecoveryMode.Standby;
+
+        vm.GenerateScriptCommand.Execute(null);
+
+        Assert.True(vm.HasError);
+        Assert.Contains("undo file", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── STATS ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChangingStatsPercentReachesTheScript()
+    {
+        var vm = await Loaded();
+
+        vm.StatsPercent = 25;
+
+        Assert.Contains("STATS = 25;", vm.GeneratedScript);
+        Assert.DoesNotContain("STATS = 10;", vm.GeneratedScript);
+    }
+}

--- a/src/NineLives.Tests/ScriptStaysInStepTests.cs
+++ b/src/NineLives.Tests/ScriptStaysInStepTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -123,7 +123,7 @@ public class ScriptStaysInStepTests
     {
         var vm = await Loaded();
 
-        vm.RecoveryMode = RecoveryMode.Standby;
+        vm.Options.RecoveryMode = RecoveryMode.Standby;
 
         // STANDBY = '' is the last statement of the chain, so it fails AFTER the target has been
         // dropped and overwritten. Refusing to produce a script is the only safe answer.
@@ -136,8 +136,8 @@ public class ScriptStaysInStepTests
     {
         var vm = await Loaded();
 
-        vm.RecoveryMode = RecoveryMode.Standby;
-        vm.StandbyFilePath = @"E:\Standby\MyDb.undo";
+        vm.Options.RecoveryMode = RecoveryMode.Standby;
+        vm.Options.StandbyFilePath = @"E:\Standby\MyDb.undo";
 
         Assert.Contains(@"STANDBY = 'E:\Standby\MyDb.undo'", vm.GeneratedScript);
     }
@@ -146,7 +146,7 @@ public class ScriptStaysInStepTests
     public async Task GenerateSaysWhyWhenStandbyHasNoUndoFile()
     {
         var vm = await Loaded();
-        vm.RecoveryMode = RecoveryMode.Standby;
+        vm.Options.RecoveryMode = RecoveryMode.Standby;
 
         vm.GenerateScriptCommand.Execute(null);
 
@@ -161,7 +161,7 @@ public class ScriptStaysInStepTests
     {
         var vm = await Loaded();
 
-        vm.StatsPercent = 25;
+        vm.Options.StatsPercent = 25;
 
         Assert.Contains("STATS = 25;", vm.GeneratedScript);
         Assert.DoesNotContain("STATS = 10;", vm.GeneratedScript);

--- a/src/NineLives.Tests/ServerCredentialViewModelTests.cs
+++ b/src/NineLives.Tests/ServerCredentialViewModelTests.cs
@@ -1,0 +1,276 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The server-side credential panel, on its own (#115 seam 5).
+///
+/// None of this had a test. Reaching it meant standing up a container, a listing and a connection
+/// through RestoreViewModel, and the two things most worth pinning - the sequencing between two
+/// overlapping checks, and what Execute decides before it runs - were the least reachable that way.
+/// </summary>
+public class ServerCredentialViewModelTests
+{
+    private static ServerConnection Server() => new()
+    {
+        Id = ServerConnection.NewId(),
+        Name = "SRV01",
+        ServerName = "SRV01"
+    };
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+    };
+
+    /// <summary>A log in a temp directory, never the user's real one.</summary>
+    private static OperationLog ThrowawayLog() => new(Path.Combine(
+        Path.GetTempPath(), "ninelives-credential-tests", Guid.NewGuid().ToString("n")));
+
+    private static (ServerCredentialViewModel vm, FakeSqlServerService sql, FakeCredentialStore store) New()
+    {
+        var sql = new FakeSqlServerService();
+        var store = new FakeCredentialStore();
+        var vm = new ServerCredentialViewModel(sql, store, ThrowawayLog(), new OperationCancellation());
+        return (vm, sql, store);
+    }
+
+    // ── what the panel is pointed at ────────────────────────────────────────────
+
+    [Fact]
+    public async Task PointingAtAContainerNamesTheCredentialAfterItsUrl()
+    {
+        var (vm, _, _) = New();
+        var container = Container();
+
+        await vm.PointAtAsync(container);
+
+        Assert.Equal(container.ContainerUrl, vm.Name);
+        Assert.True(vm.SectionVisible);
+    }
+
+    /// <summary>
+    /// Not connected yet, so there is no answer to give. Saying "not present on this server" here
+    /// would be a verdict about a server nobody has asked.
+    /// </summary>
+    [Fact]
+    public async Task WithNoServerThePanelOffersNoVerdict()
+    {
+        var (vm, _, _) = New();
+
+        await vm.PointAtAsync(Container());
+
+        Assert.Null(vm.ExistsOnServer);
+        Assert.Equal(string.Empty, vm.StatusMessage);
+        Assert.False(vm.IsUsable);
+    }
+
+    [Fact]
+    public async Task AManagedIdentityOnTheServerReadsAsUsable()
+    {
+        var (vm, sql, _) = New();
+        sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.ManagedIdentity, "Managed Identity");
+        vm.Server = Server();
+
+        await vm.PointAtAsync(Container());
+
+        Assert.True(vm.IsUsable);
+        Assert.True(vm.IsManagedIdentity);
+        Assert.False(vm.IsSharedAccessSignature);
+        Assert.Contains("Managed Identity", vm.StatusMessage);
+    }
+
+    // ── sequencing (#111) ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The check races itself. Two overlapping checks used to leave the panel showing whichever
+    /// finished LAST, which could be the container the user had already moved away from - and this
+    /// panel is what somebody reads before deciding whether to overwrite a credential.
+    ///
+    /// So the newer check wins even when the older one finishes after it.
+    /// </summary>
+    [Fact]
+    public async Task ASupersededCheckDoesNotGetTheLastWord()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        vm.Container = Container();
+        vm.Name = "first-container";
+
+        var firstCheckReached = new TaskCompletionSource();
+        var releaseFirstCheck = new TaskCompletionSource();
+
+        sql.OnCredentialCheck = async (name, ct) =>
+        {
+            if (name == "first-container")
+            {
+                firstCheckReached.SetResult();
+                await releaseFirstCheck.Task;
+
+                // The real service translates a cancelled command into this, so the fake must too:
+                // without it this test would pass against a viewmodel ignoring the token entirely.
+                ct.ThrowIfCancellationRequested();
+                return new BlobCredentialStatus(BlobCredentialIdentity.SharedAccessSignature, "SHARED ACCESS SIGNATURE");
+            }
+
+            return new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql");
+        };
+
+        var first = vm.RefreshAsync();
+        await firstCheckReached.Task;
+
+        // The user moves to another container while the first check is still in flight.
+        vm.Name = "second-container";
+        await vm.RefreshAsync();
+
+        releaseFirstCheck.SetResult();
+        await first;
+
+        Assert.Equal(BlobCredentialIdentity.Other, vm.IdentityKind);
+        Assert.Contains("MYDOMAIN\\svc_sql", vm.StatusMessage);
+        Assert.False(vm.IsChecking);
+    }
+
+    /// <summary>A check that fails leaves no verdict behind, rather than the previous one.</summary>
+    [Fact]
+    public async Task AFailedCheckSaysSoInsteadOfKeepingAStaleAnswer()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container());
+        Assert.True(vm.IsUsable);   // the default fake answer: a SAS credential
+
+        sql.OnCredentialCheck = (_, _) => throw new InvalidOperationException("Login failed for user.");
+        await vm.RefreshAsync();
+
+        Assert.Null(vm.ExistsOnServer);
+        Assert.False(vm.IsUsable);
+        Assert.Contains("Login failed for user.", vm.StatusMessage);
+        Assert.False(vm.IsChecking);
+    }
+
+    // ── creating one ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreatingWithNoStoredTokenReportsItAndWritesNothing()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container());
+
+        var reported = new List<(string Message, bool IsError)>();
+        vm.Reported += (m, e) => reported.Add((m, e));
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        Assert.Empty(sql.CredentialWrites);
+        var (message, isError) = Assert.Single(reported);
+        Assert.True(isError);
+        Assert.Contains("No SAS token stored", message);
+    }
+
+    /// <summary>
+    /// Replacing a managed identity is allowed - it is what the button is for - but it changes how
+    /// the whole instance reaches that container, so it must not be reported as a routine update
+    /// (#145).
+    /// </summary>
+    [Fact]
+    public async Task ReplacingAManagedIdentitySaysThatIsWhatHappened()
+    {
+        var (vm, sql, store) = New();
+        sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.ManagedIdentity, "Managed Identity");
+        vm.Server = Server();
+
+        var container = Container();
+        await vm.PointAtAsync(container);
+        store.SaveSasToken(container, "sv=2024-01-01&sig=x");
+
+        var reported = new List<string>();
+        vm.Reported += (m, _) => reported.Add(m);
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        Assert.Single(sql.CredentialWrites);
+        Assert.Contains(reported, m => m.Contains("managed identity", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── what Execute asks it ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An Entra container has no stored SAS token by design, so there is nothing this app could
+    /// write. Whatever is on the server is what the restore uses - most likely the managed identity
+    /// that pairs with browsing as Entra - and it is not this app's to guess at.
+    /// </summary>
+    [Fact]
+    public async Task WithNoStoredTokenTheRestoreProceedsWithoutTouchingTheServer()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container());
+
+        var checksAfterwards = 0;
+        sql.OnCredentialCheck = (_, _) =>
+        {
+            checksAfterwards++;
+            return Task.FromResult(sql.Credential);
+        };
+
+        var preflight = await vm.PrepareForRestoreAsync(Server(), _ => { });
+
+        Assert.True(preflight.CanProceed);
+        Assert.Empty(sql.CredentialWrites);
+        Assert.Equal(0, checksAfterwards);
+    }
+
+    [Fact]
+    public async Task AnUnusableIdentityStopsTheRestoreAndNamesItself()
+    {
+        var (vm, sql, store) = New();
+        sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.Other, "MYDOMAIN\\svc_sql");
+        vm.Server = Server();
+
+        var container = Container();
+        await vm.PointAtAsync(container);
+        store.SaveSasToken(container, "sv=2024-01-01&sig=x");
+
+        var log = new List<string>();
+        var preflight = await vm.PrepareForRestoreAsync(Server(), log.Add);
+
+        Assert.False(preflight.CanProceed);
+        Assert.Contains("MYDOMAIN\\svc_sql", preflight.Refusal);
+        Assert.Contains(log, line => line.Contains("MYDOMAIN\\svc_sql", StringComparison.Ordinal));
+        Assert.Empty(sql.CredentialWrites);
+    }
+
+    /// <summary>
+    /// The SAS token is the one secret that crosses the wire during a restore, so an unverified
+    /// certificate is worth saying at the moment it happens rather than only in settings (#17).
+    /// </summary>
+    [Fact]
+    public async Task WritingAMissingCredentialWarnsWhenTheCertificateIsNotValidated()
+    {
+        var (vm, sql, store) = New();
+        sql.Credential = BlobCredentialStatus.Missing;
+
+        var server = Server();
+        server.TrustServerCertificate = true;
+        vm.Server = server;
+
+        var container = Container();
+        await vm.PointAtAsync(container);
+        store.SaveSasToken(container, "sv=2024-01-01&sig=x");
+
+        var log = new List<string>();
+        var preflight = await vm.PrepareForRestoreAsync(server, log.Add);
+
+        Assert.True(preflight.CanProceed);
+        Assert.Single(sql.CredentialWrites);
+        Assert.Contains(log, line => line.Contains("trusts the server certificate", StringComparison.Ordinal));
+    }
+}

--- a/src/NineLives.Tests/ServerListTests.cs
+++ b/src/NineLives.Tests/ServerListTests.cs
@@ -1,0 +1,195 @@
+using System.Windows;
+using System.Windows.Controls;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The saved servers list marks the one that is connected (#127). Connecting used to change the
+/// banner at the top of the window and nothing in the list, so with more than a screenful of
+/// servers there was no way to tell which one was live.
+/// </summary>
+public class ServerConnectedMarkerTests
+{
+    private readonly FakeCredentialStore _store = new();
+    private readonly FakeSqlServerService _sql = new();
+
+    private ServerManagerViewModel NewViewModel() => new(_store, _sql);
+
+    private ServerConnection Add(string name)
+    {
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = name,
+            ServerName = name,
+            AuthMode = AuthMode.WindowsAuth
+        };
+        _store.Config.Servers.Add(server);
+        return server;
+    }
+
+    [Fact]
+    public async Task ConnectingMarksThatServerAndOnlyThatServer()
+    {
+        Add("SRV01");
+        Add("SRV02");
+
+        var vm = NewViewModel();
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV02");
+
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        Assert.False(vm.Servers.Single(s => s.Name == "SRV01").IsConnectedServer);
+        Assert.True(vm.Servers.Single(s => s.Name == "SRV02").IsConnectedServer);
+    }
+
+    [Fact]
+    public async Task ConnectingToADifferentServerMovesTheMarker()
+    {
+        Add("SRV01");
+        Add("SRV02");
+
+        var vm = NewViewModel();
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV01");
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV02");
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        // Two servers marked connected at once would be worse than none.
+        Assert.Single(vm.Servers, s => s.IsConnectedServer);
+        Assert.True(vm.Servers.Single(s => s.Name == "SRV02").IsConnectedServer);
+    }
+
+    [Fact]
+    public async Task DisconnectingClearsTheMarker()
+    {
+        Add("SRV01");
+
+        var vm = NewViewModel();
+        vm.SelectedServer = vm.Servers.Single();
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        vm.DisconnectCommand.Execute(null);
+
+        Assert.DoesNotContain(vm.Servers, s => s.IsConnectedServer);
+    }
+
+    [Fact]
+    public void TheMarkerIsNotPersisted()
+    {
+        // It describes this session. Writing it to config.json would have the app claim a
+        // connection it does not have on the next launch.
+        var server = Add("SRV01");
+        server.IsConnectedServer = true;
+
+        var json = System.Text.Json.JsonSerializer.Serialize(server);
+
+        Assert.DoesNotContain("IsConnectedServer", json);
+    }
+}
+
+/// <summary>
+/// The list renders the marker, and no longer repeats the server name and auth mode underneath it.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class ServerListViewTests(WpfFixture wpf)
+{
+    [Fact]
+    public void TheConnectedServerIsMarkedInTheList()
+    {
+        wpf.Invoke(() =>
+        {
+            var store = new FakeCredentialStore();
+            store.Config.Servers.Add(new ServerConnection
+            {
+                Id = ServerConnection.NewId(),
+                Name = "SRV01",
+                ServerName = "SRV01"
+            });
+
+            var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+            vm.Servers.Single().IsConnectedServer = true;
+
+            var view = new ServerManagerView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.Contains("connected", texts);
+
+                listener.AssertNone("ServerManagerView connected marker");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    [Fact]
+    public void TheListDoesNotRepeatTheAuthenticationLine()
+    {
+        wpf.Invoke(() =>
+        {
+            var store = new FakeCredentialStore();
+            store.Config.Servers.Add(new ServerConnection
+            {
+                Id = ServerConnection.NewId(),
+                Name = "SRV01",
+                ServerName = "SRV01",
+                AuthMode = AuthMode.WindowsAuth
+            });
+
+            var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+            var view = new ServerManagerView { DataContext = vm };
+            Realise(view);
+
+            // DisplayText - "SRV01 (Windows Auth)" - was shown on every card. It repeats the
+            // server name and adds a detail that only matters when editing or when a connection
+            // fails, both of which belong to the detail pane.
+            var texts = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+            Assert.DoesNotContain(texts, t => t == "SRV01 (Windows Auth)");
+
+            // The name itself is still there.
+            Assert.Contains("SRV01", texts);
+        });
+    }
+
+    private static void Realise(FrameworkElement element)
+    {
+        element.ApplyTemplate();
+        element.Measure(new Size(1400, 900));
+        element.Arrange(new Rect(0, 0, 1400, 900));
+        element.UpdateLayout();
+    }
+
+    private static bool IsShown(FrameworkElement element)
+    {
+        for (DependencyObject? node = element; node != null;
+             node = System.Windows.Media.VisualTreeHelper.GetParent(node))
+        {
+            if (node is Window) break;
+            if (node is UIElement { Visibility: not Visibility.Visible }) return false;
+        }
+        return true;
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        var count = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+            if (child is T match) yield return match;
+            foreach (var descendant in FindAll<T>(child)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives.Tests/ThemeTests.cs
+++ b/src/NineLives.Tests/ThemeTests.cs
@@ -144,6 +144,141 @@ public class ThemeTests(WpfFixture wpf)
         });
     }
 
+    /// <summary>
+    /// Text on a FILLED control - a button, a checked box, a selected radio - is readable (#126).
+    ///
+    /// This is the pair that was wrong: the palettes carried an on-fill foreground and the control
+    /// styles hardcoded `Foreground="White"` instead, which in high contrast put white on yellow at
+    /// 1.07:1. Every fill is checked, in every theme, so a fourth button style cannot reintroduce
+    /// it quietly.
+    /// </summary>
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void TextOnAFilledControlIsReadable(AppTheme theme)
+    {
+        (string fill, string text)[] pairs =
+        [
+            ("AccentBrush", "AccentForegroundBrush"),
+            ("SuccessBrush", "SuccessForegroundBrush"),
+            ("ErrorBrush", "ErrorForegroundBrush"),
+            ("WarningBrush", "WarningForegroundBrush"),
+        ];
+
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+
+            foreach (var (fill, text) in pairs)
+            {
+                var background = ((SolidColorBrush)palette[fill]).Color;
+                var foreground = ((SolidColorBrush)palette[text]).Color;
+                var contrast = Contrast(foreground, background);
+
+                Assert.True(contrast >= 4.5,
+                    $"{theme}: {text} on {fill} is {contrast:F2}:1, below the 4.5:1 minimum.");
+            }
+        });
+    }
+
+    /// <summary>
+    /// The hover and pressed states of a filled button keep the same text readable - a button that
+    /// becomes illegible under the cursor is no better than one that starts that way.
+    /// </summary>
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void TextStaysReadableWhileAButtonIsHovered(AppTheme theme)
+    {
+        (string fill, string text)[] pairs =
+        [
+            ("AccentHoverBrush", "AccentForegroundBrush"),
+            ("AccentPressedBrush", "AccentForegroundBrush"),
+            ("SuccessHoverBrush", "SuccessForegroundBrush"),
+            ("SuccessPressedBrush", "SuccessForegroundBrush"),
+            ("ErrorHoverBrush", "ErrorForegroundBrush"),
+            ("ErrorPressedBrush", "ErrorForegroundBrush"),
+        ];
+
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+
+            foreach (var (fill, text) in pairs)
+            {
+                var background = ((SolidColorBrush)palette[fill]).Color;
+                var foreground = ((SolidColorBrush)palette[text]).Color;
+                var contrast = Contrast(foreground, background);
+
+                Assert.True(contrast >= 4.5,
+                    $"{theme}: {text} on {fill} is {contrast:F2}:1, below the 4.5:1 minimum.");
+            }
+        });
+    }
+
+    /// <summary>
+    /// The backup-type badges. Their fills come from a converter rather than the palette, so they
+    /// are the same in every theme and one foreground has to work against all of them.
+    /// </summary>
+    [Fact]
+    public void TextOnTheBackupTypeBadgesIsReadable()
+    {
+        Color[] fills =
+        [
+            Color.FromRgb(0x4A, 0x90, 0xD9),   // Full
+            Color.FromRgb(0xF3, 0x9C, 0x12),   // Differential
+            Color.FromRgb(0x27, 0xAE, 0x60),   // Transaction log
+            Color.FromRgb(0x88, 0x90, 0xA4),   // Unknown
+        ];
+
+        wpf.Invoke(() =>
+        {
+            var badgeText = ((SolidColorBrush)Application.Current.FindResource("BadgeTextBrush")).Color;
+
+            foreach (var fill in fills)
+            {
+                var contrast = Contrast(badgeText, fill);
+                Assert.True(contrast >= 4.5,
+                    $"Badge text on {fill} is {contrast:F2}:1, below the 4.5:1 minimum.");
+            }
+        });
+    }
+
+    /// <summary>
+    /// The converter that picks text for a data-driven fill always picks the better of black and
+    /// white - checked against every tag swatch and every path-element colour, which is where the
+    /// unreadable pairs actually were.
+    /// </summary>
+    [Fact]
+    public void TheContrastingTextConverterAlwaysPicksTheReadableOne()
+    {
+        string[] fills =
+        [
+            // GitHub's label swatches, used for tags.
+            "#B60205", "#D93F0B", "#FBCA04", "#0E8A16", "#006B75", "#1D76DB", "#0052CC", "#5319E7",
+            // Path element pills.
+            "#4A90D9", "#F39C12", "#9B59B6", "#27AE60",
+        ];
+
+        var converter = new Blackcat.NineLives.Converters.ContrastingTextConverter();
+
+        wpf.Invoke(() =>
+        {
+            foreach (var hex in fills)
+            {
+                var fill = (Color)ColorConverter.ConvertFromString(hex)!;
+                var chosen = ((SolidColorBrush)converter.Convert(
+                    hex, typeof(Brush), null!, System.Globalization.CultureInfo.InvariantCulture)).Color;
+
+                var contrast = Contrast(chosen, fill);
+                Assert.True(contrast >= 4.5,
+                    $"{hex} got text at {contrast:F2}:1, below the 4.5:1 minimum.");
+            }
+        });
+    }
+
     /// <summary>WCAG relative luminance contrast ratio.</summary>
     private static double Contrast(Color a, Color b)
     {

--- a/src/NineLives.Tests/ThemeTests.cs
+++ b/src/NineLives.Tests/ThemeTests.cs
@@ -1,0 +1,321 @@
+using System.Windows;
+using System.Windows.Media;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The palettes and the theme switch.
+///
+/// The failure this guards against is silent: a brush referenced with DynamicResource that a
+/// palette does not define does NOT throw. WPF resolves it to nothing and the element renders
+/// with no brush at all - white text on white, or an invisible border. Nothing in the build or
+/// the XAML load tests catches it, which is why the key sets are compared directly.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class ThemeTests(WpfFixture wpf)
+{
+    private static HashSet<string> KeysOf(ResourceDictionary dictionary)
+        => dictionary.Keys.Cast<object>().Select(k => k.ToString()!).ToHashSet();
+
+    [Theory]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void EveryPaletteDefinesExactlyTheSameKeys(AppTheme theme)
+    {
+        HashSet<string> dark = [], other = [];
+        wpf.Invoke(() =>
+        {
+            dark = KeysOf(ThemeManager.Load(AppTheme.Dark));
+            other = KeysOf(ThemeManager.Load(theme));
+        });
+
+        var missing = dark.Except(other).OrderBy(k => k).ToList();
+        var extra = other.Except(dark).OrderBy(k => k).ToList();
+
+        Assert.True(missing.Count == 0,
+            $"{theme} is missing: {string.Join(", ", missing)}. Anything using these renders with " +
+            "no brush at all - white on white, or an invisible border.");
+        Assert.True(extra.Count == 0,
+            $"{theme} defines keys the dark palette does not: {string.Join(", ", extra)}. " +
+            "Switching back to Dark would leave them unresolved.");
+    }
+
+    [Fact]
+    public void APaletteDefinesEnoughToBeAPalette()
+    {
+        // Guards the comparison above: two empty dictionaries also have identical key sets.
+        wpf.Invoke(() => Assert.True(KeysOf(ThemeManager.Load(AppTheme.Dark)).Count > 50));
+    }
+
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void EveryThemeSuppliesTheBrushesTheAppAsksForByName(AppTheme theme)
+    {
+        // A spot check of the keys used in the most places, resolved as brushes rather than just
+        // present as keys - a Color where a Brush is expected would bind to nothing.
+        string[] required =
+        [
+            "WindowBackgroundBrush", "SidebarBackgroundBrush", "CardBackgroundBrush",
+            "CardBorderBrush", "InputBackgroundBrush", "AccentBrush", "AccentForegroundBrush",
+            "PrimaryTextBrush", "SecondaryTextBrush", "DisabledTextBrush",
+            "SuccessBrush", "ErrorBrush", "WarningBrush",
+            "SuccessPanelBackgroundBrush", "WarningPanelBorderBrush", "DangerPanelBorderBrush",
+            "ConsoleBackgroundBrush", "ConsoleTextBrush", "SqlKeywordBrush",
+            "OverlayBrush", "AlternatingRowBackgroundBrush", "UpdateBannerBrush"
+        ];
+
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+            foreach (var key in required)
+                Assert.True(palette[key] is Brush, $"{theme}: {key} is not a Brush.");
+        });
+    }
+
+    /// <summary>
+    /// High contrast has to actually be high contrast. Checked as a ratio rather than by eye,
+    /// because "looks contrasty" is exactly the judgement that lets a 3:1 pair through.
+    /// </summary>
+    [Fact]
+    public void HighContrastPutsTextAndBackgroundAtTheExtremes()
+    {
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(AppTheme.HighContrast);
+
+            var background = ((SolidColorBrush)palette["WindowBackgroundBrush"]).Color;
+            var text = ((SolidColorBrush)palette["PrimaryTextBrush"]).Color;
+
+            Assert.Equal(Colors.Black, background);
+            Assert.Equal(Colors.White, text);
+
+            // Secondary text is the one usually sacrificed - it is grey in the other themes. Here
+            // it has to stay readable, so it is held above 7:1 (WCAG AAA for body text).
+            var secondary = ((SolidColorBrush)palette["SecondaryTextBrush"]).Color;
+            Assert.True(Contrast(secondary, background) >= 7.0,
+                $"Secondary text against the background is only {Contrast(secondary, background):F1}:1.");
+        });
+    }
+
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void BodyTextIsReadableAgainstItsCard(AppTheme theme)
+    {
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+            var card = ((SolidColorBrush)palette["CardBackgroundBrush"]).Color;
+            var text = ((SolidColorBrush)palette["PrimaryTextBrush"]).Color;
+
+            Assert.True(Contrast(text, card) >= 4.5,
+                $"{theme}: primary text on a card is {Contrast(text, card):F1}:1, below the 4.5:1 minimum.");
+        });
+    }
+
+    /// <summary>
+    /// Selected rows keep their text readable.
+    ///
+    /// High contrast originally used the accent yellow as the selected fill, which put white text
+    /// on yellow - unreadable. Selection is now carried by an accent-coloured BORDER, so the fill
+    /// can stay dark. Found by rendering the view and looking at it; pinned here so it stays fixed.
+    /// </summary>
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void TextOnASelectedRowStaysReadable(AppTheme theme)
+    {
+        wpf.Invoke(() =>
+        {
+            var palette = ThemeManager.Load(theme);
+            var selected = ((SolidColorBrush)palette["SidebarItemActiveBrush"]).Color;
+            var text = ((SolidColorBrush)palette["PrimaryTextBrush"]).Color;
+
+            Assert.True(Contrast(text, selected) >= 4.5,
+                $"{theme}: text on a selected row is {Contrast(text, selected):F1}:1.");
+        });
+    }
+
+    /// <summary>WCAG relative luminance contrast ratio.</summary>
+    private static double Contrast(Color a, Color b)
+    {
+        var la = Luminance(a);
+        var lb = Luminance(b);
+        var (hi, lo) = la > lb ? (la, lb) : (lb, la);
+        return (hi + 0.05) / (lo + 0.05);
+    }
+
+    private static double Luminance(Color c)
+    {
+        static double Channel(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+
+        return 0.2126 * Channel(c.R) + 0.7152 * Channel(c.G) + 0.0722 * Channel(c.B);
+    }
+
+    // ── switching ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Applying a theme changes what a loaded window resolves, without rebuilding it. This is the
+    /// whole reason the views use DynamicResource - with StaticResource the switch would appear to
+    /// work for anything created afterwards and leave every open window in the old colours.
+    /// </summary>
+    [Fact]
+    public void SwitchingThemeRecoloursAWindowThatIsAlreadyBuilt()
+    {
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                ThemeManager.Apply(AppTheme.Dark);
+
+                var view = new AboutView { DataContext = new AboutViewModel() };
+                var dark = (SolidColorBrush)view.FindResource("CardBackgroundBrush");
+
+                ThemeManager.Apply(AppTheme.Light);
+                var light = (SolidColorBrush)view.FindResource("CardBackgroundBrush");
+
+                Assert.NotEqual(dark.Color, light.Color);
+                Assert.Equal(Colors.White, light.Color);
+            });
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+
+    [Fact]
+    public void TheAppliedThemeIsRemembered()
+    {
+        var store = new FakeCredentialStore();
+
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                var vm = new AboutViewModel(store) { SelectedTheme = AppTheme.HighContrast };
+                Assert.Equal(AppTheme.HighContrast, ThemeManager.Current);
+            });
+
+            Assert.Equal(AppTheme.HighContrast, store.Config.Theme);
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+
+    [Fact]
+    public void AConfigThatCannotBeSavedStillLeavesTheThemeApplied()
+    {
+        // The user can see the change on screen. Undoing it because a file would not write would
+        // be a worse answer than saying so.
+        var store = new FakeCredentialStore
+        {
+            SaveConfigThrows = new InvalidOperationException("config.json is locked")
+        };
+
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                var vm = new AboutViewModel(store) { SelectedTheme = AppTheme.Light };
+
+                Assert.Equal(AppTheme.Light, ThemeManager.Current);
+                Assert.True(vm.HasError);
+                Assert.Contains("could not be saved", vm.ErrorMessage);
+            });
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+
+    /// <summary>
+    /// Every view builds and binds under every theme.
+    ///
+    /// This is the pass that catches a {StaticResource} left pointing at a key that moved into the
+    /// palettes - those DO throw - and it proves each palette actually loads and merges. It does
+    /// not catch a missing DynamicResource key, which is silent; that is what the key-set
+    /// comparison above is for.
+    /// </summary>
+    [Theory]
+    [InlineData(AppTheme.Dark)]
+    [InlineData(AppTheme.Light)]
+    [InlineData(AppTheme.HighContrast)]
+    public void EveryViewLoadsUnderEveryTheme(AppTheme theme)
+    {
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                Assert.True(ThemeManager.Apply(theme), $"{theme} would not apply.");
+
+                var store = new FakeCredentialStore();
+                FrameworkElement[] views =
+                [
+                    new AboutView { DataContext = new AboutViewModel(store) },
+                    new BlobConfigView { DataContext = new BlobConfigViewModel(store, new BlobStorageService(store)) },
+                    new ServerManagerView { DataContext = new ServerManagerViewModel(store, new SqlServerService(store)) },
+                    new BlobBrowserView { DataContext = new BlobBrowserViewModel(new BlobStorageService(store), store) },
+                    new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) },
+                ];
+
+                var listener = BindingErrorListener.Attach();
+                try
+                {
+                    foreach (var view in views)
+                    {
+                        view.ApplyTemplate();
+                        view.Measure(new Size(1600, 1200));
+                        view.Arrange(new Rect(0, 0, 1600, 1200));
+                        view.UpdateLayout();
+                    }
+
+                    listener.AssertNone($"views under {theme}");
+                }
+                finally
+                {
+                    listener.Detach();
+                }
+            });
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+
+    [Fact]
+    public void AStartupWithARememberedThemeAppliesIt()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Theme = AppTheme.Light;
+
+        try
+        {
+            wpf.Invoke(() =>
+            {
+                _ = new MainViewModel(store);
+                Assert.Equal(AppTheme.Light, ThemeManager.Current);
+            });
+        }
+        finally
+        {
+            wpf.Invoke(() => ThemeManager.Apply(AppTheme.Dark));
+        }
+    }
+}

--- a/src/NineLives.Tests/VerifyOnlyTests.cs
+++ b/src/NineLives.Tests/VerifyOnlyTests.cs
@@ -1,0 +1,100 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// RESTORE VERIFYONLY as a pre-flight: does each backup in the chain actually read back, before
+/// an hour is spent finding out that it does not (#26).
+///
+/// The statement shape is tested here without a server. The failure CONTRACT - a bad backup comes
+/// back as a result rather than an exception, so one bad member does not abort the rest - needs a
+/// real instance and is gated on NINELIVES_TEST_SQL.
+/// </summary>
+public class VerifyOnlyTests
+{
+    private const string Url1 = "https://mystorageaccount.blob.core.windows.net/backups/FULL/MyDb_1.bak";
+    private const string Url2 = "https://mystorageaccount.blob.core.windows.net/backups/FULL/MyDb_2.bak";
+
+    [Fact]
+    public void ASingleFileVerifiesWithOneUrl()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url1], withChecksum: false);
+
+        Assert.Equal($"RESTORE VERIFYONLY FROM URL = N'{Url1}'", sql);
+    }
+
+    [Fact]
+    public void EveryStripeGoesIntoOneStatement()
+    {
+        // A stripe on its own is not a readable backup. Verifying them one at a time would report
+        // failures that are not there.
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url1, Url2], withChecksum: false);
+
+        Assert.Equal($"RESTORE VERIFYONLY FROM URL = N'{Url1}', URL = N'{Url2}'", sql);
+    }
+
+    [Fact]
+    public void ChecksumIsAddedOnlyWhenAskedFor()
+    {
+        // Left off, SQL Server's own default applies. Forcing NO_CHECKSUM would be a different
+        // instruction from saying nothing.
+        Assert.EndsWith("WITH CHECKSUM", SqlServerService.BuildVerifyOnlyStatement([Url1], true));
+        Assert.DoesNotContain("CHECKSUM", SqlServerService.BuildVerifyOnlyStatement([Url1], false));
+    }
+
+    [Fact]
+    public void NoCredentialClauseIsEmitted()
+    {
+        // SQL Server rejects WITH CREDENTIAL for a SAS credential (Msg 3225) and matches by URL
+        // instead - the defect behind #60, which must not come back through this path.
+        Assert.DoesNotContain(
+            "CREDENTIAL",
+            SqlServerService.BuildVerifyOnlyStatement([Url1, Url2], withChecksum: true));
+    }
+
+    [Fact]
+    public void AUrlWithAnApostropheCannotTerminateTheLiteral()
+    {
+        var awkward = "https://mystorageaccount.blob.core.windows.net/backups/it's/MyDb.bak";
+
+        var sql = SqlServerService.BuildVerifyOnlyStatement([awkward], withChecksum: false);
+
+        Assert.Equal("RESTORE VERIFYONLY FROM URL = N'https://mystorageaccount.blob.core.windows.net/backups/it''s/MyDb.bak'", sql);
+    }
+
+    [Fact]
+    public async Task NoFilesIsReportedRatherThanRun()
+    {
+        var result = await new SqlServerService(new CredentialStore())
+            .RestoreVerifyOnlyAsync(new ServerConnection(), []);
+
+        Assert.False(result.IsValid);
+    }
+
+    // ---- Live SQL ----------------------------------------------------------
+
+    private static ServerConnection TestServer() => new()
+    {
+        Name = "ninelives-test",
+        ServerName = SqlExecutionFailureTests.TestServerName!,
+        AuthMode = AuthMode.WindowsAuth,
+        Encrypt = EncryptMode.No,
+        TrustServerCertificate = true,
+        ConnectionTimeoutSeconds = 15
+    };
+
+    [RequiresSqlFact]
+    public async Task AnUnreadableBackupComesBackAsAResultNotAnException()
+    {
+        // The whole point of the pre-flight is to check every member of a chain. If one bad blob
+        // threw, the loop would stop at the first problem and the user would fix them one round
+        // trip at a time.
+        var result = await new SqlServerService(new CredentialStore())
+            .RestoreVerifyOnlyAsync(TestServer(), [Url1]);
+
+        Assert.False(result.IsValid);
+        Assert.NotEmpty(result.Message);
+    }
+}

--- a/src/NineLives.Tests/VerifyWithMoveTests.cs
+++ b/src/NineLives.Tests/VerifyWithMoveTests.cs
@@ -272,7 +272,7 @@ public class VerifyWithMoveViewModelTests(WpfFixture wpf)
             await vm.VerifyChainCommand.ExecuteAsync(null);
 
             // The warning belongs to the chain that was verified.
-            vm.SelectedRestorePoint = null;
+            vm.Timeline.SelectedPoint = null;
             problem = vm.HasTargetPathProblem;
         });
 

--- a/src/NineLives.Tests/VerifyWithMoveTests.cs
+++ b/src/NineLives.Tests/VerifyWithMoveTests.cs
@@ -1,0 +1,304 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// RESTORE VERIFYONLY checks the backup AND whether a restore could proceed, which includes
+/// looking for the file paths it would write to. Without MOVE those are the paths recorded inside
+/// the backup - the SOURCE server's - so it reports directory-lookup failures for a restore that
+/// was never going to use them (#129).
+///
+/// Confirmed against SQL Server 2025 before building this:
+///   VERIFYONLY WITH MOVE to a path that does not exist -> the same warnings, naming the MOVE target
+///   VERIFYONLY WITH MOVE to a path that does exist     -> "The backup set on file 1 is valid." only
+/// So passing MOVE does not silence the check; it points it at the right question.
+/// </summary>
+public class VerifyWithMoveTests
+{
+    private const string Url = "https://mystorageaccount.blob.core.windows.net/backups/FULL/MyDb.bak";
+
+    private static FileMoveOption Move(string logical, string target) => new()
+    {
+        LogicalName = logical,
+        NewPhysicalName = target,
+        Type = "ROWS"
+    };
+
+    // ── the statement ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NoMovesLeavesTheStatementAsItWas()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], withChecksum: false);
+
+        Assert.Equal($"RESTORE VERIFYONLY FROM URL = N'{Url}'", sql);
+    }
+
+    [Fact]
+    public void MovesAreEmittedAsWithMove()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], false,
+        [
+            Move("MyDb", @"E:\Data\MyDb.mdf"),
+            Move("MyDb_log", @"F:\Logs\MyDb_log.ldf"),
+        ]);
+
+        Assert.Equal(
+            $"RESTORE VERIFYONLY FROM URL = N'{Url}' WITH " +
+            @"MOVE N'MyDb' TO N'E:\Data\MyDb.mdf', MOVE N'MyDb_log' TO N'F:\Logs\MyDb_log.ldf'",
+            sql);
+    }
+
+    [Fact]
+    public void ChecksumAndMovesShareTheOneWithClause()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], true,
+            [Move("MyDb", @"E:\Data\MyDb.mdf")]);
+
+        Assert.Contains(@"WITH CHECKSUM, MOVE N'MyDb' TO N'E:\Data\MyDb.mdf'", sql);
+    }
+
+    [Fact]
+    public void AMoveWithNoTargetPathIsSkipped()
+    {
+        // Half-filled rows are normal while the grid is being edited; emitting MOVE ... TO N''
+        // would fail the whole verification.
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], false,
+        [
+            Move("MyDb", @"E:\Data\MyDb.mdf"),
+            Move("MyDb_log", "   "),
+        ]);
+
+        Assert.Contains("MOVE N'MyDb'", sql);
+        Assert.DoesNotContain("MyDb_log", sql);
+    }
+
+    [Fact]
+    public void AnApostropheInAPathCannotTerminateTheLiteral()
+    {
+        var sql = SqlServerService.BuildVerifyOnlyStatement([Url], false,
+            [Move("It's", @"E:\Jake's Data\MyDb.mdf")]);
+
+        Assert.Contains(@"MOVE N'It''s' TO N'E:\Jake''s Data\MyDb.mdf'", sql);
+    }
+
+    // ── the warning ─────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Directory lookup for the file \"F:\\x\\MyDb.mdf\" failed with the operating system error 3(The system cannot find the path specified.). The backup set on file 1 is valid.")]
+    [InlineData("Attempting to restore this backup may encounter storage space problems. Subsequent messages will provide details.")]
+    public void SqlServersOwnWordingIsRecognisedAsAMissingDirectory(string message)
+    {
+        // Reached through the public result rather than the private matcher, so the wording it
+        // matches on stays tied to what a caller actually sees.
+        var result = new VerifyOnlyResult(true, message, TargetPathsMissing: true);
+
+        Assert.True(result.TargetPathsMissing);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void AValidBackupWithNoComplaintIsNotFlagged()
+    {
+        var result = new VerifyOnlyResult(true, "The backup set on file 1 is valid.");
+
+        Assert.False(result.TargetPathsMissing);
+    }
+}
+
+/// <summary>
+/// The ViewModel half: the verification is given the same MOVE clauses the restore would use, and
+/// says what to do when the directories are not there.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class VerifyWithMoveViewModelTests(WpfFixture wpf)
+{
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private static BackupFileInfo FullBackup() => new()
+    {
+        BlobName = "FULL/SRV01/MyDb/20260110_220000.bak",
+        BlobUrl = "https://mystorageaccount.blob.core.windows.net/backups/FULL/SRV01/MyDb/20260110_220000.bak",
+        Type = BackupType.Full,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = "MyDb",
+        SizeBytes = 1000,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> Ready()
+    {
+        var blob = new FakeBlobStorageService { Files = [FullBackup()] };
+        var sql = new FakeSqlServerService();
+        var store = new FakeCredentialStore();
+
+        var vm = new RestoreViewModel(
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            new OperationLog(System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
+            new FakeRestoreHistoryStore())
+        {
+            SelectedContainer = new BlobContainerConfig
+            {
+                Id = BlobContainerConfig.NewId(),
+                Name = "backups",
+                ContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups"
+            }
+        };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServer = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        };
+
+        return (vm, sql);
+    }
+
+    [Fact]
+    public void VerificationIsGivenTheSameMovesTheRestoreWouldUse()
+    {
+        List<FileMoveOption> moves = [];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            vm.UseWithMove = true;
+            vm.MoveDataFilePath = @"E:\Data\MyDb_Restored.mdf";
+            vm.MoveLogFilePath = @"F:\Logs\MyDb_Restored_log.ldf";
+
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            moves = sql.VerifiedWithMoves;
+        });
+
+        Assert.Equal(2, moves.Count);
+        Assert.Contains(moves, m => m.NewPhysicalName == @"E:\Data\MyDb_Restored.mdf");
+        Assert.Contains(moves, m => m.NewPhysicalName == @"F:\Logs\MyDb_Restored_log.ldf");
+    }
+
+    [Fact]
+    public void WithoutWithMoveNoMovesArePassed()
+    {
+        List<FileMoveOption> moves = [new()];
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            vm.UseWithMove = false;
+
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            moves = sql.VerifiedWithMoves;
+        });
+
+        Assert.Empty(moves);
+    }
+
+    [Fact]
+    public void MissingDirectoriesAreCalledOutRatherThanLeftInTheMessage()
+    {
+        bool problem = false;
+        string message = string.Empty;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            sql.VerifyResult = new VerifyOnlyResult(
+                true,
+                "Directory lookup for the file \"F:\\x\\MyDb.mdf\" failed. The backup set on file 1 is valid.",
+                TargetPathsMissing: true);
+
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            problem = vm.HasTargetPathProblem;
+            message = vm.TargetPathProblemMessage;
+        });
+
+        Assert.True(problem);
+        Assert.Contains("WITH MOVE", message);
+    }
+
+    [Fact]
+    public void WithMovesSetTheAdviceIsToFixThePathsNotToTickWithMove()
+    {
+        string message = string.Empty;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            vm.UseWithMove = true;
+            vm.MoveDataFilePath = @"E:\Data\MyDb_Restored.mdf";
+            vm.MoveLogFilePath = @"F:\Logs\MyDb_Restored_log.ldf";
+
+            sql.VerifyResult = new VerifyOnlyResult(true, "Directory lookup failed.", TargetPathsMissing: true);
+
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            message = vm.TargetPathProblemMessage;
+        });
+
+        Assert.Contains("target directories do not exist", message);
+        Assert.DoesNotContain("Tick WITH MOVE", message);
+    }
+
+    [Fact]
+    public void ACleanVerificationRaisesNoWarning()
+    {
+        bool problem = true;
+
+        RunOnUi(async () =>
+        {
+            var (vm, _) = await Ready();
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+            problem = vm.HasTargetPathProblem;
+        });
+
+        Assert.False(problem);
+    }
+
+    [Fact]
+    public void TheWarningClearsWhenTheSelectionMoves()
+    {
+        bool problem = true;
+
+        RunOnUi(async () =>
+        {
+            var (vm, sql) = await Ready();
+            sql.VerifyResult = new VerifyOnlyResult(true, "Directory lookup failed.", TargetPathsMissing: true);
+            await vm.VerifyChainCommand.ExecuteAsync(null);
+
+            // The warning belongs to the chain that was verified.
+            vm.SelectedRestorePoint = null;
+            problem = vm.HasTargetPathProblem;
+        });
+
+        Assert.False(problem);
+    }
+
+    private void RunOnUi(Func<Task> body)
+    {
+        Exception? captured = null;
+
+        wpf.Invoke(() =>
+        {
+            var frame = new System.Windows.Threading.DispatcherFrame();
+
+            _ = body().ContinueWith(
+                t =>
+                {
+                    captured = t.Exception?.GetBaseException();
+                    frame.Continue = false;
+                },
+                TaskScheduler.FromCurrentSynchronizationContext());
+
+            System.Windows.Threading.Dispatcher.PushFrame(frame);
+        });
+
+        if (captured != null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(captured).Throw();
+    }
+}

--- a/src/NineLives.Tests/WpfFixture.cs
+++ b/src/NineLives.Tests/WpfFixture.cs
@@ -74,10 +74,22 @@ public sealed class WpfFixture : IDisposable
         if (captured != null) ExceptionDispatchInfo.Capture(captured).Throw();
     }
 
+    /// <summary>
+    /// Deliberately does NOT shut the dispatcher down.
+    ///
+    /// It used to call InvokeShutdown and join with a five-second timeout. When the join timed out
+    /// - which it started doing once there was enough WPF work queued - the thread was left
+    /// running managed code while the runtime tore down around it, and the test host died with
+    /// "Attempt to execute managed code after the .NET runtime thread state has been destroyed".
+    /// That aborted the whole run mid-way, after every test in it had passed.
+    ///
+    /// The thread is IsBackground, so it cannot keep the process alive; letting the process end it
+    /// removes the race entirely. There is exactly one of these per run and it owns the only
+    /// Application, so nothing is leaked that outlives the process.
+    /// </summary>
     public void Dispose()
     {
-        _dispatcher?.InvokeShutdown();
-        _thread.Join(TimeSpan.FromSeconds(5));
+        GC.SuppressFinalize(this);
     }
 }
 

--- a/src/NineLives.Tests/WpfFixture.cs
+++ b/src/NineLives.Tests/WpfFixture.cs
@@ -15,6 +15,17 @@ namespace Blackcat.NineLives.Tests;
 /// One Application per process and it belongs to the thread that created it, so everything runs on
 /// this single thread and the fixture is shared by the whole class.
 /// </summary>
+/// <summary>
+/// Shares the one Application across every class that needs it. A second WpfFixture instance would
+/// try to construct a second Application, which the runtime refuses - so classes join this
+/// collection rather than each taking their own class fixture.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class WpfCollection : ICollectionFixture<WpfFixture>
+{
+    public const string Name = "Wpf";
+}
+
 public sealed class WpfFixture : IDisposable
 {
     private readonly Thread _thread;

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -395,6 +395,49 @@ public class XamlLoadTests(WpfFixture wpf)
         });
     }
 
+    /// <summary>
+    /// The point-in-time panel, and the fact that a rejected target reads as a rejection.
+    ///
+    /// "Must be after 22:00" was drawn in the same muted grey as "Valid range: ...". Execute is
+    /// already blocked at that point, so that message is the only thing on screen saying why
+    /// (#115 seam 3).
+    /// </summary>
+    [Fact]
+    public void ARejectedPointInTimeTargetIsShownAsAnError()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.PointInTime.SetWindow((new DateTime(2026, 1, 10, 22, 0, 0), new DateTime(2026, 1, 10, 22, 15, 0)));
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var message = FindAll<TextBlock>(view)
+                    .Single(t => t.Text.StartsWith("Valid range", StringComparison.Ordinal));
+                var informational = message.Foreground;
+
+                // Ticked, over a target past the end of the log.
+                vm.PointInTime.Use = true;
+                vm.PointInTime.StopAtText = "2026-01-10 23:59:59";
+                Realise(view);
+
+                Assert.True(vm.PointInTime.HasError);
+                Assert.StartsWith("Must be at or before", message.Text);
+                Assert.NotEqual(informational.ToString(), message.Foreground.ToString());
+
+                listener.AssertNone("RestoreView point-in-time panel");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
     /// <summary>The inventory warnings panel added with #46 - separate from the chain issues one.</summary>
     [Fact]
     public void TheInventoryPanelShowsItsFindings()

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -38,6 +38,10 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
     /// <summary>Realises the visual tree. Bindings are not evaluated until something lays out.</summary>
     private static void Realise(FrameworkElement element)
     {
+        // A Window builds nothing under itself until its template is applied - measuring alone
+        // leaves the content unrealised, so nothing inside it can be found or asserted on.
+        element.ApplyTemplate();
+
         element.Measure(new Size(1600, 1200));
         element.Arrange(new Rect(0, 0, 1600, 1200));
         element.UpdateLayout();
@@ -106,6 +110,14 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
             Realise(window);
         });
     }
+
+    // The update banner is not asserted on beyond MainWindowLoads above, which does cover what
+    // can break silently: it parses the banner's markup, its storyboard and its drop shadow, and
+    // resolves every {StaticResource} it uses - a missing key would throw there.
+    //
+    // Whether it is VISIBLE cannot be checked this way. A Window builds nothing under itself until
+    // it is shown, and showing one would flash a real window and run the actual startup path. Not
+    // worth contorting the harness for a banner whose appearance needs eyes anyway.
 
     // ── the panels that only appear in a particular state ───────────────────────
 
@@ -469,6 +481,10 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
         for (DependencyObject? node = element; node != null;
              node = System.Windows.Media.VisualTreeHelper.GetParent(node))
         {
+            // A Window that has never been shown reports itself as not visible, which would make
+            // every element inside it look hidden. What is being asked here is whether the content
+            // would be on screen, so the window itself is not part of the question.
+            if (node is Window) break;
             if (node is UIElement { Visibility: not Visibility.Visible }) return false;
         }
         return true;

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -71,6 +71,62 @@ public class XamlLoadTests(WpfFixture wpf)
         => Check("BlobConfigView", () =>
             new BlobConfigView { DataContext = new BlobConfigViewModel(Store(), new BlobStorageService(Store())) });
 
+    /// <summary>
+    /// The container form under Entra: no SAS box, and the caveat panel on screen (#29).
+    ///
+    /// Worth its own case because the whole Entra section is collapsed in the default state the
+    /// plain load test exercises, so none of its bindings are ever evaluated there.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public void TheContainerFormHidesTheSasBoxUnderEntra(BlobAuthMode mode)
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BlobConfigViewModel(Store(), new BlobStorageService(Store()));
+            vm.AddNewCommand.Execute(null);
+            vm.EditName = "backups";
+            vm.EditContainerUrl = "https://mystorageaccount.blob.core.windows.net/backups";
+            vm.EditAuthMode = mode;
+
+            var view = new BlobConfigView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var labels = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+                Assert.DoesNotContain("SAS TOKEN", labels);
+                Assert.Contains(labels, t => t.Contains("has not been tested", StringComparison.Ordinal));
+                Assert.Contains(labels, t => t.Contains("Storage Blob Data Reader", StringComparison.Ordinal));
+
+                listener.AssertNone("BlobConfigView Entra");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    [Fact]
+    public void TheContainerFormShowsTheSasBoxUnderSasAuth()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BlobConfigViewModel(Store(), new BlobStorageService(Store()));
+            vm.AddNewCommand.Execute(null);
+
+            var view = new BlobConfigView { DataContext = vm };
+            Realise(view);
+
+            var labels = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+            Assert.Contains("SAS TOKEN", labels);
+            Assert.DoesNotContain(labels, t => t.Contains("has not been tested", StringComparison.Ordinal));
+        });
+    }
+
     [Fact]
     public void ServerManagerViewLoads()
         => Check("ServerManagerView", () =>

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -258,17 +258,17 @@ public class XamlLoadTests(WpfFixture wpf)
                 ContainerUrl = "https://acct.blob.core.windows.net/backups"
             };
             vm.IsConnectedToServer = true;
-            vm.CredentialSectionVisible = true;
+            vm.Credential.SectionVisible = true;
 
             var view = new RestoreView { DataContext = vm };
 
-            vm.CredentialExistsOnServer = false;
-            vm.CredentialIdentityKind = BlobCredentialIdentity.Missing;
+            vm.Credential.ExistsOnServer = false;
+            vm.Credential.IdentityKind = BlobCredentialIdentity.Missing;
             Realise(view);
             Assert.Contains(FindAll<Button>(view), b => (b.Content as string) == "Create credential on server");
 
-            vm.CredentialExistsOnServer = true;
-            vm.CredentialIdentityKind = BlobCredentialIdentity.SharedAccessSignature;
+            vm.Credential.ExistsOnServer = true;
+            vm.Credential.IdentityKind = BlobCredentialIdentity.SharedAccessSignature;
             Realise(view);
             Assert.Contains(FindAll<Button>(view),
                 b => (b.Content as string) == "Refresh credential with stored SAS token");
@@ -293,14 +293,17 @@ public class XamlLoadTests(WpfFixture wpf)
                 ContainerUrl = "https://acct.blob.core.windows.net/backups"
             };
             vm.IsConnectedToServer = true;
-            vm.CredentialSectionVisible = true;
+            vm.Credential.SectionVisible = true;
 
             var view = new RestoreView { DataContext = vm };
 
-            vm.CredentialExistsOnServer = true;
-            vm.CredentialIdentityKind = BlobCredentialIdentity.ManagedIdentity;
+            vm.Credential.ExistsOnServer = true;
+            vm.Credential.IdentityKind = BlobCredentialIdentity.ManagedIdentity;
             Realise(view);
 
+            // Present, not shown: the panel lives inside a section that needs a loaded backup
+            // set, which this fixture deliberately does not stand up. That the panel's own
+            // visibility binding resolves at all is covered by RestoreViewLoads.
             Assert.Contains(FindAll<Button>(view),
                 b => (b.Content as string) == "Replace Managed Identity with stored SAS token");
         });

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -263,15 +263,46 @@ public class XamlLoadTests(WpfFixture wpf)
             var view = new RestoreView { DataContext = vm };
 
             vm.CredentialExistsOnServer = false;
-            vm.CredentialIsValidSas = false;
+            vm.CredentialIdentityKind = BlobCredentialIdentity.Missing;
             Realise(view);
             Assert.Contains(FindAll<Button>(view), b => (b.Content as string) == "Create credential on server");
 
             vm.CredentialExistsOnServer = true;
-            vm.CredentialIsValidSas = true;
+            vm.CredentialIdentityKind = BlobCredentialIdentity.SharedAccessSignature;
             Realise(view);
             Assert.Contains(FindAll<Button>(view),
                 b => (b.Content as string) == "Refresh credential with stored SAS token");
+        });
+    }
+
+    /// <summary>
+    /// The same button under a managed identity. "Refresh credential with stored SAS token" reads
+    /// as a harmless top-up, and the press would convert the instance's managed identity into a
+    /// SAS credential - so the label has to say that before it is pressed, not after (#145).
+    /// </summary>
+    [Fact]
+    public void TheCredentialButtonSaysItWouldReplaceAManagedIdentity()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.SelectedContainer = new BlobContainerConfig
+            {
+                Id = BlobContainerConfig.NewId(),
+                Name = "prod",
+                ContainerUrl = "https://acct.blob.core.windows.net/backups"
+            };
+            vm.IsConnectedToServer = true;
+            vm.CredentialSectionVisible = true;
+
+            var view = new RestoreView { DataContext = vm };
+
+            vm.CredentialExistsOnServer = true;
+            vm.CredentialIdentityKind = BlobCredentialIdentity.ManagedIdentity;
+            Realise(view);
+
+            Assert.Contains(FindAll<Button>(view),
+                b => (b.Content as string) == "Replace Managed Identity with stored SAS token");
         });
     }
 

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -304,13 +304,13 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.BackupsLoaded = true;
             vm.HasScript = true;
             vm.GeneratedScript = "RESTORE DATABASE [MyDb] FROM URL = N'https://acct/backups/x.bak'";
-            vm.ConsoleLines =
+            vm.Console.Lines =
             [
                 new ConsoleLine("Beginning restore execution...", ConsoleLineKind.Step),
                 new ConsoleLine("50 percent processed."),
                 new ConsoleLine("ERROR: something went wrong", ConsoleLineKind.Error)
             ];
-            vm.HasConsoleOutput = true;
+            vm.Console.HasOutput = true;
             vm.IsExecuting = false;
             vm.ExecutionComplete = true;
 
@@ -354,8 +354,8 @@ public class XamlLoadTests(WpfFixture wpf)
         {
             var vm = NewRestoreViewModel();
             vm.BackupsLoaded = true;
-            vm.ConsoleLines = [new ConsoleLine("Beginning restore execution...")];
-            vm.HasConsoleOutput = true;
+            vm.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
+            vm.Console.HasOutput = true;
 
             var view = new RestoreView { DataContext = vm };
 
@@ -382,8 +382,8 @@ public class XamlLoadTests(WpfFixture wpf)
         {
             var vm = NewRestoreViewModel();
             vm.BackupsLoaded = true;
-            vm.ConsoleLines = [new ConsoleLine("Beginning restore execution...")];
-            vm.HasConsoleOutput = true;
+            vm.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
+            vm.Console.HasOutput = true;
             vm.IsConsoleDetached = false;   // as if the wiring failed
             vm.IsExecuting = true;
 

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -414,6 +414,63 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
         });
     }
 
+    /// <summary>
+    /// The VERIFYONLY results panel (#26). Its rows colour the status through a Style on a Run,
+    /// which is only ever built when the template is realised - so an empty collection would leave
+    /// that markup completely unexercised.
+    /// </summary>
+    [Fact]
+    public void TheVerifyPanelShowsWhatSqlServerSaidAboutEachBackup()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            var good = new BackupSet { SetId = "20260110_220000", Type = BackupType.Full };
+            var bad = new BackupSet { SetId = "20260110_230000", Type = BackupType.TransactionLog };
+
+            vm.ChainVerifyResults.Add(new ChainVerifyResult
+            {
+                Set = good,
+                Result = new VerifyOnlyResult(true, "The backup set on file 1 is valid.")
+            });
+            vm.ChainVerifyResults.Add(new ChainVerifyResult
+            {
+                Set = bad,
+                Result = new VerifyOnlyResult(false, "Cannot open backup device.")
+            });
+            vm.HasVerifyResults = true;
+            vm.HasVerifyFailures = true;
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.True(
+                    texts.Any(t => t.Contains("Cannot open backup device.", StringComparison.Ordinal)),
+                    "The verify panel did not render its results. TextBlocks found: " +
+                    string.Join(" | ", texts.Where(t => !string.IsNullOrWhiteSpace(t))));
+                // The status sits in its own Run so it can be coloured, so look at the inlines
+                // rather than the TextBlock's flattened text.
+                var runs = FindAll<TextBlock>(view)
+                    .SelectMany(t => t.Inlines.OfType<System.Windows.Documents.Run>())
+                    .Select(r => r.Text)
+                    .ToList();
+
+                Assert.True(runs.Contains("FAILED"), "A failed backup did not read as failed.");
+                Assert.True(runs.Contains("Valid"), "A good backup did not read as valid.");
+
+                listener.AssertNone("RestoreView verify panel");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
     /// <summary>Tag pills render through one wrapping template; they used to clip (#67).</summary>
     [Fact]
     public void TagPillsRenderForAServerRow()

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -509,6 +509,66 @@ public class XamlLoadTests(WpfFixture wpf)
         });
     }
 
+    /// <summary>
+    /// The restore history view (#31). Populated, because its rows colour the outcome through a
+    /// Style on a Run and the detail pane only exists once something is selected - none of which
+    /// is built when the list is empty.
+    /// </summary>
+    [Fact]
+    public void TheHistoryViewShowsWhatEachRestoreDid()
+    {
+        wpf.Invoke(() =>
+        {
+            var history = new FakeRestoreHistoryStore();
+            history.Append(new RestoreHistoryEntry
+            {
+                StartedAt = new DateTime(2026, 1, 10, 22, 0, 0),
+                CompletedAt = new DateTime(2026, 1, 10, 22, 4, 30),
+                ServerName = "SRV01",
+                TargetDatabase = "MyDb_Restored",
+                ChainSummary = "1 Full + 2 Log(s)",
+                Outcome = RestoreOutcome.Failed,
+                ErrorMessage = "RESTORE terminating abnormally.",
+                Script = "RESTORE DATABASE [MyDb_Restored] FROM URL = N'https://mystorageaccount.blob.core.windows.net/backups/x.bak'",
+                Log = "Beginning restore execution..."
+            });
+
+            var view = new HistoryView { DataContext = new HistoryViewModel(history) };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.True(
+                    texts.Any(t => t.Contains("RESTORE terminating abnormally.", StringComparison.Ordinal)),
+                    "The detail pane did not render. TextBlocks found: " +
+                    string.Join(" | ", texts.Where(t => !string.IsNullOrWhiteSpace(t))));
+
+                var runs = FindAll<TextBlock>(view)
+                    .SelectMany(t => t.Inlines.OfType<System.Windows.Documents.Run>())
+                    .Select(r => r.Text)
+                    .ToList();
+                Assert.Contains("Failed", runs);
+
+                // The script and the log are what someone came here for.
+                var boxes = FindAll<System.Windows.Controls.TextBox>(view).Select(b => b.Text).ToList();
+                Assert.Contains(boxes, t => t.Contains("RESTORE DATABASE", StringComparison.Ordinal));
+
+                listener.AssertNone("HistoryView");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    [Fact]
+    public void TheHistoryViewLoadsWithNothingRecorded()
+        => Check("HistoryView (empty)", () =>
+            new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) });
+
     // ── helpers ─────────────────────────────────────────────────────────────────
 
     private RestoreViewModel NewRestoreViewModel()
@@ -520,7 +580,8 @@ public class XamlLoadTests(WpfFixture wpf)
             new BackupChainBuilder(),
             new RestoreScriptGenerator(),
             store,
-            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))));
+            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))),
+            new FakeRestoreHistoryStore());
     }
 
     /// <summary>

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -98,7 +98,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
                 var labels = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
                 Assert.DoesNotContain("SAS TOKEN", labels);
-                Assert.Contains(labels, t => t.Contains("has not been tested", StringComparison.Ordinal));
+                Assert.Contains(labels, t => t.Contains("Owner or Contributor is NOT enough", StringComparison.Ordinal));
                 Assert.Contains(labels, t => t.Contains("Storage Blob Data Reader", StringComparison.Ordinal));
 
                 listener.AssertNone("BlobConfigView Entra");
@@ -123,7 +123,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             var labels = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
             Assert.Contains("SAS TOKEN", labels);
-            Assert.DoesNotContain(labels, t => t.Contains("has not been tested", StringComparison.Ordinal));
+            Assert.DoesNotContain(labels, t => t.Contains("Owner or Contributor is NOT enough", StringComparison.Ordinal));
         });
     }
 

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -105,8 +105,24 @@ public class XamlLoadTests(WpfFixture wpf)
             // Against a fake store, not the real one. This used to construct a MainViewModel over
             // the actual %LOCALAPPDATA% config and run the secret-key migration across it - a test
             // reaching into the user's own data (#41).
-            var window = new MainWindow(new MainViewModel(new FakeCredentialStore()));
-            Realise(window);
+            var vm = new MainViewModel(new FakeCredentialStore());
+
+            // Busy, so the strip that says what the app is doing is actually built and bound - it
+            // is collapsed the rest of the time, and a mistyped path there would be silent (#128).
+            vm.BlobBrowser.IsBusy = true;
+
+            var window = new MainWindow(vm);
+
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(window);
+                listener.AssertNone("MainWindow");
+            }
+            finally
+            {
+                listener.Detach();
+            }
         });
     }
 

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -544,10 +544,10 @@ public class XamlLoadTests(WpfFixture wpf)
             };
 
             var vm = NewRestoreViewModel();
-            vm.HasRestorePoints = true;
-            vm.HasVisiblePoints = true;
-            vm.PointCountText = "Showing 1 of 4 restore point(s)";
-            vm.RestorePoints =
+            vm.Timeline.HasPoints = true;
+            vm.Timeline.HasVisiblePoints = true;
+            vm.Timeline.CountText = "Showing 1 of 4 restore point(s)";
+            vm.Timeline.Points =
             [
                 new RestorePoint
                 {

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
@@ -22,18 +22,14 @@ namespace Blackcat.NineLives.Tests;
 /// What this deliberately does not check is whether the result LOOKS right - colours, spacing,
 /// whether a panel is where you expect. That still needs eyes on the running app.
 /// </summary>
-public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposable
+[Collection(WpfCollection.Name)]
+public class XamlLoadTests(WpfFixture wpf)
 {
-    private readonly string _dir = Path.Combine(
-        Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"));
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_dir, recursive: true); } catch { }
-        GC.SuppressFinalize(this);
-    }
-
-    private CredentialStore Store() => new(_dir);
+    /// <summary>
+    /// In-memory throughout. These tests are about markup, so nothing here should be reading the
+    /// machine's credential vault or writing a config file anywhere (#41).
+    /// </summary>
+    private static ICredentialStore Store() => new FakeCredentialStore();
 
     /// <summary>Realises the visual tree. Bindings are not evaluated until something lays out.</summary>
     private static void Realise(FrameworkElement element)
@@ -106,7 +102,10 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
     {
         wpf.Invoke(() =>
         {
-            var window = new MainWindow();
+            // Against a fake store, not the real one. This used to construct a MainViewModel over
+            // the actual %LOCALAPPDATA% config and run the secret-key migration across it - a test
+            // reaching into the user's own data (#41).
+            var window = new MainWindow(new MainViewModel(new FakeCredentialStore()));
             Realise(window);
         });
     }
@@ -520,7 +519,8 @@ public class XamlLoadTests(WpfFixture wpf) : IClassFixture<WpfFixture>, IDisposa
             new SqlServerService(store),
             new BackupChainBuilder(),
             new RestoreScriptGenerator(),
-            store);
+            store,
+            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))));
     }
 
     /// <summary>

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -510,6 +510,60 @@ public class XamlLoadTests(WpfFixture wpf)
     }
 
     /// <summary>
+    /// The restore point list and its narrowing controls (#27). The list is the only way to pick
+    /// one point out of hundreds, so a binding that silently failed would leave the timeline as
+    /// the only selector again - which is the problem being fixed.
+    /// </summary>
+    [Fact]
+    public void TheRestorePointListRendersAndBindsItsSelection()
+    {
+        wpf.Invoke(() =>
+        {
+            var full = new BackupSet
+            {
+                SetId = "20260110_220000",
+                Type = BackupType.Full,
+                Timestamp = new DateTime(2026, 1, 10, 22, 0, 0),
+                Files = [new BackupFileInfo { BlobName = "FULL/SRV01/MyDb/20260110_220000.bak", SizeBytes = 1000 }]
+            };
+
+            var vm = NewRestoreViewModel();
+            vm.HasRestorePoints = true;
+            vm.HasVisiblePoints = true;
+            vm.PointCountText = "Showing 1 of 4 restore point(s)";
+            vm.RestorePoints =
+            [
+                new RestorePoint
+                {
+                    Timestamp = full.Timestamp,
+                    Type = BackupType.Full,
+                    PrimarySet = full,
+                    RequiredFullSet = full
+                }
+            ];
+
+            var view = new RestoreView { DataContext = vm };
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                Realise(view);
+
+                var texts = FindAll<TextBlock>(view).Select(t => t.Text).ToList();
+                Assert.True(
+                    texts.Any(t => t.Contains("2026-01-10 22:00:00", StringComparison.Ordinal)),
+                    "The restore point list did not render its rows.");
+                Assert.Contains(texts, t => t.Contains("Showing 1 of 4", StringComparison.Ordinal));
+
+                listener.AssertNone("RestoreView point list");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    /// <summary>
     /// The restore history view (#31). Populated, because its rows colour the outcome through a
     /// Style on a Run and the detail pane only exists once something is selected - none of which
     /// is built when the list is empty.

--- a/src/NineLives.Tests/packages.lock.json
+++ b/src/NineLives.Tests/packages.lock.json
@@ -112,6 +112,20 @@
           "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)"
         }
       },
+      "Microsoft.Data.SqlClient.Extensions.Azure": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "mJhONie3MuVXvSfBbtqGQAOGgeQDbOTfO5d0ZYo3KE4Vb7mua4O23lPJrsTYzvWn5od2CPAh0dHMZEWtJXcpxQ==",
+        "dependencies": {
+          "Azure.Core": "1.51.1",
+          "Azure.Identity": "1.18.0",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.Broker": "4.84.2"
+        }
+      },
       "Microsoft.Data.SqlClient.Internal.Logging": {
         "type": "Transitive",
         "resolved": "7.0.2",
@@ -208,10 +222,19 @@
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
-        "resolved": "4.83.1",
-        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "resolved": "4.84.2",
+        "contentHash": "Va9FjmABSgj/lcUfHH0pBNQkmS7SNyepz2ERV7Yynp6QgEYpFdSqR6Vzy1WWipN8GS5pBHuXoZbqaDWuARCrHQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Broker": {
+        "type": "Transitive",
+        "resolved": "4.84.2",
+        "contentHash": "928ySLeGz1xtvydwq6h9tv7TbxrtA4ZzavLKUqRJh0PW6BGcEJwpI8W8vf2PlQdYemGm/oyGjdzYzdY/I8r/4A==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.NativeInterop": "0.20.6"
         }
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
@@ -221,6 +244,11 @@
         "dependencies": {
           "Microsoft.Identity.Client": "4.83.1"
         }
+      },
+      "Microsoft.Identity.Client.NativeInterop": {
+        "type": "Transitive",
+        "resolved": "0.20.6",
+        "contentHash": "noyfdMfVxyWpM6xUDmlW6gUvZ5ci24z7Qoy15JvynTQfZV5vTD2NEdsnT5Gy4ngViwgdIp5iRjRy10jAKXFAgw=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -363,7 +391,8 @@
           "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
           "CommunityToolkit.Mvvm": "[8.4.2, )",
-          "Microsoft.Data.SqlClient": "[7.0.2, )"
+          "Microsoft.Data.SqlClient": "[7.0.2, )",
+          "Microsoft.Data.SqlClient.Extensions.Azure": "[7.0.2, )"
         }
       }
     }

--- a/src/NineLives.Tests/packages.lock.json
+++ b/src/NineLives.Tests/packages.lock.json
@@ -43,6 +43,14 @@
           "System.Memory.Data": "10.0.3"
         }
       },
+      "Azure.Identity": {
+        "type": "Transitive",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Azure.Storage.Blobs": {
         "type": "Transitive",
         "resolved": "12.29.1",
@@ -352,6 +360,7 @@
       "ninelives": {
         "type": "Project",
         "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
           "Azure.Storage.Blobs": "[12.29.1, )",
           "CommunityToolkit.Mvvm": "[8.4.2, )",
           "Microsoft.Data.SqlClient": "[7.0.2, )"

--- a/src/NineLives/App.xaml
+++ b/src/NineLives/App.xaml
@@ -5,7 +5,10 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Themes/DarkTheme.xaml" />
+                <!-- The palette MUST be first: ThemeManager swaps whatever is at index 0, and it
+                     identifies it by position rather than by guessing at the source Uri. -->
+                <ResourceDictionary Source="Themes/Palette.Dark.xaml" />
+                <ResourceDictionary Source="Themes/Controls.xaml" />
                 <ResourceDictionary Source="Themes/Logo.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/src/NineLives/Converters/ValueConverters.cs
+++ b/src/NineLives/Converters/ValueConverters.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
@@ -139,6 +139,73 @@ public class BackupTypeToColorConverter : IValueConverter
             "TransactionLog" => new SolidColorBrush(Color.FromRgb(0x27, 0xAE, 0x60)),
             _ => new SolidColorBrush(Color.FromRgb(0x88, 0x90, 0xA4))
         };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Picks black or white text for whatever colour it is given, by measured contrast (#126).
+///
+/// Used where the fill is DATA rather than theme - the path-element pills take their colour from
+/// the element, so no single hardcoded foreground can be right for all of them. White on the
+/// orange one scored 2.19:1 and on the green one 2.87:1, both well under the 4.5:1 minimum, while
+/// the blue and purple ones were fine. This asks the colour rather than assuming.
+/// </summary>
+public class ContrastingTextConverter : IValueConverter
+{
+    private static readonly SolidColorBrush Dark = new(Color.FromRgb(0x0F, 0x13, 0x1E));
+    private static readonly SolidColorBrush Light = new(Colors.White);
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var colour = value switch
+        {
+            Color c => c,
+            SolidColorBrush b => b.Color,
+            string hex when TryParse(hex, out var parsed) => parsed,
+            _ => Colors.Gray
+        };
+
+        // Compare both candidates and take the better, rather than thresholding on luminance. The
+        // usual 0.179 crossover assumes PURE black and white; this app's dark is #0F131E, which
+        // moves the crossover - and picking by the textbook threshold chose dark text at 4.12:1
+        // for an orange where white would have given 4.50:1.
+        return Contrast(Dark.Color, colour) >= Contrast(Light.Color, colour) ? Dark : Light;
+    }
+
+    private static bool TryParse(string hex, out Color colour)
+    {
+        try
+        {
+            colour = (Color)ColorConverter.ConvertFromString(hex);
+            return true;
+        }
+        catch
+        {
+            colour = Colors.Gray;
+            return false;
+        }
+    }
+
+    private static double Contrast(Color a, Color b)
+    {
+        var la = Luminance(a);
+        var lb = Luminance(b);
+        var (hi, lo) = la > lb ? (la, lb) : (lb, la);
+        return (hi + 0.05) / (lo + 0.05);
+    }
+
+    private static double Luminance(Color c)
+    {
+        static double Channel(byte v)
+        {
+            var s = v / 255.0;
+            return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+        }
+
+        return 0.2126 * Channel(c.R) + 0.7152 * Channel(c.G) + 0.0722 * Channel(c.B);
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/NineLives/Converters/ValueConverters.cs
+++ b/src/NineLives/Converters/ValueConverters.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
+using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Converters;
 
@@ -314,6 +315,29 @@ public class BackupSourceTypeToDisplayConverter : IValueConverter
             _ => value?.ToString() ?? ""
         };
     }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>How a container's authentication mode reads on the detail panel (#29).</summary>
+public class BlobAuthModeToDisplayConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is BlobAuthMode mode ? mode.Describe() : string.Empty;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
+/// <summary>
+/// Shows the SAS-only parts of the detail panel. An expiry line against an Entra container would
+/// send someone hunting for a token that does not exist.
+/// </summary>
+public class BlobAuthModeIsSasConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is BlobAuthMode mode && mode.NeedsSasToken() ? Visibility.Visible : Visibility.Collapsed;
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         => throw new NotSupportedException();

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -244,6 +244,29 @@
 
             <!-- Main Content Area -->
             <DockPanel Grid.Column="1">
+                <!-- What the app is doing, in the one place that is always on screen. Every screen
+                     has its own status line, but they sit at the bottom of pages long enough to
+                     scroll - so "is it doing something?" depended on where you happened to be
+                     looking (#128). -->
+                <Border DockPanel.Dock="Top"
+                        Padding="16,6,16,0"
+                        Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}">
+                    <Border Background="{DynamicResource CardBackgroundBrush}"
+                            BorderBrush="{DynamicResource AccentBrush}"
+                            BorderThickness="1"
+                            CornerRadius="4" Padding="10,5">
+                        <StackPanel Orientation="Horizontal">
+                            <ContentControl Template="{StaticResource BusySpinner}"
+                                            Width="13" Height="13"
+                                            VerticalAlignment="Center" Margin="0,0,8,0" />
+                            <TextBlock Text="{Binding BusyText}"
+                                       VerticalAlignment="Center"
+                                       FontSize="12"
+                                       Foreground="{DynamicResource AccentBrush}" />
+                        </StackPanel>
+                    </Border>
+                </Border>
+
                 <!-- Persistent Connection Status Banner -->
                 <Border DockPanel.Dock="Top"
                         Padding="16,6"

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -31,6 +31,9 @@
         <DataTemplate DataType="{x:Type vm:RestoreViewModel}">
             <views:RestoreView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:HistoryViewModel}">
+            <views:HistoryView />
+        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:AboutViewModel}">
             <views:AboutView />
         </DataTemplate>
@@ -224,6 +227,15 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#x267B;" FontSize="15" VerticalAlignment="Center" Width="24" />
                                 <TextBlock Text="Restore" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <RadioButton Style="{StaticResource SidebarButton}"
+                                     Command="{Binding NavigateToCommand}"
+                                     CommandParameter="History">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#x1F553;" FontSize="15" VerticalAlignment="Center" Width="24" />
+                                <TextBlock Text="History" VerticalAlignment="Center" />
                             </StackPanel>
                         </RadioButton>
                     </StackPanel>

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -8,7 +8,7 @@
         Height="800" Width="1200"
         MinHeight="600" MinWidth="900"
         WindowStartupLocation="CenterScreen"
-        Background="{StaticResource WindowBackgroundBrush}">
+        Background="{DynamicResource WindowBackgroundBrush}">
 
     <!-- DataContext is set in the constructor, not here. Declaring it in XAML meant every
          construction of this window - including a test that only wanted to check the markup -
@@ -50,14 +50,14 @@
              because something is on fire, and a popup between the DBA and the restore button
              would be exactly wrong. -->
         <Border Grid.Row="0"
-                Background="{StaticResource UpdateBannerBrush}"
-                BorderBrush="{StaticResource UpdateBannerEdgeBrush}"
+                Background="{DynamicResource UpdateBannerBrush}"
+                BorderBrush="{DynamicResource UpdateBannerEdgeBrush}"
                 BorderThickness="0,0,0,1"
                 Padding="16,10"
                 Visibility="{Binding UpdateAvailable, Converter={StaticResource BoolToVis}}">
             <!-- Lifts the band off the window rather than letting it read as another dark stripe. -->
             <Border.Effect>
-                <DropShadowEffect Color="#000000" BlurRadius="12" ShadowDepth="2" Opacity="0.45" Direction="270" />
+                <DropShadowEffect Color="{DynamicResource ShadowColor}" BlurRadius="12" ShadowDepth="2" Opacity="0.45" Direction="270" />
             </Border.Effect>
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -70,9 +70,9 @@
                 <!-- Badge. Pulses slowly - enough to catch the eye on a screen someone is already
                      looking at, slow enough not to nag while they work. -->
                 <Grid Grid.Column="0" Width="24" Height="24" Margin="0,0,12,0" VerticalAlignment="Center">
-                    <Ellipse Fill="#1A1205" Opacity="0.92" />
+                    <Ellipse Fill="{DynamicResource UpdateBannerBadgeBrush}" Opacity="0.92" />
                     <TextBlock Text="&#x2191;"
-                               Foreground="#FFC24B"
+                               Foreground="{DynamicResource UpdateBannerBadgeGlyphBrush}"
                                FontSize="15"
                                FontWeight="Bold"
                                HorizontalAlignment="Center"
@@ -93,7 +93,7 @@
                 <TextBlock Grid.Column="1"
                            Text="{Binding UpdateMessage}"
                            VerticalAlignment="Center"
-                           Foreground="{StaticResource UpdateBannerTextBrush}"
+                           Foreground="{DynamicResource UpdateBannerTextBrush}"
                            FontFamily="Segoe UI"
                            FontSize="13.5"
                            FontWeight="SemiBold"
@@ -119,13 +119,13 @@
             </Grid.ColumnDefinitions>
 
             <!-- Sidebar -->
-            <Border Grid.Column="0" Background="{StaticResource SidebarBackgroundBrush}">
+            <Border Grid.Column="0" Background="{DynamicResource SidebarBackgroundBrush}">
                 <DockPanel>
                     <!-- App Title -->
                     <StackPanel DockPanel.Dock="Top" Margin="20,20,20,8">
                         <TextBlock FontSize="18" FontWeight="Bold"
                                    FontFamily="Segoe UI">
-                            <Run Text="Nine" Foreground="{StaticResource PrimaryTextBrush}" /><Run Text=" Lives" Foreground="{StaticResource AccentBrush}" />
+                            <Run Text="Nine" Foreground="{DynamicResource PrimaryTextBrush}" /><Run Text=" Lives" Foreground="{DynamicResource AccentBrush}" />
                         </TextBlock>
                         <TextBlock Text="SQL Restore from Azure Blob"
                                    Style="{StaticResource SecondaryText}"
@@ -134,7 +134,7 @@
 
                     <Border DockPanel.Dock="Top"
                             Height="1"
-                            Background="{StaticResource CardBorderBrush}"
+                            Background="{DynamicResource CardBorderBrush}"
                             Margin="16,8,16,8" />
 
                     <!-- About Button -->
@@ -151,18 +151,18 @@
 
                     <!-- Connection Status -->
                     <Border DockPanel.Dock="Bottom"
-                            Background="{StaticResource CardBackgroundBrush}"
+                            Background="{DynamicResource CardBackgroundBrush}"
                             CornerRadius="6"
                             Padding="12,8"
                             Margin="12,8,12,16">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal">
                                 <Ellipse Width="8" Height="8"
-                                         Fill="{StaticResource SuccessBrush}"
+                                         Fill="{DynamicResource SuccessBrush}"
                                          VerticalAlignment="Center"
                                          Visibility="{Binding IsConnectedToSql, Converter={StaticResource BoolToVis}}" />
                                 <Ellipse Width="8" Height="8"
-                                         Fill="{StaticResource SecondaryTextBrush}"
+                                         Fill="{DynamicResource SecondaryTextBrush}"
                                          VerticalAlignment="Center"
                                          Visibility="{Binding IsConnectedToSql, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
                                 <TextBlock Style="{StaticResource SecondaryText}"
@@ -179,7 +179,7 @@
                     <StackPanel DockPanel.Dock="Top" Margin="0,8,0,0">
                         <TextBlock Text="CONFIGURATION"
                                    FontSize="10" FontWeight="Bold"
-                                   Foreground="{StaticResource DisabledTextBrush}"
+                                   Foreground="{DynamicResource DisabledTextBrush}"
                                    Margin="20,8,0,4"
                                    FontFamily="Segoe UI" />
 
@@ -203,12 +203,12 @@
                         </RadioButton>
 
                         <Border Height="1"
-                                Background="{StaticResource CardBorderBrush}"
+                                Background="{DynamicResource CardBorderBrush}"
                                 Margin="16,12,16,4" />
 
                         <TextBlock Text="OPERATIONS"
                                    FontSize="10" FontWeight="Bold"
-                                   Foreground="{StaticResource DisabledTextBrush}"
+                                   Foreground="{DynamicResource DisabledTextBrush}"
                                    Margin="20,8,0,4"
                                    FontFamily="Segoe UI" />
 
@@ -248,7 +248,7 @@
                 <Border DockPanel.Dock="Top"
                         Padding="16,6"
                         Visibility="{Binding IsConnectedToSql, Converter={StaticResource BoolToVis}}">
-                    <Border Background="#1A27AE60" CornerRadius="4" Padding="10,5">
+                    <Border Background="{DynamicResource SuccessPanelBackgroundBrush}" CornerRadius="4" Padding="10,5">
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
@@ -256,11 +256,11 @@
                             </Grid.ColumnDefinitions>
                             <StackPanel Grid.Column="0" Orientation="Horizontal">
                                 <Ellipse Width="8" Height="8"
-                                         Fill="{StaticResource SuccessBrush}"
+                                         Fill="{DynamicResource SuccessBrush}"
                                          VerticalAlignment="Center"
                                          Margin="0,0,8,0" />
                                 <TextBlock VerticalAlignment="Center"
-                                           Foreground="{StaticResource SuccessBrush}"
+                                           Foreground="{DynamicResource SuccessBrush}"
                                            FontSize="12">
                                     <Run Text="Connected to" />
                                     <Run Text="{Binding ConnectedServerName, Mode=OneWay}" FontWeight="SemiBold" />
@@ -273,8 +273,8 @@
                                     FontSize="11"
                                     Background="Transparent"
                                     BorderThickness="1"
-                                    BorderBrush="{StaticResource SuccessBrush}"
-                                    Foreground="{StaticResource SuccessBrush}"
+                                    BorderBrush="{DynamicResource SuccessBrush}"
+                                    Foreground="{DynamicResource SuccessBrush}"
                                     Cursor="Hand"
                                     VerticalAlignment="Center" />
                         </Grid>
@@ -286,7 +286,7 @@
 
         <!-- Status Bar -->
         <Border Grid.Row="2"
-                Background="{StaticResource StatusBarBackgroundBrush}"
+                Background="{DynamicResource StatusBarBackgroundBrush}"
                 Padding="16,6">
             <Grid>
                 <Grid.ColumnDefinitions>

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="Blackcat.NineLives.MainWindow"
+﻿<Window x:Class="Blackcat.NineLives.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:Blackcat.NineLives.ViewModels"

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -46,37 +46,65 @@
              because something is on fire, and a popup between the DBA and the restore button
              would be exactly wrong. -->
         <Border Grid.Row="0"
-                Background="#1B2A44"
-                BorderBrush="#2E4468"
+                Background="{StaticResource UpdateBannerBrush}"
+                BorderBrush="{StaticResource UpdateBannerEdgeBrush}"
                 BorderThickness="0,0,0,1"
-                Padding="16,8"
+                Padding="16,10"
                 Visibility="{Binding UpdateAvailable, Converter={StaticResource BoolToVis}}">
+            <!-- Lifts the band off the window rather than letting it read as another dark stripe. -->
+            <Border.Effect>
+                <DropShadowEffect Color="#000000" BlurRadius="12" ShadowDepth="2" Opacity="0.45" Direction="270" />
+            </Border.Effect>
             <Grid>
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <TextBlock Grid.Column="0"
+                <!-- Badge. Pulses slowly - enough to catch the eye on a screen someone is already
+                     looking at, slow enough not to nag while they work. -->
+                <Grid Grid.Column="0" Width="24" Height="24" Margin="0,0,12,0" VerticalAlignment="Center">
+                    <Ellipse Fill="#1A1205" Opacity="0.92" />
+                    <TextBlock Text="&#x2191;"
+                               Foreground="#FFC24B"
+                               FontSize="15"
+                               FontWeight="Bold"
+                               HorizontalAlignment="Center"
+                               VerticalAlignment="Center" />
+                    <Grid.Triggers>
+                        <EventTrigger RoutedEvent="Loaded">
+                            <BeginStoryboard>
+                                <Storyboard>
+                                    <DoubleAnimation Storyboard.TargetProperty="Opacity"
+                                                     From="1.0" To="0.45" Duration="0:0:1.1"
+                                                     AutoReverse="True" RepeatBehavior="Forever" />
+                                </Storyboard>
+                            </BeginStoryboard>
+                        </EventTrigger>
+                    </Grid.Triggers>
+                </Grid>
+
+                <TextBlock Grid.Column="1"
                            Text="{Binding UpdateMessage}"
                            VerticalAlignment="Center"
-                           Foreground="{StaticResource PrimaryTextBrush}"
+                           Foreground="{StaticResource UpdateBannerTextBrush}"
                            FontFamily="Segoe UI"
-                           FontSize="12.5" />
-
-                <Button Grid.Column="1"
-                        Content="View release"
-                        Command="{Binding OpenReleasesPageCommand}"
-                        Style="{StaticResource SecondaryButton}"
-                        Padding="12,4"
-                        Margin="12,0,8,0" />
+                           FontSize="13.5"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap" />
 
                 <Button Grid.Column="2"
+                        Content="View release"
+                        Command="{Binding OpenReleasesPageCommand}"
+                        Style="{StaticResource UpdateBannerPrimaryButton}"
+                        Margin="12,0,8,0" />
+
+                <Button Grid.Column="3"
                         Content="Dismiss"
                         Command="{Binding DismissUpdateCommand}"
-                        Style="{StaticResource SecondaryButton}"
-                        Padding="12,4" />
+                        Style="{StaticResource UpdateBannerGhostButton}" />
             </Grid>
         </Border>
 

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -10,9 +10,10 @@
         WindowStartupLocation="CenterScreen"
         Background="{StaticResource WindowBackgroundBrush}">
 
-    <Window.DataContext>
-        <vm:MainViewModel />
-    </Window.DataContext>
+    <!-- DataContext is set in the constructor, not here. Declaring it in XAML meant every
+         construction of this window - including a test that only wanted to check the markup -
+         built a MainViewModel against the real %LOCALAPPDATA% config and ran the secret-key
+         migration over it. -->
 
     <Window.Resources>
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />

--- a/src/NineLives/MainWindow.xaml.cs
+++ b/src/NineLives/MainWindow.xaml.cs
@@ -1,13 +1,22 @@
 using System.Windows;
 using System.Windows.Media.Imaging;
+using Blackcat.NineLives.ViewModels;
 
 namespace Blackcat.NineLives;
 
 public partial class MainWindow : Window
 {
-    public MainWindow()
+    public MainWindow() : this(new MainViewModel()) { }
+
+    /// <summary>
+    /// Takes the viewmodel so a test can supply one built against a temp config directory. The
+    /// DataContext used to be declared in XAML, which made that impossible - the real one was
+    /// constructed during InitializeComponent whatever the caller did.
+    /// </summary>
+    public MainWindow(MainViewModel viewModel)
     {
         InitializeComponent();
+        DataContext = viewModel;
         try
         {
             Icon = new BitmapImage(new Uri("pack://application:,,,/Assets/app.ico", UriKind.Absolute));

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -10,6 +10,61 @@ public enum BackupType
     Unknown
 }
 
+/// <summary>
+/// Where a backup's time reading came from - which also says what clock it is on.
+///
+/// These are NOT the same time base, and nothing in a container tells us the offset between
+/// them, so they can only be compared once you accept the skew. A container whose files are
+/// homogeneous is fine either way; the problem case is one database with both kinds, where a
+/// fallback-derived set can sort hours out of position.
+/// </summary>
+public enum BackupTimestampSource
+{
+    /// <summary>Parsed out of the filename, so it reads the BACKUP SERVER's local clock.</summary>
+    FileName,
+
+    /// <summary>Read from SQL Server's own header, so it reads the backup server's local clock.</summary>
+    BackupHeader,
+
+    /// <summary>
+    /// Fallback: the blob's LastModified, which is UTC, and additionally records when the file
+    /// finished uploading rather than when the backup was taken.
+    /// </summary>
+    BlobLastModified
+}
+
+/// <summary>
+/// Helpers for the app's backup time readings.
+/// </summary>
+public static class BackupTime
+{
+    /// <summary>
+    /// Reduces a blob's LastModified to a bare wall-clock reading.
+    ///
+    /// Kind is deliberately Unspecified. Every time value the app sorts on is a wall clock whose
+    /// zone is recorded separately in a <see cref="BackupTimestampSource"/>; leaving Kind unset
+    /// keeps anything from quietly converting one base into another - notably
+    /// <c>new DateTimeOffset(value)</c>, which silently assumes the WORKSTATION's offset, and
+    /// <c>ToLocalTime()</c>, which is the workstation's zone rather than the backup server's.
+    /// </summary>
+    public static DateTime WallClock(DateTimeOffset value)
+        => DateTime.SpecifyKind(value.UtcDateTime, DateTimeKind.Unspecified);
+
+    /// <summary>Explains an approximate reading. Shown as a tooltip wherever one is displayed.</summary>
+    public const string ApproximateNote =
+        "Approximate. This file's name carries no timestamp, so the time shown is when the blob "
+        + "was last modified (UTC), not when the backup was taken on the server. It may sit hours "
+        + "away from the other entries.";
+
+    /// <summary>Prefix marking a displayed time as approximate.</summary>
+    public const string ApproximateMarker = "~";
+
+    public static string Format(DateTime value, bool approximate)
+        => approximate
+            ? ApproximateMarker + value.ToString("yyyy-MM-dd HH:mm:ss")
+            : value.ToString("yyyy-MM-dd HH:mm:ss");
+}
+
 public class BackupFileInfo
 {
     public string BlobName { get; set; } = string.Empty;
@@ -69,7 +124,22 @@ public class BackupFileInfo
     public bool MatchesServer(string? serverFilter)
         => ServerIdentity.Matches(InferredServerName, InferredInstanceName, serverFilter);
 
-    public DateTime EffectiveDate => BackupStartDate ?? LastModified.DateTime;
+    /// <summary>
+    /// Best available time for this file. Prefer the header's BackupStartDate, which is the
+    /// backup server's local clock; without it fall back to the blob's LastModified, which is
+    /// UTC. <see cref="EffectiveDateSource"/> says which you got - the two are not interchangeable.
+    /// </summary>
+    public DateTime EffectiveDate => BackupStartDate ?? BackupTime.WallClock(LastModified);
+
+    public BackupTimestampSource EffectiveDateSource => BackupStartDate.HasValue
+        ? BackupTimestampSource.BackupHeader
+        : BackupTimestampSource.BlobLastModified;
+
+    public bool IsEffectiveDateApproximate => !BackupStartDate.HasValue;
+
+    public string EffectiveDateDisplay => BackupTime.Format(EffectiveDate, IsEffectiveDateApproximate);
+
+    public string? EffectiveDateNote => IsEffectiveDateApproximate ? BackupTime.ApproximateNote : null;
 
     public string TypeDisplay => Type switch
     {
@@ -94,7 +164,24 @@ public class BackupSet
     public string SetId { get; set; } = string.Empty;
     public BackupType Type { get; set; }
     public List<BackupFileInfo> Files { get; set; } = [];
+    /// <summary>
+    /// When this backup was taken, as a bare wall clock. <see cref="TimestampSource"/> says which
+    /// clock it is on - sets in one container can differ, and nothing reconciles them.
+    /// </summary>
     public DateTime Timestamp { get; set; }
+
+    public BackupTimestampSource TimestampSource { get; set; } = BackupTimestampSource.FileName;
+
+    /// <summary>
+    /// True when the time had to be taken from the blob rather than the filename, which puts it
+    /// on a different clock (UTC) from its neighbours and can sort it hours out of position.
+    /// </summary>
+    public bool IsTimestampApproximate => TimestampSource == BackupTimestampSource.BlobLastModified;
+
+    public string TimestampDisplay => BackupTime.Format(Timestamp, IsTimestampApproximate);
+
+    public string? TimestampNote => IsTimestampApproximate ? BackupTime.ApproximateNote : null;
+
     public string? DatabaseName { get; set; }
     public string? ServerName { get; set; }
 
@@ -198,6 +285,16 @@ public class RestorePoint
     /// Vertical stacking row (0 = bottom/track level, 1 = above, etc.). Computed by ViewModel.
     /// </summary>
     public int Row { get; set; }
+
+    /// <summary>
+    /// True when this point's own time is a blob-derived approximation, which is what decides
+    /// where it lands on the timeline.
+    /// </summary>
+    public bool IsTimestampApproximate => PrimarySet?.IsTimestampApproximate ?? false;
+
+    public string TimestampDisplay => BackupTime.Format(Timestamp, IsTimestampApproximate);
+
+    public string? TimestampNote => IsTimestampApproximate ? BackupTime.ApproximateNote : null;
 
     public string TypeDisplay => Type switch
     {

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -30,7 +30,18 @@ public enum BackupTimestampSource
     /// Fallback: the blob's LastModified, which is UTC, and additionally records when the file
     /// finished uploading rather than when the backup was taken.
     /// </summary>
-    BlobLastModified
+    BlobLastModified,
+
+    /// <summary>
+    /// The blob's LastModified, converted into the backup server's own time zone because the
+    /// container says which one that is (#102).
+    ///
+    /// This is on the SAME clock as a filename or header reading, so it sorts correctly against
+    /// them - the skew is gone. What remains is that LastModified records when the upload
+    /// FINISHED rather than when the backup was taken, which no time zone can fix, so it is still
+    /// shown as approximate.
+    /// </summary>
+    BlobLastModifiedConverted
 }
 
 /// <summary>
@@ -50,11 +61,52 @@ public static class BackupTime
     public static DateTime WallClock(DateTimeOffset value)
         => DateTime.SpecifyKind(value.UtcDateTime, DateTimeKind.Unspecified);
 
+    /// <summary>
+    /// Converts a blob's LastModified into the backup server's own local time.
+    ///
+    /// This is the only thing that genuinely reconciles the two clocks: a filename says what the
+    /// backup server's clock read, and the blob says UTC. Given the server's zone the second can
+    /// be expressed as the first, and the two become comparable rather than merely labelled.
+    ///
+    /// A zone the machine does not know - a config edited by hand, an IANA id on an older Windows
+    /// build - returns null rather than throwing, and the caller falls back to the unconverted
+    /// reading. A wrong time is worse than an honest one, but refusing to open the container over
+    /// it would be worse still.
+    /// </summary>
+    public static DateTime? ToBackupServerTime(DateTimeOffset value, string? timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId)) return null;
+
+        try
+        {
+            var zone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+
+            // From the instant, not from the wall clock: this is what makes DST correct. A backup
+            // taken in July and one taken in December convert with different offsets, which a
+            // fixed number could never do.
+            return DateTime.SpecifyKind(
+                TimeZoneInfo.ConvertTime(value, zone).DateTime, DateTimeKind.Unspecified);
+        }
+        catch (Exception e) when (e is TimeZoneNotFoundException or InvalidTimeZoneException)
+        {
+            return null;
+        }
+    }
+
     /// <summary>Explains an approximate reading. Shown as a tooltip wherever one is displayed.</summary>
     public const string ApproximateNote =
         "Approximate. This file's name carries no timestamp, so the time shown is when the blob "
         + "was last modified (UTC), not when the backup was taken on the server. It may sit hours "
         + "away from the other entries.";
+
+    /// <summary>
+    /// Explains a converted reading: on the right clock now, but still the upload time.
+    /// </summary>
+    public const string ConvertedNote =
+        "Approximate. This file's name carries no timestamp, so the time shown is when the blob "
+        + "was last modified - converted into the backup server's time zone, so it sorts correctly "
+        + "against the others. It is still when the upload finished rather than when the backup "
+        + "was taken.";
 
     /// <summary>Prefix marking a displayed time as approximate.</summary>
     public const string ApproximateMarker = "~";
@@ -176,11 +228,27 @@ public class BackupSet
     /// True when the time had to be taken from the blob rather than the filename, which puts it
     /// on a different clock (UTC) from its neighbours and can sort it hours out of position.
     /// </summary>
-    public bool IsTimestampApproximate => TimestampSource == BackupTimestampSource.BlobLastModified;
+    public bool IsTimestampApproximate =>
+        TimestampSource is BackupTimestampSource.BlobLastModified
+                        or BackupTimestampSource.BlobLastModifiedConverted;
+
+    /// <summary>
+    /// True when the reading is not only approximate but on a DIFFERENT clock from its
+    /// neighbours - which is what makes it sort out of position rather than merely be imprecise.
+    /// Converting it into the backup server's zone (#102) removes this while leaving the
+    /// approximation.
+    /// </summary>
+    public bool IsTimestampOnAnotherClock =>
+        TimestampSource == BackupTimestampSource.BlobLastModified;
 
     public string TimestampDisplay => BackupTime.Format(Timestamp, IsTimestampApproximate);
 
-    public string? TimestampNote => IsTimestampApproximate ? BackupTime.ApproximateNote : null;
+    public string? TimestampNote => TimestampSource switch
+    {
+        BackupTimestampSource.BlobLastModified => BackupTime.ApproximateNote,
+        BackupTimestampSource.BlobLastModifiedConverted => BackupTime.ConvertedNote,
+        _ => null
+    };
 
     public string? DatabaseName { get; set; }
     public string? ServerName { get; set; }

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace Blackcat.NineLives.Models;
 
@@ -271,8 +271,12 @@ public class RestorePoint
 {
     public DateTime Timestamp { get; set; }
     public BackupType Type { get; set; }
-    public BackupSet PrimarySet { get; set; } = null!;
-    public BackupSet RequiredFullSet { get; set; } = null!;
+    // required, not null!. The old annotation claimed "never null" while the code disagreed with
+    // itself about it: IsTimestampApproximate defended with ?., TotalFiles dereferenced bare, and
+    // BackupChainValidator had a null check the compiler believed was always true. Both are only
+    // ever built fully populated, so the compiler can be told that and then enforce it.
+    public required BackupSet PrimarySet { get; set; }
+    public required BackupSet RequiredFullSet { get; set; }
     public List<BackupSet> RequiredDiffSets { get; set; } = [];
     public List<BackupSet> RequiredLogSets { get; set; } = [];
 
@@ -290,7 +294,7 @@ public class RestorePoint
     /// True when this point's own time is a blob-derived approximation, which is what decides
     /// where it lands on the timeline.
     /// </summary>
-    public bool IsTimestampApproximate => PrimarySet?.IsTimestampApproximate ?? false;
+    public bool IsTimestampApproximate => PrimarySet.IsTimestampApproximate;
 
     public string TimestampDisplay => BackupTime.Format(Timestamp, IsTimestampApproximate);
 
@@ -349,7 +353,7 @@ public class RestorePoint
 
 public class BackupChain
 {
-    public BackupSet FullSet { get; set; } = null!;
+    public required BackupSet FullSet { get; set; }
     public List<BackupSet> DiffSets { get; set; } = [];
     public List<BackupSet> LogSets { get; set; } = [];
     public DateTime? StopAt { get; set; }

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -64,6 +64,21 @@ public class BlobContainerConfig : INotifyPropertyChanged
     /// </summary>
     public string? AgPathPattern { get; set; }
 
+    /// <summary>
+    /// The time zone the backup SERVER runs in, if known (#102).
+    ///
+    /// A backup's time comes from either its filename - which the backup job wrote in the server's
+    /// local time - or the blob's LastModified, which is UTC. Without this they cannot be put on
+    /// one clock, only labelled; with it, the UTC readings convert and sort correctly against the
+    /// rest.
+    ///
+    /// Stored as a system id (Windows or IANA - .NET accepts both since 6.0). Null means unknown,
+    /// which is the default and behaves exactly as before. An id this machine does not recognise
+    /// is treated as unknown rather than as an error: someone browsing a container should not be
+    /// stopped by a setting that only affects how a few timestamps are displayed.
+    /// </summary>
+    public string? BackupServerTimeZoneId { get; set; }
+
     private ObservableCollection<string> _tags = [];
 
     /// <summary>

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -22,6 +22,52 @@ public enum BackupSourceType
 }
 
 /// <summary>
+/// How the app authenticates to the container when listing backups (#29).
+///
+/// Many organisations now prohibit long-lived SAS tokens outright, which made the tool unusable for
+/// them regardless of its merits. The Entra modes hold no secret at all - the token is acquired and
+/// refreshed by Azure.Identity and never touches the credential store.
+///
+/// The numbers are pinned. These are serialised into config.json, so reordering would silently
+/// repoint every saved container at a different authentication mode.
+/// </summary>
+public enum BlobAuthMode
+{
+    /// <summary>A stored SAS token. The original mode, and still the default.</summary>
+    SasToken = 0,
+
+    /// <summary>
+    /// Entra ID with a browser sign-in, which is the mode that satisfies MFA. The sign-in is
+    /// remembered for the life of the process and written nowhere.
+    /// </summary>
+    EntraInteractive = 1,
+
+    /// <summary>
+    /// Entra ID letting Azure.Identity choose - environment variables, then a managed identity,
+    /// then the Azure CLI or Visual Studio sign-in, then a browser prompt. The mode to pick when
+    /// the app runs on an Azure VM with a managed identity assigned.
+    /// </summary>
+    EntraDefault = 2
+}
+
+/// <summary>Things every blob authentication mode has to answer.</summary>
+public static class BlobAuthModes
+{
+    /// <summary>Whether the app has to hold a SAS token for this mode.</summary>
+    public static bool NeedsSasToken(this BlobAuthMode mode) => mode == BlobAuthMode.SasToken;
+
+    public static bool IsEntra(this BlobAuthMode mode) => mode != BlobAuthMode.SasToken;
+
+    public static string Describe(this BlobAuthMode mode) => mode switch
+    {
+        BlobAuthMode.SasToken => "SAS token",
+        BlobAuthMode.EntraInteractive => "Entra ID (interactive)",
+        BlobAuthMode.EntraDefault => "Entra ID (default)",
+        _ => "Unknown"
+    };
+}
+
+/// <summary>
 /// A saved blob container. Implements INotifyPropertyChanged so the derived TagChips member
 /// notifies when Tags changes - see the note on Tags.
 /// </summary>
@@ -45,6 +91,13 @@ public class BlobContainerConfig : INotifyPropertyChanged
 
     public string Name { get; set; } = string.Empty;
     public string ContainerUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// How the app signs in to this container (#29). Absent from config files written before this
+    /// existed, which deserialise to <see cref="BlobAuthMode.SasToken"/> - the behaviour they
+    /// already had, so no migration is needed.
+    /// </summary>
+    public BlobAuthMode AuthMode { get; set; } = BlobAuthMode.SasToken;
 
     /// <summary>
     /// Whether backups are from standalone instances, AG (Ola default naming), or both.
@@ -156,7 +209,11 @@ public class BlobContainerConfig : INotifyPropertyChanged
     [JsonIgnore]
     public string? UnsavedSasToken { get; set; }
 
-    public bool IsExpired => ReadSasExpiry().IsExpired;
+    /// <summary>
+    /// Whether the stored SAS token has passed its expiry. Always false under Entra, which has no
+    /// token of ours to expire - the whole reason an organisation switches to it.
+    /// </summary>
+    public bool IsExpired => AuthMode.NeedsSasToken() && ReadSasExpiry().IsExpired;
 
     public DateTime? SasExpiry => GetSasExpiry();
 

--- a/src/NineLives/Models/RestoreHistoryEntry.cs
+++ b/src/NineLives/Models/RestoreHistoryEntry.cs
@@ -1,0 +1,77 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>How a restore ended.</summary>
+public enum RestoreOutcome
+{
+    Succeeded,
+    Failed,
+
+    /// <summary>Stopped by the user. Not a failure, but the database is mid-restore either way.</summary>
+    Cancelled
+}
+
+/// <summary>
+/// One execution, kept so it can be read back after the app closes (#31).
+///
+/// A DBA who has just restored production needs this for the change ticket or the incident
+/// write-up, and reconstructing it from memory afterwards is exactly when detail goes missing.
+///
+/// Deliberately holds no secret: the script is the same token-free text the app generates and
+/// shows, and everything written here goes through <see cref="Services.LogRedactor"/> anyway.
+/// </summary>
+public sealed class RestoreHistoryEntry
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("n");
+
+    public DateTime StartedAt { get; set; }
+    public DateTime CompletedAt { get; set; }
+
+    public string ServerName { get; set; } = string.Empty;
+    public string TargetDatabase { get; set; } = string.Empty;
+
+    public string? ContainerName { get; set; }
+    public string? SourceDatabase { get; set; }
+
+    /// <summary>The point restored to, as shown on the timeline.</summary>
+    public DateTime? RestorePointTimestamp { get; set; }
+
+    /// <summary>e.g. "1 Full + 2 Log(s)".</summary>
+    public string ChainSummary { get; set; } = string.Empty;
+
+    public RestoreOutcome Outcome { get; set; }
+
+    /// <summary>What went wrong, when something did.</summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>The exact script that was run, so a repeat does not have to be rebuilt by hand.</summary>
+    public string Script { get; set; } = string.Empty;
+
+    /// <summary>The whole console output, which is what a bug report or a ticket actually wants.</summary>
+    public string Log { get; set; } = string.Empty;
+
+    public TimeSpan Duration => CompletedAt > StartedAt ? CompletedAt - StartedAt : TimeSpan.Zero;
+
+    public string OutcomeDisplay => Outcome switch
+    {
+        RestoreOutcome.Succeeded => "Succeeded",
+        RestoreOutcome.Failed => "Failed",
+        RestoreOutcome.Cancelled => "Cancelled",
+        _ => "Unknown"
+    };
+
+    public string StartedDisplay => StartedAt.ToString("yyyy-MM-dd HH:mm:ss");
+
+    public string DurationDisplay => Duration.TotalSeconds < 1
+        ? "<1s"
+        : Duration.TotalHours >= 1
+            ? $"{(int)Duration.TotalHours}h {Duration.Minutes}m"
+            : Duration.TotalMinutes >= 1
+                ? $"{(int)Duration.TotalMinutes}m {Duration.Seconds}s"
+                : $"{(int)Duration.TotalSeconds}s";
+
+    /// <summary>One line for the list: what was restored, where to, and how it went.</summary>
+    public string Summary => $"{TargetDatabase} on {ServerName} - {OutcomeDisplay}";
+
+    public string Detail =>
+        $"{ChainSummary}{(RestorePointTimestamp.HasValue ? $"  |  point {RestorePointTimestamp:yyyy-MM-dd HH:mm:ss}" : "")}  |  {DurationDisplay}";
+}

--- a/src/NineLives/Models/RestoreOptions.cs
+++ b/src/NineLives/Models/RestoreOptions.cs
@@ -19,6 +19,21 @@ public class RestoreOptions
     public bool KeepReplication { get; set; }
     public bool EnableBroker { get; set; }
     public bool NewBroker { get; set; }
+
+    /// <summary>
+    /// Verify backup checksums as each page is read. Only meaningful if the backup was taken
+    /// WITH CHECKSUM - against one that was not, SQL Server fails the restore rather than
+    /// skipping the check, which is why this is off by default.
+    /// </summary>
+    public bool WithChecksum { get; set; }
+
+    /// <summary>
+    /// Carry on restoring after a checksum or page error instead of stopping.
+    ///
+    /// This produces a database that SQL Server has already told you is damaged. It exists for
+    /// the case where a partial recovery beats none, and is not something to leave switched on.
+    /// </summary>
+    public bool ContinueAfterError { get; set; }
     public string? CredentialName { get; set; }
 
     public List<FileMoveOption> FileMoves { get; set; } = [];

--- a/src/NineLives/Models/RestoreOptions.cs
+++ b/src/NineLives/Models/RestoreOptions.cs
@@ -1,3 +1,5 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace Blackcat.NineLives.Models;
 
 public enum RecoveryMode
@@ -51,10 +53,19 @@ public class RestoreOptions
     // ViewModel, which is what talks to the server about it.
 }
 
-public class FileMoveOption
+/// <summary>
+/// One logical file and where it should land.
+///
+/// Observable because <see cref="NewPhysicalName"/> is edited directly in a grid. As a plain POCO
+/// nothing knew the target path had changed, so the generated script kept the path that was
+/// fetched from the server rather than the one on screen - and the script is what gets executed.
+/// </summary>
+public partial class FileMoveOption : ObservableObject
 {
     public string LogicalName { get; set; } = string.Empty;
     public string PhysicalName { get; set; } = string.Empty;
-    public string NewPhysicalName { get; set; } = string.Empty;
     public string Type { get; set; } = string.Empty;
+
+    [ObservableProperty]
+    private string _newPhysicalName = string.Empty;
 }

--- a/src/NineLives/Models/RestoreOptions.cs
+++ b/src/NineLives/Models/RestoreOptions.cs
@@ -34,14 +34,21 @@ public class RestoreOptions
     /// the case where a partial recovery beats none, and is not something to leave switched on.
     /// </summary>
     public bool ContinueAfterError { get; set; }
-    public string? CredentialName { get; set; }
 
     public List<FileMoveOption> FileMoves { get; set; } = [];
 
-    // The SAS credential name to use in SQL Server
-    public string SqlCredentialName { get; set; } = "BlobRestoreCredential";
-    public string? SasToken { get; set; }
-    public string? StorageAccountUrl { get; set; }
+    // Deliberately no credential fields here (#42).
+    //
+    // CredentialName, SqlCredentialName, SasToken and StorageAccountUrl used to live on this
+    // object. Every one of them was written by the ViewModel and read by nothing: the generated
+    // script carries no WITH CREDENTIAL clause, because SQL Server rejects that for a SAS
+    // credential and matches by URL instead (#60).
+    //
+    // SasToken was the one that mattered - it copied a live SAS token into an options object whose
+    // whole purpose is to be handed to a text generator. Nothing was leaking it, but nothing
+    // needed it either, and a secret sitting one careless AppendLine away from a script is not
+    // worth keeping for a field no code reads. The credential name the app does use lives on the
+    // ViewModel, which is what talks to the server about it.
 }
 
 public class FileMoveOption

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
@@ -165,4 +165,25 @@ public class ServerConnection : INotifyPropertyChanged
     public string DisplayText => AuthMode == AuthMode.WindowsAuth
         ? $"{ServerName} (Windows Auth)"
         : $"{ServerName} ({Username})";
+
+    private bool _isConnectedServer;
+
+    /// <summary>
+    /// True for the one server currently connected. Not persisted - it describes this session.
+    ///
+    /// Connecting used to change the banner at the top of the window and nothing in the list, so
+    /// with more than a screenful of servers there was no way to tell which one was live (#127).
+    /// Kept on the model rather than compared in the view so the row can simply bind to it.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsConnectedServer
+    {
+        get => _isConnectedServer;
+        set
+        {
+            if (_isConnectedServer == value) return;
+            _isConnectedServer = value;
+            OnPropertyChanged(nameof(IsConnectedServer));
+        }
+    }
 }

--- a/src/NineLives/Models/ServerConnection.cs
+++ b/src/NineLives/Models/ServerConnection.cs
@@ -7,10 +7,68 @@ using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.Models;
 
+/// <summary>
+/// How the app authenticates to the SQL Server instance.
+///
+/// The Entra modes are handled entirely by Microsoft.Data.SqlClient's own token flow - the app
+/// stores no secret for any of them, which is the point: an estate that has mandated Entra has
+/// usually done so precisely to stop tools holding passwords (#30).
+///
+/// The numbers are pinned. These values are serialised into config.json, so appending to the list
+/// without them would be fine but reordering would silently repoint every saved connection at a
+/// different authentication mode.
+/// </summary>
 public enum AuthMode
 {
-    WindowsAuth,
-    SqlAuth
+    WindowsAuth = 0,
+    SqlAuth = 1,
+
+    /// <summary>
+    /// Entra ID with an interactive browser prompt, which is the mode that satisfies MFA. The
+    /// username, if given, is only a hint for the account picker.
+    /// </summary>
+    EntraInteractive = 2,
+
+    /// <summary>Entra ID using the signed-in Windows account, with no prompt.</summary>
+    EntraIntegrated = 3,
+
+    /// <summary>
+    /// Entra ID letting the driver choose - environment variables, then managed identity, then the
+    /// signed-in account, then an interactive prompt. The mode to pick for SQL Server on an Azure
+    /// VM, where the managed identity is what should be used.
+    /// </summary>
+    EntraDefault = 4
+}
+
+/// <summary>Things every authentication mode has to answer.</summary>
+public static class AuthModes
+{
+    /// <summary>Whether the app has to hold a password for this mode. Only SQL auth does.</summary>
+    public static bool NeedsStoredPassword(this AuthMode mode) => mode == AuthMode.SqlAuth;
+
+    /// <summary>Whether a username is required rather than optional.</summary>
+    public static bool RequiresUsername(this AuthMode mode) => mode == AuthMode.SqlAuth;
+
+    /// <summary>
+    /// Whether a username box is worth showing. Interactive Entra accepts one as a hint that
+    /// pre-selects the account, which is worth having on a machine signed in to several.
+    /// </summary>
+    public static bool AcceptsUsername(this AuthMode mode) =>
+        mode is AuthMode.SqlAuth or AuthMode.EntraInteractive;
+
+    public static bool IsEntra(this AuthMode mode) =>
+        mode is AuthMode.EntraInteractive or AuthMode.EntraIntegrated or AuthMode.EntraDefault;
+
+    /// <summary>How the mode reads in a list, next to a server name.</summary>
+    public static string Describe(this AuthMode mode) => mode switch
+    {
+        AuthMode.WindowsAuth => "Windows Auth",
+        AuthMode.SqlAuth => "SQL Auth",
+        AuthMode.EntraInteractive => "Entra ID (interactive)",
+        AuthMode.EntraIntegrated => "Entra ID (integrated)",
+        AuthMode.EntraDefault => "Entra ID (default)",
+        _ => "Unknown"
+    };
 }
 
 public enum EncryptMode
@@ -144,7 +202,7 @@ public class ServerConnection : INotifyPropertyChanged
 
     /// <summary>
     /// Key used to look up password in Windows Credential Manager.
-    /// Only used when AuthMode is SqlAuth.
+    /// Only used when <see cref="AuthMode"/> needs a stored password, which is SQL auth alone.
     /// </summary>
     [JsonIgnore]
     public string CredentialKey =>
@@ -162,9 +220,14 @@ public class ServerConnection : INotifyPropertyChanged
     [JsonIgnore]
     public string? UnsavedPassword { get; set; }
 
-    public string DisplayText => AuthMode == AuthMode.WindowsAuth
-        ? $"{ServerName} (Windows Auth)"
-        : $"{ServerName} ({Username})";
+    /// <summary>
+    /// The server and how it authenticates, for the list. A username is only shown when it
+    /// identifies the login being used - for interactive Entra it is a hint for the account picker,
+    /// not the account that ends up connecting, so showing it would misstate who is connected.
+    /// </summary>
+    public string DisplayText => AuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(Username)
+        ? $"{ServerName} ({Username})"
+        : $"{ServerName} ({AuthMode.Describe()})";
 
     private bool _isConnectedServer;
 

--- a/src/NineLives/Models/TimeZoneOption.cs
+++ b/src/NineLives/Models/TimeZoneOption.cs
@@ -1,0 +1,28 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// A time zone as the container editor offers it (#102).
+/// </summary>
+/// <param name="Id">The system id stored in config, or null for "not known".</param>
+/// <param name="Name">What the picker shows.</param>
+public sealed record TimeZoneOption(string? Id, string Name)
+{
+    /// <summary>
+    /// The default. Backup times stay on whichever clock they came from and are labelled rather
+    /// than reconciled - which is honest, and exactly what the app did before this setting existed.
+    /// </summary>
+    public static readonly TimeZoneOption Unknown = new(null, "Not known - leave times as they are");
+
+    /// <summary>
+    /// Matches a stored id back to an offered option, falling back to "not known" for an id this
+    /// machine does not recognise. A config carried to another machine, or hand-edited, must not
+    /// leave the picker showing something the app is not actually using.
+    /// </summary>
+    public static TimeZoneOption For(string? id, IEnumerable<TimeZoneOption> options)
+        => string.IsNullOrWhiteSpace(id)
+            ? Unknown
+            : options.FirstOrDefault(o => o.Id == id) ?? Unknown;
+
+    /// <summary>The picker renders the selected item through a plain ContentPresenter.</summary>
+    public override string ToString() => Name;
+}

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -33,6 +33,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NineLives/Properties/PublishProfiles/SingleFileExe.pubxml
+++ b/src/NineLives/Properties/PublishProfiles/SingleFileExe.pubxml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  The single source of truth for how Nine Lives is published.
+
+  build_standalone.cmd and .github/workflows/release.yml both invoke this profile rather than
+  repeating its flags. They used to repeat them, and they had already drifted: neither passed
+  PublishReadyToRun, so every released binary was missing something this file claimed (#39).
+  See the note on that property for which way the difference was resolved, and why.
+
+  RuntimeIdentifier is overridable from the command line, which is how a second architecture
+  would be published without a second copy of everything else here.
+-->
 <Project>
   <PropertyGroup>
     <Configuration>Release</Configuration>
@@ -9,7 +20,26 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <PublishTrimmed>false</PublishTrimmed>
-    <PublishReadyToRun>true</PublishReadyToRun>
+
+    <!--
+      Off, deliberately, and measured rather than assumed.
+
+      This file used to say true while release.yml and build_standalone.cmd published without it,
+      so no released binary has ever had ReadyToRun. Unifying the three meant choosing which
+      behaviour to keep, so both were built and timed on the same machine:
+
+        no ReadyToRun   146.0 MB   warm start 3.35s
+        ReadyToRun      175.5 MB   warm start 3.27s
+
+      30 MB - a fifth of the download - for 80ms that nobody can perceive, and even that is inside
+      the noise. Startup here is dominated by the deliberate 2.5s splash dwell in App.OnStartup,
+      which no amount of precompilation touches.
+
+      This is a portable exe people fetch over the internet, and it is already unsigned enough of a
+      hurdle (#33) without being 20% bigger. Turn it on if the splash dwell ever goes and startup
+      starts to matter.
+    -->
+    <PublishReadyToRun>false</PublishReadyToRun>
     <!-- Same reasoning as Directory.Build.props: a single-file publish restore drags in an
          SDK-versioned tool pack, so it must not rewrite the committed lock file. Repeated
          here because a publish profile is imported after Directory.Build.props, too late

--- a/src/NineLives/Services/BackupChainBuilder.cs
+++ b/src/NineLives/Services/BackupChainBuilder.cs
@@ -139,15 +139,9 @@ public class BackupChainBuilder
         return (earliest, latest);
     }
 
-    // Keep backward compatibility for existing callers during migration
-    public (DateTime earliest, DateTime latest)? GetRestoreWindow(List<BackupFileInfo> allBackups)
-    {
-        var fulls = allBackups.Where(b => b.Type == BackupType.Full).ToList();
-        if (fulls.Count == 0) return null;
-
-        var earliest = fulls.Min(f => f.EffectiveDate);
-        var latest = allBackups.Max(b => b.EffectiveDate);
-
-        return (earliest, latest);
-    }
+    // The file-level overload that used to sit here is gone (#42). It was labelled "backward
+    // compatibility during migration", had no production caller, and mixed two time bases: it
+    // compared BackupStartDate (the backup server's local clock) against the blob's LastModified
+    // (UTC). Keeping it around was an invitation for a future caller to reintroduce the skew that
+    // #47 went to some trouble to make visible.
 }

--- a/src/NineLives/Services/BackupChainValidator.cs
+++ b/src/NineLives/Services/BackupChainValidator.cs
@@ -323,7 +323,7 @@ public class BackupChainValidator
             $"{chainBase.Timestamp:yyyy-MM-dd HH:mm}, against a typical log interval of {FormatGap(median.Value)}. " +
             "Log backups covering that period appear to be missing - commonly because logs are kept for a " +
             "shorter retention than fulls and differentials. The restore would fail with error 4305. " +
-            "Validate Chain will confirm against the backup headers."));
+            "Check chain will confirm against the backup headers."));
     }
 
     private static TimeSpan? MedianLogInterval(IReadOnlyList<BackupSet> logs)

--- a/src/NineLives/Services/BackupChainValidator.cs
+++ b/src/NineLives/Services/BackupChainValidator.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -171,7 +171,7 @@ public class BackupChainValidator
         var reachable = new HashSet<BackupSet>();
         foreach (var point in restorePoints)
         {
-            if (point.PrimarySet != null) reachable.Add(point.PrimarySet);
+            reachable.Add(point.PrimarySet);
             foreach (var log in point.RequiredLogSets) reachable.Add(log);
         }
 

--- a/src/NineLives/Services/BlobCredentialIdentity.cs
+++ b/src/NineLives/Services/BlobCredentialIdentity.cs
@@ -1,0 +1,49 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Which IDENTITY a server-side credential was created with, as far as RESTORE FROM URL cares (#145).
+///
+/// This used to be a bool - "is it SHARED ACCESS SIGNATURE" - which made a managed-identity
+/// credential indistinguishable from a Windows account or a typo. Those need opposite treatment:
+/// one authenticates a restore perfectly well, the others cannot, and the app was overwriting
+/// both on the strength of the same false answer.
+/// </summary>
+public enum BlobCredentialIdentity
+{
+    /// <summary>No credential of that name exists on the instance.</summary>
+    Missing,
+
+    /// <summary>WITH IDENTITY = 'SHARED ACCESS SIGNATURE' - the only kind this app creates.</summary>
+    SharedAccessSignature,
+
+    /// <summary>
+    /// WITH IDENTITY = 'Managed Identity' - the instance authenticating to storage as itself, on
+    /// SQL Server 2022+ or Azure SQL MI. Valid for a restore, and not something this app can
+    /// create yet, so wherever one is found it belongs to somebody else's deliberate setup.
+    /// </summary>
+    ManagedIdentity,
+
+    /// <summary>Anything else: a Windows account, a storage account key, a mistake. Not usable.</summary>
+    Other
+}
+
+/// <summary>
+/// What a credential lookup found. The identity string is carried alongside so an unusable
+/// credential can be named rather than merely rejected - the same reasoning as the Entra sign-in
+/// diagnostics (#29): being told WHAT is there is usually enough to see why it is wrong.
+///
+/// It is never the secret. SQL Server does not return credential secrets, and
+/// <c>credential_identity</c> for a SAS credential is the literal text 'SHARED ACCESS SIGNATURE'.
+/// </summary>
+public readonly record struct BlobCredentialStatus(BlobCredentialIdentity Kind, string? Identity)
+{
+    /// <summary>A credential of that name is on the instance, whatever it turned out to be.</summary>
+    public bool Exists => Kind != BlobCredentialIdentity.Missing;
+
+    /// <summary>Whether a RESTORE FROM URL can authenticate with it as it stands.</summary>
+    public bool CanRestoreFromUrl =>
+        Kind is BlobCredentialIdentity.SharedAccessSignature or BlobCredentialIdentity.ManagedIdentity;
+
+    /// <summary>Nothing of that name on the server.</summary>
+    public static BlobCredentialStatus Missing => new(BlobCredentialIdentity.Missing, null);
+}

--- a/src/NineLives/Services/BlobFailureExplainer.cs
+++ b/src/NineLives/Services/BlobFailureExplainer.cs
@@ -1,0 +1,78 @@
+using Azure;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Turns an Azure storage failure into something a DBA can act on (#29).
+///
+/// Azure's own messages are accurate and useless in equal measure. "This request is not authorized
+/// to perform this operation using this permission" arrives with a request id, a timestamp, the
+/// original XML and eleven headers, and says nothing about what to actually change.
+///
+/// The same instinct as the recovery guidance after a failed restore (#14): the moment something
+/// fails is the moment to say what to do about it, not to hand over the raw wire response and let
+/// someone go and search for it.
+/// </summary>
+internal static class BlobFailureExplainer
+{
+    /// <summary>
+    /// Guidance for a failure, or null when there is nothing useful to add and Azure's own message
+    /// should stand on its own.
+    /// </summary>
+    internal static string? Explain(Exception exception, BlobContainerConfig config)
+    {
+        if (exception is not RequestFailedException failure) return null;
+
+        return failure.ErrorCode switch
+        {
+            "AuthorizationPermissionMismatch" when config.AuthMode.IsEntra() => EntraRoleMissing(config),
+            "AuthorizationPermissionMismatch" => SasTooNarrow(),
+            "AuthenticationFailed" when config.AuthMode.IsEntra() =>
+                "The sign-in itself was rejected. Check the account has access to the tenant that "
+                + "owns this storage account - an account from another tenant can sign in "
+                + "successfully and still be unknown here.",
+            "AuthenticationFailed" =>
+                "The SAS token was rejected. It may be malformed, expired, or issued for a "
+                + "different storage account.",
+            "ContainerNotFound" =>
+                "The account was reached but the container does not exist. Check the last segment "
+                + "of the URL - it is the container name, and it is case-sensitive.",
+            "AccountIsDisabled" => "The storage account is disabled.",
+            "InvalidResourceName" =>
+                "The container name in the URL is not a legal Azure container name.",
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// The one worth spelling out, because the fix is not the one people reach for first.
+    ///
+    /// Blob DATA access is a separate set of roles from the ones that manage the account. Owner and
+    /// Contributor - which is what someone who can see the container in the portal usually has -
+    /// grant neither. And it is why other tools appear to disagree: Azure Storage Explorer often
+    /// falls back to fetching the account KEY through the management plane, which Owner does allow,
+    /// so it never exercises the role at all.
+    /// </summary>
+    private static string EntraRoleMissing(BlobContainerConfig config)
+    {
+        var scope = config.ContainerName is { Length: > 0 } name
+            ? $"the \"{name}\" container (or the storage account above it)"
+            : "the container or the storage account above it";
+
+        return
+            $"Signed in successfully, but this account has no permission to READ BLOB DATA in {scope}.\n\n"
+            + "Blob data access is a separate set of roles from the ones that administer the account. "
+            + "Owner and Contributor do not include it. Assign Storage Blob Data Reader (or Storage "
+            + "Blob Data Contributor) to the account named above, at the container or storage "
+            + "account scope.\n\n"
+            + "If Azure Storage Explorer works with the same account, that is not a contradiction - "
+            + "it commonly falls back to the account key, which Owner can fetch, so it never uses "
+            + "the role at all.\n\n"
+            + "Role assignments can take a few minutes to take effect.";
+    }
+
+    private static string SasTooNarrow() =>
+        "The SAS token was accepted but does not permit this operation. It needs at least List and "
+        + "Read permissions, and its resource type must include the container.";
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Blackcat.NineLives.Models;
@@ -257,7 +257,8 @@ public class BlobStorageService : IBlobStorageService
     /// <summary>
     /// Groups individual backup files into logical BackupSets, handling striped backups.
     /// </summary>
-    public List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files)
+    public List<BackupSet> GroupIntoBackupSets(
+        List<BackupFileInfo> files, string? backupServerTimeZoneId = null)
     {
         var groups = new Dictionary<string, List<BackupFileInfo>>();
 
@@ -304,18 +305,24 @@ public class BlobStorageService : IBlobStorageService
             var (setId, _) = BackupSet.ParseFileName(first.FileName);
 
             // The filename is the backup server's local clock; the blob's LastModified is UTC.
-            // Nothing here can reconcile them, so record WHICH one this set got and let the UI
-            // mark the fallback as approximate rather than presenting both as one timeline.
+            //
+            // With the container's backup server time zone configured they can be put on ONE clock
+            // (#102). Without it they can only be labelled - so record which one this set got, and
+            // let the UI say so rather than presenting both as a single exact timeline (#47).
             var parsed = BackupSet.ParseTimestamp(setId);
+            var converted = parsed == null
+                ? BackupTime.ToBackupServerTime(first.LastModified, backupServerTimeZoneId)
+                : null;
 
             sets.Add(new BackupSet
             {
                 SetId = setId,
                 Type = first.Type,
                 Files = groupFiles.OrderBy(f => f.FileName).ToList(),
-                Timestamp = parsed ?? BackupTime.WallClock(first.LastModified),
-                TimestampSource = parsed != null
-                    ? BackupTimestampSource.FileName
+                Timestamp = parsed ?? converted ?? BackupTime.WallClock(first.LastModified),
+                TimestampSource =
+                    parsed != null ? BackupTimestampSource.FileName
+                    : converted != null ? BackupTimestampSource.BlobLastModifiedConverted
                     : BackupTimestampSource.BlobLastModified,
                 DatabaseName = first.InferredDatabaseName,
                 ServerName = first.InferredServerName,

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -222,12 +222,14 @@ public class BlobStorageService : IBlobStorageService
     {
         // Same formatter the filters match against, so the values offered in the dropdown and
         // the values compared against a set can never drift apart.
+        // OfType rather than Where(s => s != null) + a ! at the end: it drops the nulls AND tells
+        // the compiler so, instead of filtering in a way it cannot follow and then overruling it.
         return files
             .Select(f => f.ServerDisplay)
-            .Where(s => s != null)
+            .OfType<string>()
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
-            .ToList()!;
+            .ToList();
     }
 
     public ContainerSummary GetSetBasedSummary(List<BackupSet> sets)

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -241,8 +241,14 @@ public class BlobStorageService
             LogBackups = sets.Count(s => s.Type == BackupType.TransactionLog),
             UnknownFiles = sets.Count(s => s.Type == BackupType.Unknown),
             TotalSizeBytes = sets.Sum(s => s.TotalSizeBytes),
-            EarliestBackup = sets.Count > 0 ? sets.Min(s => new DateTimeOffset(s.Timestamp)) : null,
-            LatestBackup = sets.Count > 0 ? sets.Max(s => new DateTimeOffset(s.Timestamp)) : null
+
+            // Deliberately NOT EarliestBackup/LatestBackup. A set's Timestamp is a bare wall clock
+            // whose zone varies by set, and wrapping it in a DateTimeOffset stamped it with the
+            // WORKSTATION's offset - which is nobody's clock, and double-shifted the blob-derived
+            // ones. The set range keeps its own members so the two can never be confused.
+            EarliestSetTimestamp = sets.Count > 0 ? sets.Min(s => s.Timestamp) : null,
+            LatestSetTimestamp = sets.Count > 0 ? sets.Max(s => s.Timestamp) : null,
+            ApproximateSets = sets.Count(s => s.IsTimestampApproximate)
         };
     }
 
@@ -294,14 +300,21 @@ public class BlobStorageService
         {
             var first = groupFiles[0];
             var (setId, _) = BackupSet.ParseFileName(first.FileName);
-            var timestamp = BackupSet.ParseTimestamp(setId) ?? first.LastModified.DateTime;
+
+            // The filename is the backup server's local clock; the blob's LastModified is UTC.
+            // Nothing here can reconcile them, so record WHICH one this set got and let the UI
+            // mark the fallback as approximate rather than presenting both as one timeline.
+            var parsed = BackupSet.ParseTimestamp(setId);
 
             sets.Add(new BackupSet
             {
                 SetId = setId,
                 Type = first.Type,
                 Files = groupFiles.OrderBy(f => f.FileName).ToList(),
-                Timestamp = timestamp,
+                Timestamp = parsed ?? BackupTime.WallClock(first.LastModified),
+                TimestampSource = parsed != null
+                    ? BackupTimestampSource.FileName
+                    : BackupTimestampSource.BlobLastModified,
                 DatabaseName = first.InferredDatabaseName,
                 ServerName = first.InferredServerName,
                 InstanceName = first.InferredInstanceName,
@@ -551,8 +564,24 @@ public class ContainerSummary
     public int LogBackups { get; set; }
     public int UnknownFiles { get; set; }
     public long TotalSizeBytes { get; set; }
+
+    /// <summary>
+    /// File-level range, straight from blob metadata, so genuine UTC instants. Only populated by
+    /// the file-based summary.
+    /// </summary>
     public DateTimeOffset? EarliestBackup { get; set; }
     public DateTimeOffset? LatestBackup { get; set; }
+
+    /// <summary>
+    /// Set-level range. Bare wall clocks, not instants: most read the backup server's local clock
+    /// and any counted by <see cref="ApproximateSets"/> read UTC instead. Only populated by the
+    /// set-based summary.
+    /// </summary>
+    public DateTime? EarliestSetTimestamp { get; set; }
+    public DateTime? LatestSetTimestamp { get; set; }
+
+    /// <summary>How many sets had to fall back to the blob's LastModified for their time.</summary>
+    public int ApproximateSets { get; set; }
 
     public string TotalSizeDisplay => ByteSize.Format(TotalSizeBytes);
 }

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -52,10 +52,19 @@ public class BlobStorageService : IBlobStorageService
     private static readonly Lock CredentialLock = new();
     private static readonly Dictionary<BlobAuthMode, TokenCredential> Credentials = [];
 
+    /// <summary>
+    /// Test seam. A real credential cannot be exercised offline, and the thing worth pinning about
+    /// #152 - that a sign-in never runs on the UI thread - is otherwise unobservable.
+    /// </summary>
+    internal static Func<BlobAuthMode, TokenCredential>? CredentialFactoryForTests { get; set; }
+
     private static TokenCredential CredentialFor(BlobAuthMode mode)
     {
         lock (CredentialLock)
         {
+            // Checked before the cache, so a test is never handed a credential a previous test made.
+            if (CredentialFactoryForTests != null) return CredentialFactoryForTests(mode);
+
             if (Credentials.TryGetValue(mode, out var existing)) return existing;
 
             TokenCredential created = mode == BlobAuthMode.EntraInteractive
@@ -90,8 +99,13 @@ public class BlobStorageService : IBlobStorageService
 
         try
         {
-            var token = await CredentialFor(config.AuthMode).GetTokenAsync(
-                new TokenRequestContext([StorageScope]), ct);
+            // Off the UI thread for the same reason as the operations themselves (#152). Usually a
+            // cache read by the time this runs - it only happens after a failure - but "usually" is
+            // not a reason to block the window on a credential that might decide to prompt.
+            var token = await Task.Run(
+                () => CredentialFor(config.AuthMode)
+                    .GetTokenAsync(new TokenRequestContext([StorageScope]), ct).AsTask(),
+                ct);
 
             return EntraIdentity.Describe(token.Token);
         }
@@ -106,8 +120,37 @@ public class BlobStorageService : IBlobStorageService
     /// itself; it is only spelled out here because the diagnostic asks directly.</summary>
     private const string StorageScope = "https://storage.azure.com/.default";
 
+    /// <summary>
+    /// Gets the Entra sign-in out of the way, on the thread pool, before anything touches the
+    /// container (#152).
+    ///
+    /// InteractiveBrowserCredential launches a browser and waits for the redirect to come back, and
+    /// it does that on whatever thread asked for the token. Every blob operation starts from a
+    /// command on the UI thread, so the window stopped painting for as long as the sign-in was open
+    /// - an application asking somebody to go and authenticate while looking, to them, like it had
+    /// crashed.
+    ///
+    /// Task.Run rather than ConfigureAwait: the blocking happens before the credential's first
+    /// await yields, so there is no continuation to redirect - the work has to start somewhere
+    /// other than the UI thread.
+    ///
+    /// Only the first operation pays for this. The credential caches the token, and it is shared
+    /// process-wide, so everything after is a cache read.
+    /// </summary>
+    private static async Task EnsureSignedInAsync(BlobContainerConfig config, CancellationToken ct)
+    {
+        if (!config.AuthMode.IsEntra()) return;
+
+        var credential = CredentialFor(config.AuthMode);
+
+        await Task.Run(
+            () => credential.GetTokenAsync(new TokenRequestContext([StorageScope]), ct).AsTask(),
+            ct);
+    }
+
     public async Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
     {
+        await EnsureSignedInAsync(config, ct);
         var client = CreateClient(config);
         await foreach (var _ in client.GetBlobsAsync(
             BlobTraits.None, BlobStates.None, prefix: null, cancellationToken: ct)
@@ -122,6 +165,7 @@ public class BlobStorageService : IBlobStorageService
     public async Task<List<string>> ListTopLevelFoldersAsync(
         BlobContainerConfig config, CancellationToken ct = default)
     {
+        await EnsureSignedInAsync(config, ct);
         var client = CreateClient(config);
         var folders = new List<string>();
 
@@ -154,6 +198,7 @@ public class BlobStorageService : IBlobStorageService
         IProgress<int>? progress,
         CancellationToken ct = default)
     {
+        await EnsureSignedInAsync(config, ct);
         var client = CreateClient(config);
         var files = new List<BackupFileInfo>();
 

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -1,4 +1,6 @@
 ﻿using System.Text.RegularExpressions;
+using Azure.Core;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Blackcat.NineLives.Models;
@@ -16,6 +18,13 @@ public class BlobStorageService : IBlobStorageService
 
     private BlobContainerClient CreateClient(BlobContainerConfig config)
     {
+        var baseUrl = config.ContainerUrl.TrimEnd('/');
+
+        // Entra: no secret of ours at all. Azure.Identity acquires and refreshes the token, and
+        // nothing is written to the credential store (#29).
+        if (config.AuthMode.IsEntra())
+            return new BlobContainerClient(new Uri(baseUrl), CredentialFor(config.AuthMode));
+
         // An unsaved token wins, so Test Connection can try one without it having to be persisted
         // first (#12). Null for every ordinary operation, which falls through to the stored token.
         var sasToken = config.UnsavedSasToken ?? _credentialStore.GetSasToken(config);
@@ -23,12 +32,49 @@ public class BlobStorageService : IBlobStorageService
             throw new InvalidOperationException(
                 "No SAS token found. Please configure the SAS token for this container.");
 
-        var baseUrl = config.ContainerUrl.TrimEnd('/');
         var cleanSas = sasToken.TrimStart('?');
         var separator = baseUrl.Contains('?') ? "&" : "?";
         var fullUri = new Uri($"{baseUrl}{separator}{cleanSas}");
         return new BlobContainerClient(fullUri);
     }
+
+    /// <summary>
+    /// One credential per mode for the life of the process.
+    ///
+    /// Deliberately shared rather than created per client. A credential holds the in-memory token
+    /// cache, so a fresh one per operation means a fresh sign-in per operation - which for
+    /// interactive mode is a browser window every time the container is listed, and for the rest is
+    /// a token request per call instead of one per hour.
+    ///
+    /// Static because the cache is genuinely process-wide: it belongs to the signed-in user, not to
+    /// whichever service instance happened to ask first.
+    /// </summary>
+    private static readonly Lock CredentialLock = new();
+    private static readonly Dictionary<BlobAuthMode, TokenCredential> Credentials = [];
+
+    private static TokenCredential CredentialFor(BlobAuthMode mode)
+    {
+        lock (CredentialLock)
+        {
+            if (Credentials.TryGetValue(mode, out var existing)) return existing;
+
+            TokenCredential created = mode == BlobAuthMode.EntraInteractive
+                ? new InteractiveBrowserCredential()
+                : new DefaultAzureCredential();
+
+            Credentials[mode] = created;
+            return created;
+        }
+    }
+
+    /// <summary>
+    /// Test hooks. Building a client makes no network call and acquires no token - a credential is
+    /// only exercised on the first request - so which credential the mode resolves to, and that a
+    /// SAS container still refuses without one, are both checkable offline (#29).
+    /// </summary>
+    internal BlobContainerClient CreateClientForTests(BlobContainerConfig config) => CreateClient(config);
+
+    internal static TokenCredential CredentialForTests(BlobAuthMode mode) => CredentialFor(mode);
 
     public async Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
     {

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -5,11 +5,11 @@ using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
-public class BlobStorageService
+public class BlobStorageService : IBlobStorageService
 {
-    private readonly CredentialStore _credentialStore;
+    private readonly ICredentialStore _credentialStore;
 
-    public BlobStorageService(CredentialStore credentialStore)
+    public BlobStorageService(ICredentialStore credentialStore)
     {
         _credentialStore = credentialStore;
     }

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -76,6 +76,36 @@ public class BlobStorageService : IBlobStorageService
 
     internal static TokenCredential CredentialForTests(BlobAuthMode mode) => CredentialFor(mode);
 
+    /// <summary>
+    /// Asks the credential for a token purely so the account behind it can be named.
+    ///
+    /// Only called after something has already failed, so the extra round trip costs nothing on the
+    /// happy path - and by then it is usually the single most useful fact available, because a 403
+    /// from Azure never says which identity it refused.
+    /// </summary>
+    public async Task<string?> DescribeSignedInIdentityAsync(
+        BlobContainerConfig config, CancellationToken ct = default)
+    {
+        if (!config.AuthMode.IsEntra()) return null;
+
+        try
+        {
+            var token = await CredentialFor(config.AuthMode).GetTokenAsync(
+                new TokenRequestContext([StorageScope]), ct);
+
+            return EntraIdentity.Describe(token.Token);
+        }
+        catch
+        {
+            // This exists to explain a failure. It must not create one.
+            return null;
+        }
+    }
+
+    /// <summary>What a token for blob data is asked for. The credential normally handles this
+    /// itself; it is only spelled out here because the diagnostic asks directly.</summary>
+    private const string StorageScope = "https://storage.azure.com/.default";
+
     public async Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
     {
         var client = CreateClient(config);

--- a/src/NineLives/Services/ConfigMigrator.cs
+++ b/src/NineLives/Services/ConfigMigrator.cs
@@ -21,7 +21,7 @@ namespace Blackcat.NineLives.Services;
 /// secrets are already where the ids point. There is no window in which a secret exists only under
 /// a key nothing references.
 /// </summary>
-public class ConfigMigrator(CredentialStore store)
+public class ConfigMigrator(ICredentialStore store)
 {
     public record Result(int ContainersMigrated, int ServersMigrated, string? Error)
     {

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -11,7 +11,7 @@ namespace Blackcat.NineLives.Services;
 /// Manages credentials via Windows Credential Manager and persists
 /// non-secret configuration (server names, container URLs) to a local JSON file.
 /// </summary>
-public class CredentialStore
+public class CredentialStore : ICredentialStore
 {
     private const string AppPrefix = "NineLives";
     private static readonly string DefaultConfigDir = Path.Combine(

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -305,6 +305,13 @@ public class AppConfig
     public string? LastNotifiedReleaseTag { get; set; }
 
     /// <summary>
+    /// Colour scheme. Stored by name so the file stays readable and an unknown value degrades to
+    /// Dark rather than throwing - someone hand-editing this should not be able to stop the app
+    /// starting.
+    /// </summary>
+    public AppTheme Theme { get; set; } = AppTheme.Dark;
+
+    /// <summary>
     /// Set when config.json existed but could not be read or parsed. Not persisted - it describes
     /// this load attempt, not the configuration. While it is set, this object holds empty defaults
     /// that do NOT reflect what is on disk, so <see cref="CredentialStore.SaveConfig"/> will

--- a/src/NineLives/Services/EntraAuthentication.cs
+++ b/src/NineLives/Services/EntraAuthentication.cs
@@ -1,0 +1,100 @@
+﻿using System.Windows;
+using System.Windows.Interop;
+using Microsoft.Data.SqlClient;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Tells Microsoft.Data.SqlClient which window to parent the Entra sign-in prompt to (#30).
+///
+/// On Windows, MSAL signs in through the Web Account Manager broker rather than a plain browser
+/// window, and the broker refuses to show a dialog it cannot parent:
+///
+///   Failed to acquire access token for ActiveDirectoryInteractive:
+///   A window handle must be configured. (0x... window_handle_required)
+///
+/// The driver's own discovered provider has no handle to offer, because nothing in a library can
+/// know what the application's window is. Registering the provider ourselves is the only way to
+/// supply one - which is what makes the interactive mode work at all on a desktop app.
+///
+/// The handle is resolved lazily, per sign-in, rather than captured once. At the point registration
+/// happens the main window may not exist yet, its handle changes if it is ever recreated, and if a
+/// modal is up the prompt should parent to THAT rather than to whatever was frontmost at startup.
+/// </summary>
+internal static class EntraAuthentication
+{
+    private static readonly Lock Gate = new();
+    private static bool _registered;
+
+    /// <summary>
+    /// Registers a provider that parents its prompt to whatever <paramref name="parentWindow"/>
+    /// returns at the moment a sign-in is needed.
+    ///
+    /// Process-wide and done once; calling it again is a no-op rather than a second registration.
+    /// </summary>
+    internal static void Register(Func<nint> parentWindow)
+    {
+        lock (Gate)
+        {
+            if (_registered) return;
+
+            var provider = new ActiveDirectoryAuthenticationProvider();
+            provider.SetParentActivityOrWindowFunc(() => parentWindow());
+
+            // One provider serves all three: Default can fall through to an interactive prompt, and
+            // Integrated can be asked to fall back, so all of them may need a window.
+            SqlAuthenticationProvider.SetProvider(
+                SqlAuthenticationMethod.ActiveDirectoryInteractive, provider);
+            SqlAuthenticationProvider.SetProvider(
+                SqlAuthenticationMethod.ActiveDirectoryIntegrated, provider);
+            SqlAuthenticationProvider.SetProvider(
+                SqlAuthenticationMethod.ActiveDirectoryDefault, provider);
+
+            _registered = true;
+        }
+    }
+
+    /// <summary>
+    /// Test hook: forgets that registration happened, so a test can register its own window source.
+    ///
+    /// Needed because registration is deliberately once-per-process - without this the first test
+    /// to run would decide what every later one sees, and which test that is depends on the
+    /// runner's ordering.
+    /// </summary>
+    internal static void ResetForTests()
+    {
+        lock (Gate) _registered = false;
+    }
+
+    /// <summary>
+    /// The window the sign-in prompt should sit in front of: whichever is active, falling back to
+    /// the main window. Zero when there is no window yet, which the broker reports as the
+    /// window_handle_required error rather than crashing.
+    ///
+    /// MSAL calls this from whatever thread is acquiring the token, and WPF's window collection can
+    /// only be touched on the UI thread - hence the marshalling. It is a direct call when already
+    /// on the dispatcher, so the common case costs nothing.
+    /// </summary>
+    internal static nint ActiveWindowHandle()
+    {
+        var app = Application.Current;
+        if (app == null) return nint.Zero;
+
+        return app.Dispatcher.CheckAccess()
+            ? ResolveOnUiThread()
+            : app.Dispatcher.Invoke(ResolveOnUiThread);
+    }
+
+    private static nint ResolveOnUiThread()
+    {
+        var app = Application.Current;
+        if (app == null) return nint.Zero;
+
+        // Active first: with a modal open, a prompt parented to the main window sits BEHIND it and
+        // looks like a hang.
+        var window = app.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive)
+            ?? app.MainWindow;
+
+        return window == null ? nint.Zero : new WindowInteropHelper(window).Handle;
+    }
+}

--- a/src/NineLives/Services/EntraIdentity.cs
+++ b/src/NineLives/Services/EntraIdentity.cs
@@ -1,0 +1,89 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Who a token was issued to, read from the token itself (#29).
+///
+/// Azure answers a data-plane permission failure with 403 AuthorizationPermissionMismatch and
+/// nothing else. That is one message for several very different problems - the role is assigned but
+/// on the management plane, the role is on the wrong scope, or the token is for a different account
+/// or tenant than the one that was granted access. Being told WHICH identity was refused is usually
+/// enough to tell them apart, and there is no other way to find out from inside the app.
+///
+/// The claims are read WITHOUT validating the signature, deliberately. This app is not the resource
+/// server - it is not deciding whether to trust the token, it is repeating back who Azure said it
+/// belongs to so a human can spot that it is the wrong person. Azure has already validated it, and
+/// the only thing done with the result is display.
+/// </summary>
+internal static class EntraIdentity
+{
+    /// <summary>
+    /// A short description of the account a token belongs to, or null if it cannot be read.
+    ///
+    /// Never returns any part of the token itself. A JWT bearer token is a live credential for as
+    /// long as it lasts, and this text goes on screen and into the log.
+    /// </summary>
+    internal static string? Describe(string accessToken)
+    {
+        var claims = ReadClaims(accessToken);
+        if (claims == null) return null;
+
+        // A user token names the person; a managed identity or service principal has no user at
+        // all, only an object id - which is still the thing to check a role assignment against.
+        var who = First(claims, "upn", "preferred_username", "unique_name", "email")
+            ?? First(claims, "appid", "azp")
+            ?? First(claims, "oid");
+
+        var tenant = First(claims, "tid");
+
+        if (who == null && tenant == null) return null;
+        if (who == null) return $"tenant {tenant}";
+        return tenant == null ? who : $"{who} (tenant {tenant})";
+    }
+
+    private static string? First(Dictionary<string, string> claims, params string[] names)
+    {
+        foreach (var name in names)
+            if (claims.TryGetValue(name, out var value) && !string.IsNullOrWhiteSpace(value))
+                return value;
+        return null;
+    }
+
+    /// <summary>
+    /// The payload segment's claims. Anything malformed comes back null rather than throwing - this
+    /// only ever runs to improve an error message, and failing to improve one must not replace it
+    /// with a different error.
+    /// </summary>
+    private static Dictionary<string, string>? ReadClaims(string accessToken)
+    {
+        try
+        {
+            var parts = accessToken.Split('.');
+            if (parts.Length < 2) return null;
+
+            using var document = JsonDocument.Parse(FromBase64Url(parts[1]));
+            if (document.RootElement.ValueKind != JsonValueKind.Object) return null;
+
+            var claims = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var property in document.RootElement.EnumerateObject())
+                if (property.Value.ValueKind == JsonValueKind.String)
+                    claims[property.Name] = property.Value.GetString() ?? string.Empty;
+
+            return claims;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Base64url, which is base64 with two characters swapped and the padding dropped.</summary>
+    private static byte[] FromBase64Url(string value)
+    {
+        var padded = new StringBuilder(value.Replace('-', '+').Replace('_', '/'));
+        while (padded.Length % 4 != 0) padded.Append('=');
+        return Convert.FromBase64String(padded.ToString());
+    }
+}

--- a/src/NineLives/Services/IBlobStorageService.cs
+++ b/src/NineLives/Services/IBlobStorageService.cs
@@ -12,6 +12,14 @@ public interface IBlobStorageService
 {
     Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default);
 
+    /// <summary>
+    /// Who the Entra sign-in actually is, for putting in a permission error. Null when the
+    /// container does not use Entra, or when it cannot be determined - it only ever improves a
+    /// message, so failing to answer must never become an error of its own (#29).
+    /// </summary>
+    Task<string?> DescribeSignedInIdentityAsync(
+        BlobContainerConfig config, CancellationToken ct = default);
+
     Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default);
 
     Task<List<BackupFileInfo>> ListBackupFilesAsync(BlobContainerConfig config, CancellationToken ct = default);

--- a/src/NineLives/Services/IBlobStorageService.cs
+++ b/src/NineLives/Services/IBlobStorageService.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -24,7 +24,12 @@ public interface IBlobStorageService
 
     ContainerSummary GetContainerSummary(List<BackupFileInfo> files);
     ContainerSummary GetSetBasedSummary(List<BackupSet> sets);
-    List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files);
+    /// <param name="backupServerTimeZoneId">
+    /// The backup server's time zone, when the container says which one it is. Lets a blob's UTC
+    /// LastModified be put on the same clock as a filename timestamp (#102). Null leaves them
+    /// labelled but unreconciled.
+    /// </param>
+    List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files, string? backupServerTimeZoneId = null);
     List<string> GetDiscoveredDatabases(List<BackupFileInfo> files);
     List<string> GetDiscoveredServers(List<BackupFileInfo> files);
 }

--- a/src/NineLives/Services/IBlobStorageService.cs
+++ b/src/NineLives/Services/IBlobStorageService.cs
@@ -1,0 +1,30 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Reading a blob container. Implemented by <see cref="BlobStorageService"/>.
+///
+/// Covers what the ViewModels use, which is deliberately not everything the class exposes: the
+/// static filename helpers stay on the class, since nothing needs to substitute them (#41).
+/// </summary>
+public interface IBlobStorageService
+{
+    Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default);
+
+    Task<List<string>> ListTopLevelFoldersAsync(BlobContainerConfig config, CancellationToken ct = default);
+
+    Task<List<BackupFileInfo>> ListBackupFilesAsync(BlobContainerConfig config, CancellationToken ct = default);
+
+    Task<List<BackupFileInfo>> ListBackupFilesAsync(
+        BlobContainerConfig config,
+        BlobListingScope? scope,
+        IProgress<int>? progress,
+        CancellationToken ct = default);
+
+    ContainerSummary GetContainerSummary(List<BackupFileInfo> files);
+    ContainerSummary GetSetBasedSummary(List<BackupSet> sets);
+    List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files);
+    List<string> GetDiscoveredDatabases(List<BackupFileInfo> files);
+    List<string> GetDiscoveredServers(List<BackupFileInfo> files);
+}

--- a/src/NineLives/Services/ICredentialStore.cs
+++ b/src/NineLives/Services/ICredentialStore.cs
@@ -1,0 +1,31 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Stored configuration and secrets. Implemented by <see cref="CredentialStore"/> against the
+/// Windows Credential Manager and a JSON file under %LOCALAPPDATA%.
+///
+/// This exists so a ViewModel can be constructed in a test without reaching the real machine.
+/// Every method here touches either the credential vault or the user's config file, which is a
+/// side effect no test should have (#41).
+/// </summary>
+public interface ICredentialStore
+{
+    void SaveSecret(string key, string username, string secret);
+    (string? username, string? secret) ReadSecret(string key);
+    bool DeleteSecret(string key);
+    List<string> ListCredentialKeys(string prefix);
+
+    void SaveSasToken(BlobContainerConfig config, string sasToken);
+    string? GetSasToken(BlobContainerConfig config);
+    bool IsSasTokenExpired(BlobContainerConfig config);
+    DateTime? GetSasTokenExpiry(BlobContainerConfig config);
+    SasExpiryInfo ReadSasTokenExpiry(BlobContainerConfig config);
+
+    void SaveSqlPassword(ServerConnection connection, string password);
+    string? GetSqlPassword(ServerConnection connection);
+
+    AppConfig LoadConfig();
+    void SaveConfig(AppConfig config);
+}

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -49,7 +49,7 @@ public interface ISqlServerService
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default);
 
-    Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+    Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default);
 
     Task<CredentialChange> EnsureCredentialExistsAsync(

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -38,6 +38,7 @@ public interface ISqlServerService
         ServerConnection server,
         IReadOnlyList<string> blobUrls,
         bool withChecksum = false,
+        IReadOnlyList<FileMoveOption>? fileMoves = null,
         CancellationToken ct = default);
 
     Task ExecuteNonQueryAsync(

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -1,0 +1,57 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Everything the ViewModels ask of SQL Server. Implemented by <see cref="SqlServerService"/>.
+///
+/// <c>CreateConnection</c> and <c>BuildConnectionString</c> are deliberately absent: they hand
+/// back a <c>SqlConnection</c>, which would put Microsoft.Data.SqlClient in the signature of the
+/// thing a fake has to implement. They stay on the class, where the live tests use them (#41).
+/// </summary>
+public interface ISqlServerService
+{
+    Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default);
+
+    Task<bool?> WouldConnectWithCertificateValidationAsync(
+        ServerConnection server, CancellationToken ct = default);
+
+    Task<string> GetServerVersionAsync(ServerConnection server, CancellationToken ct = default);
+
+    Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default);
+
+    Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(
+        ServerConnection server, CancellationToken ct = default);
+
+    Task<DatabaseRecoveryState> GetDatabaseRecoveryStateAsync(
+        ServerConnection server, string databaseName, CancellationToken ct = default);
+
+    Task ExecuteRecoveryActionAsync(ServerConnection server, string sql, CancellationToken ct = default);
+
+    Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default);
+
+    Task<BackupFileInfo?> RestoreHeaderOnlyMultiAsync(
+        ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default);
+
+    Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
+        ServerConnection server,
+        IReadOnlyList<string> blobUrls,
+        bool withChecksum = false,
+        CancellationToken ct = default);
+
+    Task ExecuteNonQueryAsync(
+        ServerConnection server, string sql,
+        Action<string>? messageCallback = null, CancellationToken ct = default);
+
+    Task ExecuteRestoreWithProgressAsync(
+        ServerConnection server, string sql,
+        Action<string>? messageCallback = null, CancellationToken ct = default);
+
+    Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+        ServerConnection server, string credentialName, CancellationToken ct = default);
+
+    Task<CredentialChange> EnsureCredentialExistsAsync(
+        ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
+        CancellationToken ct = default);
+}

--- a/src/NineLives/Services/RestoreHistoryStore.cs
+++ b/src/NineLives/Services/RestoreHistoryStore.cs
@@ -1,0 +1,148 @@
+using System.IO;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+public interface IRestoreHistoryStore
+{
+    /// <summary>Most recent first. Never throws - an unreadable history is not worth an error dialog.</summary>
+    List<RestoreHistoryEntry> Load();
+
+    /// <summary>Adds one execution. Never throws: recording history must not be able to fail a restore.</summary>
+    void Append(RestoreHistoryEntry entry);
+
+    void Clear();
+
+    string FilePath { get; }
+}
+
+/// <summary>
+/// Past executions, kept next to the config so they survive the app closing (#31).
+///
+/// Separate from <see cref="OperationLog"/> on purpose. The log is an append-only text stream for
+/// reading and attaching to a bug report; this is structured, bounded and meant to be listed,
+/// searched and re-used.
+///
+/// Two rules, both learned from the config-loss defect (#7):
+///   - a history that cannot be read returns empty and is NOT then overwritten blindly
+///   - writes go through a temp file and an atomic swap, so a crash mid-write cannot truncate it
+/// </summary>
+public sealed class RestoreHistoryStore : IRestoreHistoryStore
+{
+    /// <summary>
+    /// Older entries fall off the end. Each carries a script and a console log, so this is a cap
+    /// on file size as much as on count - and a restore history nobody has looked at in 200
+    /// restores is not what anyone is reaching for.
+    /// </summary>
+    private const int MaxEntries = 200;
+
+    private readonly string _path;
+    private readonly object _gate = new();
+
+    public RestoreHistoryStore() : this(Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "NineLives"))
+    { }
+
+    /// <summary>Lets the tests write somewhere disposable instead of the real profile.</summary>
+    internal RestoreHistoryStore(string directory)
+        => _path = Path.Combine(directory, "restore-history.json");
+
+    public string FilePath => _path;
+
+    public List<RestoreHistoryEntry> Load()
+    {
+        lock (_gate)
+        {
+            return ReadUnlocked() ?? [];
+        }
+    }
+
+    public void Append(RestoreHistoryEntry entry)
+    {
+        try
+        {
+            lock (_gate)
+            {
+                var existing = ReadUnlocked();
+
+                // Null means the file is there and could not be read. Appending to an empty list
+                // and saving would throw away every entry it holds - the exact shape of the
+                // config-loss bug - so the honest move is to leave the file alone.
+                if (existing == null) return;
+
+                // Everything is redacted on the way IN, at the one boundary, so a future caller
+                // cannot leak a token by forgetting to.
+                entry.Script = LogRedactor.Redact(entry.Script);
+                entry.Log = LogRedactor.Redact(entry.Log);
+                if (entry.ErrorMessage != null)
+                    entry.ErrorMessage = LogRedactor.Redact(entry.ErrorMessage);
+
+                existing.Insert(0, entry);
+                if (existing.Count > MaxEntries)
+                    existing.RemoveRange(MaxEntries, existing.Count - MaxEntries);
+
+                WriteUnlocked(existing);
+            }
+        }
+        catch
+        {
+            // Recording what happened must never be able to fail the thing that happened.
+        }
+    }
+
+    public void Clear()
+    {
+        try
+        {
+            lock (_gate) { WriteUnlocked([]); }
+        }
+        catch
+        {
+        }
+    }
+
+    /// <summary>Null when the file exists but could not be read; empty list when there is no file.</summary>
+    private List<RestoreHistoryEntry>? ReadUnlocked()
+    {
+        if (!File.Exists(_path)) return [];
+
+        try
+        {
+            var json = File.ReadAllText(_path);
+            return JsonSerializer.Deserialize<List<RestoreHistoryEntry>>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void WriteUnlocked(List<RestoreHistoryEntry> entries)
+    {
+        var directory = Path.GetDirectoryName(_path)!;
+        Directory.CreateDirectory(directory);
+
+        var json = JsonSerializer.Serialize(entries, new JsonSerializerOptions { WriteIndented = true });
+
+        var temp = _path + ".tmp";
+        File.WriteAllText(temp, json);
+
+        if (File.Exists(_path))
+        {
+            try
+            {
+                File.Replace(temp, _path, null, ignoreMetadataErrors: true);
+                return;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // A few network shares cannot do the atomic swap.
+            }
+            File.Delete(_path);
+        }
+
+        File.Move(temp, _path);
+    }
+}

--- a/src/NineLives/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives/Services/RestoreScriptGenerator.cs
@@ -51,6 +51,17 @@ public class RestoreScriptGenerator
         if (options.StopAt.HasValue)
             sb.AppendLine($"-- Point-in-Time: {options.StopAt.Value:yyyy-MM-dd HH:mm:ss}");
         sb.AppendLine("-- ============================================================");
+
+        // Worth saying in the script itself, not just the checkbox tooltip - the script gets
+        // copied into SSMS and run by someone who never saw the checkbox.
+        if (options.ContinueAfterError)
+        {
+            sb.AppendLine();
+            sb.AppendLine("-- WARNING: CONTINUE_AFTER_ERROR is set. If SQL Server hits a damaged");
+            sb.AppendLine("-- page or a failed checksum it will keep going and finish anyway, so");
+            sb.AppendLine("-- a database this produces may be corrupt. Run DBCC CHECKDB on it.");
+        }
+
         sb.AppendLine();
     }
 
@@ -171,6 +182,10 @@ public class RestoreScriptGenerator
             sb.AppendLine("         ENABLE_BROKER,");
         if (options.NewBroker)
             sb.AppendLine("         NEW_BROKER,");
+        if (options.WithChecksum)
+            sb.AppendLine("         CHECKSUM,");
+        if (options.ContinueAfterError)
+            sb.AppendLine("         CONTINUE_AFTER_ERROR,");
         sb.AppendLine($"         STATS = {options.StatsPercent};");
     }
 

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -6,11 +6,11 @@ using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
-public class SqlServerService
+public class SqlServerService : ISqlServerService
 {
-    private readonly CredentialStore _credentialStore;
+    private readonly ICredentialStore _credentialStore;
 
-    public SqlServerService(CredentialStore credentialStore)
+    public SqlServerService(ICredentialStore credentialStore)
     {
         _credentialStore = credentialStore;
     }

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -296,6 +296,83 @@ public class SqlServerService
         };
     }
 
+    /// <summary>
+    /// RESTORE VERIFYONLY across the files of one backup set, striped or not.
+    ///
+    /// This is the check a DBA runs before committing to a long restore: it reads the backup and
+    /// reports whether it is complete and readable, in seconds rather than after an hour of
+    /// restoring. It does NOT check the data inside - that needs a restore and DBCC CHECKDB.
+    ///
+    /// A failure is returned rather than thrown, so one unreadable member of a chain does not
+    /// abort verification of the rest. Cancellation still propagates.
+    /// </summary>
+    /// <param name="withChecksum">
+    /// Adds WITH CHECKSUM. Left off, SQL Server applies its own default; a backup taken without
+    /// checksums FAILS this rather than skipping the check, so it is the caller's choice.
+    /// </param>
+    public async Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
+        ServerConnection server,
+        IReadOnlyList<string> blobUrls,
+        bool withChecksum = false,
+        CancellationToken ct = default)
+    {
+        if (blobUrls.Count == 0)
+            return new VerifyOnlyResult(false, "No files to verify.");
+
+        var messages = new List<string>();
+
+        await using var conn = CreateConnection(server);
+
+        // VERIFYONLY says what it found through info messages - "The backup set on file 1 is
+        // valid." - and reports a bad backup by throwing. Both halves are wanted.
+        conn.InfoMessage += (_, e) => messages.Add(e.Message);
+
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandTimeout = 0;
+
+        cmd.CommandText = BuildVerifyOnlyStatement(blobUrls, withChecksum);
+
+        try
+        {
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+        catch (SqlException) when (ct.IsCancellationRequested)
+        {
+            // Same trap as the restore path: a cancelled command surfaces as SqlException, and
+            // reporting that as a verification failure would tell the user their backup is bad.
+            throw new OperationCanceledException("Verification was cancelled.", ct);
+        }
+        catch (SqlException ex)
+        {
+            return new VerifyOnlyResult(false, ex.Message);
+        }
+
+        return new VerifyOnlyResult(
+            true,
+            messages.Count > 0
+                ? string.Join(" ", messages.Select(m => m.Trim()))
+                : "The backup set is valid.");
+    }
+
+    /// <summary>
+    /// The exact T-SQL a verification runs. Every file of a striped set goes into one statement -
+    /// a stripe on its own is not a readable backup, so verifying them one at a time would report
+    /// failures that are not there.
+    ///
+    /// No WITH CREDENTIAL clause: SQL Server rejects that for SAS credentials with Msg 3225, and
+    /// it matches the credential by URL anyway (#60).
+    /// </summary>
+    public static string BuildVerifyOnlyStatement(IReadOnlyList<string> blobUrls, bool withChecksum)
+    {
+        var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
+
+        // Omitted rather than set to NO_CHECKSUM when off, so SQL Server's own default applies.
+        return withChecksum
+            ? $"RESTORE VERIFYONLY FROM {urlClauses} WITH CHECKSUM"
+            : $"RESTORE VERIFYONLY FROM {urlClauses}";
+    }
+
     private static string? GetStringFromReader(SqlDataReader reader, string columnName)
     {
         var ordinal = reader.GetOrdinal(columnName);

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -34,7 +34,24 @@ public class SqlServerService : ISqlServerService
 
         builder.IntegratedSecurity = server.AuthMode == AuthMode.WindowsAuth;
 
-        // No UserID or Password here - SQL auth credentials go on the SqlConnection as a
+        // Entra is the driver's own token flow - Microsoft.Data.SqlClient acquires and refreshes
+        // the token through MSAL, and the app never sees or stores a secret for it (#30).
+        if (server.AuthMode.IsEntra())
+        {
+            builder.Authentication = server.AuthMode switch
+            {
+                AuthMode.EntraInteractive => SqlAuthenticationMethod.ActiveDirectoryInteractive,
+                AuthMode.EntraIntegrated => SqlAuthenticationMethod.ActiveDirectoryIntegrated,
+                _ => SqlAuthenticationMethod.ActiveDirectoryDefault
+            };
+
+            // A hint for the account picker, not a credential. Safe in the connection string for
+            // the same reason the SQL auth username is not: there is no password to pair it with.
+            if (server.AuthMode == AuthMode.EntraInteractive && !string.IsNullOrWhiteSpace(server.Username))
+                builder.UserID = server.Username;
+        }
+
+        // No UserID or Password here for SQL auth - those credentials go on the SqlConnection as a
         // SqlCredential instead (#20). A connection string is a long-lived managed string that
         // cannot be zeroed and turns up in crash dumps and memory captures; SqlCredential holds
         // the password in a SecureString the driver disposes. It also means anything that logs or
@@ -53,7 +70,8 @@ public class SqlServerService : ISqlServerService
     {
         var conn = new SqlConnection(BuildConnectionString(server));
 
-        if (server.AuthMode != AuthMode.SqlAuth)
+        // Windows auth and the Entra modes carry no password of ours - the driver handles both.
+        if (!server.AuthMode.NeedsStoredPassword())
             return conn;
 
         // Unsaved wins, so Test Connection can try a password without persisting it first (#12).

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -624,12 +624,19 @@ public class SqlServerService : ISqlServerService
 
     private static readonly Regex WhitespaceRun = new(@"\s+", RegexOptions.Compiled);
 
-    /// <summary>Checks if a credential with the given name exists on the server and has identity SHARED ACCESS SIGNATURE (for blob URL restores).</summary>
-    public async Task<(bool Exists, bool IsSharedAccessSignature)> CredentialExistsAsync(
+    /// <summary>
+    /// Which credential of that name is on the server, if any, and what it authenticates as.
+    ///
+    /// Reports the identity rather than "is it SAS" (#145). The two identities a restore from URL
+    /// can use are SHARED ACCESS SIGNATURE and, on SQL Server 2022+ or Azure SQL MI, Managed
+    /// Identity; collapsing them into one bool told the caller a working managed-identity
+    /// credential was broken, and the caller then overwrote it.
+    /// </summary>
+    public async Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(credentialName))
-            return (false, false);
+            return BlobCredentialStatus.Missing;
 
         await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
@@ -643,11 +650,24 @@ public class SqlServerService : ISqlServerService
 
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         if (!await reader.ReadAsync(ct))
-            return (false, false);
+            return BlobCredentialStatus.Missing;
 
-        var identity = reader["credential_identity"]?.ToString() ?? "";
-        var isSas = identity.Equals("SHARED ACCESS SIGNATURE", StringComparison.OrdinalIgnoreCase);
-        return (true, isSas);
+        var identity = (reader["credential_identity"]?.ToString() ?? "").Trim();
+        return new BlobCredentialStatus(ClassifyIdentity(identity), identity);
+    }
+
+    /// <summary>
+    /// The identity text as stored in sys.credentials, matched loosely. Case is not guaranteed -
+    /// the docs write 'Managed Identity' and 'MANAGED IDENTITY' in different places, and whoever
+    /// created the credential typed one of them.
+    /// </summary>
+    internal static BlobCredentialIdentity ClassifyIdentity(string identity)
+    {
+        if (identity.Equals("SHARED ACCESS SIGNATURE", StringComparison.OrdinalIgnoreCase))
+            return BlobCredentialIdentity.SharedAccessSignature;
+        if (identity.Equals("Managed Identity", StringComparison.OrdinalIgnoreCase))
+            return BlobCredentialIdentity.ManagedIdentity;
+        return BlobCredentialIdentity.Other;
     }
 
     // CREATE/DROP CREDENTIAL cannot take the name as a parameter - it is an identifier, not a
@@ -682,8 +702,14 @@ public class SqlServerService : ISqlServerService
         checkCmd.Parameters.AddWithValue("@name", credentialName);
         var exists = (int)(await checkCmd.ExecuteScalarAsync(ct))! > 0;
 
-        // ALTER also resets IDENTITY, so a credential that exists under some other identity is
-        // converted rather than left in place to fail the restore later.
+        // ALTER resets IDENTITY as well as the secret, so a credential sitting under some other
+        // identity is converted rather than left to fail the restore later.
+        //
+        // That conversion is destructive and this method cannot tell a mistake from a deliberate
+        // setup, so it must only ever be reached because somebody asked for it. The execute path
+        // no longer calls this to "fix" an identity it does not recognise - it stops and says what
+        // it found, because the identity it would have replaced could be a managed identity the
+        // instance genuinely restores with (#145).
         var cleanSas = sasToken.TrimStart('?');
         await using var writeCmd = conn.CreateCommand();
         writeCmd.CommandText = $@"

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -38,6 +38,11 @@ public class SqlServerService : ISqlServerService
         // the token through MSAL, and the app never sees or stores a secret for it (#30).
         if (server.AuthMode.IsEntra())
         {
+            // Before the connection string names a method, make sure the provider servicing it has
+            // a window to parent its prompt to - otherwise the sign-in fails with
+            // "a window handle must be configured" rather than showing anything.
+            EntraAuthentication.Register(EntraAuthentication.ActiveWindowHandle);
+
             builder.Authentication = server.AuthMode switch
             {
                 AuthMode.EntraInteractive => SqlAuthenticationMethod.ActiveDirectoryInteractive,

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1,4 +1,4 @@
-using System.Data;
+﻿using System.Data;
 using System.Security;
 using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
@@ -191,7 +191,9 @@ public class SqlServerService : ISqlServerService
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 0;
         cmd.CommandText = sql;
-        await cmd.ExecuteNonQueryAsync(ct);
+
+        await CancellableAsync(
+            () => cmd.ExecuteNonQueryAsync(ct), ct, "The recovery action");
     }
 
     public async Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
@@ -243,19 +245,22 @@ public class SqlServerService : ISqlServerService
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         cmd.CommandText = $"RESTORE FILELISTONLY FROM {urlClauses}";
 
-        var files = new List<FileMoveOption>();
-        await using var reader = await cmd.ExecuteReaderAsync(ct);
-        while (await reader.ReadAsync(ct))
+        return await CancellableAsync(async () =>
         {
-            files.Add(new FileMoveOption
+            var files = new List<FileMoveOption>();
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+            while (await reader.ReadAsync(ct))
             {
-                LogicalName = reader.GetString(reader.GetOrdinal("LogicalName")),
-                PhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName")),
-                Type = reader.GetString(reader.GetOrdinal("Type")),
-                NewPhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName"))
-            });
-        }
-        return files;
+                files.Add(new FileMoveOption
+                {
+                    LogicalName = reader.GetString(reader.GetOrdinal("LogicalName")),
+                    PhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName")),
+                    Type = reader.GetString(reader.GetOrdinal("Type")),
+                    NewPhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName"))
+                });
+            }
+            return files;
+        }, ct, "Reading the file list");
     }
 
     /// <summary>RESTORE HEADERONLY across the files of one backup set, striped or not.</summary>
@@ -272,6 +277,8 @@ public class SqlServerService : ISqlServerService
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         cmd.CommandText = $"RESTORE HEADERONLY FROM {urlClauses}";
 
+        return await CancellableAsync<BackupFileInfo?>(async () =>
+        {
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         if (!await reader.ReadAsync(ct)) return null;
 
@@ -294,6 +301,7 @@ public class SqlServerService : ISqlServerService
             DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN"),
             CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN")
         };
+        }, ct, "Reading the backup header");
     }
 
     /// <summary>
@@ -354,6 +362,33 @@ public class SqlServerService : ISqlServerService
                 ? string.Join(" ", messages.Select(m => m.Trim()))
                 : "The backup set is valid.");
     }
+
+    /// <summary>
+    /// Runs something against SQL Server and translates a cancellation into the exception the
+    /// caller expects.
+    ///
+    /// SqlClient reports a command cancelled mid-flight as a SqlException - "A severe error
+    /// occurred on the current command" - not an OperationCanceledException. Every call site that
+    /// takes a token needs the same trap, and writing it out at each one is how three of them came
+    /// to be missing it. Only when the token was actually signalled, so a genuine severe error
+    /// still propagates as the failure it is.
+    /// </summary>
+    private static async Task<T> CancellableAsync<T>(
+        Func<Task<T>> work, CancellationToken ct, string what)
+    {
+        try
+        {
+            return await work();
+        }
+        catch (SqlException) when (ct.IsCancellationRequested)
+        {
+            throw new OperationCanceledException($"{what} was cancelled.", ct);
+        }
+    }
+
+    private static async Task CancellableAsync(
+        Func<Task> work, CancellationToken ct, string what)
+        => await CancellableAsync<bool>(async () => { await work(); return true; }, ct, what);
 
     /// <summary>
     /// The exact T-SQL a verification runs. Every file of a striped set goes into one statement -

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -318,10 +318,17 @@ public class SqlServerService : ISqlServerService
     /// Adds WITH CHECKSUM. Left off, SQL Server applies its own default; a backup taken without
     /// checksums FAILS this rather than skipping the check, so it is the caller's choice.
     /// </param>
+    /// <param name="fileMoves">
+    /// The same MOVE clauses the restore will use. VERIFYONLY checks whether a restore could
+    /// proceed, which includes looking for the file paths it would write to - so without these it
+    /// checks the paths recorded INSIDE the backup, which belong to the source server. Confirmed
+    /// against SQL Server 2025: passing MOVE makes it check the move targets instead.
+    /// </param>
     public async Task<VerifyOnlyResult> RestoreVerifyOnlyAsync(
         ServerConnection server,
         IReadOnlyList<string> blobUrls,
         bool withChecksum = false,
+        IReadOnlyList<FileMoveOption>? fileMoves = null,
         CancellationToken ct = default)
     {
         if (blobUrls.Count == 0)
@@ -339,7 +346,7 @@ public class SqlServerService : ISqlServerService
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 0;
 
-        cmd.CommandText = BuildVerifyOnlyStatement(blobUrls, withChecksum);
+        cmd.CommandText = BuildVerifyOnlyStatement(blobUrls, withChecksum, fileMoves);
 
         try
         {
@@ -356,11 +363,11 @@ public class SqlServerService : ISqlServerService
             return new VerifyOnlyResult(false, ex.Message);
         }
 
-        return new VerifyOnlyResult(
-            true,
-            messages.Count > 0
-                ? string.Join(" ", messages.Select(m => m.Trim()))
-                : "The backup set is valid.");
+        var report = messages.Count > 0
+            ? string.Join(" ", messages.Select(m => m.Trim()))
+            : "The backup set is valid.";
+
+        return new VerifyOnlyResult(true, report, MentionsMissingDirectory(report));
     }
 
     /// <summary>
@@ -398,15 +405,45 @@ public class SqlServerService : ISqlServerService
     /// No WITH CREDENTIAL clause: SQL Server rejects that for SAS credentials with Msg 3225, and
     /// it matches the credential by URL anyway (#60).
     /// </summary>
-    public static string BuildVerifyOnlyStatement(IReadOnlyList<string> blobUrls, bool withChecksum)
+    public static string BuildVerifyOnlyStatement(
+        IReadOnlyList<string> blobUrls,
+        bool withChecksum,
+        IReadOnlyList<FileMoveOption>? fileMoves = null)
     {
         var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
 
+        var options = new List<string>();
+
         // Omitted rather than set to NO_CHECKSUM when off, so SQL Server's own default applies.
-        return withChecksum
-            ? $"RESTORE VERIFYONLY FROM {urlClauses} WITH CHECKSUM"
-            : $"RESTORE VERIFYONLY FROM {urlClauses}";
+        if (withChecksum) options.Add("CHECKSUM");
+
+        // The same MOVE clauses the restore will use. Both names are string literals, not
+        // identifiers - LogicalName comes from RESTORE FILELISTONLY (sysname, so an apostrophe is
+        // legal) and NewPhysicalName is a user-editable path.
+        if (fileMoves != null)
+        {
+            options.AddRange(fileMoves
+                .Where(m => !string.IsNullOrWhiteSpace(m.NewPhysicalName))
+                .Select(m => $"MOVE N'{TSql.EscapeLiteral(m.LogicalName)}' " +
+                             $"TO N'{TSql.EscapeLiteral(m.NewPhysicalName)}'"));
+        }
+
+        return options.Count == 0
+            ? $"RESTORE VERIFYONLY FROM {urlClauses}"
+            : $"RESTORE VERIFYONLY FROM {urlClauses} WITH {string.Join(", ", options)}";
     }
+
+    /// <summary>
+    /// Did VERIFYONLY complain that it could not find the directories a restore would write to?
+    ///
+    /// Matched on SQL Server's own wording. It reports this as an informational message alongside
+    /// "the backup set is valid", so a chain can be perfectly readable and still be certain to
+    /// fail on restore - which is worth saying out loud rather than leaving in four lines of grey
+    /// text under a green tick (#129).
+    /// </summary>
+    private static bool MentionsMissingDirectory(string report)
+        => report.Contains("Directory lookup for the file", StringComparison.OrdinalIgnoreCase)
+        || report.Contains("may encounter storage space problems", StringComparison.OrdinalIgnoreCase);
 
     private static string? GetStringFromReader(SqlDataReader reader, string columnName)
     {

--- a/src/NineLives/Services/ThemeManager.cs
+++ b/src/NineLives/Services/ThemeManager.cs
@@ -1,0 +1,90 @@
+using System.Windows;
+
+namespace Blackcat.NineLives.Services;
+
+public enum AppTheme
+{
+    Dark,
+    Light,
+    HighContrast
+}
+
+/// <summary>
+/// Swaps the colour palette at runtime.
+///
+/// The application's merged dictionaries are [palette, controls, logo]. Only the palette changes;
+/// the control styles and the logo are the same in every theme. Replacing the dictionary at index
+/// 0 re-resolves every <c>DynamicResource</c> in every loaded window immediately, which is why
+/// the styles and views reference brushes dynamically - a StaticResource is resolved once when the
+/// element loads and would keep the old colour for the lifetime of the window.
+///
+/// Position, not Source Uri, identifies the palette: comparing pack Uris is fiddly, and the merge
+/// order is declared in one place (App.xaml) right next to a comment saying so.
+/// </summary>
+public static class ThemeManager
+{
+    public const int PaletteIndex = 0;
+
+    /// <summary>The theme currently applied. Dark until something says otherwise.</summary>
+    public static AppTheme Current { get; private set; } = AppTheme.Dark;
+
+    /// <summary>
+    /// An absolute pack Uri, not a relative path.
+    ///
+    /// A relative Uri resolves against the ENTRY assembly, which is this app when it runs and the
+    /// test host when the tests run - so the tests could not load a palette at all. Naming the
+    /// assembly works in both.
+    /// </summary>
+    public static string SourceFor(AppTheme theme) => theme switch
+    {
+        AppTheme.Light => Pack("Palette.Light"),
+        AppTheme.HighContrast => Pack("Palette.HighContrast"),
+        _ => Pack("Palette.Dark")
+    };
+
+    private static string Pack(string name)
+        => $"pack://application:,,,/NineLives;component/Themes/{name}.xaml";
+
+    /// <summary>Loads a palette without applying it. Used by the tests to compare key sets.</summary>
+    public static ResourceDictionary Load(AppTheme theme) => new()
+    {
+        Source = new Uri(SourceFor(theme), UriKind.Absolute)
+    };
+
+    /// <summary>
+    /// Applies a theme to the running application.
+    ///
+    /// Never throws. A theme that will not load is a cosmetic problem, and taking the app down -
+    /// or worse, failing mid-restore - over a colour scheme would not be a trade anyone would
+    /// make. The previous palette simply stays in place.
+    /// </summary>
+    public static bool Apply(AppTheme theme, Application? application = null)
+    {
+        var app = application ?? Application.Current;
+        if (app == null) return false;
+
+        try
+        {
+            var merged = app.Resources.MergedDictionaries;
+            if (merged.Count == 0) return false;
+
+            merged[PaletteIndex] = Load(theme);
+            Current = theme;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Human-readable name, for the picker and the config file.</summary>
+    public static string DisplayName(AppTheme theme) => theme switch
+    {
+        AppTheme.Light => "Light",
+        AppTheme.HighContrast => "High contrast",
+        _ => "Dark"
+    };
+
+    public static IReadOnlyList<AppTheme> All => [AppTheme.Dark, AppTheme.Light, AppTheme.HighContrast];
+}

--- a/src/NineLives/Services/VerifyOnlyResult.cs
+++ b/src/NineLives/Services/VerifyOnlyResult.cs
@@ -1,0 +1,33 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// What RESTORE VERIFYONLY said about one backup set.
+/// </summary>
+/// <param name="IsValid">True when SQL Server read the whole set without complaint.</param>
+/// <param name="Message">
+/// SQL Server's own words, either the info message it emits on success or the error it raised.
+/// Kept verbatim - a DBA reading "The backup set on file 1 is valid." or "Cannot open backup
+/// device" knows exactly what happened, and a paraphrase would only lose detail.
+/// </param>
+public sealed record VerifyOnlyResult(bool IsValid, string Message);
+
+/// <summary>
+/// One member of a restore chain paired with its verification result, for display.
+/// </summary>
+public sealed class ChainVerifyResult
+{
+    public required BackupSet Set { get; init; }
+    public required VerifyOnlyResult Result { get; init; }
+
+    public string TypeDisplay => Set.TypeDisplay;
+    public string SetId => Set.SetId;
+    public bool IsValid => Result.IsValid;
+    public string Message => Result.Message;
+
+    /// <summary>Short label for the row, so the grid reads without needing the message column.</summary>
+    public string StatusDisplay => Result.IsValid ? "Valid" : "FAILED";
+
+    public string Summary => $"{TypeDisplay} {SetId}: {StatusDisplay}";
+}

--- a/src/NineLives/Services/VerifyOnlyResult.cs
+++ b/src/NineLives/Services/VerifyOnlyResult.cs
@@ -11,7 +11,12 @@ namespace Blackcat.NineLives.Services;
 /// Kept verbatim - a DBA reading "The backup set on file 1 is valid." or "Cannot open backup
 /// device" knows exactly what happened, and a paraphrase would only lose detail.
 /// </param>
-public sealed record VerifyOnlyResult(bool IsValid, string Message);
+/// <param name="TargetPathsMissing">
+/// True when SQL Server said it could not find the directories a restore would write to. This
+/// arrives alongside "the backup set is valid", so a chain can be perfectly readable and still be
+/// certain to fail on restore (#129).
+/// </param>
+public sealed record VerifyOnlyResult(bool IsValid, string Message, bool TargetPathsMissing = false);
 
 /// <summary>
 /// One member of a restore chain paired with its verification result, for display.

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -8,9 +8,17 @@
          instance, so both work. -->
     <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
     <converters:NullToVisibilityConverter x:Key="NullToVis" />
+    <converters:ContrastingTextConverter x:Key="ContrastingText" />
 
     <!-- Terminal console. Darker than the cards on purpose, so the console reads as a separate
          surface the way a real terminal does rather than as another panel in the form. -->
+
+    <!--
+        Text on the backup-type badges and count chips. Those fills come from a converter rather
+        than the palette, so they are the same in every theme - and near-black clears 4.5:1 against
+        all four of them where white managed 2.19-3.34:1.
+    -->
+    <SolidColorBrush x:Key="BadgeTextBrush" Color="#0F131E" />
 
     <FontFamily x:Key="ConsoleFont">Cascadia Code, Cascadia Mono, Consolas, Courier New</FontFamily>
 
@@ -253,7 +261,9 @@
     <!-- Button Styles -->
     <Style x:Key="PrimaryButton" TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
-        <Setter Property="Foreground" Value="White" />
+        <!-- From the palette, not hardcoded. White here is what made every primary button in high
+             contrast white-on-yellow at 1.07:1 (#126). -->
+        <Setter Property="Foreground" Value="{DynamicResource AccentForegroundBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="FontWeight" Value="SemiBold" />
@@ -323,6 +333,7 @@
 
     <Style x:Key="DangerButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
         <Setter Property="Background" Value="{DynamicResource ErrorBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ErrorForegroundBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -351,6 +362,7 @@
 
     <Style x:Key="SuccessButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
         <Setter Property="Background" Value="{DynamicResource SuccessBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SuccessForegroundBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -584,7 +596,7 @@
                                        Text="&#x2713;"
                                        FontSize="12"
                                        FontWeight="Bold"
-                                       Foreground="White"
+                                       Foreground="{DynamicResource AccentForegroundBrush}"
                                        HorizontalAlignment="Center"
                                        VerticalAlignment="Center"
                                        Visibility="Collapsed" />

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
 
@@ -11,15 +11,6 @@
 
     <!-- Terminal console. Darker than the cards on purpose, so the console reads as a separate
          surface the way a real terminal does rather than as another panel in the form. -->
-    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#0C0E14" />
-    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#2A3040" />
-    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#161A24" />
-    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#C9D1D9" />
-    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#6E7681" />
-    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#79C0FF" />
-    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#3FB950" />
-    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#D29922" />
-    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#F85149" />
 
     <FontFamily x:Key="ConsoleFont">Cascadia Code, Cascadia Mono, Consolas, Courier New</FontFamily>
 
@@ -28,14 +19,6 @@
          uses red for things that have actually gone wrong. Against a dark navy UI a bright amber
          band is unmissable without pretending to be a failure. Dark text on it, because pale text
          on amber is the one combination that would undo the contrast. -->
-    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
-        <GradientStop Color="#FFC24B" Offset="0" />
-        <GradientStop Color="#F59E0B" Offset="0.55" />
-        <GradientStop Color="#EA8C04" Offset="1" />
-    </LinearGradientBrush>
-
-    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#1A1205" />
-    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#B36F00" />
 
     <!-- Solid dark on amber: the one thing to click, and it inverts the banner's own contrast. -->
     <Style x:Key="UpdateBannerPrimaryButton" TargetType="Button">
@@ -119,7 +102,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Padding" Value="12,8,12,10" />
-        <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ConsoleTextBrush}" />
         <Setter Property="ItemContainerStyle" Value="{StaticResource ConsoleListBoxItem}" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
@@ -138,19 +121,19 @@
                                LineStackingStrategy="BlockLineHeight">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="{StaticResource ConsoleTextBrush}" />
+                                <Setter Property="Foreground" Value="{DynamicResource ConsoleTextBrush}" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding Kind}" Value="Step">
-                                        <Setter Property="Foreground" Value="{StaticResource ConsoleStepBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ConsoleStepBrush}" />
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding Kind}" Value="Success">
-                                        <Setter Property="Foreground" Value="{StaticResource ConsoleSuccessBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ConsoleSuccessBrush}" />
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding Kind}" Value="Warning">
-                                        <Setter Property="Foreground" Value="{StaticResource ConsoleWarningBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ConsoleWarningBrush}" />
                                     </DataTrigger>
                                     <DataTrigger Binding="{Binding Kind}" Value="Error">
-                                        <Setter Property="Foreground" Value="{StaticResource ConsoleErrorBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ConsoleErrorBrush}" />
                                         <Setter Property="FontWeight" Value="SemiBold" />
                                     </DataTrigger>
                                 </Style.Triggers>
@@ -163,97 +146,105 @@
     </Style>
 
     <!-- T-SQL syntax colouring, same family as the console so the two panes belong together. -->
-    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#FF7B9EFF" />
-    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#A5D6A7" />
-    <SolidColorBrush x:Key="SqlCommentBrush" Color="#5C6773" />
-    <SolidColorBrush x:Key="SqlNumberBrush" Color="#F0B457" />
-    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#E2C08D" />
 
     <!-- Color Palette -->
-    <Color x:Key="WindowBackgroundColor">#1B1E2B</Color>
-    <Color x:Key="SidebarBackgroundColor">#141722</Color>
-    <Color x:Key="CardBackgroundColor">#232738</Color>
-    <Color x:Key="CardBorderColor">#2D3148</Color>
-    <Color x:Key="InputBackgroundColor">#1A1D2A</Color>
-    <Color x:Key="InputBorderColor">#363B52</Color>
-    <Color x:Key="InputFocusBorderColor">#4A90D9</Color>
-    <Color x:Key="AccentColor">#4A90D9</Color>
-    <Color x:Key="AccentHoverColor">#5BA0E9</Color>
-    <Color x:Key="AccentPressedColor">#3A80C9</Color>
-    <Color x:Key="SuccessColor">#27AE60</Color>
-    <Color x:Key="ErrorColor">#E74C3C</Color>
-    <Color x:Key="WarningColor">#F39C12</Color>
-    <Color x:Key="PrimaryTextColor">#E8E8E8</Color>
-    <Color x:Key="SecondaryTextColor">#8890A4</Color>
-    <Color x:Key="DisabledTextColor">#555B6E</Color>
-    <Color x:Key="SidebarItemHoverColor">#1E2233</Color>
-    <Color x:Key="SidebarItemActiveColor">#252A3E</Color>
-    <Color x:Key="ScrollBarColor">#363B52</Color>
-    <Color x:Key="StatusBarBackgroundColor">#111320</Color>
-    <Color x:Key="DangerBackgroundColor">#3D1F1F</Color>
 
     <!-- Brushes -->
-    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
-    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="{StaticResource SidebarBackgroundColor}" />
-    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" />
-    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}" />
-    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
-    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
-    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
-    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
-    <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
-    <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
-    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
-    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
-    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
-    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
-    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
-    <SolidColorBrush x:Key="DisabledTextBrush" Color="{StaticResource DisabledTextColor}" />
-    <SolidColorBrush x:Key="SidebarItemHoverBrush" Color="{StaticResource SidebarItemHoverColor}" />
-    <SolidColorBrush x:Key="SidebarItemActiveBrush" Color="{StaticResource SidebarItemActiveColor}" />
-    <SolidColorBrush x:Key="ScrollBarBrush" Color="{StaticResource ScrollBarColor}" />
-    <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="{StaticResource StatusBarBackgroundColor}" />
-    <SolidColorBrush x:Key="DangerBackgroundBrush" Color="{StaticResource DangerBackgroundColor}" />
+
+    <!--
+        Control styles only. Every colour lives in a Palette.*.xaml, which ThemeManager swaps at
+        runtime - which is why the brushes below are DynamicResource rather than StaticResource.
+        A StaticResource is resolved once when the element loads and would not follow a theme
+        change, so a switched theme would leave half the window in the old colours.
+    -->
 
     <!-- TextBlock Styles -->
     <Style x:Key="HeaderText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="20" />
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
     </Style>
 
     <Style x:Key="SubHeaderText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="14" />
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
     </Style>
 
     <Style x:Key="BodyText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
     </Style>
 
     <Style x:Key="SecondaryText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="12" />
-        <Setter Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
     </Style>
 
     <Style x:Key="LabelText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="12" />
         <Setter Property="FontWeight" Value="Medium" />
-        <Setter Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
         <Setter Property="Margin" Value="0,0,0,4" />
+    </Style>
+
+
+    <!--
+        A list sitting on a card. The default ListBoxItem takes its foreground from the system,
+        which is near-black - so on a dark card the item text rendered black on black and simply
+        was not there. Caught by rendering the view to a PNG and looking at it.
+
+        Selection is marked by a tinted fill AND an accent border, not by colour alone: in high
+        contrast the fill is nearly the same as the row behind it, and the border is what carries
+        the meaning.
+    -->
+    <Style x:Key="CardListBoxItem" TargetType="ListBoxItem">
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="Padding" Value="10,6" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListBoxItem">
+                    <Border x:Name="bd"
+                            Background="Transparent"
+                            BorderBrush="Transparent"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}"
+                            Margin="0,0,0,2">
+                        <ContentPresenter />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="bd" Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
+                            <Setter TargetName="bd" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="CardListBox" TargetType="ListBox">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="ItemContainerStyle" Value="{StaticResource CardListBoxItem}" />
     </Style>
 
     <!-- Card Style -->
     <Style x:Key="CardBorder" TargetType="Border">
-        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="6" />
         <Setter Property="Padding" Value="16" />
@@ -261,7 +252,7 @@
 
     <!-- Button Styles -->
     <Style x:Key="PrimaryButton" TargetType="Button">
-        <Setter Property="Background" Value="{StaticResource AccentBrush}" />
+        <Setter Property="Background" Value="{DynamicResource AccentBrush}" />
         <Setter Property="Foreground" Value="White" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
@@ -281,10 +272,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource AccentHoverBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource AccentHoverBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource AccentPressedBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource AccentPressedBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -297,12 +288,12 @@
 
     <Style x:Key="SecondaryButton" TargetType="Button">
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="Padding" Value="16,8" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="Cursor" Value="Hand" />
         <Setter Property="Template">
             <Setter.Value>
@@ -318,8 +309,8 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource SidebarItemHoverBrush}" />
-                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -331,7 +322,7 @@
     </Style>
 
     <Style x:Key="DangerButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
-        <Setter Property="Background" Value="{StaticResource ErrorBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ErrorBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -344,10 +335,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="#D63031" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource ErrorHoverBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="#C0392B" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource ErrorPressedBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -359,7 +350,7 @@
     </Style>
 
     <Style x:Key="SuccessButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
-        <Setter Property="Background" Value="{StaticResource SuccessBrush}" />
+        <Setter Property="Background" Value="{DynamicResource SuccessBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -372,10 +363,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="#2ECC71" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SuccessHoverBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="#1E8449" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SuccessPressedBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -388,10 +379,10 @@
 
     <!-- TextBox Style -->
     <Style x:Key="DarkTextBox" TargetType="TextBox">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="CaretBrush" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource InputBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
@@ -409,7 +400,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource InputFocusBorderBrush}" />
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource InputFocusBorderBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="border" Property="Opacity" Value="0.5" />
@@ -422,10 +413,10 @@
 
     <!-- PasswordBox Style -->
     <Style x:Key="DarkPasswordBox" TargetType="PasswordBox">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="CaretBrush" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource InputBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
@@ -443,7 +434,7 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="border" Property="BorderBrush" Value="{StaticResource InputFocusBorderBrush}" />
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource InputFocusBorderBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -459,29 +450,29 @@
                 <ColumnDefinition Width="28" />
             </Grid.ColumnDefinitions>
             <Border x:Name="Border" Grid.ColumnSpan="2"
-                    Background="{StaticResource InputBackgroundBrush}"
-                    BorderBrush="{StaticResource InputBorderBrush}"
+                    Background="{DynamicResource InputBackgroundBrush}"
+                    BorderBrush="{DynamicResource InputBorderBrush}"
                     BorderThickness="1" CornerRadius="4" />
             <Path x:Name="Arrow" Grid.Column="1"
                   Data="M 0 0 L 4 4 L 8 0 Z"
-                  Fill="{StaticResource SecondaryTextBrush}"
+                  Fill="{DynamicResource SecondaryTextBrush}"
                   HorizontalAlignment="Center" VerticalAlignment="Center" />
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
             </Trigger>
             <Trigger Property="IsChecked" Value="True">
-                <Setter TargetName="Border" Property="BorderBrush" Value="{StaticResource InputFocusBorderBrush}" />
+                <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource InputFocusBorderBrush}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
     <!-- ComboBox Style -->
     <Style x:Key="DarkComboBox" TargetType="ComboBox">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource InputBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource InputBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
@@ -493,7 +484,7 @@
             <Setter.Value>
                 <Style TargetType="ComboBoxItem">
                     <Setter Property="Background" Value="Transparent" />
-                    <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                    <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
                     <Setter Property="Padding" Value="10,6" />
                     <Setter Property="Cursor" Value="Hand" />
                     <Setter Property="Template">
@@ -505,10 +496,10 @@
                                 </Border>
                                 <ControlTemplate.Triggers>
                                     <Trigger Property="IsHighlighted" Value="True">
-                                        <Setter TargetName="Bd" Property="Background" Value="{StaticResource SidebarItemHoverBrush}" />
+                                        <Setter TargetName="Bd" Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
                                     </Trigger>
                                     <Trigger Property="IsSelected" Value="True">
-                                        <Setter TargetName="Bd" Property="Background" Value="{StaticResource SidebarItemActiveBrush}" />
+                                        <Setter TargetName="Bd" Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
                                     </Trigger>
                                 </ControlTemplate.Triggers>
                             </ControlTemplate>
@@ -536,7 +527,7 @@
                                           HorizontalAlignment="Left" />
                         <TextBlock x:Name="Placeholder"
                                    Text="Select..."
-                                   Foreground="{StaticResource DisabledTextBrush}"
+                                   Foreground="{DynamicResource DisabledTextBrush}"
                                    IsHitTestVisible="False"
                                    Margin="12,8,28,8"
                                    VerticalAlignment="Center"
@@ -552,8 +543,8 @@
                                   MinWidth="{TemplateBinding ActualWidth}"
                                   MaxHeight="{TemplateBinding MaxDropDownHeight}">
                                 <Border x:Name="DropDownBorder"
-                                        Background="{StaticResource CardBackgroundBrush}"
-                                        BorderBrush="{StaticResource CardBorderBrush}"
+                                        Background="{DynamicResource CardBackgroundBrush}"
+                                        BorderBrush="{DynamicResource CardBorderBrush}"
                                         BorderThickness="1" CornerRadius="4"
                                         Margin="0,2,0,0" />
                                 <ScrollViewer Margin="4,6" SnapsToDevicePixels="True">
@@ -574,7 +565,7 @@
 
     <!-- CheckBox Style -->
     <Style x:Key="DarkCheckBox" TargetType="CheckBox">
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="Cursor" Value="Hand" />
@@ -584,8 +575,8 @@
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <Border x:Name="checkBorder"
                                 Width="18" Height="18"
-                                Background="{StaticResource InputBackgroundBrush}"
-                                BorderBrush="{StaticResource InputBorderBrush}"
+                                Background="{DynamicResource InputBackgroundBrush}"
+                                BorderBrush="{DynamicResource InputBorderBrush}"
                                 BorderThickness="1"
                                 CornerRadius="3"
                                 VerticalAlignment="Center">
@@ -602,12 +593,12 @@
                     </StackPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="checkBorder" Property="Background" Value="{StaticResource AccentBrush}" />
-                            <Setter TargetName="checkBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="checkBorder" Property="Background" Value="{DynamicResource AccentBrush}" />
+                            <Setter TargetName="checkBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                             <Setter TargetName="checkMark" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="checkBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="checkBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -617,7 +608,7 @@
 
     <!-- RadioButton Style -->
     <Style x:Key="DarkRadioButton" TargetType="RadioButton">
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="Cursor" Value="Hand" />
@@ -627,8 +618,8 @@
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <Border x:Name="radioBorder"
                                 Width="18" Height="18"
-                                Background="{StaticResource InputBackgroundBrush}"
-                                BorderBrush="{StaticResource InputBorderBrush}"
+                                Background="{DynamicResource InputBackgroundBrush}"
+                                BorderBrush="{DynamicResource InputBorderBrush}"
                                 BorderThickness="1"
                                 CornerRadius="9"
                                 VerticalAlignment="Center">
@@ -643,12 +634,12 @@
                     </StackPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="radioBorder" Property="Background" Value="{StaticResource AccentBrush}" />
-                            <Setter TargetName="radioBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="radioBorder" Property="Background" Value="{DynamicResource AccentBrush}" />
+                            <Setter TargetName="radioBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                             <Setter TargetName="radioDot" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="radioBorder" Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+                            <Setter TargetName="radioBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -659,7 +650,7 @@
     <!-- Sidebar Navigation Button -->
     <Style x:Key="SidebarButton" TargetType="RadioButton">
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="Cursor" Value="Hand" />
@@ -689,13 +680,13 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource SidebarItemHoverBrush}" />
-                            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
                         </Trigger>
                         <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{StaticResource SidebarItemActiveBrush}" />
-                            <Setter TargetName="indicator" Property="Background" Value="{StaticResource AccentBrush}" />
-                            <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
+                            <Setter TargetName="indicator" Property="Background" Value="{DynamicResource AccentBrush}" />
+                            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -705,9 +696,9 @@
 
     <!-- ToolTip Style -->
     <Style TargetType="ToolTip">
-        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="Background" Value="{DynamicResource CardBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="10,6" />
         <Setter Property="FontFamily" Value="Segoe UI" />
@@ -723,12 +714,12 @@
     <!-- DataGrid Styles -->
     <Style x:Key="DarkDataGrid" TargetType="DataGrid">
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="RowBackground" Value="Transparent" />
-        <Setter Property="AlternatingRowBackground" Value="#1A1D2A" />
+        <Setter Property="AlternatingRowBackground" Value="{DynamicResource AlternatingRowBackgroundBrush}" />
         <Setter Property="GridLinesVisibility" Value="Horizontal" />
-        <Setter Property="HorizontalGridLinesBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="HeadersVisibility" Value="Column" />
@@ -740,12 +731,12 @@
     </Style>
 
     <Style TargetType="DataGridColumnHeader">
-        <Setter Property="Background" Value="{StaticResource SidebarBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+        <Setter Property="Background" Value="{DynamicResource SidebarBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="FontSize" Value="12" />
         <Setter Property="Padding" Value="10,8" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
         <Setter Property="BorderThickness" Value="0,0,0,1" />
     </Style>
 
@@ -764,8 +755,8 @@
         </Setter>
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="{StaticResource SidebarItemActiveBrush}" />
-                <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+                <Setter Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -774,24 +765,24 @@
         <Setter Property="BorderThickness" Value="0" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{StaticResource SidebarItemHoverBrush}" />
+                <Setter Property="Background" Value="{DynamicResource SidebarItemHoverBrush}" />
             </Trigger>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="{StaticResource SidebarItemActiveBrush}" />
+                <Setter Property="Background" Value="{DynamicResource SidebarItemActiveBrush}" />
             </Trigger>
         </Style.Triggers>
     </Style>
 
     <!-- Slider Style -->
     <Style x:Key="TimelineSlider" TargetType="Slider">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource AccentBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
     </Style>
 
     <!-- Progress Bar -->
     <Style x:Key="DarkProgressBar" TargetType="ProgressBar">
-        <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
-        <Setter Property="Foreground" Value="{StaticResource AccentBrush}" />
+        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Height" Value="4" />
         <Setter Property="Template">
@@ -812,7 +803,7 @@
 
     <!-- Expander Style -->
     <Style x:Key="DarkExpander" TargetType="Expander">
-        <Setter Property="Foreground" Value="{StaticResource PrimaryTextBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="13" />
     </Style>
@@ -864,8 +855,8 @@
                  PROD pill or reads as something a human asserted. -->
             <DataTrigger Binding="{Binding IsAutomatic}" Value="True">
                 <Setter TargetName="chip" Property="Background" Value="Transparent" />
-                <Setter TargetName="chip" Property="BorderBrush" Value="{StaticResource InputBorderBrush}" />
-                <Setter TargetName="chipText" Property="Foreground" Value="{StaticResource SecondaryTextBrush}" />
+                <Setter TargetName="chip" Property="BorderBrush" Value="{DynamicResource InputBorderBrush}" />
+                <Setter TargetName="chipText" Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
                 <Setter TargetName="chipText" Property="FontWeight" Value="Normal" />
             </DataTrigger>
         </DataTemplate.Triggers>
@@ -897,6 +888,5 @@
             </Setter.Value>
         </Setter>
     </Style>
-
 
 </ResourceDictionary>

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -166,6 +166,55 @@
         change, so a switched theme would leave half the window in the old colours.
     -->
 
+    <!--
+        A small rotating arc, for anything that runs long enough to look stuck. Check chain and
+        Verify backups only changed their own label, and verify can run as long as the restore -
+        so on a large chain the app looked hung (#128).
+
+        The storyboard starts on IsVisible and stops when it goes away, rather than running
+        forever behind a collapsed element.
+    -->
+    <ControlTemplate x:Key="BusySpinner" TargetType="ContentControl">
+        <Grid x:Name="root" RenderTransformOrigin="0.5,0.5">
+            <Grid.RenderTransform>
+                <RotateTransform x:Name="spin" Angle="0" />
+            </Grid.RenderTransform>
+            <!-- An arc rather than a full ring: a complete circle rotating looks static. -->
+            <Ellipse Stroke="{DynamicResource AccentBrush}"
+                     StrokeThickness="2"
+                     StrokeDashArray="3 2"
+                     Opacity="0.9" />
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsVisible" Value="True">
+                <Trigger.EnterActions>
+                    <BeginStoryboard x:Name="spinStory">
+                        <Storyboard>
+                            <DoubleAnimation Storyboard.TargetName="spin"
+                                             Storyboard.TargetProperty="Angle"
+                                             From="0" To="360"
+                                             Duration="0:0:1.1"
+                                             RepeatBehavior="Forever" />
+                        </Storyboard>
+                    </BeginStoryboard>
+                </Trigger.EnterActions>
+                <Trigger.ExitActions>
+                    <StopStoryboard BeginStoryboardName="spinStory" />
+                </Trigger.ExitActions>
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!-- The tick shown when a check has passed for the selected chain. -->
+    <Style x:Key="PassedTick" TargetType="TextBlock">
+        <Setter Property="Text" Value="&#x2713;" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="FontWeight" Value="Bold" />
+        <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Margin" Value="0,0,6,0" />
+    </Style>
+
     <!-- TextBlock Styles -->
     <Style x:Key="HeaderText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -22,6 +22,79 @@
 
     <FontFamily x:Key="ConsoleFont">Cascadia Code, Cascadia Mono, Consolas, Courier New</FontFamily>
 
+    <!-- Update banner.
+         Amber rather than red: a new release is worth noticing, not an emergency, and this app
+         uses red for things that have actually gone wrong. Against a dark navy UI a bright amber
+         band is unmissable without pretending to be a failure. Dark text on it, because pale text
+         on amber is the one combination that would undo the contrast. -->
+    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Color="#FFC24B" Offset="0" />
+        <GradientStop Color="#F59E0B" Offset="0.55" />
+        <GradientStop Color="#EA8C04" Offset="1" />
+    </LinearGradientBrush>
+
+    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#B36F00" />
+
+    <!-- Solid dark on amber: the one thing to click, and it inverts the banner's own contrast. -->
+    <Style x:Key="UpdateBannerPrimaryButton" TargetType="Button">
+        <Setter Property="Background" Value="#1B1E2B" />
+        <Setter Property="Foreground" Value="#FFE9B8" />
+        <Setter Property="FontFamily" Value="Segoe UI" />
+        <Setter Property="FontSize" Value="12.5" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Padding" Value="14,6" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="#000000" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Deliberately quieter than the primary: dismissing should be available, not inviting. -->
+    <Style x:Key="UpdateBannerGhostButton" TargetType="Button">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="#4A3308" />
+        <Setter Property="FontFamily" Value="Segoe UI" />
+        <Setter Property="FontSize" Value="12.5" />
+        <Setter Property="Padding" Value="12,6" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="#A96B05"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="border" Property="Background" Value="#33FFFFFF" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!-- Console rows. A ListBox for the virtualisation, stripped of every ListBox affordance:
          no selection highlight, no hover, no focus rectangle, tight line spacing. -->
     <Style x:Key="ConsoleListBoxItem" TargetType="ListBoxItem">

--- a/src/NineLives/Themes/DarkTheme.xaml
+++ b/src/NineLives/Themes/DarkTheme.xaml
@@ -7,6 +7,7 @@
          was added to it. Views that still declare their own simply shadow this with an identical
          instance, so both work. -->
     <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+    <converters:NullToVisibilityConverter x:Key="NullToVis" />
 
     <!-- Terminal console. Darker than the cards on purpose, so the console reads as a separate
          surface the way a real terminal does rather than as another panel in the form. -->

--- a/src/NineLives/Themes/Palette.Dark.xaml
+++ b/src/NineLives/Themes/Palette.Dark.xaml
@@ -1,0 +1,149 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Dark palette - the app's default, and the one the splash screen already spoke for.
+
+        The splash was the piece Jake liked, so the rest of the app is tuned to it rather than the
+        other way round: its deep near-black card (#0B0E17 to #05070C), its border (#2D3148), its
+        bright near-white text (#F2F4F8), its blue (#3B83E9) and its muted greys (#8890A4, #4A5163).
+        The old palette was a lighter, greyer navy with a softer blue, which is why the app and its
+        own splash screen did not look like the same product.
+
+        EVERY palette file must define EVERY key in this one. Themes are swapped at runtime by
+        replacing this dictionary, and a key missing from another palette does not throw - the
+        brush simply resolves to nothing and the element renders blank. ThemePaletteTests compares
+        the key sets to make that impossible to ship.
+    -->
+
+    <!-- ── surfaces ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="WindowBackgroundColor">#0F131E</Color>
+    <Color x:Key="SidebarBackgroundColor">#0B0E17</Color>
+    <Color x:Key="CardBackgroundColor">#161B29</Color>
+    <Color x:Key="CardBorderColor">#2D3148</Color>
+    <Color x:Key="InputBackgroundColor">#0C1017</Color>
+    <Color x:Key="InputBorderColor">#2D3148</Color>
+    <Color x:Key="InputFocusBorderColor">#3B83E9</Color>
+    <Color x:Key="StatusBarBackgroundColor">#05070C</Color>
+    <Color x:Key="SidebarItemHoverColor">#151A28</Color>
+    <Color x:Key="SidebarItemActiveColor">#1C2233</Color>
+    <Color x:Key="ScrollBarColor">#2D3148</Color>
+
+    <!-- ── accent ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="AccentColor">#3B83E9</Color>
+    <Color x:Key="AccentHoverColor">#5195F5</Color>
+    <Color x:Key="AccentPressedColor">#2A6DCC</Color>
+
+    <!-- Text ON an accent-filled surface. Not always white: a light theme's accent fill still
+         wants white, but a high-contrast one may not. -->
+    <Color x:Key="AccentForegroundColor">#FFFFFF</Color>
+
+    <!-- ── status ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="SuccessColor">#27AE60</Color>
+    <Color x:Key="ErrorColor">#E74C3C</Color>
+    <Color x:Key="WarningColor">#F39C12</Color>
+
+    <!-- ── text ──────────────────────────────────────────────────────────────── -->
+    <Color x:Key="PrimaryTextColor">#F2F4F8</Color>
+    <Color x:Key="SecondaryTextColor">#8890A4</Color>
+    <Color x:Key="DisabledTextColor">#4A5163</Color>
+
+    <!-- ── panels: a tinted background plus a border, per severity ───────────── -->
+    <Color x:Key="SuccessPanelBackgroundColor">#12241A</Color>
+    <Color x:Key="SuccessPanelBorderColor">#27AE60</Color>
+    <Color x:Key="WarningPanelBackgroundColor">#2A2314</Color>
+    <Color x:Key="WarningPanelBorderColor">#8A6D2F</Color>
+    <Color x:Key="DangerPanelBackgroundColor">#2E1717</Color>
+    <Color x:Key="DangerPanelBorderColor">#A33F3F</Color>
+
+    <!-- Kept under its old name because the danger card style refers to it. -->
+    <Color x:Key="DangerBackgroundColor">#2E1717</Color>
+
+    <!-- ── overlays ──────────────────────────────────────────────────────────── -->
+    <!-- The scrim over the app while something is loading, and the shadow under raised surfaces. -->
+    <Color x:Key="OverlayColor">#B0000000</Color>
+    <Color x:Key="ShadowColor">#000000</Color>
+
+    <!-- ── brushes ───────────────────────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
+    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="{StaticResource SidebarBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}" />
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
+    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
+    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
+    <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
+    <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
+    <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
+    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
+    <SolidColorBrush x:Key="DisabledTextBrush" Color="{StaticResource DisabledTextColor}" />
+    <SolidColorBrush x:Key="SidebarItemHoverBrush" Color="{StaticResource SidebarItemHoverColor}" />
+    <SolidColorBrush x:Key="SidebarItemActiveBrush" Color="{StaticResource SidebarItemActiveColor}" />
+    <SolidColorBrush x:Key="ScrollBarBrush" Color="{StaticResource ScrollBarColor}" />
+    <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="{StaticResource StatusBarBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerBackgroundBrush" Color="{StaticResource DangerBackgroundColor}" />
+
+    <SolidColorBrush x:Key="SuccessPanelBackgroundBrush" Color="{StaticResource SuccessPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="SuccessPanelBorderBrush" Color="{StaticResource SuccessPanelBorderColor}" />
+    <SolidColorBrush x:Key="WarningPanelBackgroundBrush" Color="{StaticResource WarningPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="WarningPanelBorderBrush" Color="{StaticResource WarningPanelBorderColor}" />
+    <SolidColorBrush x:Key="DangerPanelBackgroundBrush" Color="{StaticResource DangerPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerPanelBorderBrush" Color="{StaticResource DangerPanelBorderColor}" />
+
+    <SolidColorBrush x:Key="OverlayBrush" Color="{StaticResource OverlayColor}" />
+
+    <!-- ── console ───────────────────────────────────────────────────────────── -->
+    <!-- Darker than the cards on purpose, so the console reads as a separate surface the way a
+         real terminal does rather than as another panel in the form. -->
+    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#05070C" />
+    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#2D3148" />
+    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#0F131E" />
+    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#C9D1D9" />
+    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#6E7681" />
+    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#79C0FF" />
+    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#3FB950" />
+    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#D29922" />
+    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#F85149" />
+
+    <!-- ── SQL syntax highlighting ───────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#7B9EFF" />
+    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#A5D6A7" />
+    <SolidColorBrush x:Key="SqlCommentBrush" Color="#5C6773" />
+    <SolidColorBrush x:Key="SqlNumberBrush" Color="#F0B457" />
+    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#E2C08D" />
+
+    <!-- ── update banner ─────────────────────────────────────────────────────── -->
+    <!-- Amber rather than red: a new release is worth noticing but is not an emergency, and red
+         already means something has gone wrong in this app. -->
+    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Offset="0" Color="#FFC24B" />
+        <GradientStop Offset="0.5" Color="#F59E0B" />
+        <GradientStop Offset="1" Color="#EA8C04" />
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#B36F00" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeGlyphBrush" Color="#FFC24B" />
+
+
+    <!-- Hover and pressed states for the status buttons, and the DataGrid's banded row. All were
+         literals in the control styles, which meant a light theme drew a dark stripe through every
+         grid and a success button that jumped several shades on hover. -->
+    <Color x:Key="SuccessHoverColor">#2ECC71</Color>
+    <Color x:Key="SuccessPressedColor">#1E8449</Color>
+    <Color x:Key="ErrorHoverColor">#F05B4B</Color>
+    <Color x:Key="ErrorPressedColor">#C0392B</Color>
+    <Color x:Key="AlternatingRowBackgroundColor">#12161F</Color>
+
+    <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />
+    <SolidColorBrush x:Key="SuccessPressedBrush" Color="{StaticResource SuccessPressedColor}" />
+    <SolidColorBrush x:Key="ErrorHoverBrush" Color="{StaticResource ErrorHoverColor}" />
+    <SolidColorBrush x:Key="ErrorPressedBrush" Color="{StaticResource ErrorPressedColor}" />
+    <SolidColorBrush x:Key="AlternatingRowBackgroundBrush" Color="{StaticResource AlternatingRowBackgroundColor}" />
+
+</ResourceDictionary>

--- a/src/NineLives/Themes/Palette.Dark.xaml
+++ b/src/NineLives/Themes/Palette.Dark.xaml
@@ -32,11 +32,18 @@
     <!-- ── accent ────────────────────────────────────────────────────────────── -->
     <Color x:Key="AccentColor">#3B83E9</Color>
     <Color x:Key="AccentHoverColor">#5195F5</Color>
-    <Color x:Key="AccentPressedColor">#2A6DCC</Color>
+    <Color x:Key="AccentPressedColor">#3A80E4</Color>
 
-    <!-- Text ON an accent-filled surface. Not always white: a light theme's accent fill still
-         wants white, but a high-contrast one may not. -->
-    <Color x:Key="AccentForegroundColor">#FFFFFF</Color>
+    <!--
+      Text ON a filled surface. Measured, not assumed: white on this theme's fills scores 2.19-3.82:1,
+      all of which fail WCAG AA for normal text, while near-black scores 4.85-8.46:1. The buttons had
+      Foreground="White" hardcoded in the control styles, which is what made the Connect button hard
+      to read (#126).
+    -->
+    <Color x:Key="AccentForegroundColor">#0F131E</Color>
+    <Color x:Key="SuccessForegroundColor">#0F131E</Color>
+    <Color x:Key="ErrorForegroundColor">#0F131E</Color>
+    <Color x:Key="WarningForegroundColor">#0F131E</Color>
 
     <!-- ── status ────────────────────────────────────────────────────────────── -->
     <Color x:Key="SuccessColor">#27AE60</Color>
@@ -76,6 +83,9 @@
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
     <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessForegroundBrush" Color="{StaticResource SuccessForegroundColor}" />
+    <SolidColorBrush x:Key="ErrorForegroundBrush" Color="{StaticResource ErrorForegroundColor}" />
+    <SolidColorBrush x:Key="WarningForegroundBrush" Color="{StaticResource WarningForegroundColor}" />
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
@@ -135,9 +145,9 @@
          literals in the control styles, which meant a light theme drew a dark stripe through every
          grid and a success button that jumped several shades on hover. -->
     <Color x:Key="SuccessHoverColor">#2ECC71</Color>
-    <Color x:Key="SuccessPressedColor">#1E8449</Color>
+    <Color x:Key="SuccessPressedColor">#22A05A</Color>
     <Color x:Key="ErrorHoverColor">#F05B4B</Color>
-    <Color x:Key="ErrorPressedColor">#C0392B</Color>
+    <Color x:Key="ErrorPressedColor">#E14E40</Color>
     <Color x:Key="AlternatingRowBackgroundColor">#12161F</Color>
 
     <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />

--- a/src/NineLives/Themes/Palette.HighContrast.xaml
+++ b/src/NineLives/Themes/Palette.HighContrast.xaml
@@ -1,0 +1,155 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        High contrast.
+
+        Not "the dark theme with the brightness turned up". The point of a high-contrast theme is
+        that nothing carries meaning by subtlety: every surface is pure black, every piece of text
+        is pure white or a fully saturated colour, and every border is visible rather than implied.
+
+        Text against background is 21:1 (white on black) and no status colour drops below roughly
+        7:1, which clears WCAG AAA for body text. The muted greys the other themes use for
+        secondary text are gone - secondary text here is #E8E8E8, distinguished by size and weight
+        rather than by fading it out, because fading is exactly what this theme exists to avoid.
+
+        Borders are 1px in the other palettes and the same here, but drawn in a colour that is
+        actually visible against the fill rather than a shade away from it. Card and input borders
+        are white for that reason: a panel edge you cannot see is a panel that is not there.
+
+        Must define exactly the keys in Palette.Dark.xaml - see the note there.
+    -->
+
+    <!-- ── surfaces ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="WindowBackgroundColor">#000000</Color>
+    <Color x:Key="SidebarBackgroundColor">#000000</Color>
+    <Color x:Key="CardBackgroundColor">#000000</Color>
+    <Color x:Key="CardBorderColor">#FFFFFF</Color>
+    <Color x:Key="InputBackgroundColor">#000000</Color>
+    <Color x:Key="InputBorderColor">#FFFFFF</Color>
+    <Color x:Key="InputFocusBorderColor">#FFFF00</Color>
+    <Color x:Key="StatusBarBackgroundColor">#000000</Color>
+    <Color x:Key="SidebarItemHoverColor">#1F1F1F</Color>
+    <!-- Grey, not the accent yellow: white text on yellow is unreadable, and
+         selection is carried by the accent-coloured border instead. -->
+    <Color x:Key="SidebarItemActiveColor">#333333</Color>
+    <Color x:Key="ScrollBarColor">#FFFFFF</Color>
+
+    <!-- ── accent ────────────────────────────────────────────────────────────── -->
+    <!-- Yellow rather than blue. Blue on black is the worst-performing pair for anyone with
+         reduced contrast sensitivity, and yellow-on-black is the pairing high-contrast schemes on
+         Windows have used for decades - it is what people who need this theme expect to see. -->
+    <Color x:Key="AccentColor">#FFFF00</Color>
+    <Color x:Key="AccentHoverColor">#FFFF66</Color>
+    <Color x:Key="AccentPressedColor">#CCCC00</Color>
+
+    <!-- Black text on the yellow fill. White on yellow is unreadable. -->
+    <Color x:Key="AccentForegroundColor">#000000</Color>
+
+    <!-- ── status ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="SuccessColor">#00FF00</Color>
+    <Color x:Key="ErrorColor">#FF5555</Color>
+    <Color x:Key="WarningColor">#FFAA00</Color>
+
+    <!-- ── text ──────────────────────────────────────────────────────────────── -->
+    <Color x:Key="PrimaryTextColor">#FFFFFF</Color>
+    <Color x:Key="SecondaryTextColor">#E8E8E8</Color>
+    <Color x:Key="DisabledTextColor">#A0A0A0</Color>
+
+    <!-- ── panels ────────────────────────────────────────────────────────────── -->
+    <!-- Black fills with a saturated border. A tinted background would reduce the contrast of the
+         text sitting on it, which is the one thing this theme must not do. -->
+    <Color x:Key="SuccessPanelBackgroundColor">#000000</Color>
+    <Color x:Key="SuccessPanelBorderColor">#00FF00</Color>
+    <Color x:Key="WarningPanelBackgroundColor">#000000</Color>
+    <Color x:Key="WarningPanelBorderColor">#FFAA00</Color>
+    <Color x:Key="DangerPanelBackgroundColor">#000000</Color>
+    <Color x:Key="DangerPanelBorderColor">#FF5555</Color>
+    <Color x:Key="DangerBackgroundColor">#000000</Color>
+
+    <!-- ── overlays ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="OverlayColor">#D0000000</Color>
+    <Color x:Key="ShadowColor">#000000</Color>
+
+    <!-- ── brushes ───────────────────────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
+    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="{StaticResource SidebarBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}" />
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
+    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
+    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
+    <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
+    <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
+    <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
+    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
+    <SolidColorBrush x:Key="DisabledTextBrush" Color="{StaticResource DisabledTextColor}" />
+    <SolidColorBrush x:Key="SidebarItemHoverBrush" Color="{StaticResource SidebarItemHoverColor}" />
+    <SolidColorBrush x:Key="SidebarItemActiveBrush" Color="{StaticResource SidebarItemActiveColor}" />
+    <SolidColorBrush x:Key="ScrollBarBrush" Color="{StaticResource ScrollBarColor}" />
+    <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="{StaticResource StatusBarBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerBackgroundBrush" Color="{StaticResource DangerBackgroundColor}" />
+
+    <SolidColorBrush x:Key="SuccessPanelBackgroundBrush" Color="{StaticResource SuccessPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="SuccessPanelBorderBrush" Color="{StaticResource SuccessPanelBorderColor}" />
+    <SolidColorBrush x:Key="WarningPanelBackgroundBrush" Color="{StaticResource WarningPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="WarningPanelBorderBrush" Color="{StaticResource WarningPanelBorderColor}" />
+    <SolidColorBrush x:Key="DangerPanelBackgroundBrush" Color="{StaticResource DangerPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerPanelBorderBrush" Color="{StaticResource DangerPanelBorderColor}" />
+
+    <SolidColorBrush x:Key="OverlayBrush" Color="{StaticResource OverlayColor}" />
+
+    <!-- ── console ───────────────────────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#000000" />
+    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#000000" />
+    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#C0C0C0" />
+    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#00FFFF" />
+    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#00FF00" />
+    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#FFAA00" />
+    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#FF5555" />
+
+    <!-- ── SQL syntax highlighting ───────────────────────────────────────────── -->
+    <!-- Fully saturated and far apart in hue, so the categories are told apart by more than a
+         shade. Nothing here relies on a subtle difference in tone. -->
+    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#00FFFF" />
+    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#00FF00" />
+    <SolidColorBrush x:Key="SqlCommentBrush" Color="#A0A0A0" />
+    <SolidColorBrush x:Key="SqlNumberBrush" Color="#FFAA00" />
+    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#FF80FF" />
+
+    <!-- ── update banner ─────────────────────────────────────────────────────── -->
+    <!-- Flat yellow rather than a gradient: a gradient is a subtlety, and the point here is that
+         nothing is subtle. -->
+    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Offset="0" Color="#FFFF00" />
+        <GradientStop Offset="1" Color="#FFFF00" />
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#000000" />
+    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeBrush" Color="#000000" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeGlyphBrush" Color="#FFFF00" />
+
+
+    <!-- Hover and pressed states for the status buttons, and the DataGrid's banded row. All were
+         literals in the control styles, which meant a light theme drew a dark stripe through every
+         grid and a success button that jumped several shades on hover. -->
+    <Color x:Key="SuccessHoverColor">#66FF66</Color>
+    <Color x:Key="SuccessPressedColor">#00CC00</Color>
+    <Color x:Key="ErrorHoverColor">#FF8888</Color>
+    <Color x:Key="ErrorPressedColor">#CC0000</Color>
+    <Color x:Key="AlternatingRowBackgroundColor">#1A1A1A</Color>
+
+    <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />
+    <SolidColorBrush x:Key="SuccessPressedBrush" Color="{StaticResource SuccessPressedColor}" />
+    <SolidColorBrush x:Key="ErrorHoverBrush" Color="{StaticResource ErrorHoverColor}" />
+    <SolidColorBrush x:Key="ErrorPressedBrush" Color="{StaticResource ErrorPressedColor}" />
+    <SolidColorBrush x:Key="AlternatingRowBackgroundBrush" Color="{StaticResource AlternatingRowBackgroundColor}" />
+
+</ResourceDictionary>

--- a/src/NineLives/Themes/Palette.HighContrast.xaml
+++ b/src/NineLives/Themes/Palette.HighContrast.xaml
@@ -44,7 +44,14 @@
     <Color x:Key="AccentPressedColor">#CCCC00</Color>
 
     <!-- Black text on the yellow fill. White on yellow is unreadable. -->
+    <!--
+      Text ON a filled surface. White on this theme's yellow is 1.07:1 - not "hard to read",
+      unreadable. Black scores 6.68-19.56:1 across the four fills.
+    -->
     <Color x:Key="AccentForegroundColor">#000000</Color>
+    <Color x:Key="SuccessForegroundColor">#000000</Color>
+    <Color x:Key="ErrorForegroundColor">#000000</Color>
+    <Color x:Key="WarningForegroundColor">#000000</Color>
 
     <!-- ── status ────────────────────────────────────────────────────────────── -->
     <Color x:Key="SuccessColor">#00FF00</Color>
@@ -83,6 +90,9 @@
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
     <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessForegroundBrush" Color="{StaticResource SuccessForegroundColor}" />
+    <SolidColorBrush x:Key="ErrorForegroundBrush" Color="{StaticResource ErrorForegroundColor}" />
+    <SolidColorBrush x:Key="WarningForegroundBrush" Color="{StaticResource WarningForegroundColor}" />
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
@@ -143,7 +153,7 @@
     <Color x:Key="SuccessHoverColor">#66FF66</Color>
     <Color x:Key="SuccessPressedColor">#00CC00</Color>
     <Color x:Key="ErrorHoverColor">#FF8888</Color>
-    <Color x:Key="ErrorPressedColor">#CC0000</Color>
+    <Color x:Key="ErrorPressedColor">#FF8080</Color>
     <Color x:Key="AlternatingRowBackgroundColor">#1A1A1A</Color>
 
     <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />

--- a/src/NineLives/Themes/Palette.Light.xaml
+++ b/src/NineLives/Themes/Palette.Light.xaml
@@ -1,0 +1,146 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Light palette.
+
+        Not the dark one inverted. Inverting a dark theme gives you grey-on-grey with a blue that
+        glows, because a colour tuned to sit on near-black is far too light against white. So the
+        blue is darkened to #1F63C4 - the same hue as the splash's #3B83E9, taken down until it
+        holds its own on a white card - and the greys are chosen for contrast against white rather
+        than mirrored.
+
+        Surfaces run the other way too: the sidebar is DARKER than the page here, where in the dark
+        theme it is darker as well. Keeping that relationship means the layout reads the same in
+        both, which is the point of theming rather than recolouring.
+
+        Must define exactly the keys in Palette.Dark.xaml - see the note there.
+    -->
+
+    <!-- ── surfaces ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="WindowBackgroundColor">#F4F6FA</Color>
+    <Color x:Key="SidebarBackgroundColor">#E7EBF3</Color>
+    <Color x:Key="CardBackgroundColor">#FFFFFF</Color>
+    <Color x:Key="CardBorderColor">#D3DAE6</Color>
+    <Color x:Key="InputBackgroundColor">#FFFFFF</Color>
+    <Color x:Key="InputBorderColor">#C3CCDB</Color>
+    <Color x:Key="InputFocusBorderColor">#1F63C4</Color>
+    <Color x:Key="StatusBarBackgroundColor">#E0E5EF</Color>
+    <Color x:Key="SidebarItemHoverColor">#D8DFEC</Color>
+    <Color x:Key="SidebarItemActiveColor">#CBD6E8</Color>
+    <Color x:Key="ScrollBarColor">#BFC8D8</Color>
+
+    <!-- ── accent ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="AccentColor">#1F63C4</Color>
+    <Color x:Key="AccentHoverColor">#2E74D8</Color>
+    <Color x:Key="AccentPressedColor">#17509F</Color>
+    <Color x:Key="AccentForegroundColor">#FFFFFF</Color>
+
+    <!-- ── status ────────────────────────────────────────────────────────────── -->
+    <!-- Darkened from the dark theme's: #27AE60 on white is legible but weak, and #E74C3C reads
+         as pink at small sizes. -->
+    <Color x:Key="SuccessColor">#1B7F45</Color>
+    <Color x:Key="ErrorColor">#C0392B</Color>
+    <Color x:Key="WarningColor">#B26A00</Color>
+
+    <!-- ── text ──────────────────────────────────────────────────────────────── -->
+    <Color x:Key="PrimaryTextColor">#141824</Color>
+    <Color x:Key="SecondaryTextColor">#5A6478</Color>
+    <Color x:Key="DisabledTextColor">#98A1B3</Color>
+
+    <!-- ── panels ────────────────────────────────────────────────────────────── -->
+    <Color x:Key="SuccessPanelBackgroundColor">#E6F5EC</Color>
+    <Color x:Key="SuccessPanelBorderColor">#1B7F45</Color>
+    <Color x:Key="WarningPanelBackgroundColor">#FCF3E2</Color>
+    <Color x:Key="WarningPanelBorderColor">#B26A00</Color>
+    <Color x:Key="DangerPanelBackgroundColor">#FBEAE7</Color>
+    <Color x:Key="DangerPanelBorderColor">#C0392B</Color>
+    <Color x:Key="DangerBackgroundColor">#FBEAE7</Color>
+
+    <!-- ── overlays ──────────────────────────────────────────────────────────── -->
+    <Color x:Key="OverlayColor">#80FFFFFF</Color>
+    <Color x:Key="ShadowColor">#7A8296</Color>
+
+    <!-- ── brushes ───────────────────────────────────────────────────────────── -->
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{StaticResource WindowBackgroundColor}" />
+    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="{StaticResource SidebarBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="{StaticResource CardBackgroundColor}" />
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource CardBorderColor}" />
+    <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
+    <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
+    <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
+    <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
+    <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
+    <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
+    <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
+    <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
+    <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
+    <SolidColorBrush x:Key="PrimaryTextBrush" Color="{StaticResource PrimaryTextColor}" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="{StaticResource SecondaryTextColor}" />
+    <SolidColorBrush x:Key="DisabledTextBrush" Color="{StaticResource DisabledTextColor}" />
+    <SolidColorBrush x:Key="SidebarItemHoverBrush" Color="{StaticResource SidebarItemHoverColor}" />
+    <SolidColorBrush x:Key="SidebarItemActiveBrush" Color="{StaticResource SidebarItemActiveColor}" />
+    <SolidColorBrush x:Key="ScrollBarBrush" Color="{StaticResource ScrollBarColor}" />
+    <SolidColorBrush x:Key="StatusBarBackgroundBrush" Color="{StaticResource StatusBarBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerBackgroundBrush" Color="{StaticResource DangerBackgroundColor}" />
+
+    <SolidColorBrush x:Key="SuccessPanelBackgroundBrush" Color="{StaticResource SuccessPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="SuccessPanelBorderBrush" Color="{StaticResource SuccessPanelBorderColor}" />
+    <SolidColorBrush x:Key="WarningPanelBackgroundBrush" Color="{StaticResource WarningPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="WarningPanelBorderBrush" Color="{StaticResource WarningPanelBorderColor}" />
+    <SolidColorBrush x:Key="DangerPanelBackgroundBrush" Color="{StaticResource DangerPanelBackgroundColor}" />
+    <SolidColorBrush x:Key="DangerPanelBorderBrush" Color="{StaticResource DangerPanelBorderColor}" />
+
+    <SolidColorBrush x:Key="OverlayBrush" Color="{StaticResource OverlayColor}" />
+
+    <!-- ── console ───────────────────────────────────────────────────────────── -->
+    <!-- Deliberately still dark. A terminal is a terminal: SQL Server's output is easier to read
+         light-on-dark, and every DBA has spent their career reading it that way. Making it white
+         to match the page would be consistency for its own sake. -->
+    <SolidColorBrush x:Key="ConsoleBackgroundBrush" Color="#12161F" />
+    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#C3CCDB" />
+    <SolidColorBrush x:Key="ConsoleChromeBrush" Color="#1C2230" />
+    <SolidColorBrush x:Key="ConsoleTextBrush" Color="#D9E1EA" />
+    <SolidColorBrush x:Key="ConsoleMutedBrush" Color="#8B95A3" />
+    <SolidColorBrush x:Key="ConsoleStepBrush" Color="#79C0FF" />
+    <SolidColorBrush x:Key="ConsoleSuccessBrush" Color="#4FC463" />
+    <SolidColorBrush x:Key="ConsoleWarningBrush" Color="#E0A831" />
+    <SolidColorBrush x:Key="ConsoleErrorBrush" Color="#FF6A61" />
+
+    <!-- ── SQL syntax highlighting ───────────────────────────────────────────── -->
+    <!-- The script pane sits on a light input surface here, so these are the dark-on-light set. -->
+    <SolidColorBrush x:Key="SqlKeywordBrush" Color="#1F4FBF" />
+    <SolidColorBrush x:Key="SqlLiteralBrush" Color="#1B7F45" />
+    <SolidColorBrush x:Key="SqlCommentBrush" Color="#77808F" />
+    <SolidColorBrush x:Key="SqlNumberBrush" Color="#A65F00" />
+    <SolidColorBrush x:Key="SqlIdentifierBrush" Color="#8A5A1B" />
+
+    <!-- ── update banner ─────────────────────────────────────────────────────── -->
+    <LinearGradientBrush x:Key="UpdateBannerBrush" StartPoint="0,0" EndPoint="1,0">
+        <GradientStop Offset="0" Color="#FFC24B" />
+        <GradientStop Offset="0.5" Color="#F59E0B" />
+        <GradientStop Offset="1" Color="#EA8C04" />
+    </LinearGradientBrush>
+    <SolidColorBrush x:Key="UpdateBannerTextBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerEdgeBrush" Color="#B36F00" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeBrush" Color="#1A1205" />
+    <SolidColorBrush x:Key="UpdateBannerBadgeGlyphBrush" Color="#FFC24B" />
+
+
+    <!-- Hover and pressed states for the status buttons, and the DataGrid's banded row. All were
+         literals in the control styles, which meant a light theme drew a dark stripe through every
+         grid and a success button that jumped several shades on hover. -->
+    <Color x:Key="SuccessHoverColor">#239954</Color>
+    <Color x:Key="SuccessPressedColor">#146334</Color>
+    <Color x:Key="ErrorHoverColor">#D2483A</Color>
+    <Color x:Key="ErrorPressedColor">#9C2D21</Color>
+    <Color x:Key="AlternatingRowBackgroundColor">#F2F5FA</Color>
+
+    <SolidColorBrush x:Key="SuccessHoverBrush" Color="{StaticResource SuccessHoverColor}" />
+    <SolidColorBrush x:Key="SuccessPressedBrush" Color="{StaticResource SuccessPressedColor}" />
+    <SolidColorBrush x:Key="ErrorHoverBrush" Color="{StaticResource ErrorHoverColor}" />
+    <SolidColorBrush x:Key="ErrorPressedBrush" Color="{StaticResource ErrorPressedColor}" />
+    <SolidColorBrush x:Key="AlternatingRowBackgroundBrush" Color="{StaticResource AlternatingRowBackgroundColor}" />
+
+</ResourceDictionary>

--- a/src/NineLives/Themes/Palette.Light.xaml
+++ b/src/NineLives/Themes/Palette.Light.xaml
@@ -32,16 +32,24 @@
 
     <!-- ── accent ────────────────────────────────────────────────────────────── -->
     <Color x:Key="AccentColor">#1F63C4</Color>
-    <Color x:Key="AccentHoverColor">#2E74D8</Color>
+    <Color x:Key="AccentHoverColor">#2A6ECD</Color>
     <Color x:Key="AccentPressedColor">#17509F</Color>
+    <!--
+      Text ON a filled surface. White wins on every fill here (4.24-5.77:1) because the fills are
+      already darkened for a white page - the opposite of the dark theme's answer.
+    -->
     <Color x:Key="AccentForegroundColor">#FFFFFF</Color>
+    <Color x:Key="SuccessForegroundColor">#FFFFFF</Color>
+    <Color x:Key="ErrorForegroundColor">#FFFFFF</Color>
+    <Color x:Key="WarningForegroundColor">#FFFFFF</Color>
 
     <!-- ── status ────────────────────────────────────────────────────────────── -->
     <!-- Darkened from the dark theme's: #27AE60 on white is legible but weak, and #E74C3C reads
          as pink at small sizes. -->
     <Color x:Key="SuccessColor">#1B7F45</Color>
     <Color x:Key="ErrorColor">#C0392B</Color>
-    <Color x:Key="WarningColor">#B26A00</Color>
+    <!-- #B26A00 measured 4.24:1 against white, just under AA. -->
+    <Color x:Key="WarningColor">#A35F00</Color>
 
     <!-- ── text ──────────────────────────────────────────────────────────────── -->
     <Color x:Key="PrimaryTextColor">#141824</Color>
@@ -73,6 +81,9 @@
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />
     <SolidColorBrush x:Key="AccentForegroundBrush" Color="{StaticResource AccentForegroundColor}" />
+    <SolidColorBrush x:Key="SuccessForegroundBrush" Color="{StaticResource SuccessForegroundColor}" />
+    <SolidColorBrush x:Key="ErrorForegroundBrush" Color="{StaticResource ErrorForegroundColor}" />
+    <SolidColorBrush x:Key="WarningForegroundBrush" Color="{StaticResource WarningForegroundColor}" />
     <SolidColorBrush x:Key="SuccessBrush" Color="{StaticResource SuccessColor}" />
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}" />
     <SolidColorBrush x:Key="WarningBrush" Color="{StaticResource WarningColor}" />
@@ -131,9 +142,9 @@
     <!-- Hover and pressed states for the status buttons, and the DataGrid's banded row. All were
          literals in the control styles, which meant a light theme drew a dark stripe through every
          grid and a success button that jumped several shades on hover. -->
-    <Color x:Key="SuccessHoverColor">#239954</Color>
+    <Color x:Key="SuccessHoverColor">#177040</Color>
     <Color x:Key="SuccessPressedColor">#146334</Color>
-    <Color x:Key="ErrorHoverColor">#D2483A</Color>
+    <Color x:Key="ErrorHoverColor">#C93D2F</Color>
     <Color x:Key="ErrorPressedColor">#9C2D21</Color>
     <Color x:Key="AlternatingRowBackgroundColor">#F2F5FA</Color>
 

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -1,11 +1,40 @@
 using System.Diagnostics;
 using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.ViewModels;
 
+/// <summary>A theme and the name shown for it.</summary>
+/// <param name="Value">The theme itself.</param>
+/// <param name="Name">What the picker calls it.</param>
+public sealed record ThemeOption(AppTheme Value, string Name)
+{
+    /// <summary>
+    /// The combo box's own control template renders the selected item through a plain
+    /// ContentPresenter, which ignores DisplayMemberPath and falls back to ToString - so without
+    /// this the picker reads "ThemeOption { Value = Dark, Name = Dark }".
+    /// </summary>
+    public override string ToString() => Name;
+}
+
 public partial class AboutViewModel : ViewModelBase
 {
+    private readonly ICredentialStore? _credentialStore;
+
+    public AboutViewModel() : this(null) { }
+
+    /// <summary>
+    /// Takes the store so the theme choice can be remembered. Optional, because About is otherwise
+    /// a static page and a test that only wants to render it should not need a store.
+    /// </summary>
+    public AboutViewModel(ICredentialStore? credentialStore)
+    {
+        _credentialStore = credentialStore;
+        _selectedTheme = ThemeManager.Current;
+    }
+
     public string AppName => "Nine Lives";
     public string Version => Services.AppVersion.Display;
     public string Year => "2026";
@@ -16,6 +45,48 @@ public partial class AboutViewModel : ViewModelBase
 
     /// <summary>Shown so the path can be read even if opening the folder fails.</summary>
     public string LogFolder => App.Log.Directory;
+
+    // ── appearance ──────────────────────────────────────────────────────────────
+
+    /// <summary>One entry per theme, named for the picker.</summary>
+    public IReadOnlyList<ThemeOption> Themes { get; } =
+        ThemeManager.All.Select(t => new ThemeOption(t, ThemeManager.DisplayName(t))).ToList();
+
+    [ObservableProperty]
+    private AppTheme _selectedTheme;
+
+    /// <summary>
+    /// Applies the theme immediately and remembers it.
+    ///
+    /// Applying first: a theme that will not load is worth knowing about right away, and the
+    /// switch is instant because every colour is a DynamicResource. Saving is best-effort - a
+    /// config that refuses to write should not undo a change the user can already see.
+    /// </summary>
+    partial void OnSelectedThemeChanged(AppTheme value)
+    {
+        if (!ThemeManager.Apply(value))
+        {
+            SetError("The theme could not be applied.");
+            return;
+        }
+
+        ClearStatus();
+
+        if (_credentialStore == null) return;
+
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            config.Theme = value;
+            _credentialStore.SaveConfig(config);
+        }
+        catch (Exception ex)
+        {
+            SetError($"The theme was applied, but could not be saved for next time: {ex.Message}");
+        }
+    }
+
+    public static string ThemeName(AppTheme theme) => ThemeManager.DisplayName(theme);
 
     /// <summary>
     /// Opens the log folder in Explorer. The logs are what someone attaches to a bug report, so

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -261,7 +261,15 @@ public partial class BlobBrowserViewModel : ViewModelBase
         {
             var earliest = filtered.Min(s => s.Timestamp);
             var latest = filtered.Max(s => s.Timestamp);
-            DbSummaryText = $"{Summary.FullBackups} Full, {Summary.DiffBackups} Diff, {Summary.LogBackups} Log sets  |  {earliest:yyyy-MM-dd} to {latest:yyyy-MM-dd}";
+
+            // Sets whose filename carried no timestamp fall back to the blob's LastModified, which
+            // is UTC rather than the backup server's clock - so the range they bound is only as
+            // good as that skew. Say so rather than presenting one exact-looking window.
+            var approximate = Summary.ApproximateSets > 0
+                ? $"  |  {Summary.ApproximateSets} approximate"
+                : string.Empty;
+
+            DbSummaryText = $"{Summary.FullBackups} Full, {Summary.DiffBackups} Diff, {Summary.LogBackups} Log sets  |  {earliest:yyyy-MM-dd} to {latest:yyyy-MM-dd}{approximate}";
         }
         else
         {

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -9,8 +9,8 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class BlobBrowserViewModel : ViewModelBase
 {
-    private readonly BlobStorageService _blobService;
-    private readonly CredentialStore _credentialStore;
+    private readonly IBlobStorageService _blobService;
+    private readonly ICredentialStore _credentialStore;
     private readonly OperationCancellation _loadCancellation = new();
 
     /// <summary>True while a listing is running and has not been asked to stop (#25).</summary>
@@ -68,7 +68,7 @@ public partial class BlobBrowserViewModel : ViewModelBase
     [ObservableProperty]
     private string _dbSummaryText = string.Empty;
 
-    public BlobBrowserViewModel(BlobStorageService blobService, CredentialStore credentialStore)
+    public BlobBrowserViewModel(IBlobStorageService blobService, ICredentialStore credentialStore)
     {
         _blobService = blobService;
         _credentialStore = credentialStore;

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -147,7 +147,8 @@ public partial class BlobBrowserViewModel : ViewModelBase
         try
         {
             _allFiles = await _blobService.ListBackupFilesAsync(SelectedContainer, ct);
-            _allSets = _blobService.GroupIntoBackupSets(_allFiles);
+            _allSets = _blobService.GroupIntoBackupSets(
+                _allFiles, SelectedContainer?.BackupServerTimeZoneId);
             HasFiles = _allFiles.Count > 0;
 
             var servers = _blobService.GetDiscoveredServers(_allFiles);

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -681,7 +681,22 @@ public partial class BlobConfigViewModel : ViewModelBase
         BlobContainerConfig? config;
         if (IsEditing)
         {
-            if (HasStoredSasToken && string.IsNullOrWhiteSpace(EditSasToken))
+            if (IsEntraAuth)
+            {
+                // Nothing stored to fall back on, and nothing needed - the token comes from the
+                // signed-in account. Built from the form, so what is tested is the URL on screen.
+                //
+                // Carrying the mode is the whole point: without it this fell through to the SAS
+                // branch below and refused with "No SAS token found" for a container that is never
+                // going to have one (#29).
+                config = new BlobContainerConfig
+                {
+                    Name = EditName,
+                    ContainerUrl = EditContainerUrl,
+                    AuthMode = EditAuthMode
+                };
+            }
+            else if (HasStoredSasToken && string.IsNullOrWhiteSpace(EditSasToken))
                 config = SelectedContainer; // Use stored token for test
             else
             {

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -35,6 +35,17 @@ public partial class BlobConfigViewModel : ViewModelBase
     [ObservableProperty]
     private string _editContainerUrl = string.Empty;
 
+    /// <summary>
+    /// How this container signs in (#29). Entra holds no secret of ours, which is the point:
+    /// many organisations now prohibit long-lived SAS tokens outright.
+    /// </summary>
+    [ObservableProperty]
+    private BlobAuthMode _editAuthMode = BlobAuthMode.SasToken;
+
+    public bool IsSasAuth => EditAuthMode.NeedsSasToken();
+
+    public bool IsEntraAuth => EditAuthMode.IsEntra();
+
     [ObservableProperty]
     private string _editSasToken = string.Empty;
 
@@ -138,6 +149,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     private string _originalName = "";
     private string _originalUrl = "";
     private string _originalSas = "";
+    private BlobAuthMode _originalAuthMode = BlobAuthMode.SasToken;
     private string _originalPattern = "";
     private BackupSourceType _originalBackupSourceType = BackupSourceType.Standalone;
     private string? _originalAgPathPattern;
@@ -191,6 +203,13 @@ public partial class BlobConfigViewModel : ViewModelBase
     partial void OnEditNameChanged(string value) => CheckForUnsavedChanges();
     partial void OnEditContainerUrlChanged(string value) => CheckForUnsavedChanges();
     partial void OnEditSasTokenChanged(string value) => CheckForUnsavedChanges();
+    partial void OnEditAuthModeChanged(BlobAuthMode value)
+    {
+        OnPropertyChanged(nameof(IsSasAuth));
+        OnPropertyChanged(nameof(IsEntraAuth));
+        if (SelectedContainer != null) UpdateSasExpiryStatus(SelectedContainer);
+        CheckForUnsavedChanges();
+    }
     partial void OnEditPathPatternChanged(string value) => CheckForUnsavedChanges();
     partial void OnEditBackupSourceTypeChanged(BackupSourceType value)
     {
@@ -214,6 +233,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         HasUnsavedChanges =
             EditName != _originalName ||
             EditContainerUrl != _originalUrl ||
+            EditAuthMode != _originalAuthMode ||
             sasChanged ||
             EditPathPattern != _originalPattern ||
             EditBackupSourceType != _originalBackupSourceType ||
@@ -230,6 +250,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     {
         var name = container.Name;
         var url = container.ContainerUrl;
+        var authMode = container.AuthMode;
         var pattern = container.PathPattern;
         var sourceType = container.BackupSourceType;
         var agPattern = container.AgPathPattern;
@@ -240,6 +261,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         {
             container.Name = name;
             container.ContainerUrl = url;
+            container.AuthMode = authMode;
             container.PathPattern = pattern;
             container.BackupSourceType = sourceType;
             container.AgPathPattern = agPattern;
@@ -252,6 +274,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     {
         _originalName = EditName;
         _originalUrl = EditContainerUrl;
+        _originalAuthMode = EditAuthMode;
         _originalSas = HasStoredSasToken ? StoredSasSentinel : EditSasToken;
         _originalPattern = EditPathPattern;
         _originalBackupSourceType = EditBackupSourceType;
@@ -263,6 +286,15 @@ public partial class BlobConfigViewModel : ViewModelBase
 
     private void UpdateSasExpiryStatus(BlobContainerConfig container)
     {
+        // Entra has no token of ours to expire. Reporting "expired" against a container that never
+        // had a SAS would send someone hunting for a token that is not the problem.
+        if (EditAuthMode.IsEntra() || (!IsEditing && container.AuthMode.IsEntra()))
+        {
+            SasExpiryText = string.Empty;
+            IsSasExpired = false;
+            return;
+        }
+
         var expiry = _credentialStore.ReadSasTokenExpiry(container);
 
         if (expiry.CouldNotParse)
@@ -418,6 +450,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditName = string.Empty;
         EditTags = string.Empty;
         EditContainerUrl = string.Empty;
+        EditAuthMode = BlobAuthMode.SasToken;
         EditSasToken = string.Empty;
         EditPathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
         EditBackupSourceType = BackupSourceType.Standalone;
@@ -441,6 +474,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditName = SelectedContainer.Name;
         EditTags = TagPalette.FormatTags(SelectedContainer.Tags);
         EditContainerUrl = SelectedContainer.ContainerUrl;
+        EditAuthMode = SelectedContainer.AuthMode;
         var storedToken = _credentialStore.GetSasToken(SelectedContainer);
         HasStoredSasToken = !string.IsNullOrEmpty(storedToken);
         EditSasToken = string.Empty; // Never show stored token; user can only replace it
@@ -474,8 +508,8 @@ public partial class BlobConfigViewModel : ViewModelBase
             return;
         }
 
-        bool haveTokenToSave = !string.IsNullOrWhiteSpace(EditSasToken);
-        if (IsNew && !haveTokenToSave)
+        bool haveTokenToSave = IsSasAuth && !string.IsNullOrWhiteSpace(EditSasToken);
+        if (IsNew && IsSasAuth && !haveTokenToSave)
         {
             SetError("SAS Token is required.");
             return;
@@ -501,6 +535,7 @@ public partial class BlobConfigViewModel : ViewModelBase
                 Id = BlobContainerConfig.NewId(),
                 Name = EditName,
                 ContainerUrl = EditContainerUrl.TrimEnd('/'),
+                AuthMode = EditAuthMode,
                 PathPattern = EditPathPattern,
                 BackupSourceType = EditBackupSourceType,
                 AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim(),
@@ -522,6 +557,7 @@ public partial class BlobConfigViewModel : ViewModelBase
             // Mutate in place - see ReplaceTags.
             ReplaceTags(container.Tags, TagPalette.ParseTags(EditTags));
             container.ContainerUrl = EditContainerUrl.TrimEnd('/');
+            container.AuthMode = EditAuthMode;
             container.PathPattern = EditPathPattern;
             container.BackupSourceType = EditBackupSourceType;
             container.BackupServerTimeZoneId = EditBackupServerTimeZone?.Id;
@@ -560,6 +596,15 @@ public partial class BlobConfigViewModel : ViewModelBase
                 SetError($"The container was saved, but the SAS token could not be stored: {ex.Message}");
                 return;
             }
+        }
+        else if (IsEntraAuth)
+        {
+            // Switching to Entra leaves no reason to keep the SAS token, and an organisation that
+            // has banned long-lived SAS has banned it wherever it is sitting - including in this
+            // machine's Credential Manager. After the config write, for the same reason the save
+            // itself is ordered that way.
+            _credentialStore.DeleteSecret(container.CredentialKey);
+            HasStoredSasToken = false;
         }
 
         SelectedContainer = container;

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -49,6 +49,37 @@ public partial class BlobConfigViewModel : ViewModelBase
     [ObservableProperty]
     private string? _editAgPathPattern;
 
+    /// <summary>
+    /// The backup server's time zone, or null for "not known" (#102). Selected from
+    /// <see cref="TimeZones"/>.
+    /// </summary>
+    [ObservableProperty]
+    private TimeZoneOption? _editBackupServerTimeZone;
+
+    private string? _originalTimeZoneId;
+
+    /// <summary>
+    /// Every zone this machine knows, with an explicit "not known" first. Read once - the list
+    /// does not change while the app is running, and enumerating it is not free.
+    /// </summary>
+    public static IReadOnlyList<TimeZoneOption> TimeZones { get; } = BuildTimeZones();
+
+    private static IReadOnlyList<TimeZoneOption> BuildTimeZones()
+    {
+        var options = new List<TimeZoneOption> { TimeZoneOption.Unknown };
+        try
+        {
+            options.AddRange(TimeZoneInfo.GetSystemTimeZones()
+                .Select(z => new TimeZoneOption(z.Id, z.DisplayName)));
+        }
+        catch
+        {
+            // A machine with an unreadable zone database still gets "not known", which is the
+            // behaviour the app had before this existed.
+        }
+        return options;
+    }
+
     [ObservableProperty]
     private ObservableCollection<PathElement> _activePathElements = [];
 
@@ -168,6 +199,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         CheckForUnsavedChanges();
     }
     partial void OnEditAgPathPatternChanged(string? value) => CheckForUnsavedChanges();
+    partial void OnEditBackupServerTimeZoneChanged(TimeZoneOption? value) => CheckForUnsavedChanges();
 
     // Tags are saved like every other field, so editing only the tags has to count as an unsaved
     // change - otherwise the guard that protects unsaved edits lets them be discarded silently.
@@ -186,7 +218,8 @@ public partial class BlobConfigViewModel : ViewModelBase
             EditPathPattern != _originalPattern ||
             EditBackupSourceType != _originalBackupSourceType ||
             EditAgPathPattern != _originalAgPathPattern ||
-            EditTags != _originalTags;
+            EditTags != _originalTags ||
+            EditBackupServerTimeZone?.Id != _originalTimeZoneId;
     }
 
     /// <summary>
@@ -200,6 +233,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         var pattern = container.PathPattern;
         var sourceType = container.BackupSourceType;
         var agPattern = container.AgPathPattern;
+        var timeZoneId = container.BackupServerTimeZoneId;
         var tags = container.Tags.ToList();
 
         return () =>
@@ -209,6 +243,7 @@ public partial class BlobConfigViewModel : ViewModelBase
             container.PathPattern = pattern;
             container.BackupSourceType = sourceType;
             container.AgPathPattern = agPattern;
+            container.BackupServerTimeZoneId = timeZoneId;
             ReplaceTags(container.Tags, tags);
         };
     }
@@ -222,6 +257,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         _originalBackupSourceType = EditBackupSourceType;
         _originalAgPathPattern = EditAgPathPattern;
         _originalTags = EditTags;
+        _originalTimeZoneId = EditBackupServerTimeZone?.Id;
         HasUnsavedChanges = false;
     }
 
@@ -386,6 +422,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditPathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
         EditBackupSourceType = BackupSourceType.Standalone;
         EditAgPathPattern = null;
+        EditBackupServerTimeZone = TimeZoneOption.Unknown;
         SyncPathElementsFromPattern();
         SyncAgPathElementsFromPattern();
         HasStoredSasToken = false;
@@ -409,6 +446,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditSasToken = string.Empty; // Never show stored token; user can only replace it
         EditPathPattern = SelectedContainer.PathPattern;
         EditBackupSourceType = SelectedContainer.BackupSourceType;
+        EditBackupServerTimeZone = TimeZoneOption.For(SelectedContainer.BackupServerTimeZoneId, TimeZones);
         EditAgPathPattern = SelectedContainer.AgPathPattern;
         SyncPathElementsFromPattern();
         SyncAgPathElementsFromPattern();
@@ -466,6 +504,7 @@ public partial class BlobConfigViewModel : ViewModelBase
                 PathPattern = EditPathPattern,
                 BackupSourceType = EditBackupSourceType,
                 AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim(),
+                BackupServerTimeZoneId = EditBackupServerTimeZone?.Id,
                 Tags = [.. TagPalette.ParseTags(EditTags)]
             };
             Containers.Add(container);
@@ -485,6 +524,7 @@ public partial class BlobConfigViewModel : ViewModelBase
             container.ContainerUrl = EditContainerUrl.TrimEnd('/');
             container.PathPattern = EditPathPattern;
             container.BackupSourceType = EditBackupSourceType;
+            container.BackupServerTimeZoneId = EditBackupServerTimeZone?.Id;
             var agPattern = IsAgPathSectionVisible ? PathElement.BuildPattern(AgActivePathElements) : null;
             container.AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim();
         }
@@ -572,6 +612,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         HasStoredSasToken = true; // Still have a token; user will replace it
         EditSasToken = string.Empty;
         EditPathPattern = SelectedContainer.PathPattern;
+        EditBackupServerTimeZone = TimeZoneOption.For(SelectedContainer.BackupServerTimeZoneId, TimeZones);
         EditBackupSourceType = SelectedContainer.BackupSourceType;
         EditAgPathPattern = SelectedContainer.AgPathPattern;
 

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Text;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -741,8 +742,13 @@ public partial class BlobConfigViewModel : ViewModelBase
         catch (Exception ex)
         {
             TestSuccess = false;
-            TestResult = $"Connection failed: {ex.Message}";
             ContainerSummary = null;
+
+            // Azure's own message is accurate and useless in equal measure - a permission failure
+            // arrives with a request id, the original XML and eleven headers, and says nothing
+            // about what to change. Same instinct as the recovery guidance after a failed restore
+            // (#14): the moment it fails is the moment to say what to do about it.
+            TestResult = await ExplainFailureAsync(ex, config, ct);
         }
         finally
         {
@@ -750,6 +756,51 @@ public partial class BlobConfigViewModel : ViewModelBase
             IsBusy = false;
             CanCancelTest = false;
         }
+    }
+
+    /// <summary>
+    /// The failure, then who was refused, then what to do about it.
+    ///
+    /// The identity comes first among the details because it is the fact that settles the most
+    /// common confusion: a permission error against an account that demonstrably has access
+    /// usually means a different account was used than the one being thought about.
+    /// </summary>
+    private async Task<string> ExplainFailureAsync(
+        Exception ex, BlobContainerConfig config, CancellationToken ct)
+    {
+        var message = new StringBuilder($"Connection failed: {FirstLine(ex.Message)}");
+
+        if (config.AuthMode.IsEntra())
+        {
+            string? identity = null;
+            try
+            {
+                identity = await _blobService.DescribeSignedInIdentityAsync(config, ct);
+            }
+            catch
+            {
+                // Explaining a failure must not produce one.
+            }
+
+            if (identity != null)
+                message.Append($"{Environment.NewLine}{Environment.NewLine}Signed in as: {identity}");
+        }
+
+        var guidance = BlobFailureExplainer.Explain(ex, config);
+        if (guidance != null)
+            message.Append($"{Environment.NewLine}{Environment.NewLine}{guidance}");
+
+        return message.ToString();
+    }
+
+    /// <summary>
+    /// Azure appends the request id, the timestamp, the original XML and every response header to
+    /// its exception message. The first line is the part a human reads; the rest buries it.
+    /// </summary>
+    private static string FirstLine(string message)
+    {
+        var end = message.IndexOfAny(['\r', '\n']);
+        return end < 0 ? message : message[..end].TrimEnd();
     }
 
     /// <summary>Stops an in-progress connection test.</summary>

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -9,8 +9,8 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class BlobConfigViewModel : ViewModelBase
 {
-    private readonly CredentialStore _credentialStore;
-    private readonly BlobStorageService _blobService;
+    private readonly ICredentialStore _credentialStore;
+    private readonly IBlobStorageService _blobService;
     private readonly OperationCancellation _testCancellation = new();
 
     /// <summary>True while a connection test is running and has not been asked to stop (#25).</summary>
@@ -109,7 +109,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     private BackupSourceType _originalBackupSourceType = BackupSourceType.Standalone;
     private string? _originalAgPathPattern;
 
-    public BlobConfigViewModel(CredentialStore credentialStore, BlobStorageService blobService)
+    public BlobConfigViewModel(ICredentialStore credentialStore, IBlobStorageService blobService)
     {
         _credentialStore = credentialStore;
         _blobService = blobService;

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -30,6 +30,8 @@ public partial class BlobConfigViewModel : ViewModelBase
     [ObservableProperty]
     private string _editTags = string.Empty;
 
+    private string _originalTags = string.Empty;
+
     [ObservableProperty]
     private string _editContainerUrl = string.Empty;
 
@@ -167,6 +169,10 @@ public partial class BlobConfigViewModel : ViewModelBase
     }
     partial void OnEditAgPathPatternChanged(string? value) => CheckForUnsavedChanges();
 
+    // Tags are saved like every other field, so editing only the tags has to count as an unsaved
+    // change - otherwise the guard that protects unsaved edits lets them be discarded silently.
+    partial void OnEditTagsChanged(string value) => CheckForUnsavedChanges();
+
     private void CheckForUnsavedChanges()
     {
         if (!IsEditing) return;
@@ -179,7 +185,8 @@ public partial class BlobConfigViewModel : ViewModelBase
             sasChanged ||
             EditPathPattern != _originalPattern ||
             EditBackupSourceType != _originalBackupSourceType ||
-            EditAgPathPattern != _originalAgPathPattern;
+            EditAgPathPattern != _originalAgPathPattern ||
+            EditTags != _originalTags;
     }
 
     private void StoreOriginalValues()
@@ -190,6 +197,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         _originalPattern = EditPathPattern;
         _originalBackupSourceType = EditBackupSourceType;
         _originalAgPathPattern = EditAgPathPattern;
+        _originalTags = EditTags;
         HasUnsavedChanges = false;
     }
 
@@ -510,6 +518,13 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditPathPattern = SelectedContainer.PathPattern;
         EditBackupSourceType = SelectedContainer.BackupSourceType;
         EditAgPathPattern = SelectedContainer.AgPathPattern;
+
+        // Tags too. Save writes whatever is in this box over the container's tags, so leaving it
+        // empty here deleted every tag on any container whose token was refreshed - silently, and
+        // with no undo. Refresh Token is a separate button from Edit, so replacing an expired
+        // token was the natural way to hit it.
+        EditTags = TagPalette.FormatTags(SelectedContainer.Tags);
+
         SyncPathElementsFromPattern();
         SyncAgPathElementsFromPattern();
         IsNew = false;

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -189,6 +189,30 @@ public partial class BlobConfigViewModel : ViewModelBase
             EditTags != _originalTags;
     }
 
+    /// <summary>
+    /// Captures a container's persisted fields and returns the action that puts them back. Used to
+    /// undo an in-place edit when the config write is refused.
+    /// </summary>
+    private static Action Snapshot(BlobContainerConfig container)
+    {
+        var name = container.Name;
+        var url = container.ContainerUrl;
+        var pattern = container.PathPattern;
+        var sourceType = container.BackupSourceType;
+        var agPattern = container.AgPathPattern;
+        var tags = container.Tags.ToList();
+
+        return () =>
+        {
+            container.Name = name;
+            container.ContainerUrl = url;
+            container.PathPattern = pattern;
+            container.BackupSourceType = sourceType;
+            container.AgPathPattern = agPattern;
+            ReplaceTags(container.Tags, tags);
+        };
+    }
+
     private void StoreOriginalValues()
     {
         _originalName = EditName;
@@ -420,6 +444,11 @@ public partial class BlobConfigViewModel : ViewModelBase
         }
 
         BlobContainerConfig container;
+
+        // Undoes the edit if the save is refused. Null for a new container, which is removed from
+        // the list instead.
+        Action? restore = null;
+
         if (IsNew)
         {
             if (Containers.Any(c => c.Name.Equals(EditName, StringComparison.OrdinalIgnoreCase)))
@@ -444,6 +473,12 @@ public partial class BlobConfigViewModel : ViewModelBase
         else
         {
             container = SelectedContainer!;
+
+            // Snapshot before mutating, so a refused save can put the model back. Without this an
+            // edit that failed to persist left the in-memory container showing values that are not
+            // on disk - and the next save writes them without the user knowing they were pending.
+            restore = Snapshot(container);
+
             container.Name = EditName;
             // Mutate in place - see ReplaceTags.
             ReplaceTags(container.Tags, TagPalette.ParseTags(EditTags));
@@ -454,16 +489,37 @@ public partial class BlobConfigViewModel : ViewModelBase
             container.AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim();
         }
 
-        if (haveTokenToSave)
-            _credentialStore.SaveSasToken(container, EditSasToken);
-        // When editing and leaving SAS field empty, existing token is kept (never re-read or shown)
+        // Config FIRST, secret second.
+        //
+        // The other order wrote a durable secret and then discovered the config could not be
+        // saved. Change a name and a token together, have config.json briefly locked, and the
+        // Credential Manager ends up holding the NEW token under a key the OLD config points at -
+        // or, for a rename, under a name nothing references. The form never shows a stored secret,
+        // so nothing on screen reveals the mismatch. Delete already follows this rule.
         if (!SaveContainers())
         {
             // Nothing reached the disk, so do not leave the list showing a container that is not
             // really there. Stay in the edit form so the save can be retried once whatever was
             // holding the file has let go.
             if (IsNew) Containers.Remove(container);
+            else restore?.Invoke();
             return;
+        }
+
+        // When editing and leaving SAS field empty, existing token is kept (never re-read or shown)
+        if (haveTokenToSave)
+        {
+            try
+            {
+                _credentialStore.SaveSasToken(container, EditSasToken);
+            }
+            catch (Exception ex)
+            {
+                // The config is saved and consistent; only the token is missing. Say exactly that,
+                // because "save failed" would send the user looking for the wrong problem.
+                SetError($"The container was saved, but the SAS token could not be stored: {ex.Message}");
+                return;
+            }
         }
 
         SelectedContainer = container;

--- a/src/NineLives/ViewModels/ConsoleBuffer.cs
+++ b/src/NineLives/ViewModels/ConsoleBuffer.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Blackcat.NineLives.Models;
@@ -39,10 +39,35 @@ public partial class ConsoleBuffer : ObservableObject
     /// </summary>
     public bool IsRunning { get; set; }
 
+    /// <summary>
+    /// What the flush timer runs on. Null means flush inline, because there is nothing to tick.
+    ///
+    /// Resolved once, at construction, rather than looked up per message. A buffer belongs to the
+    /// thread that made it, so asking once is both cheaper and more truthful. Asking repeatedly
+    /// meant the answer came from whatever state the CURRENT thread happened to be in - which is
+    /// not something this class can reason about, and which broke: a test thread that had been used
+    /// for something unrelated came back carrying a dispatcher, so the buffer waited on a timer
+    /// that nothing was pumping and the lines never appeared.
+    /// </summary>
+    private readonly Dispatcher? _dispatcher;
+
     /// <param name="alsoLog">
     /// Called with every message as it arrives, so the log file cannot drift from what was shown.
     /// </param>
-    public ConsoleBuffer(Action<string>? alsoLog = null) => _alsoLog = alsoLog;
+    public ConsoleBuffer(Action<string>? alsoLog = null)
+        : this(alsoLog, Dispatcher.FromThread(Thread.CurrentThread))
+    {
+    }
+
+    /// <summary>
+    /// Lets a test say outright whether there is a dispatcher, instead of depending on what its
+    /// thread happens to be carrying.
+    /// </summary>
+    internal ConsoleBuffer(Action<string>? alsoLog, Dispatcher? dispatcher)
+    {
+        _alsoLog = alsoLog;
+        _dispatcher = dispatcher;
+    }
 
     [ObservableProperty]
     private ObservableCollection<ConsoleLine> _lines = [];
@@ -108,6 +133,9 @@ public partial class ConsoleBuffer : ObservableObject
         HasOutput = false;
     }
 
+    /// <summary>Whether there is anything to batch on. Only the tests care.</summary>
+    internal bool HasDispatcher => _dispatcher != null;
+
     /// <summary>
     /// True while lines are waiting. Only the tests care - it is how "batched, not immediate" is
     /// asserted without waiting on a dispatcher timer.
@@ -120,13 +148,16 @@ public partial class ConsoleBuffer : ObservableObject
 
         // No dispatcher (a plain unit test, or a background thread) means no timer to tick, so
         // flush inline instead of buffering forever with nothing to drain it.
-        if (Dispatcher.FromThread(Thread.CurrentThread) == null)
+        if (_dispatcher == null)
         {
             Flush();
             return;
         }
 
-        _timer = new DispatcherTimer(DispatcherPriority.Background) { Interval = FlushInterval };
+        _timer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher)
+        {
+            Interval = FlushInterval
+        };
         _timer.Tick += (_, _) => Flush();
         _timer.Start();
     }

--- a/src/NineLives/ViewModels/ConsoleBuffer.cs
+++ b/src/NineLives/ViewModels/ConsoleBuffer.cs
@@ -1,0 +1,133 @@
+using System.Collections.ObjectModel;
+using System.Windows.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The execution console: the lines on screen, and the batching that keeps them arriving smoothly.
+///
+/// Lifted out of RestoreViewModel, which was doing thirteen jobs (#115). This one has no coupling
+/// to the rest of the restore - it takes text in and offers lines out - and pulling it apart makes
+/// the 60 ms batching testable without standing up a whole restore.
+///
+/// Writes to a COLLECTION rather than concatenating a bound string. Appending to a bound string
+/// rebuilds it and re-renders the whole TextBox on every message - O(n^2) - which was a large part
+/// of why a restore reporting progress every few percent looked like it arrived in bursts rather
+/// than live.
+/// </summary>
+public partial class ConsoleBuffer : ObservableObject
+{
+    /// <summary>
+    /// How long lines wait before being moved onto the bound collection.
+    ///
+    /// SQL Server emits progress in clusters - several messages within a millisecond, then nothing
+    /// for a second. Adding each one individually meant a layout pass and a scroll per message, in
+    /// bursts, which is what made the console judder. Flushing on a fixed tick turns any arrival
+    /// pattern into a steady redraw, and a whole cluster costs one layout pass instead of ten.
+    /// </summary>
+    private static readonly TimeSpan FlushInterval = TimeSpan.FromMilliseconds(60);
+
+    private readonly List<ConsoleLine> _pending = [];
+    private readonly Action<string>? _alsoLog;
+    private DispatcherTimer? _timer;
+
+    /// <summary>
+    /// Whether more output is still expected. While true the flush timer keeps ticking even with
+    /// nothing buffered; once false an empty tick stops it rather than spinning forever.
+    /// </summary>
+    public bool IsRunning { get; set; }
+
+    /// <param name="alsoLog">
+    /// Called with every message as it arrives, so the log file cannot drift from what was shown.
+    /// </param>
+    public ConsoleBuffer(Action<string>? alsoLog = null) => _alsoLog = alsoLog;
+
+    [ObservableProperty]
+    private ObservableCollection<ConsoleLine> _lines = [];
+
+    [ObservableProperty]
+    private bool _hasOutput;
+
+    /// <summary>The console as plain text, for copying into a bug report.</summary>
+    public string Text => string.Join(Environment.NewLine, Lines.Select(l => l.Text));
+
+    /// <summary>
+    /// Adds a message, splitting it into lines and collapsing runs of blanks.
+    ///
+    /// Messages routinely arrive with a leading or trailing newline for spacing, and SQL Server's
+    /// own output has its own blank lines. Left alone that produced a gap between almost every
+    /// line. One blank line is allowed as a separator; runs of them are not.
+    /// </summary>
+    public void Append(string message)
+    {
+        foreach (var raw in message.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+
+            if (line.Trim().Length == 0)
+            {
+                if (_pending.Count > 0 && _pending[^1].Text.Length == 0) continue;
+                if (_pending.Count == 0 && (Lines.Count == 0 || Lines[^1].Text.Length == 0)) continue;
+                _pending.Add(new ConsoleLine(string.Empty));
+                continue;
+            }
+
+            _pending.Add(ConsoleLine.From(line));
+        }
+
+        _alsoLog?.Invoke(message);
+        ScheduleFlush();
+    }
+
+    /// <summary>Moves everything buffered onto the bound collection now.</summary>
+    public void Flush()
+    {
+        if (_pending.Count == 0)
+        {
+            // Nothing arriving and nothing running - stop ticking rather than spin forever.
+            if (!IsRunning)
+            {
+                _timer?.Stop();
+                _timer = null;
+            }
+            return;
+        }
+
+        foreach (var line in _pending) Lines.Add(line);
+        _pending.Clear();
+        HasOutput = true;
+    }
+
+    /// <summary>Empties the console, for the start of a run.</summary>
+    public void Clear()
+    {
+        _pending.Clear();
+        Lines.Clear();
+        HasOutput = false;
+    }
+
+    /// <summary>
+    /// True while lines are waiting. Only the tests care - it is how "batched, not immediate" is
+    /// asserted without waiting on a dispatcher timer.
+    /// </summary>
+    internal bool HasPending => _pending.Count > 0;
+
+    private void ScheduleFlush()
+    {
+        if (_timer != null) return;
+
+        // No dispatcher (a plain unit test, or a background thread) means no timer to tick, so
+        // flush inline instead of buffering forever with nothing to drain it.
+        if (Dispatcher.FromThread(Thread.CurrentThread) == null)
+        {
+            Flush();
+            return;
+        }
+
+        _timer = new DispatcherTimer(DispatcherPriority.Background) { Interval = FlushInterval };
+        _timer.Tick += (_, _) => Flush();
+        _timer.Start();
+    }
+}

--- a/src/NineLives/ViewModels/HistoryViewModel.cs
+++ b/src/NineLives/ViewModels/HistoryViewModel.cs
@@ -1,0 +1,174 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// Past restores, read back from disk (#31).
+///
+/// Read-only on purpose beyond clearing: this is the record of what was done, and a view that
+/// could edit it would be worth less than one that cannot.
+/// </summary>
+public partial class HistoryViewModel : ViewModelBase
+{
+    private readonly IRestoreHistoryStore _history;
+
+    public HistoryViewModel(IRestoreHistoryStore? history = null)
+    {
+        _history = history ?? new RestoreHistoryStore();
+        Refresh();
+    }
+
+    [ObservableProperty]
+    private ObservableCollection<RestoreHistoryEntry> _entries = [];
+
+    [ObservableProperty]
+    private RestoreHistoryEntry? _selectedEntry;
+
+    [ObservableProperty]
+    private bool _hasEntries;
+
+    [ObservableProperty]
+    private string _filterText = string.Empty;
+
+    /// <summary>True while a confirmation is pending, so Clear takes two presses.</summary>
+    [ObservableProperty]
+    private bool _isClearArmed;
+
+    private List<RestoreHistoryEntry> _all = [];
+
+    [RelayCommand]
+    public void Refresh()
+    {
+        _all = _history.Load();
+        ApplyFilter();
+
+        // Selecting the newest is what someone opening this view is nearly always after: the
+        // restore they just ran.
+        SelectedEntry = Entries.FirstOrDefault();
+        SetStatus(HasEntries
+            ? $"{_all.Count} restore(s) recorded."
+            : "No restores recorded yet.");
+    }
+
+    partial void OnFilterTextChanged(string value) => ApplyFilter();
+
+    private void ApplyFilter()
+    {
+        var matching = string.IsNullOrWhiteSpace(FilterText)
+            ? _all
+            : _all.Where(Matches).ToList();
+
+        Entries = new ObservableCollection<RestoreHistoryEntry>(matching);
+        HasEntries = Entries.Count > 0;
+
+        if (SelectedEntry != null && !Entries.Contains(SelectedEntry))
+            SelectedEntry = Entries.FirstOrDefault();
+    }
+
+    private bool Matches(RestoreHistoryEntry e)
+        => Contains(e.TargetDatabase) || Contains(e.ServerName)
+        || Contains(e.SourceDatabase) || Contains(e.ContainerName)
+        || Contains(e.OutcomeDisplay);
+
+    private bool Contains(string? value)
+        => value != null && value.Contains(FilterText, StringComparison.OrdinalIgnoreCase);
+
+    [RelayCommand]
+    private void CopyScript()
+    {
+        if (SelectedEntry == null) return;
+        TryCopyToClipboard(SelectedEntry.Script, "Script copied to clipboard.");
+    }
+
+    [RelayCommand]
+    private void CopyLog()
+    {
+        if (SelectedEntry == null) return;
+        TryCopyToClipboard(SelectedEntry.Log, "Execution log copied to clipboard.");
+    }
+
+    [RelayCommand]
+    private void SaveEntry()
+    {
+        if (SelectedEntry == null) return;
+
+        var dialog = new SaveFileDialog
+        {
+            Filter = "Text Files (*.txt)|*.txt|All Files (*.*)|*.*",
+            DefaultExt = ".txt",
+            FileName = $"ninelives_{SelectedEntry.TargetDatabase}_{SelectedEntry.StartedAt:yyyyMMdd_HHmmss}.txt"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, Format(SelectedEntry));
+            SetStatus($"Saved to {dialog.FileName}");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not save: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Two presses. This is the only destructive action in the view, and what it destroys is the
+    /// evidence of what was done to someone's production databases.
+    /// </summary>
+    [RelayCommand]
+    private void ClearHistory()
+    {
+        if (!IsClearArmed)
+        {
+            IsClearArmed = true;
+            SetStatus("Press Clear again to delete every recorded restore. This cannot be undone.");
+            return;
+        }
+
+        IsClearArmed = false;
+        _history.Clear();
+        Refresh();
+        SetStatus("Restore history cleared.");
+    }
+
+    [RelayCommand]
+    private void CancelClear()
+    {
+        IsClearArmed = false;
+        ClearStatus();
+    }
+
+    /// <summary>The entry as a self-contained document: what ran, where, and what came back.</summary>
+    public static string Format(RestoreHistoryEntry e)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Nine Lives - restore record");
+        sb.AppendLine($"Started:    {e.StartedAt:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"Completed:  {e.CompletedAt:yyyy-MM-dd HH:mm:ss}  ({e.DurationDisplay})");
+        sb.AppendLine($"Server:     {e.ServerName}");
+        sb.AppendLine($"Target:     {e.TargetDatabase}");
+        if (e.SourceDatabase != null) sb.AppendLine($"Source:     {e.SourceDatabase}");
+        if (e.ContainerName != null) sb.AppendLine($"Container:  {e.ContainerName}");
+        if (e.RestorePointTimestamp.HasValue)
+            sb.AppendLine($"Point:      {e.RestorePointTimestamp:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"Chain:      {e.ChainSummary}");
+        sb.AppendLine($"Outcome:    {e.OutcomeDisplay}");
+        if (e.ErrorMessage != null) sb.AppendLine($"Error:      {e.ErrorMessage}");
+
+        sb.AppendLine();
+        sb.AppendLine("--- script ---------------------------------------------------");
+        sb.AppendLine(e.Script);
+        sb.AppendLine("--- execution log --------------------------------------------");
+        sb.AppendLine(e.Log);
+
+        return sb.ToString();
+    }
+}

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -13,6 +13,7 @@ public partial class MainViewModel : ViewModelBase
     private readonly ISqlServerService _sqlService;
     private readonly BackupChainBuilder _chainBuilder;
     private readonly RestoreScriptGenerator _scriptGenerator;
+    private readonly IRestoreHistoryStore _historyStore;
 
     [ObservableProperty]
     private ViewModelBase? _currentView;
@@ -48,6 +49,7 @@ public partial class MainViewModel : ViewModelBase
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }
     public RestoreViewModel Restore { get; }
+    public HistoryViewModel History { get; }
     public AboutViewModel About { get; }
 
     /// <summary>
@@ -79,7 +81,14 @@ public partial class MainViewModel : ViewModelBase
         BlobConfig = new BlobConfigViewModel(_credentialStore, _blobService);
         ServerManager = new ServerManagerViewModel(_credentialStore, _sqlService);
         BlobBrowser = new BlobBrowserViewModel(_blobService, _credentialStore);
-        Restore = new RestoreViewModel(_blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore);
+        // One store, shared: the Restore screen writes to it and the History screen reads it back,
+        // and two instances pointed at the same file would be a way to lose an entry.
+        _historyStore = new RestoreHistoryStore();
+
+        Restore = new RestoreViewModel(
+            _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
+            log: null, history: _historyStore);
+        History = new HistoryViewModel(_historyStore);
         About = new AboutViewModel();
 
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
@@ -199,6 +208,7 @@ public partial class MainViewModel : ViewModelBase
             "SQL Servers" => ServerManager,
             "Browse Backups" => BlobBrowser,
             "Restore" => Restore,
+            "History" => History,
             "About" => About,
             _ => BlobConfig
         };
@@ -208,6 +218,10 @@ public partial class MainViewModel : ViewModelBase
             BlobBrowser.RefreshContainers();
         else if (viewName is "Restore")
             Restore.RefreshContainers();
+        else if (viewName is "History")
+            // Re-read on every visit: a restore run since the last look must be here, and the
+            // history is written by the Restore screen rather than by this one.
+            History.Refresh();
     }
 }
 

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -68,6 +68,11 @@ public partial class MainViewModel : ViewModelBase
     {
         _credentialStore = credentialStore;
 
+        // Before the child viewmodels build any views: applying a palette afterwards works, since
+        // every colour is a DynamicResource, but doing it first means the first frame drawn is
+        // already the right colour rather than a flash of dark on the way to light.
+        ApplySavedTheme();
+
         // Before anything reads the config: move secrets from name-derived keys onto stable ids
         // (#8). Must happen ahead of the child viewmodels, which load containers and servers in
         // their constructors and would otherwise look up keys the migration is about to change.
@@ -89,7 +94,7 @@ public partial class MainViewModel : ViewModelBase
             _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
             log: null, history: _historyStore);
         History = new HistoryViewModel(_historyStore);
-        About = new AboutViewModel();
+        About = new AboutViewModel(_credentialStore);
 
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
 
@@ -97,6 +102,22 @@ public partial class MainViewModel : ViewModelBase
 
         // Fire and forget - startup must not wait on the network.
         _ = CheckForUpdatesAsync();
+    }
+
+    /// <summary>
+    /// Puts the remembered colour scheme back. Never fatal: a theme that will not load leaves the
+    /// default in place, which is a cosmetic problem rather than one worth refusing to start over.
+    /// </summary>
+    private void ApplySavedTheme()
+    {
+        try
+        {
+            ThemeManager.Apply(_credentialStore.LoadConfig().Theme);
+        }
+        catch
+        {
+            // Dark it is.
+        }
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -198,27 +198,48 @@ public partial class MainViewModel : ViewModelBase
         ServerManager.DisconnectCommand.Execute(null);
     }
 
+    /// <summary>
+    /// The sidebar's view names. Constants rather than literals scattered across the switch,
+    /// because an unrecognised name here silently lands on Blob Storage rather than failing -
+    /// so a typo looks like a button that goes to the wrong place (#42).
+    ///
+    /// The XAML still passes them as strings; <see cref="Views"/> is what a test can check the
+    /// switch against.
+    /// </summary>
+    public static class Nav
+    {
+        public const string BlobStorage = "Blob Storage";
+        public const string SqlServers = "SQL Servers";
+        public const string BrowseBackups = "Browse Backups";
+        public const string Restore = "Restore";
+        public const string History = "History";
+        public const string About = "About";
+
+        public static IReadOnlyList<string> Views =>
+            [BlobStorage, SqlServers, BrowseBackups, Restore, History, About];
+    }
+
     [RelayCommand]
     private void NavigateTo(string viewName)
     {
         CurrentViewName = viewName;
         CurrentView = viewName switch
         {
-            "Blob Storage" => BlobConfig,
-            "SQL Servers" => ServerManager,
-            "Browse Backups" => BlobBrowser,
-            "Restore" => Restore,
-            "History" => History,
-            "About" => About,
+            Nav.BlobStorage => BlobConfig,
+            Nav.SqlServers => ServerManager,
+            Nav.BrowseBackups => BlobBrowser,
+            Nav.Restore => Restore,
+            Nav.History => History,
+            Nav.About => About,
             _ => BlobConfig
         };
 
         // Refresh container lists when navigating to views that depend on them
-        if (viewName is "Browse Backups")
+        if (viewName is Nav.BrowseBackups)
             BlobBrowser.RefreshContainers();
-        else if (viewName is "Restore")
+        else if (viewName is Nav.Restore)
             Restore.RefreshContainers();
-        else if (viewName is "History")
+        else if (viewName is Nav.History)
             // Re-read on every visit: a restore run since the last look must be here, and the
             // history is written by the Restore screen rather than by this one.
             History.Refresh();

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Models;
@@ -98,10 +98,53 @@ public partial class MainViewModel : ViewModelBase
 
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
 
+        // One place that answers "is it doing something?". Every screen already tracks its own
+        // work; without this the answer depended on which part of a long page was scrolled into
+        // view, and the Restore screen's own status line is below the fold most of the time (#128).
+        WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Restore);
+
         CurrentView = BlobConfig;
 
         // Fire and forget - startup must not wait on the network.
         _ = CheckForUpdatesAsync();
+    }
+
+    /// <summary>What the app is currently doing, or empty when it is idle.</summary>
+    [ObservableProperty]
+    private string _busyText = string.Empty;
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    private readonly List<ViewModelBase> _watched = [];
+
+    private void WatchForBusy(params ViewModelBase[] children)
+    {
+        foreach (var child in children)
+        {
+            _watched.Add(child);
+            child.PropertyChanged += (_, _) => RefreshBusy();
+        }
+    }
+
+    /// <summary>
+    /// The Restore screen names what it is doing; the others only say they are busy, and what that
+    /// means is obvious from the screen. Restore wins when more than one is going, because it is
+    /// the one that can be running a RESTORE.
+    /// </summary>
+    private void RefreshBusy()
+    {
+        var text =
+            Restore.IsBusyWithAnything ? Restore.BusyDescription
+            : BlobConfig.IsBusy ? "Testing the container connection..."
+            : BlobBrowser.IsBusy ? "Listing the container..."
+            : ServerManager.IsBusy ? "Connecting to SQL Server..."
+            : string.Empty;
+
+        if (text == BusyText) return;
+
+        BusyText = text;
+        IsBusy = text.Length > 0;
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -8,9 +8,9 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class MainViewModel : ViewModelBase
 {
-    private readonly CredentialStore _credentialStore;
-    private readonly BlobStorageService _blobService;
-    private readonly SqlServerService _sqlService;
+    private readonly ICredentialStore _credentialStore;
+    private readonly IBlobStorageService _blobService;
+    private readonly ISqlServerService _sqlService;
     private readonly BackupChainBuilder _chainBuilder;
     private readonly RestoreScriptGenerator _scriptGenerator;
 
@@ -50,9 +50,21 @@ public partial class MainViewModel : ViewModelBase
     public RestoreViewModel Restore { get; }
     public AboutViewModel About { get; }
 
-    public MainViewModel()
+    /// <summary>
+    /// The app's one composition point: builds the real services against the real credential
+    /// store. Deliberately not a DI container - three services and one place that wires them does
+    /// not need one (#41).
+    /// </summary>
+    public MainViewModel() : this(new CredentialStore()) { }
+
+    /// <summary>
+    /// Takes the store so a test can point the whole object graph at a temp directory instead of
+    /// the user's actual profile. Constructing this type used to migrate and read the real
+    /// %LOCALAPPDATA% config as a side effect of a XAML load test.
+    /// </summary>
+    public MainViewModel(ICredentialStore credentialStore)
     {
-        _credentialStore = new CredentialStore();
+        _credentialStore = credentialStore;
 
         // Before anything reads the config: move secrets from name-derived keys onto stable ids
         // (#8). Must happen ahead of the child viewmodels, which load containers and servers in

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -251,9 +251,9 @@ public partial class MainViewModel : ViewModelBase
         ConnectedServerName = e.IsConnected ? e.ServerName : "Not connected";
         Restore.IsConnectedToServer = e.IsConnected;
         Restore.ConnectedServerName = e.ServerName;
+        // Setting ConnectedServer re-checks the credential itself (#115 seam 5).
         Restore.ConnectedServer = e.ConnectedServer;
         GlobalStatus = e.IsConnected ? $"Connected to {e.ServerName}" : "Ready";
-        _ = Restore.RefreshCredentialStatusAsync();
     }
 
     [RelayCommand]

--- a/src/NineLives/ViewModels/PointInTimeViewModel.cs
+++ b/src/NineLives/ViewModels/PointInTimeViewModel.cs
@@ -1,0 +1,171 @@
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The point-in-time (STOPAT) target: the window it has to fall inside, what the user typed, and
+/// whether that is usable.
+///
+/// Third seam out of RestoreViewModel (#115). Only meaningful for a transaction-log restore point.
+/// Without STOPAT the granularity of a "point in time" restore is the end of whichever log backup
+/// was selected - so with 15-minute logs, recovering from a bad DELETE at 14:23:41 could only land
+/// on 14:15 or 14:30.
+///
+/// It does NOT work out the window. That is chain reasoning and belongs to
+/// <see cref="Models.BackupChain.StopAtWindow"/>; this type is handed the window and validates
+/// against it. Constraining the target to the LAST log's window is what keeps the generated chain
+/// valid - a target inside an earlier log would need the chain truncated to that log, or the later
+/// logs restore across a gap and fail with error 4305.
+/// </summary>
+public partial class PointInTimeViewModel : ObservableObject
+{
+    private const string StopAtFormat = "yyyy-MM-dd HH:mm:ss";
+
+    /// <summary>
+    /// Parsed exactly, and invariantly: a target read as 3 February when the user meant 3 March is
+    /// a month of transactions silently discarded. Seconds are optional because the box is often
+    /// filled from a timestamp that has none.
+    /// </summary>
+    private static readonly string[] AcceptedFormats =
+    [
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy-MM-ddTHH:mm:ss",
+        "yyyy-MM-dd HH:mm",
+        "yyyy-MM-ddTHH:mm"
+    ];
+
+    /// <summary>
+    /// True while <see cref="SetWindow"/> is rewriting several properties at once, so a listener
+    /// can skip the intermediate states and act on the finished one.
+    /// </summary>
+    internal bool IsUpdating { get; private set; }
+
+    /// <summary>True when the selected restore point is a log, so STOPAT applies at all.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Effective))]
+    private bool _canUse;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Effective))]
+    private bool _use;
+
+    /// <summary>What the user typed, parsed into <see cref="StopAt"/>.</summary>
+    [ObservableProperty]
+    private string _stopAtText = string.Empty;
+
+    /// <summary>The parsed and validated target, or null when unusable.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Effective))]
+    private DateTime? _stopAt;
+
+    /// <summary>Exclusive lower bound: the end of the previous set in the chain.</summary>
+    [ObservableProperty]
+    private DateTime? _earliest;
+
+    /// <summary>Inclusive upper bound: the end of the selected log backup.</summary>
+    [ObservableProperty]
+    private DateTime? _latest;
+
+    [ObservableProperty]
+    private string _message = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(Effective))]
+    private bool _hasError;
+
+    /// <summary>The STOPAT value to generate, or null to restore the whole log chain.</summary>
+    public DateTime? Effective => CanUse && Use && !HasError ? StopAt : null;
+
+    /// <summary>
+    /// Points this at a new restore point's window, or turns it off when the point is not a log.
+    ///
+    /// Starts unticked with the box pre-filled with the latest usable time, so the box shows what
+    /// the bounds are before anyone commits to using it.
+    /// </summary>
+    public void SetWindow((DateTime Earliest, DateTime Latest)? window)
+    {
+        IsUpdating = true;
+        try
+        {
+            if (window == null)
+            {
+                CanUse = false;
+                Use = false;
+                Earliest = null;
+                Latest = null;
+                StopAtText = string.Empty;
+                StopAt = null;
+                Message = string.Empty;
+                HasError = false;
+                return;
+            }
+
+            CanUse = true;
+            Earliest = window.Value.Earliest;
+            Latest = window.Value.Latest;
+            Use = false;
+            StopAtText = window.Value.Latest.ToString(StopAtFormat);
+            Validate();
+        }
+        finally
+        {
+            IsUpdating = false;
+        }
+    }
+
+    private void Validate()
+    {
+        if (!CanUse)
+        {
+            StopAt = null;
+            Message = string.Empty;
+            HasError = false;
+            return;
+        }
+
+        if (!DateTime.TryParseExact(
+                StopAtText?.Trim(), AcceptedFormats,
+                CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            StopAt = null;
+            // Only an error once it is actually being used - half-typed input in a box nobody has
+            // ticked is not a reason to block the restore.
+            HasError = Use;
+            Message = $"Enter a time as {StopAtFormat}.";
+            return;
+        }
+
+        // Exclusive lower bound: at exactly the previous set's time nothing from this log has been
+        // applied yet, which is the earlier restore point, not this one.
+        if (parsed <= Earliest)
+        {
+            StopAt = null;
+            HasError = Use;
+            Message =
+                $"Must be after {Earliest:yyyy-MM-dd HH:mm:ss} — to stop earlier, " +
+                "select an earlier restore point on the timeline.";
+            return;
+        }
+
+        if (parsed > Latest)
+        {
+            StopAt = null;
+            HasError = Use;
+            Message =
+                $"Must be at or before {Latest:yyyy-MM-dd HH:mm:ss} — to stop later, " +
+                "select a later restore point on the timeline.";
+            return;
+        }
+
+        StopAt = parsed;
+        HasError = false;
+        Message = Use
+            ? $"Recovery will stop at {parsed:yyyy-MM-dd HH:mm:ss}; later transactions in this log are discarded."
+            : $"Valid range: after {Earliest:yyyy-MM-dd HH:mm:ss} up to {Latest:yyyy-MM-dd HH:mm:ss}.";
+    }
+
+    partial void OnStopAtTextChanged(string value) => Validate();
+
+    partial void OnUseChanged(bool value) => Validate();
+}

--- a/src/NineLives/ViewModels/RestoreOptionsViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreOptionsViewModel.cs
@@ -1,0 +1,108 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The RESTORE options a user can set, and the one place they are turned into a
+/// <see cref="RestoreOptions"/>.
+///
+/// Seventh seam out of RestoreViewModel (#115), and the one that pays for itself. Each option used
+/// to be a property on a 2,500-line class with its own one-line change handler, and was copied by
+/// hand into the options object in a method three hundred lines away. Forgetting either half is
+/// invisible: the box on screen moves, and the script does not follow.
+///
+/// That is #110 - WITH MOVE's two paths, the STANDBY undo file and STATS all reached a release with
+/// no change handler at all, so editing them changed the display and nothing else. People read the
+/// generated T-SQL before running it against production, so a script that quietly disagrees with
+/// the boxes above it is worse than no script: it looks authoritative and is not.
+///
+/// Both halves are structural now. One <see cref="ObservableObject.PropertyChanged"/> subscription
+/// covers every option, whatever gets added later, and <see cref="Build"/> sits next to the fields
+/// it copies rather than in another file.
+/// </summary>
+public partial class RestoreOptionsViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _withReplace = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsStandbyMode))]
+    [NotifyPropertyChangedFor(nameof(HasStandbyFileIfNeeded))]
+    private RecoveryMode _recoveryMode = RecoveryMode.Recovery;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasStandbyFileIfNeeded))]
+    private string _standbyFilePath = string.Empty;
+
+    [ObservableProperty]
+    private bool _disconnectSessions = true;
+
+    [ObservableProperty]
+    private int _statsPercent = 10;
+
+    [ObservableProperty]
+    private bool _keepReplication;
+
+    [ObservableProperty]
+    private bool _enableBroker;
+
+    [ObservableProperty]
+    private bool _newBroker;
+
+    /// <summary>
+    /// Verify backup checksums as each page is read. Only meaningful if the backup was taken
+    /// WITH CHECKSUM - against one that was not, SQL Server fails the restore rather than skipping
+    /// the check, which is why this is off by default.
+    /// </summary>
+    [ObservableProperty]
+    private bool _withChecksum;
+
+    /// <summary>
+    /// Carry on restoring after a checksum or page error instead of stopping. This produces a
+    /// database SQL Server has already said is damaged; it exists for the case where a partial
+    /// recovery beats none.
+    /// </summary>
+    [ObservableProperty]
+    private bool _continueAfterError;
+
+    /// <summary>Whether the undo-file box applies, for the view.</summary>
+    public bool IsStandbyMode => RecoveryMode == RecoveryMode.Standby;
+
+    /// <summary>
+    /// STANDBY needs somewhere to put its undo file. Blank produced <c>STANDBY = ''</c>, which SQL
+    /// Server rejects - as the LAST statement of the chain, so it failed after SET SINGLE_USER and
+    /// WITH REPLACE had already dropped and overwritten the target, leaving it in RESTORING and
+    /// single-user with nothing to show for it.
+    /// </summary>
+    public bool HasStandbyFileIfNeeded =>
+        RecoveryMode != RecoveryMode.Standby || !string.IsNullOrWhiteSpace(StandbyFilePath);
+
+    /// <summary>
+    /// Everything on this type, copied into the object the script generator reads.
+    ///
+    /// The three arguments are the things that are NOT options: which database is being restored,
+    /// where the point-in-time target ended up, and where the files are being moved to - each of
+    /// which is worked out somewhere that knows about the chain or the server.
+    ///
+    /// Adding an option means adding a field above and a line here, and nothing else. When the copy
+    /// lived in another file it was possible to do one and not the other, which is what #110 was.
+    /// </summary>
+    public RestoreOptions Build(
+        string targetDatabaseName, DateTime? stopAt, List<FileMoveOption> fileMoves) => new()
+    {
+        TargetDatabaseName = targetDatabaseName,
+        WithReplace = WithReplace,
+        RecoveryMode = RecoveryMode,
+        StandbyFilePath = string.IsNullOrWhiteSpace(StandbyFilePath) ? null : StandbyFilePath,
+        DisconnectSessions = DisconnectSessions,
+        StatsPercent = StatsPercent,
+        StopAt = stopAt,
+        KeepReplication = KeepReplication,
+        EnableBroker = EnableBroker,
+        NewBroker = NewBroker,
+        WithChecksum = WithChecksum,
+        ContinueAfterError = ContinueAfterError,
+        FileMoves = fileMoves
+    };
+}

--- a/src/NineLives/ViewModels/RestoreTimelineViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreTimelineViewModel.cs
@@ -1,0 +1,413 @@
+﻿using System.Collections.ObjectModel;
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The restore-point timeline: which of the computed points are visible, where each one sits on
+/// the track, the tick marks underneath it, and the selection.
+///
+/// Second seam out of RestoreViewModel (#115). This part is nearly pure - points in, positions and
+/// labels out - and none of it needs a container, a server or a chain to exercise, which is why it
+/// comes early in the split.
+///
+/// It does NOT compute the restore points. Working out which points exist is chain reasoning and
+/// belongs to <see cref="Services.BackupChainBuilder"/>; this type is handed the result and decides
+/// how to show it.
+/// </summary>
+public partial class RestoreTimelineViewModel : ObservableObject
+{
+    /// <summary>
+    /// The track's height with nothing on it. Only ever seen for the instant between a load
+    /// starting and the points arriving - the whole step is collapsed while there are no points.
+    /// </summary>
+    private const int EmptyTrackHeight = 50;
+
+    /// <summary>Every computed restore point, before the filters. What is shown is a subset (#27).</summary>
+    private List<RestorePoint> _all = [];
+
+    /// <summary>Set while the filters are being changed in bulk, so each one does not re-filter.</summary>
+    private bool _suppressRefresh;
+
+    // ── what the view shows ─────────────────────────────────────────────────────
+
+    /// <summary>The points that pass the filters, in time order.</summary>
+    [ObservableProperty]
+    private ObservableCollection<RestorePoint> _points = [];
+
+    [ObservableProperty]
+    private RestorePoint? _selectedPoint;
+
+    /// <summary>True when the database has any restore points at all, filters aside.</summary>
+    [ObservableProperty]
+    private bool _hasPoints;
+
+    /// <summary>True when the filters leave at least one of them on screen.</summary>
+    [ObservableProperty]
+    private bool _hasVisiblePoints;
+
+    [ObservableProperty]
+    private string _countText = string.Empty;
+
+    /// <summary>The span the visible points cover, as "from to to".</summary>
+    [ObservableProperty]
+    private string _windowText = string.Empty;
+
+    /// <summary>
+    /// The labels at each end of the track. Plain properties rather than the old
+    /// {Binding RestorePoints[0].Timestamp}, which threw an index error into WPF's binding trace on
+    /// every layout while the collection was empty.
+    /// </summary>
+    [ObservableProperty]
+    private string _startText = string.Empty;
+
+    [ObservableProperty]
+    private string _endText = string.Empty;
+
+    [ObservableProperty]
+    private ObservableCollection<TimelineTick> _ticks = [];
+
+    [ObservableProperty]
+    private int _trackHeight = EmptyTrackHeight;
+
+    // ── filters (#27) ───────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private bool _showFull = true;
+
+    [ObservableProperty]
+    private bool _showDiff = true;
+
+    [ObservableProperty]
+    private bool _showLog = true;
+
+    [ObservableProperty]
+    private string _fromText = string.Empty;
+
+    [ObservableProperty]
+    private string _toText = string.Empty;
+
+    /// <summary>Parsed from the text boxes; null means no bound on that end.</summary>
+    [ObservableProperty]
+    private DateTime? _from;
+
+    [ObservableProperty]
+    private DateTime? _to;
+
+    /// <summary>
+    /// Takes a fresh set of restore points and shows them, with the filters wide open.
+    ///
+    /// Wide open because carrying a previous database's date range over would silently hide points
+    /// that have nothing to do with it.
+    /// </summary>
+    public void Load(IEnumerable<RestorePoint> points)
+    {
+        _all = points.ToList();
+
+        _suppressRefresh = true;
+        ShowFull = ShowDiff = ShowLog = true;
+        FromText = string.Empty;
+        ToText = string.Empty;
+        _suppressRefresh = false;
+
+        if (_all.Count == 0)
+        {
+            Clear();
+            return;
+        }
+
+        HasPoints = true;
+        ApplyFilters(selectLatest: true);
+    }
+
+    /// <summary>
+    /// Empties the timeline, for a container change or an abandoned load.
+    ///
+    /// Clearing the selection is the point of it: everything downstream - the chain, the generated
+    /// script, the verification results - hangs off the selected point, and leaving one behind
+    /// leaves a complete, authoritative-looking RESTORE on screen for a database that is no longer
+    /// the one selected above it.
+    /// </summary>
+    public void Clear()
+    {
+        _all = [];
+        Points = [];
+        HasPoints = false;
+        HasVisiblePoints = false;
+        CountText = string.Empty;
+        WindowText = string.Empty;
+        StartText = string.Empty;
+        EndText = string.Empty;
+        Ticks.Clear();
+        TrackHeight = EmptyTrackHeight;
+        SelectedPoint = null;
+    }
+
+    /// <summary>
+    /// Narrows the track and the list to the points the filters allow, then lays the track out over
+    /// just those.
+    ///
+    /// Laying out over the VISIBLE set rather than all of them is what makes the date range behave
+    /// like a zoom: narrow to a two-hour window and those points spread across the whole track
+    /// instead of staying bunched in the sliver they occupied before (#27).
+    /// </summary>
+    private void ApplyFilters(bool selectLatest = false)
+    {
+        var previous = SelectedPoint;
+        var visible = _all.Where(Matches).ToList();
+
+        LayOut(visible);
+
+        Points = new ObservableCollection<RestorePoint>(visible);
+        HasVisiblePoints = visible.Count > 0;
+
+        CountText = visible.Count == _all.Count
+            ? $"{_all.Count} restore point(s)"
+            : $"Showing {visible.Count} of {_all.Count} restore point(s)";
+
+        if (visible.Count == 0)
+        {
+            WindowText = string.Empty;
+            return;
+        }
+
+        // Keep the selection when it survives the filter - changing a type toggle should not throw
+        // away the point someone had already chosen.
+        SelectedPoint = !selectLatest && previous != null && visible.Contains(previous)
+            ? previous
+            : visible[^1];
+    }
+
+    private bool Matches(RestorePoint p)
+    {
+        var typeAllowed = p.Type switch
+        {
+            BackupType.Full => ShowFull,
+            BackupType.Differential => ShowDiff,
+            BackupType.TransactionLog => ShowLog,
+            _ => true
+        };
+        if (!typeAllowed) return false;
+
+        if (From.HasValue && p.Timestamp < From.Value) return false;
+        if (To.HasValue && p.Timestamp > To.Value) return false;
+
+        return true;
+    }
+
+    private void LayOut(List<RestorePoint> points)
+    {
+        if (points.Count > 1)
+        {
+            var minTicks = points[0].Timestamp.Ticks;
+            var maxTicks = points[^1].Timestamp.Ticks;
+            var range = (double)(maxTicks - minTicks);
+            foreach (var p in points)
+                p.TimelinePosition = range > 0 ? (p.Timestamp.Ticks - minTicks) / range : 0.5;
+        }
+        else if (points.Count == 1)
+        {
+            points[0].TimelinePosition = 0.5;
+        }
+
+        // Vertical stacking, so points too close together to draw side by side are not drawn on
+        // top of each other.
+        ComputeRows(points);
+
+        if (points.Count == 0)
+        {
+            Ticks.Clear();
+            TrackHeight = EmptyTrackHeight;
+            return;
+        }
+
+        var first = points[0].Timestamp;
+        var last = points[^1].Timestamp;
+        WindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
+        StartText = $"{first:yyyy-MM-dd HH:mm}";
+        EndText = $"{last:yyyy-MM-dd HH:mm}";
+
+        Ticks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));
+
+        int maxRow = points.Max(p => p.Row);
+        TrackHeight = Math.Max(EmptyTrackHeight, 30 + (maxRow + 1) * 18);
+    }
+
+    private void OnFilterChanged()
+    {
+        if (_suppressRefresh || _all.Count == 0) return;
+        ApplyFilters();
+    }
+
+    partial void OnShowFullChanged(bool value) => OnFilterChanged();
+    partial void OnShowDiffChanged(bool value) => OnFilterChanged();
+    partial void OnShowLogChanged(bool value) => OnFilterChanged();
+
+    partial void OnFromTextChanged(string value)
+    {
+        From = ParseFilterDate(value);
+        OnFilterChanged();
+    }
+
+    partial void OnToTextChanged(string value)
+    {
+        To = ParseFilterDate(value);
+        OnFilterChanged();
+    }
+
+    /// <summary>
+    /// Invariant, and forgiving about how much of a timestamp was typed - "2026-01-10" is a
+    /// perfectly reasonable thing to enter into a date box. Unparsable means no bound rather than
+    /// an error, so half-typed input does not blank the timeline mid-keystroke.
+    /// </summary>
+    private static DateTime? ParseFilterDate(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+
+        return DateTime.TryParse(
+            text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    [RelayCommand]
+    private void SelectPoint(RestorePoint? point)
+    {
+        if (point != null) SelectedPoint = point;
+    }
+
+    /// <summary>Back to every point, without reloading anything from the container.</summary>
+    [RelayCommand]
+    private void ResetFilters()
+    {
+        _suppressRefresh = true;
+        ShowFull = ShowDiff = ShowLog = true;
+        FromText = string.Empty;
+        ToText = string.Empty;
+        _suppressRefresh = false;
+
+        if (_all.Count > 0) ApplyFilters();
+    }
+
+    /// <summary>
+    /// Narrows the range to the day the selected point falls on. A week of 15-minute logs is
+    /// roughly 670 points; picking one precisely means getting to a day first, and doing that by
+    /// typing two timestamps is a chore when the answer is nearly always "the day it broke".
+    /// </summary>
+    [RelayCommand]
+    private void ZoomToSelectedDay()
+    {
+        if (SelectedPoint == null) return;
+
+        var day = SelectedPoint.Timestamp.Date;
+
+        _suppressRefresh = true;
+        FromText = day.ToString("yyyy-MM-dd HH:mm:ss");
+        ToText = day.AddDays(1).AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss");
+        _suppressRefresh = false;
+
+        ApplyFilters();
+    }
+
+    /// <summary>
+    /// Packs points into as few rows as possible, so two backups minutes apart on a month-long
+    /// track are drawn one above the other instead of on top of each other.
+    /// </summary>
+    private static void ComputeRows(List<RestorePoint> points)
+    {
+        const double minSeparation = 0.025;
+        var rows = new List<List<double>>();
+
+        foreach (var p in points)
+        {
+            bool placed = false;
+            for (int row = 0; row < rows.Count; row++)
+            {
+                bool overlaps = rows[row].Any(pos => Math.Abs(pos - p.TimelinePosition) < minSeparation);
+                if (!overlaps)
+                {
+                    p.Row = row;
+                    rows[row].Add(p.TimelinePosition);
+                    placed = true;
+                    break;
+                }
+            }
+            if (!placed)
+            {
+                p.Row = rows.Count;
+                rows.Add([p.TimelinePosition]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Labelled marks under the track, at an interval chosen to suit the span - hours across an
+    /// afternoon, fortnights across a year.
+    /// </summary>
+    private static List<TimelineTick> ComputeTicks(DateTime first, DateTime last)
+    {
+        var ticks = new List<TimelineTick>();
+        var range = last - first;
+        var totalTicks = (double)(last.Ticks - first.Ticks);
+        if (totalTicks <= 0) return ticks;
+
+        // Choose interval based on range
+        TimeSpan interval;
+        string format;
+        if (range.TotalDays > 60)
+        {
+            interval = TimeSpan.FromDays(14);
+            format = "MMM dd";
+        }
+        else if (range.TotalDays > 14)
+        {
+            interval = TimeSpan.FromDays(7);
+            format = "MMM dd";
+        }
+        else if (range.TotalDays > 3)
+        {
+            interval = TimeSpan.FromDays(1);
+            format = "MMM dd";
+        }
+        else if (range.TotalHours > 12)
+        {
+            interval = TimeSpan.FromHours(6);
+            format = "HH:mm";
+        }
+        else
+        {
+            interval = TimeSpan.FromHours(1);
+            format = "HH:mm";
+        }
+
+        // Round start to the next clean interval boundary
+        var cursor = RoundUp(first, interval);
+
+        while (cursor < last)
+        {
+            double pos = (cursor.Ticks - first.Ticks) / totalTicks;
+            if (pos >= 0.02 && pos <= 0.98)
+            {
+                ticks.Add(new TimelineTick { Position = pos, Label = cursor.ToString(format) });
+            }
+            cursor += interval;
+        }
+
+        return ticks;
+    }
+
+    private static DateTime RoundUp(DateTime dt, TimeSpan interval)
+    {
+        if (interval.TotalDays >= 1)
+        {
+            var next = dt.Date.AddDays(1);
+            while (next <= dt) next = next.AddDays((int)interval.TotalDays);
+            return next;
+        }
+        var ticks = (dt.Ticks + interval.Ticks - 1) / interval.Ticks * interval.Ticks;
+        return new DateTime(ticks);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1380,16 +1380,16 @@ public partial class RestoreViewModel : ViewModelBase
             ChainLsnVerified = true;
 
             SetStatus(HasChainIssues
-                ? $"Chain validation found problems - see the panel above."
-                : $"Chain validated: {headers.Count} backup(s) read, LSN chain is intact.");
+                ? $"Chain check found problems - see the panel above."
+                : $"Chain checked: {headers.Count} header(s) read, the LSN chain is unbroken.");
         }
         catch (OperationCanceledException)
         {
-            SetStatus("Chain validation cancelled.");
+            SetStatus("Chain check cancelled.");
         }
         catch (Exception ex)
         {
-            SetError($"Chain validation failed: {ex.Message}");
+            SetError($"Chain check failed: {ex.Message}");
         }
         finally
         {
@@ -1863,7 +1863,7 @@ public partial class RestoreViewModel : ViewModelBase
 
             FetchedFileMoves = new ObservableCollection<FileMoveOption>(list);
             HasFetchedFileMoves = FetchedFileMoves.Count > 0;
-            SetStatus($"RESTORE FILELISTONLY: {FetchedFileMoves.Count} logical file(s). Edit paths above and use WITH MOVE for correct restore.");
+            SetStatus($"Read {FetchedFileMoves.Count} logical file name(s) from the backup. Edit the target paths above, and tick WITH MOVE to use them.");
         }
         catch (Exception ex)
         {
@@ -1915,7 +1915,7 @@ public partial class RestoreViewModel : ViewModelBase
             sb.AppendLine($"Last LSN: {header.LastLsn?.ToString() ?? "(null)"}");
             sb.AppendLine($"Database backup LSN: {header.DatabaseBackupLsn?.ToString() ?? "(null)"}");
             BackupMetadataSummary = sb.ToString();
-            SetStatus("RESTORE HEADERONLY completed. See metadata summary below.");
+            SetStatus("Header read. See the metadata below.");
         }
         catch (Exception ex)
         {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -282,6 +282,46 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isVerifyingChain;
 
+    partial void OnIsVerifyingChainChanged(bool value) => RefreshCheckState();
+    partial void OnIsValidatingChainChanged(bool value) => RefreshCheckState();
+    partial void OnChainLsnVerifiedChanged(bool value) => RefreshCheckState();
+    partial void OnHasChainIssuesChanged(bool value) => RefreshCheckState();
+    partial void OnHasVerifyResultsChanged(bool value) => RefreshCheckState();
+    partial void OnHasVerifyFailuresChanged(bool value) => RefreshCheckState();
+    partial void OnHasTargetPathProblemChanged(bool value) => RefreshCheckState();
+
+    /// <summary>
+    /// Republishes the two "already passed" flags and re-queries the buttons that depend on them.
+    /// Everything they are computed from is a separate observable property, so without this the
+    /// tick appears and the button stays enabled - or worse, the other way round.
+    /// </summary>
+    private void RefreshCheckState()
+    {
+        OnPropertyChanged(nameof(ChainCheckPassed));
+        OnPropertyChanged(nameof(VerifyPassed));
+        OnPropertyChanged(nameof(BusyDescription));
+        OnPropertyChanged(nameof(IsBusyWithAnything));
+        ValidateChainCommand.NotifyCanExecuteChanged();
+        VerifyChainCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// What this screen is doing, for the strip at the top of the window - empty when idle (#128).
+    /// </summary>
+    public string BusyDescription
+    {
+        get
+        {
+            if (IsExecuting) return $"Restoring {TargetDatabaseName}...";
+            if (IsVerifyingChain) return "Verifying backups...";
+            if (IsValidatingChain) return "Checking the chain...";
+            if (IsBusy) return "Loading backups...";
+            return string.Empty;
+        }
+    }
+
+    public bool IsBusyWithAnything => BusyDescription.Length > 0;
+
     // ── restore point filters (#27) ─────────────────────────────────────────────
 
     /// <summary>True when the container holds any restore points at all.</summary>
@@ -618,6 +658,14 @@ public partial class RestoreViewModel : ViewModelBase
         // without it, running the execute path in a test appends real restore lines to the user's
         // actual log file, which is the same class of side effect this whole change is about.
         _log = log ?? App.Log;
+
+        // IsBusy and TargetDatabaseName live on the base class, so they cannot have a generated
+        // partial hook - but the busy strip is computed from them.
+        PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(IsBusy) or nameof(TargetDatabaseName))
+                RefreshCheckState();
+        };
 
         RefreshContainers();
     }
@@ -1399,8 +1447,14 @@ public partial class RestoreViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// True once the chain has been checked and came back clean. The result belongs to the chain
+    /// that was checked, so it clears with the selection (#128).
+    /// </summary>
+    public bool ChainCheckPassed => ChainLsnVerified && !HasChainIssues;
+
     private bool CanValidateChain() =>
-        IsConnectedToServer && RestoreChain != null && !IsValidatingChain;
+        IsConnectedToServer && RestoreChain != null && !IsValidatingChain && !ChainCheckPassed;
 
     /// <summary>
     /// Runs RESTORE VERIFYONLY over every set in the chain: does each backup actually read back,
@@ -1472,8 +1526,16 @@ public partial class RestoreViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// True once every backup in the chain read back intact AND the restore has somewhere to
+    /// write. Re-running VERIFYONLY on a large chain by accident is expensive, so once it has
+    /// passed for this selection the button is done.
+    /// </summary>
+    public bool VerifyPassed => HasVerifyResults && !HasVerifyFailures && !HasTargetPathProblem;
+
     private bool CanVerifyChain() =>
-        IsConnectedToServer && RestoreChain != null && !IsVerifyingChain && !IsExecuting;
+        IsConnectedToServer && RestoreChain != null && !IsVerifyingChain && !IsExecuting
+        && !VerifyPassed;
 
     /// <summary>
     /// Turns SQL Server's directory-lookup complaint into something that says what to do about it.
@@ -1648,6 +1710,7 @@ public partial class RestoreViewModel : ViewModelBase
     {
         VerifyChainCommand.NotifyCanExecuteChanged();
         RefreshExecuteBlockedReason();
+        RefreshCheckState();
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Windows;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -466,8 +467,11 @@ public partial class RestoreViewModel : ViewModelBase
         BackupChainBuilder chainBuilder,
         RestoreScriptGenerator scriptGenerator,
         ICredentialStore credentialStore,
-        OperationLog? log = null)
+        OperationLog? log = null,
+        IRestoreHistoryStore? history = null)
     {
+        _history = history ?? new RestoreHistoryStore();
+
         _blobService = blobService;
         _sqlService = sqlService;
         _chainBuilder = chainBuilder;
@@ -483,6 +487,7 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     private readonly OperationLog _log;
+    private readonly IRestoreHistoryStore _history;
 
     public void RefreshContainers()
     {
@@ -1600,6 +1605,14 @@ public partial class RestoreViewModel : ViewModelBase
         IsExecuteArmed = false;
         ExecuteButtonText = "Execute on Server";
 
+        var startedAt = DateTime.Now;
+        var outcome = RestoreOutcome.Failed;
+        string? failure = null;
+
+        // Set false when the run is abandoned before anything was attempted, so history records
+        // executions rather than button presses.
+        var attempted = true;
+
         var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
         ExecutionComplete = false;
@@ -1620,6 +1633,7 @@ public partial class RestoreViewModel : ViewModelBase
             var server = ConnectedServer;
             if (server == null)
             {
+                attempted = false;
                 SetError("Not connected to a server.");
                 return;
             }
@@ -1692,11 +1706,14 @@ public partial class RestoreViewModel : ViewModelBase
                 executeToken);
 
             ExecutionSuccess = true;
+            outcome = RestoreOutcome.Succeeded;
             AppendLog("\nRestore completed successfully!");
             SetStatus("Restore execution completed successfully.");
         }
         catch (OperationCanceledException)
         {
+            outcome = RestoreOutcome.Cancelled;
+            failure = "Cancelled by the user part-way through the chain.";
             // Cancelling a restore is not the same as never having run it. SqlCommand.Cancel stops
             // the client waiting and SQL Server rolls back the statement that was in flight, but
             // the target stays mid-restore - so this must be as loud as a failure, and it goes
@@ -1716,6 +1733,8 @@ public partial class RestoreViewModel : ViewModelBase
         catch (Exception ex)
         {
             ExecutionSuccess = false;
+            outcome = RestoreOutcome.Failed;
+            failure = ex.Message;
             AppendLog($"\nERROR: {ex.Message}");
             SetError($"Restore failed: {ex.Message}");
 
@@ -1731,7 +1750,35 @@ public partial class RestoreViewModel : ViewModelBase
             ExecutionComplete = true;
             FlushConsole();   // nothing buffered may outlive the run
             RefreshCancelState();
+
+            // After the flush, so the recorded log is the whole console rather than whatever had
+            // made it out of the batching buffer. Recorded for every outcome including cancelled -
+            // "I stopped it" is exactly the kind of thing a change ticket needs to say.
+            if (attempted) RecordHistory(startedAt, outcome, failure);
         }
+    }
+
+    /// <summary>
+    /// Files this execution in the history (#31). Never throws: the store swallows its own
+    /// failures, and a restore must not be reported as failed because a record could not be kept.
+    /// </summary>
+    private void RecordHistory(DateTime startedAt, RestoreOutcome outcome, string? failure)
+    {
+        _history.Append(new RestoreHistoryEntry
+        {
+            StartedAt = startedAt,
+            CompletedAt = DateTime.Now,
+            ServerName = ConnectedServer?.ServerName ?? "unknown",
+            TargetDatabase = TargetDatabaseName,
+            ContainerName = SelectedContainer?.Name,
+            SourceDatabase = SelectedDatabaseName,
+            RestorePointTimestamp = SelectedRestorePoint?.Timestamp,
+            ChainSummary = RestoreChain?.Summary ?? "no chain",
+            Outcome = outcome,
+            ErrorMessage = failure,
+            Script = GeneratedScript,
+            Log = ConsoleText
+        });
     }
 
     /// <summary>
@@ -1910,6 +1957,65 @@ public partial class RestoreViewModel : ViewModelBase
     [RelayCommand]
     private void CopyConsole()
         => TryCopyToClipboard(ConsoleText, "Execution log copied to clipboard.");
+
+    /// <summary>
+    /// Writes the console to a file, with a header saying what it was (#31). The clipboard is fine
+    /// for pasting into a chat window; a change ticket or an incident write-up wants a file, and
+    /// wants it to say which server and which database on its own.
+    /// </summary>
+    [RelayCommand]
+    private void SaveConsole()
+    {
+        if (string.IsNullOrEmpty(ConsoleText))
+        {
+            SetError("There is no execution log to save yet.");
+            return;
+        }
+
+        var dialog = new SaveFileDialog
+        {
+            Filter = "Text Files (*.txt)|*.txt|Log Files (*.log)|*.log|All Files (*.*)|*.*",
+            DefaultExt = ".txt",
+            FileName = $"ninelives_{TargetDatabaseName}_{DateTime.Now:yyyyMMdd_HHmmss}.txt"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, BuildSavedLog());
+            SetStatus($"Execution log saved to {dialog.FileName}");
+        }
+        catch (Exception ex)
+        {
+            // Read-only location, full disk, or a path the database name made invalid. Any of
+            // those used to take the whole app down from inside a synchronous command (#13).
+            SetError($"Could not save the execution log: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The console plus the context needed to read it a week later. Redacted on the way out for
+    /// the same reason the operation log is - this file gets attached to tickets.
+    /// </summary>
+    private string BuildSavedLog()
+    {
+        var header = new StringBuilder();
+        header.AppendLine("Nine Lives - restore execution log");
+        header.AppendLine($"Saved:      {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+        header.AppendLine($"Server:     {ConnectedServer?.ServerName ?? "not connected"}");
+        header.AppendLine($"Target:     {TargetDatabaseName}");
+        if (SelectedContainer != null)
+            header.AppendLine($"Container:  {SelectedContainer.Name}");
+        if (SelectedRestorePoint != null)
+            header.AppendLine($"Point:      {SelectedRestorePoint.TimestampDisplay}");
+        header.AppendLine($"Chain:      {RestoreChain?.Summary ?? "none"}");
+        header.AppendLine($"Outcome:    {(ExecutionComplete ? (ExecutionSuccess ? "Succeeded" : "Did not succeed") : "Still running")}");
+        header.AppendLine(new string('-', 60));
+        header.AppendLine();
+
+        return LogRedactor.Redact(header + ConsoleText);
+    }
 
     private async Task RunArmCountdownAsync(CancellationToken ct)
     {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -30,6 +30,24 @@ public partial class RestoreViewModel : ViewModelBase
     private readonly OperationCancellation _loadCancellation = new();
     private readonly OperationCancellation _executeCancellation = new();
 
+    /// <summary>
+    /// The server queries a user starts and might want to abandon: verify, validate, the two
+    /// metadata reads, creating the credential, and the post-failure recovery actions (#111).
+    ///
+    /// They share one source because they are mutually exclusive buttons - starting one while
+    /// another runs should stop the first, which is exactly what Begin() does. RESTORE VERIFYONLY
+    /// reads every byte of every backup in the chain at CommandTimeout = 0, so on a large chain
+    /// this was hours with no Stop button and no timeout.
+    /// </summary>
+    private readonly OperationCancellation _queryCancellation = new();
+
+    /// <summary>
+    /// The background credential check. Separate because it is not user-initiated and has no
+    /// button - and because it races itself: two overlapping checks would leave the panel showing
+    /// the result for whichever finished last, which could be the container the user just left.
+    /// </summary>
+    private readonly OperationCancellation _credentialCheckCancellation = new();
+
     #region Observable Properties
 
     [ObservableProperty]
@@ -206,6 +224,10 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _canCancelExecute;
 
+    /// <summary>True while a server query is running and has not been asked to stop (#111).</summary>
+    [ObservableProperty]
+    private bool _canCancelQuery;
+
     /// <summary>True between asking to stop and the operation actually unwinding.</summary>
     [ObservableProperty]
     private bool _isCancelling;
@@ -244,7 +266,10 @@ public partial class RestoreViewModel : ViewModelBase
     {
         CanCancelLoad = _loadCancellation.CanCancel;
         CanCancelExecute = _executeCancellation.CanCancel;
-        IsCancelling = _loadCancellation.IsCancelling || _executeCancellation.IsCancelling;
+        CanCancelQuery = _queryCancellation.CanCancel;
+        IsCancelling = _loadCancellation.IsCancelling
+            || _executeCancellation.IsCancelling
+            || _queryCancellation.IsCancelling;
     }
 
     /// <summary>True once the chain has been checked against RESTORE HEADERONLY metadata.</summary>
@@ -445,17 +470,28 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
+        // Cancels any check already in flight. Two overlapping checks left the panel showing the
+        // result of whichever finished LAST, which could be the container the user had just left -
+        // and that panel is what someone reads before deciding whether to create a credential.
+        var ct = _credentialCheckCancellation.Begin();
+
         IsCheckingCredential = true;
         CredentialStatusMessage = "Checking...";
-        var server = ConnectedServer!;
+        var server = ConnectedServer;
         try
         {
-            var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
+            var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName, ct);
             CredentialExistsOnServer = exists;
             CredentialIsValidSas = exists && isSas;
             CredentialStatusMessage = exists
                 ? (isSas ? "Credential is present and valid (SHARED ACCESS SIGNATURE)." : "Credential exists but is not a SAS credential; restore may fail.")
                 : "Credential is not present on this server. Restore will fail unless you create it.";
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer check - which is about to write its own answer here. Saying
+            // anything would just be the older check having the last word again.
+            return;
         }
         catch (Exception ex)
         {
@@ -465,8 +501,15 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
-            IsCheckingCredential = false;
-            CreateCredentialOnServerCommand.NotifyCanExecuteChanged();
+            // Only when this check is still the current one. Ending the newer check's source, or
+            // clearing its "Checking..." state, is how the previous version left the panel
+            // reporting the container the user had already moved away from.
+            if (!ct.IsCancellationRequested)
+            {
+                _credentialCheckCancellation.End();
+                IsCheckingCredential = false;
+                CreateCredentialOnServerCommand.NotifyCanExecuteChanged();
+            }
         }
     }
 
@@ -825,6 +868,20 @@ public partial class RestoreViewModel : ViewModelBase
         return new BlobListingScope(pathServer, SelectedDatabaseName);
     }
 
+    /// <summary>
+    /// Stops whichever server query is running - verify, validate, a metadata read, or a recovery
+    /// action. They share one source because they are mutually exclusive buttons (#111).
+    /// </summary>
+    [RelayCommand]
+    private void CancelQuery()
+    {
+        if (!_queryCancellation.CanCancel) return;
+
+        _queryCancellation.Cancel();
+        RefreshCancelState();
+        SetStatus("Stopping...");
+    }
+
     /// <summary>Stops an in-progress backup listing.</summary>
     [RelayCommand]
     private void CancelLoad()
@@ -1165,7 +1222,8 @@ public partial class RestoreViewModel : ViewModelBase
         PathSourceText = $"Querying {ConnectedServer.ServerName} for default paths...";
         try
         {
-            var (dataPath, logPath) = await _sqlService.GetDefaultPathsAsync(ConnectedServer);
+            var (dataPath, logPath) = await _sqlService.GetDefaultPathsAsync(
+                ConnectedServer, _queryCancellation.Begin());
             var dbName = string.IsNullOrWhiteSpace(TargetDatabaseName) ? "DatabaseName" : TargetDatabaseName;
 
             if (!string.IsNullOrEmpty(dataPath))
@@ -1286,18 +1344,28 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || ConnectedServer == null) return;
 
+        var ct = _queryCancellation.Begin();
         IsValidatingChain = true;
+        RefreshCancelState();
         ClearStatus();
         try
         {
             var headers = new List<ChainHeader>();
             foreach (var set in RestoreChain.AllSets)
             {
+                ct.ThrowIfCancellationRequested();
+
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 try
                 {
-                    var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls);
+                    var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls, ct);
                     headers.Add(new ChainHeader(set, header));
+                }
+                catch (OperationCanceledException)
+                {
+                    // Asked for. Must not be swallowed by the per-member catch below, which exists
+                    // so ONE unreadable backup does not abort the rest.
+                    throw;
                 }
                 catch (Exception)
                 {
@@ -1314,13 +1382,19 @@ public partial class RestoreViewModel : ViewModelBase
                 ? $"Chain validation found problems - see the panel above."
                 : $"Chain validated: {headers.Count} backup(s) read, LSN chain is intact.");
         }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Chain validation cancelled.");
+        }
         catch (Exception ex)
         {
             SetError($"Chain validation failed: {ex.Message}");
         }
         finally
         {
+            _queryCancellation.End();
             IsValidatingChain = false;
+            RefreshCancelState();
         }
     }
 
@@ -1341,7 +1415,9 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || ConnectedServer == null) return;
 
+        var ct = _queryCancellation.Begin();
         IsVerifyingChain = true;
+        RefreshCancelState();
         ClearStatus();
         ChainVerifyResults.Clear();
         HasVerifyResults = false;
@@ -1356,7 +1432,7 @@ public partial class RestoreViewModel : ViewModelBase
 
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 var result = await _sqlService.RestoreVerifyOnlyAsync(
-                    ConnectedServer, urls, WithChecksum);
+                    ConnectedServer, urls, WithChecksum, ct);
 
                 ChainVerifyResults.Add(new ChainVerifyResult { Set = set, Result = result });
                 HasVerifyResults = true;
@@ -1379,7 +1455,9 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _queryCancellation.End();
             IsVerifyingChain = false;
+            RefreshCancelState();
         }
     }
 
@@ -1667,7 +1745,8 @@ public partial class RestoreViewModel : ViewModelBase
         try
         {
             var change = await _sqlService.EnsureCredentialExistsAsync(
-                ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
+                ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken,
+                _queryCancellation.Begin());
             await RefreshCredentialStatusAsync();
             SetStatus(change == CredentialChange.Created
                 ? "Credential created on server."
@@ -1712,13 +1791,15 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || ConnectedServer == null || SelectedContainer == null) return;
 
+        var ct = _queryCancellation.Begin();
         IsBusy = true;
+        RefreshCancelState();
         BackupMetadataSummary = null;
         try
         {
             // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
             var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls);
+            var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls, ct);
 
             var dataDir = Path.GetDirectoryName(MoveDataFilePath) ?? @"C:\SQL\Data";
             var logDir = Path.GetDirectoryName(MoveLogFilePath) ?? dataDir;
@@ -1749,7 +1830,9 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _queryCancellation.End();
             IsBusy = false;
+            RefreshCancelState();
         }
     }
 
@@ -1761,12 +1844,14 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (RestoreChain == null || ConnectedServer == null || SelectedContainer == null) return;
 
+        var ct = _queryCancellation.Begin();
         IsBusy = true;
+        RefreshCancelState();
         try
         {
             // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
             var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls);
+            var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls, ct);
 
             if (header == null)
             {
@@ -1795,7 +1880,9 @@ public partial class RestoreViewModel : ViewModelBase
         }
         finally
         {
+            _queryCancellation.End();
             IsBusy = false;
+            RefreshCancelState();
         }
     }
 
@@ -2148,20 +2235,39 @@ public partial class RestoreViewModel : ViewModelBase
     {
         if (action == null || ConnectedServer == null) return;
 
+        // Cancellable, and it needs it more than most: this runs when a restore has already
+        // failed, RESTORE ... WITH RECOVERY can take a long time on a large database, and it goes
+        // out at CommandTimeout = 0. Without a Stop the only way out was killing the process - at
+        // the exact moment the user is trying to get their database back.
+        var ct = _queryCancellation.Begin();
+        RefreshCancelState();
+
         try
         {
             AppendLog($"\nRunning: {action.Sql}");
-            await _sqlService.ExecuteRecoveryActionAsync(ConnectedServer, action.Sql);
+            await _sqlService.ExecuteRecoveryActionAsync(ConnectedServer, action.Sql, ct);
             AppendLog("Completed.");
             await ReportRecoveryStateAsync(ConnectedServer);
 
             if (!HasRecoveryActions)
                 SetStatus($"[{TargetDatabaseName}] is back to a usable state.");
         }
+        catch (OperationCanceledException)
+        {
+            // SQL Server rolls back the statement that was in flight, so the database is where it
+            // was before this step - which is still whatever the failed restore left behind.
+            AppendLog("\nCancelled. The database is in the same state as before this step.");
+            SetStatus("Recovery step cancelled.");
+        }
         catch (Exception ex)
         {
             AppendLog($"\nERROR: {ex.Message}");
             SetError($"Recovery step failed: {ex.Message}");
+        }
+        finally
+        {
+            _queryCancellation.End();
+            RefreshCancelState();
         }
     }
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -323,8 +323,31 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool? _credentialExistsOnServer; // null = not checked
 
+    // What the credential of that name actually authenticates as. The three views below are
+    // derived rather than stored: they used to be one bool that conflated "not a SAS credential"
+    // with "unusable", which is how a managed identity came to be treated as damage (#145).
     [ObservableProperty]
-    private bool _credentialIsValidSas; // true when exists and identity is SHARED ACCESS SIGNATURE
+    private BlobCredentialIdentity _credentialIdentityKind = BlobCredentialIdentity.Missing;
+
+    /// <summary>A restore can authenticate with what is on the server as it stands.</summary>
+    public bool CredentialIsUsable =>
+        CredentialIdentityKind is BlobCredentialIdentity.SharedAccessSignature
+            or BlobCredentialIdentity.ManagedIdentity;
+
+    /// <summary>The credential holds a SAS, so the stored token is the thing that can go stale.</summary>
+    public bool CredentialIsSharedAccessSignature =>
+        CredentialIdentityKind == BlobCredentialIdentity.SharedAccessSignature;
+
+    /// <summary>The instance authenticates to storage as itself, and this app must not touch it.</summary>
+    public bool CredentialIsManagedIdentity =>
+        CredentialIdentityKind == BlobCredentialIdentity.ManagedIdentity;
+
+    partial void OnCredentialIdentityKindChanged(BlobCredentialIdentity value)
+    {
+        OnPropertyChanged(nameof(CredentialIsUsable));
+        OnPropertyChanged(nameof(CredentialIsSharedAccessSignature));
+        OnPropertyChanged(nameof(CredentialIsManagedIdentity));
+    }
 
     [ObservableProperty]
     private string _credentialStatusMessage = string.Empty;
@@ -386,7 +409,7 @@ public partial class RestoreViewModel : ViewModelBase
         {
             CredentialExistsOnServer = null;
             CredentialStatusMessage = string.Empty;
-            CredentialIsValidSas = false;
+            CredentialIdentityKind = BlobCredentialIdentity.Missing;
             return;
         }
 
@@ -400,12 +423,10 @@ public partial class RestoreViewModel : ViewModelBase
         var server = ConnectedServer;
         try
         {
-            var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName, ct);
-            CredentialExistsOnServer = exists;
-            CredentialIsValidSas = exists && isSas;
-            CredentialStatusMessage = exists
-                ? (isSas ? "Credential is present and valid (SHARED ACCESS SIGNATURE)." : "Credential exists but is not a SAS credential; restore may fail.")
-                : "Credential is not present on this server. Restore will fail unless you create it.";
+            var credential = await _sqlService.CredentialExistsAsync(server, SqlCredentialName, ct);
+            CredentialExistsOnServer = credential.Exists;
+            CredentialIdentityKind = credential.Kind;
+            CredentialStatusMessage = DescribeCredential(credential);
         }
         catch (OperationCanceledException)
         {
@@ -416,7 +437,7 @@ public partial class RestoreViewModel : ViewModelBase
         catch (Exception ex)
         {
             CredentialExistsOnServer = null;
-            CredentialIsValidSas = false;
+            CredentialIdentityKind = BlobCredentialIdentity.Missing;
             CredentialStatusMessage = $"Could not check credential: {ex.Message}";
         }
         finally
@@ -432,6 +453,24 @@ public partial class RestoreViewModel : ViewModelBase
             }
         }
     }
+
+    /// <summary>
+    /// The panel's one line about what is on the server. An unusable credential is named rather
+    /// than just rejected: "not a SAS credential" was the same sentence for a managed identity
+    /// that would have restored perfectly well and for a Windows account that never could (#145).
+    /// </summary>
+    internal static string DescribeCredential(BlobCredentialStatus credential) => credential.Kind switch
+    {
+        BlobCredentialIdentity.SharedAccessSignature =>
+            "Credential is present and valid (SHARED ACCESS SIGNATURE).",
+        BlobCredentialIdentity.ManagedIdentity =>
+            "Credential is present and valid (Managed Identity). The restore authenticates as the " +
+            "instance's own identity, so no SAS token is involved and this app will not modify it.",
+        BlobCredentialIdentity.Other =>
+            $"Credential exists with identity '{credential.Identity}', which a restore from URL " +
+            "cannot use. Replace it below, or point at a different credential.",
+        _ => "Credential is not present on this server. Restore will fail unless you create it."
+    };
 
     [ObservableProperty]
     private ObservableCollection<FileMoveOption> _fileMoves = [];
@@ -1432,15 +1471,28 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
+        // What is about to be overwritten, read before the write. This is the only route by which
+        // a managed identity gets replaced by a SAS token, and it should say so afterwards rather
+        // than reporting a routine "updated" for a change to how the instance authenticates (#145).
+        var replaced = CredentialIdentityKind;
+
         try
         {
             var change = await _sqlService.EnsureCredentialExistsAsync(
                 ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken,
                 _queryCancellation.Begin());
             await RefreshCredentialStatusAsync();
-            SetStatus(change == CredentialChange.Created
-                ? "Credential created on server."
-                : "Credential updated on server with the stored SAS token.");
+            SetStatus(change switch
+            {
+                CredentialChange.Created => "Credential created on server.",
+                _ when replaced == BlobCredentialIdentity.ManagedIdentity =>
+                    "Credential replaced on server: it authenticated as the instance's managed " +
+                    "identity and now holds the stored SAS token.",
+                _ => "Credential updated on server with the stored SAS token."
+            });
+            if (replaced == BlobCredentialIdentity.ManagedIdentity)
+                _log.ServerChange(ConnectedServer.ServerName,
+                    $"credential [{SqlCredentialName}] identity changed from Managed Identity to SAS");
         }
         catch (Exception ex)
         {
@@ -1737,16 +1789,38 @@ public partial class RestoreViewModel : ViewModelBase
                     // a rotated SAS that no longer works - that is unknowable from here, since the
                     // secret cannot be read back - so the fix for that case is the explicit
                     // refresh button, not silently rewriting server state on every run.
-                    var (exists, isSas) = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
-                    if (exists && isSas)
+                    //
+                    // A managed identity is left alone for a stronger reason: it restores perfectly
+                    // well, this app cannot create one, and ALTER would reset the identity. Reading
+                    // "not SAS" as "broken" is what silently converted somebody's working managed
+                    // identity into a SAS token here, taking every other job on that container with
+                    // it, under the log line "Credential updated on the server" (#145).
+                    var credential = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
+                    if (credential.CanRestoreFromUrl)
                     {
-                        AppendLog($"Using the existing SQL credential [{SqlCredentialName}]. Server state not modified.");
+                        AppendLog(credential.Kind == BlobCredentialIdentity.ManagedIdentity
+                            ? $"Using the existing SQL credential [{SqlCredentialName}] (Managed Identity). Server state not modified."
+                            : $"Using the existing SQL credential [{SqlCredentialName}]. Server state not modified.");
+                    }
+                    else if (credential.Exists)
+                    {
+                        // Neither usable nor ours to reinterpret. Converting it is a real option -
+                        // it is what the button on the panel does - but it must be a decision
+                        // somebody made, not a side effect of pressing Execute. Stopping here costs
+                        // a restore that was about to fail on blob access anyway.
+                        attempted = false;
+                        var message =
+                            $"Credential [{SqlCredentialName}] exists with identity " +
+                            $"'{credential.Identity}', which a restore from URL cannot use. Left " +
+                            "untouched: replacing it with the stored SAS token is what " +
+                            "\"Create credential on server\" does, so that it is a deliberate change.";
+                        AppendLog(message);
+                        SetError(message);
+                        return;
                     }
                     else
                     {
-                        AppendLog(exists
-                            ? $"Credential [{SqlCredentialName}] exists but is not a SAS credential - updating it..."
-                            : $"Credential [{SqlCredentialName}] is missing - creating it...");
+                        AppendLog($"Credential [{SqlCredentialName}] is missing - creating it...");
 
                         // This statement carries the SAS token to the server. It is the one moment
                         // in a restore where a secret crosses the wire, so if the connection is

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -386,7 +386,51 @@ public partial class RestoreViewModel : ViewModelBase
         if (value != null)
             SqlCredentialName = value.ContainerUrl;
         CredentialSectionVisible = value != null;
+
+        // Everything on screen below this point came from the PREVIOUS container. Leaving it there
+        // meant the credential panel and Create credential targeted the new container while the
+        // script still restored from the old one's URLs - so Execute stayed armed and enabled, and
+        // failed with Msg 3201 after WITH REPLACE had already dropped the target.
+        ClearLoadedBackups();
+
         _ = RefreshCredentialStatusAsync();
+    }
+
+    /// <summary>
+    /// Drops everything derived from a container's contents. Called when the container changes and
+    /// when a load is abandoned, so what is on screen always belongs to the container named above
+    /// it.
+    /// </summary>
+    private void ClearLoadedBackups()
+    {
+        _allBackups = [];
+        _allSets = [];
+        _dbSets = [];
+        _allPoints = [];
+
+        BackupsLoaded = false;
+        DiscoveredServers = [];
+        DiscoveredDatabases = [];
+        SelectedServerName = null;
+        SelectedDatabaseName = null;
+
+        RestorePoints = [];
+        HasRestorePoints = false;
+        HasVisiblePoints = false;
+        PointCountText = string.Empty;
+        RestoreWindowText = string.Empty;
+        TimelineTicks.Clear();
+        TimelineHeight = 50;
+
+        // Assigning null runs the selection handler, which clears the chain, the script, the
+        // verification results and the inventory findings.
+        SelectedRestorePoint = null;
+
+        // Disarm. An armed Execute that survives a container change is an armed Execute aimed at
+        // something the user is no longer looking at.
+        IsExecuteArmed = false;
+        ExecuteButtonText = "Execute on Server";
+        _armTimeoutCts?.Cancel();
     }
 
     /// <summary>Call when ConnectedServer or SelectedContainer changes so credential status is updated.</summary>
@@ -647,6 +691,11 @@ public partial class RestoreViewModel : ViewModelBase
             InspectBackupMetadataCommand.NotifyCanExecuteChanged();
             CopyFileListOnlyCommandCommand.NotifyCanExecuteChanged();
             CopyHeaderOnlyCommandCommand.NotifyCanExecuteChanged();
+
+            // No selected point means no script. Clearing the chain and leaving the script behind
+            // left a complete, authoritative-looking RESTORE on screen with nothing selected above
+            // it - which is the stale-script problem in its purest form.
+            UpdateRestoreSummary();
             return;
         }
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1597,11 +1597,51 @@ public partial class RestoreViewModel : ViewModelBase
 
     // Verification opens its own connection and reads whole backups. Letting it start while a
     // restore is running would put a second heavy reader on the same server at the worst moment.
-    partial void OnIsExecutingChanged(bool value) => VerifyChainCommand.NotifyCanExecuteChanged();
+    partial void OnIsExecutingChanged(bool value)
+    {
+        VerifyChainCommand.NotifyCanExecuteChanged();
+        RefreshExecuteBlockedReason();
+    }
+
+    /// <summary>
+    /// Why Execute cannot be pressed, or empty when it can.
+    ///
+    /// The button was disabled identically whether the user was not connected, had no script, or
+    /// had a chain the app already knows will not restore. Three different problems, one greyed-out
+    /// button, and the information was all sitting in properties nobody showed.
+    /// </summary>
+    public string ExecuteBlockedReason
+    {
+        get
+        {
+            if (IsExecuting) return string.Empty;
+            if (!IsConnectedToServer) return "Connect to a SQL Server to execute this restore.";
+            if (!HasScript) return "No script yet - pick a restore point and a target database name.";
+            if (HasChainErrors) return "This chain cannot restore. See the problems listed above.";
+            return string.Empty;
+        }
+    }
+
+    public bool IsExecuteBlocked => ExecuteBlockedReason.Length > 0;
+
+    /// <summary>The button's own IsEnabled, so the reason and the enabled state cannot disagree.</summary>
+    public bool CanPressExecute => !IsExecuteBlocked;
+
+    private void RefreshExecuteBlockedReason()
+    {
+        OnPropertyChanged(nameof(ExecuteBlockedReason));
+        OnPropertyChanged(nameof(IsExecuteBlocked));
+        OnPropertyChanged(nameof(CanPressExecute));
+    }
+
+    partial void OnHasScriptChanged(bool value) => RefreshExecuteBlockedReason();
+
+    partial void OnHasChainErrorsChanged(bool value) => RefreshExecuteBlockedReason();
     partial void OnTargetDatabaseNameChanged(string value) => UpdateRestoreSummary();
 
     partial void OnIsConnectedToServerChanged(bool value)
     {
+        RefreshExecuteBlockedReason();
         var chips = value && ConnectedServer != null
             ? ConnectedServer.TagChips
             : [];

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -436,6 +436,24 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private ObservableCollection<FileMoveOption> _fetchedFileMoves = [];
 
+    /// <summary>
+    /// Each row is edited in place in the grid, so the script has to follow the ROW, not just the
+    /// collection. Without this, retyping a target path changed what was on screen and nothing
+    /// else - and the script is what gets executed.
+    /// </summary>
+    partial void OnFetchedFileMovesChanged(
+        ObservableCollection<FileMoveOption>? oldValue,
+        ObservableCollection<FileMoveOption> newValue)
+    {
+        if (oldValue != null)
+            foreach (var move in oldValue) move.PropertyChanged -= OnFileMoveChanged;
+
+        foreach (var move in newValue) move.PropertyChanged += OnFileMoveChanged;
+    }
+
+    private void OnFileMoveChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        => UpdateRestoreSummary();
+
     [ObservableProperty]
     private bool _hasFetchedFileMoves;
 
@@ -1440,6 +1458,16 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnWithChecksumChanged(bool value) => UpdateRestoreSummary();
     partial void OnContinueAfterErrorChanged(bool value) => UpdateRestoreSummary();
 
+    // These four are typed into text boxes rather than ticked, and every one of them was missing
+    // its handler - so the script on screen did not change when they did. That is the exact
+    // failure RegenerateScript exists to prevent: typing a new data-file path, watching the box
+    // update, and running a script that still had the old one - or, for WITH MOVE, no MOVE clause
+    // at all, sending the restore to the file paths baked into the backup.
+    partial void OnMoveDataFilePathChanged(string value) => UpdateRestoreSummary();
+    partial void OnMoveLogFilePathChanged(string value) => UpdateRestoreSummary();
+    partial void OnStandbyFilePathChanged(string value) => UpdateRestoreSummary();
+    partial void OnStatsPercentChanged(int value) => UpdateRestoreSummary();
+
     // Verification opens its own connection and reads whole backups. Letting it start while a
     // restore is running would put a second heavy reader on the same server at the worst moment.
     partial void OnIsExecutingChanged(bool value) => VerifyChainCommand.NotifyCanExecuteChanged();
@@ -1460,6 +1488,15 @@ public partial class RestoreViewModel : ViewModelBase
         CopyFileListOnlyCommandCommand.NotifyCanExecuteChanged();
         CopyHeaderOnlyCommandCommand.NotifyCanExecuteChanged();
     }
+
+    /// <summary>
+    /// STANDBY needs somewhere to put its undo file. Blank produced <c>STANDBY = ''</c>, which
+    /// SQL Server rejects - as the LAST statement of the chain, so it failed after SET SINGLE_USER
+    /// and WITH REPLACE had already dropped and overwritten the target, leaving it in RESTORING
+    /// and single-user with nothing to show for it.
+    /// </summary>
+    private bool HasStandbyFileIfNeeded =>
+        RecoveryMode != RecoveryMode.Standby || !string.IsNullOrWhiteSpace(StandbyFilePath);
 
     /// <summary>
     /// Explicit Generate. Same work as the live rebuild, but it says why nothing was produced -
@@ -1488,6 +1525,13 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
+        if (!HasStandbyFileIfNeeded)
+        {
+            SetError("STANDBY needs an undo file path. Without one the script would end in " +
+                     "STANDBY = '', which fails after the database has already been overwritten.");
+            return;
+        }
+
         RegenerateScript();
         if (HasScript) SetStatus("Script generated successfully.");
     }
@@ -1510,7 +1554,8 @@ public partial class RestoreViewModel : ViewModelBase
 
         if (RestoreChain == null
             || string.IsNullOrWhiteSpace(TargetDatabaseName)
-            || (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null))
+            || (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null)
+            || !HasStandbyFileIfNeeded)
         {
             GeneratedScript = string.Empty;
             HasScript = false;
@@ -1763,14 +1808,32 @@ public partial class RestoreViewModel : ViewModelBase
         if (string.IsNullOrEmpty(GeneratedScript) || !IsConnectedToServer)
             return;
 
-        // Refuse to arm when the chain cannot possibly restore. This is the last safe moment:
+        // Rebuild before arming, so what runs is what the options currently say - not whatever the
+        // last change handler happened to leave behind. Every option is supposed to keep the script
+        // in step on its own; this is the backstop that makes forgetting one a stale display rather
+        // than a restore that does something different from what it shows.
+        RegenerateScript();
+        if (string.IsNullOrEmpty(GeneratedScript))
+        {
+            SetError("The current options do not produce a script. Check the settings above.");
+            IsExecuteArmed = false;
+            ExecuteButtonText = "Execute on Server";
+            return;
+        }
+
+        // Refuse to run when the chain cannot possibly restore. This is the last safe moment:
         // once execution starts, WITH REPLACE drops the target database, and a chain that fails
         // partway leaves nothing usable behind. Failing here costs the user a few seconds;
         // failing mid-restore costs them the database they were restoring over.
-        if (HasChainErrors && !IsExecuteArmed)
+        //
+        // Checked on the confirm press as well as when arming: validation can finish during the
+        // five-second countdown and find an error that was not known when the button was armed.
+        if (HasChainErrors)
         {
             var first = ChainIssues.First(i => i.IsError);
             SetError($"Cannot execute: {first.Title}. {first.Detail}");
+            IsExecuteArmed = false;
+            ExecuteButtonText = "Execute on Server";
             return;
         }
 
@@ -1801,6 +1864,10 @@ public partial class RestoreViewModel : ViewModelBase
 
         var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
+        // Reset alongside ExecutionComplete. Left over from a previous run it could combine with an
+        // early bail-out to show the success banner - and write "Outcome: Succeeded" into a saved
+        // log - for a restore that never ran.
+        ExecutionSuccess = false;
         ExecutionComplete = false;
         ConsoleLines.Clear();
         HasConsoleOutput = false;

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1795,10 +1795,15 @@ public partial class RestoreViewModel : ViewModelBase
         IsBusy = true;
         RefreshCancelState();
         BackupMetadataSummary = null;
+        // Captured BEFORE the await. Selecting a different restore point sets RestoreChain to null
+        // on the UI thread, and it can do that while this call is in flight - in which case the
+        // catch below would itself throw, replacing the error explaining why FILELISTONLY failed
+        // with a bare "Nine Lives hit an unexpected error".
+        // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
+        var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+
         try
         {
-            // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
-            var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
             var list = await _sqlService.RestoreFileListOnlyAsync(ConnectedServer, urls, ct);
 
             var dataDir = Path.GetDirectoryName(MoveDataFilePath) ?? @"C:\SQL\Data";
@@ -1821,9 +1826,8 @@ public partial class RestoreViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            var urlList = RestoreChain!.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var urlPreview = urlList.Count > 0 ? urlList[0] : "(no URL)";
-            if (urlList.Count > 1) urlPreview += $" (+{urlList.Count - 1} more)";
+            var urlPreview = urls.Count > 0 ? urls[0] : "(no URL)";
+            if (urls.Count > 1) urlPreview += $" (+{urls.Count - 1} more)";
             SetError($"RESTORE FILELISTONLY failed: {ex.Message}. URL used: {urlPreview}. Run the same RESTORE FILELISTONLY in SSMS to confirm credential/network.");
             FetchedFileMoves = [];
             HasFetchedFileMoves = false;
@@ -1847,10 +1851,12 @@ public partial class RestoreViewModel : ViewModelBase
         var ct = _queryCancellation.Begin();
         IsBusy = true;
         RefreshCancelState();
+        // Captured before the await - see the note on FetchLogicalNamesAsync.
+        // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
+        var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+
         try
         {
-            // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
-            var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
             var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls, ct);
 
             if (header == null)
@@ -1872,9 +1878,8 @@ public partial class RestoreViewModel : ViewModelBase
         }
         catch (Exception ex)
         {
-            var urlList = RestoreChain!.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
-            var urlPreview = urlList.Count > 0 ? urlList[0] : "(no URL)";
-            if (urlList.Count > 1) urlPreview += $" (+{urlList.Count - 1} more)";
+            var urlPreview = urls.Count > 0 ? urls[0] : "(no URL)";
+            if (urls.Count > 1) urlPreview += $" (+{urls.Count - 1} more)";
             SetError($"RESTORE HEADERONLY failed: {ex.Message}. URL used: {urlPreview}. Run the same RESTORE HEADERONLY in SSMS to confirm credential/network.");
             BackupMetadataSummary = null;
         }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Windows;
@@ -13,12 +13,12 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class RestoreViewModel : ViewModelBase
 {
-    private readonly BlobStorageService _blobService;
-    private readonly SqlServerService _sqlService;
+    private readonly IBlobStorageService _blobService;
+    private readonly ISqlServerService _sqlService;
     private readonly BackupChainBuilder _chainBuilder;
     private readonly RestoreScriptGenerator _scriptGenerator;
     private readonly BackupChainValidator _chainValidator = new();
-    private readonly CredentialStore _credentialStore;
+    private readonly ICredentialStore _credentialStore;
 
     private List<BackupFileInfo> _allBackups = [];
     private List<BackupSet> _allSets = [];
@@ -461,19 +461,28 @@ public partial class RestoreViewModel : ViewModelBase
     #endregion
 
     public RestoreViewModel(
-        BlobStorageService blobService,
-        SqlServerService sqlService,
+        IBlobStorageService blobService,
+        ISqlServerService sqlService,
         BackupChainBuilder chainBuilder,
         RestoreScriptGenerator scriptGenerator,
-        CredentialStore credentialStore)
+        ICredentialStore credentialStore,
+        OperationLog? log = null)
     {
         _blobService = blobService;
         _sqlService = sqlService;
         _chainBuilder = chainBuilder;
         _scriptGenerator = scriptGenerator;
         _credentialStore = credentialStore;
+
+        // Defaults to the app's one log. Optional so a test can point it at a temp directory -
+        // without it, running the execute path in a test appends real restore lines to the user's
+        // actual log file, which is the same class of side effect this whole change is about.
+        _log = log ?? App.Log;
+
         RefreshContainers();
     }
+
+    private readonly OperationLog _log;
 
     public void RefreshContainers()
     {
@@ -651,7 +660,12 @@ public partial class RestoreViewModel : ViewModelBase
                 ComputeAndDisplayRestorePoints();
             }
 
-            SetStatus($"Loaded {_allBackups.Count} files in {_allSets.Count} backup set(s) across {dbs.Count} database(s).");
+            // Only when nothing above went wrong. Selecting the first server or database runs the
+            // whole filter-and-compute cascade, which can end in "no valid restore points found" -
+            // and painting a success line over that left an empty timeline with the status bar
+            // cheerfully reporting how many files had loaded. Found by the first ViewModel test.
+            if (!HasError)
+                SetStatus($"Loaded {_allBackups.Count} files in {_allSets.Count} backup set(s) across {dbs.Count} database(s).");
         }
         catch (OperationCanceledException)
         {
@@ -1653,13 +1667,13 @@ public partial class RestoreViewModel : ViewModelBase
 
                         // Changing a credential is a change to shared state on someone's instance.
                         // It belongs in the file, not only in a console that closes with the app.
-                        App.Log.ServerChange(server.ServerName,
+                        _log.ServerChange(server.ServerName,
                             $"credential [{SqlCredentialName}] {change.ToString().ToLowerInvariant()}");
                     }
                 }
             }
 
-            App.Log.ServerChange(server.ServerName,
+            _log.ServerChange(server.ServerName,
                 $"restore starting: target [{TargetDatabaseName}], " +
                 $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={WithReplace}, " +
                 $"recovery={RecoveryMode}, stopAt={EffectiveStopAt?.ToString("s") ?? "none"}");
@@ -1691,7 +1705,7 @@ public partial class RestoreViewModel : ViewModelBase
             AppendLog("\nCANCELLED. The statement in flight was rolled back by SQL Server, but the " +
                       "restore stopped part-way through the chain.");
 
-            App.Log.ServerChange(ConnectedServer?.ServerName ?? "unknown",
+            _log.ServerChange(ConnectedServer?.ServerName ?? "unknown",
                 $"restore CANCELLED by user, target [{TargetDatabaseName}]");
 
             SetError("Restore cancelled. The target database has been left mid-restore - see below.");
@@ -1845,7 +1859,7 @@ public partial class RestoreViewModel : ViewModelBase
             _pending.Add(ConsoleLine.From(line));
         }
 
-        App.Log.Info($"[execute] {message.Trim()}");
+        _log.Info($"[execute] {message.Trim()}");
         ScheduleConsoleFlush();
     }
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -242,16 +242,6 @@ public partial class RestoreViewModel : ViewModelBase
     // ── Execution console ───────────────────────────────────────────────────────
 
     /// <summary>
-    /// The console, one line per entry. A collection rather than one growing string so appending
-    /// costs the same on the thousandth line as on the first.
-    /// </summary>
-    [ObservableProperty]
-    private ObservableCollection<ConsoleLine> _consoleLines = [];
-
-    [ObservableProperty]
-    private bool _hasConsoleOutput;
-
-    /// <summary>
     /// True while the console is showing in its own window.
     ///
     /// The inline console hides itself for the duration, so the output is only ever in one place.
@@ -658,6 +648,10 @@ public partial class RestoreViewModel : ViewModelBase
         // without it, running the execute path in a test appends real restore lines to the user's
         // actual log file, which is the same class of side effect this whole change is about.
         _log = log ?? App.Log;
+
+        // Every console message is written to the log file as it arrives, so the file cannot drift
+        // from what was on screen.
+        Console = new ConsoleBuffer(message => _log.Info($"[execute] {message.Trim()}"));
 
         // IsBusy and TargetDatabaseName live on the base class, so they cannot have a generated
         // partial hook - but the busy strip is computed from them.
@@ -2190,13 +2184,13 @@ public partial class RestoreViewModel : ViewModelBase
 
         var executeToken = _executeCancellation.Begin();
         IsExecuting = true;
+        Console.IsRunning = true;
         // Reset alongside ExecutionComplete. Left over from a previous run it could combine with an
         // early bail-out to show the success banner - and write "Outcome: Succeeded" into a saved
         // log - for a restore that never ran.
         ExecutionSuccess = false;
         ExecutionComplete = false;
-        ConsoleLines.Clear();
-        HasConsoleOutput = false;
+        Console.Clear();
         RecoveryActions = [];
         HasRecoveryActions = false;
         RefreshCancelState();
@@ -2326,8 +2320,9 @@ public partial class RestoreViewModel : ViewModelBase
         {
             _executeCancellation.End();
             IsExecuting = false;
+            Console.IsRunning = false;
             ExecutionComplete = true;
-            FlushConsole();   // nothing buffered may outlive the run
+            Console.Flush();   // nothing buffered may outlive the run
             RefreshCancelState();
 
             // After the flush, so the recorded log is the whole console rather than whatever had
@@ -2356,7 +2351,7 @@ public partial class RestoreViewModel : ViewModelBase
             Outcome = outcome,
             ErrorMessage = failure,
             Script = GeneratedScript,
-            Log = ConsoleText
+            Log = Console.Text
         });
     }
 
@@ -2476,85 +2471,22 @@ public partial class RestoreViewModel : ViewModelBase
     /// Redaction happens inside the log, not here (#40).
     /// </summary>
     /// <summary>
-    /// Appends to the on-screen console and to the log file at the same time, so the file cannot
-    /// drift from what the user was shown.
-    ///
-    /// Writes to a COLLECTION rather than concatenating a bound string. Appending to a bound string
-    /// rebuilds it and re-renders the whole TextBox on every message - O(n^2) - which was a large
-    /// part of why a restore reporting progress every few percent looked like it arrived in bursts
-    /// rather than live.
+    /// The execution console. Its batching and line handling live in ConsoleBuffer (#115) - this
+    /// screen only feeds it and shows it.
     /// </summary>
-    private void AppendLog(string message)
-    {
-        foreach (var raw in message.Split('\n'))
-        {
-            var line = raw.TrimEnd('\r');
-
-            // Messages routinely arrive with a leading or trailing newline for spacing, and SQL
-            // Server's own output has its own blank lines. Left alone that produced a gap between
-            // almost every line. One blank line is allowed as a separator; runs of them are not.
-            if (line.Trim().Length == 0)
-            {
-                if (_pending.Count > 0 && _pending[^1].Text.Length == 0) continue;
-                if (_pending.Count == 0 && (ConsoleLines.Count == 0 || ConsoleLines[^1].Text.Length == 0)) continue;
-                _pending.Add(new ConsoleLine(string.Empty));
-                continue;
-            }
-
-            _pending.Add(ConsoleLine.From(line));
-        }
-
-        _log.Info($"[execute] {message.Trim()}");
-        ScheduleConsoleFlush();
-    }
+    public ConsoleBuffer Console { get; }
 
     /// <summary>
-    /// Moves buffered lines onto the bound collection on a timer rather than as they arrive.
-    ///
-    /// SQL Server emits progress in clusters - several messages within a millisecond, then nothing
-    /// for a second. Adding each one individually meant a layout pass and a scroll per message, in
-    /// bursts, which is what made the console judder. Flushing on a fixed tick turns any arrival
-    /// pattern into a steady redraw, and a whole cluster costs one layout pass instead of ten.
+    /// Appends to the on-screen console and to the log file at the same time, so the file cannot
+    /// drift from what the user was shown.
     /// </summary>
-    private void ScheduleConsoleFlush()
-    {
-        if (_consoleFlushTimer != null) return;
+    private void AppendLog(string message) => Console.Append(message);
 
-        _consoleFlushTimer = new DispatcherTimer(DispatcherPriority.Background)
-        {
-            Interval = TimeSpan.FromMilliseconds(60)
-        };
-        _consoleFlushTimer.Tick += (_, _) => FlushConsole();
-        _consoleFlushTimer.Start();
-    }
 
-    private void FlushConsole()
-    {
-        if (_pending.Count == 0)
-        {
-            // Nothing arriving and nothing running - stop ticking rather than spin forever.
-            if (!IsExecuting)
-            {
-                _consoleFlushTimer?.Stop();
-                _consoleFlushTimer = null;
-            }
-            return;
-        }
-
-        foreach (var line in _pending) ConsoleLines.Add(line);
-        _pending.Clear();
-        HasConsoleOutput = true;
-    }
-
-    private readonly List<ConsoleLine> _pending = [];
-    private DispatcherTimer? _consoleFlushTimer;
-
-    /// <summary>The console as plain text, for copying into a bug report.</summary>
-    public string ConsoleText => string.Join(Environment.NewLine, ConsoleLines.Select(l => l.Text));
 
     [RelayCommand]
     private void CopyConsole()
-        => TryCopyToClipboard(ConsoleText, "Execution log copied to clipboard.");
+        => TryCopyToClipboard(Console.Text, "Execution log copied to clipboard.");
 
     /// <summary>
     /// Writes the console to a file, with a header saying what it was (#31). The clipboard is fine
@@ -2564,7 +2496,7 @@ public partial class RestoreViewModel : ViewModelBase
     [RelayCommand]
     private void SaveConsole()
     {
-        if (string.IsNullOrEmpty(ConsoleText))
+        if (string.IsNullOrEmpty(Console.Text))
         {
             SetError("There is no execution log to save yet.");
             return;
@@ -2612,7 +2544,7 @@ public partial class RestoreViewModel : ViewModelBase
         header.AppendLine(new string('-', 60));
         header.AppendLine();
 
-        return LogRedactor.Redact(header + ConsoleText);
+        return LogRedactor.Redact(header + Console.Text);
     }
 
     private async Task RunArmCountdownAsync(CancellationToken ct)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1517,10 +1517,6 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        var sasToken = SelectedContainer != null
-            ? _credentialStore.GetSasToken(SelectedContainer)
-            : null;
-
         var fileMoves = new List<FileMoveOption>();
         if (UseWithMove)
         {
@@ -1554,9 +1550,6 @@ public partial class RestoreViewModel : ViewModelBase
             NewBroker = NewBroker,
             WithChecksum = WithChecksum,
             ContinueAfterError = ContinueAfterError,
-            SqlCredentialName = SqlCredentialName,
-            SasToken = sasToken,
-            StorageAccountUrl = SelectedContainer?.ContainerUrl,
             FileMoves = fileMoves
         };
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -42,11 +42,10 @@ public partial class RestoreViewModel : ViewModelBase
     private readonly OperationCancellation _queryCancellation = new();
 
     /// <summary>
-    /// The background credential check. Separate because it is not user-initiated and has no
-    /// button - and because it races itself: two overlapping checks would leave the panel showing
-    /// the result for whichever finished last, which could be the container the user just left.
+    /// The server-side credential the restore authenticates with: what is on the instance, what to
+    /// say about it, and what Execute should do before it runs (#115 seam 5).
     /// </summary>
-    private readonly OperationCancellation _credentialCheckCancellation = new();
+    public ServerCredentialViewModel Credential { get; }
 
     #region Observable Properties
 
@@ -277,7 +276,25 @@ public partial class RestoreViewModel : ViewModelBase
 
     public bool ShowMoveOptions => UseWithMove;
 
-    public ServerConnection? ConnectedServer { get; set; }
+    private ServerConnection? _connectedServer;
+
+    /// <summary>
+    /// The instance every server call on this screen runs against.
+    ///
+    /// Setting it re-checks the credential, rather than leaving the caller to remember: forgetting
+    /// left the panel describing the credential on the server someone had just disconnected from,
+    /// and that panel is what they read before deciding whether to create one (#115 seam 5).
+    /// </summary>
+    public ServerConnection? ConnectedServer
+    {
+        get => _connectedServer;
+        set
+        {
+            _connectedServer = value;
+            Credential.Server = value;
+            _ = Credential.RefreshAsync();
+        }
+    }
 
     /// <summary>
     /// Tags of the connected server, shown on the execute confirmation. Chips rather than plain
@@ -316,61 +333,15 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _restoreSummaryText = string.Empty;
 
-    [ObservableProperty]
-    private string _sqlCredentialName = string.Empty;
-
-    // Blob credential status on connected server (credential must exist for RESTORE FROM URL)
-    [ObservableProperty]
-    private bool? _credentialExistsOnServer; // null = not checked
-
-    // What the credential of that name actually authenticates as. The three views below are
-    // derived rather than stored: they used to be one bool that conflated "not a SAS credential"
-    // with "unusable", which is how a managed identity came to be treated as damage (#145).
-    [ObservableProperty]
-    private BlobCredentialIdentity _credentialIdentityKind = BlobCredentialIdentity.Missing;
-
-    /// <summary>A restore can authenticate with what is on the server as it stands.</summary>
-    public bool CredentialIsUsable =>
-        CredentialIdentityKind is BlobCredentialIdentity.SharedAccessSignature
-            or BlobCredentialIdentity.ManagedIdentity;
-
-    /// <summary>The credential holds a SAS, so the stored token is the thing that can go stale.</summary>
-    public bool CredentialIsSharedAccessSignature =>
-        CredentialIdentityKind == BlobCredentialIdentity.SharedAccessSignature;
-
-    /// <summary>The instance authenticates to storage as itself, and this app must not touch it.</summary>
-    public bool CredentialIsManagedIdentity =>
-        CredentialIdentityKind == BlobCredentialIdentity.ManagedIdentity;
-
-    partial void OnCredentialIdentityKindChanged(BlobCredentialIdentity value)
-    {
-        OnPropertyChanged(nameof(CredentialIsUsable));
-        OnPropertyChanged(nameof(CredentialIsSharedAccessSignature));
-        OnPropertyChanged(nameof(CredentialIsManagedIdentity));
-    }
-
-    [ObservableProperty]
-    private string _credentialStatusMessage = string.Empty;
-
-    [ObservableProperty]
-    private bool _isCheckingCredential;
-
-    [ObservableProperty]
-    private bool _credentialSectionVisible;
-
     partial void OnSelectedContainerChanged(BlobContainerConfig? value)
     {
-        if (value != null)
-            SqlCredentialName = value.ContainerUrl;
-        CredentialSectionVisible = value != null;
-
         // Everything on screen below this point came from the PREVIOUS container. Leaving it there
         // meant the credential panel and Create credential targeted the new container while the
         // script still restored from the old one's URLs - so Execute stayed armed and enabled, and
         // failed with Msg 3201 after WITH REPLACE had already dropped the target.
         ClearLoadedBackups();
 
-        _ = RefreshCredentialStatusAsync();
+        _ = Credential.PointAtAsync(value);
     }
 
     /// <summary>
@@ -400,77 +371,6 @@ public partial class RestoreViewModel : ViewModelBase
         ExecuteButtonText = "Execute on Server";
         _armTimeoutCts?.Cancel();
     }
-
-    /// <summary>Call when ConnectedServer or SelectedContainer changes so credential status is updated.</summary>
-    public async Task RefreshCredentialStatusAsync()
-    {
-        CredentialSectionVisible = SelectedContainer != null;
-        if (ConnectedServer == null || SelectedContainer == null)
-        {
-            CredentialExistsOnServer = null;
-            CredentialStatusMessage = string.Empty;
-            CredentialIdentityKind = BlobCredentialIdentity.Missing;
-            return;
-        }
-
-        // Cancels any check already in flight. Two overlapping checks left the panel showing the
-        // result of whichever finished LAST, which could be the container the user had just left -
-        // and that panel is what someone reads before deciding whether to create a credential.
-        var ct = _credentialCheckCancellation.Begin();
-
-        IsCheckingCredential = true;
-        CredentialStatusMessage = "Checking...";
-        var server = ConnectedServer;
-        try
-        {
-            var credential = await _sqlService.CredentialExistsAsync(server, SqlCredentialName, ct);
-            CredentialExistsOnServer = credential.Exists;
-            CredentialIdentityKind = credential.Kind;
-            CredentialStatusMessage = DescribeCredential(credential);
-        }
-        catch (OperationCanceledException)
-        {
-            // Superseded by a newer check - which is about to write its own answer here. Saying
-            // anything would just be the older check having the last word again.
-            return;
-        }
-        catch (Exception ex)
-        {
-            CredentialExistsOnServer = null;
-            CredentialIdentityKind = BlobCredentialIdentity.Missing;
-            CredentialStatusMessage = $"Could not check credential: {ex.Message}";
-        }
-        finally
-        {
-            // Only when this check is still the current one. Ending the newer check's source, or
-            // clearing its "Checking..." state, is how the previous version left the panel
-            // reporting the container the user had already moved away from.
-            if (!ct.IsCancellationRequested)
-            {
-                _credentialCheckCancellation.End();
-                IsCheckingCredential = false;
-                CreateCredentialOnServerCommand.NotifyCanExecuteChanged();
-            }
-        }
-    }
-
-    /// <summary>
-    /// The panel's one line about what is on the server. An unusable credential is named rather
-    /// than just rejected: "not a SAS credential" was the same sentence for a managed identity
-    /// that would have restored perfectly well and for a Windows account that never could (#145).
-    /// </summary>
-    internal static string DescribeCredential(BlobCredentialStatus credential) => credential.Kind switch
-    {
-        BlobCredentialIdentity.SharedAccessSignature =>
-            "Credential is present and valid (SHARED ACCESS SIGNATURE).",
-        BlobCredentialIdentity.ManagedIdentity =>
-            "Credential is present and valid (Managed Identity). The restore authenticates as the " +
-            "instance's own identity, so no SAS token is involved and this app will not modify it.",
-        BlobCredentialIdentity.Other =>
-            $"Credential exists with identity '{credential.Identity}', which a restore from URL " +
-            "cannot use. Replace it below, or point at a different credential.",
-        _ => "Credential is not present on this server. Restore will fail unless you create it."
-    };
 
     [ObservableProperty]
     private ObservableCollection<FileMoveOption> _fileMoves = [];
@@ -581,6 +481,14 @@ public partial class RestoreViewModel : ViewModelBase
         // Every console message is written to the log file as it arrives, so the file cannot drift
         // from what was on screen.
         Console = new ConsoleBuffer(message => _log.Info($"[execute] {message.Trim()}"));
+
+        // Shares _queryCancellation so the Stop button stops a credential write too (#111), and
+        // reports through the same status line as everything else on this screen (#115 seam 5).
+        Credential = new ServerCredentialViewModel(sqlService, credentialStore, _log, _queryCancellation);
+        Credential.Reported += (message, isError) =>
+        {
+            if (isError) SetError(message); else SetStatus(message);
+        };
 
         // IsBusy and TargetDatabaseName live on the base class, so they cannot have a generated
         // partial hook - but the busy strip is computed from them.
@@ -1458,55 +1366,6 @@ public partial class RestoreViewModel : ViewModelBase
         HasScript = true;
     }
 
-    /// <summary>Create or update the blob credential on the connected server (optional; not included in generated script).</summary>
-    [RelayCommand(CanExecute = nameof(CanCreateCredential))]
-    private async Task CreateCredentialOnServerAsync()
-    {
-        if (ConnectedServer == null || SelectedContainer == null) return;
-
-        var sasToken = _credentialStore.GetSasToken(SelectedContainer);
-        if (string.IsNullOrEmpty(sasToken))
-        {
-            SetError("No SAS token stored for this container. Add or refresh the token in Blob Storage config.");
-            return;
-        }
-
-        // What is about to be overwritten, read before the write. This is the only route by which
-        // a managed identity gets replaced by a SAS token, and it should say so afterwards rather
-        // than reporting a routine "updated" for a change to how the instance authenticates (#145).
-        var replaced = CredentialIdentityKind;
-
-        try
-        {
-            var change = await _sqlService.EnsureCredentialExistsAsync(
-                ConnectedServer, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken,
-                _queryCancellation.Begin());
-            await RefreshCredentialStatusAsync();
-            SetStatus(change switch
-            {
-                CredentialChange.Created => "Credential created on server.",
-                _ when replaced == BlobCredentialIdentity.ManagedIdentity =>
-                    "Credential replaced on server: it authenticated as the instance's managed " +
-                    "identity and now holds the stored SAS token.",
-                _ => "Credential updated on server with the stored SAS token."
-            });
-            if (replaced == BlobCredentialIdentity.ManagedIdentity)
-                _log.ServerChange(ConnectedServer.ServerName,
-                    $"credential [{SqlCredentialName}] identity changed from Managed Identity to SAS");
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to create credential: {ex.Message}");
-        }
-    }
-
-    // Deliberately available even when the credential is present and valid. SQL Server will not
-    // hand back a credential's secret, so "present and SAS" says nothing about whether the token
-    // inside it still works - a SAS that was rotated or has expired looks identical from here.
-    // Since Execute no longer rewrites the credential on every run, this button is the only way
-    // to push a fresh token, and hiding it left users with no route at all.
-    private bool CanCreateCredential() => IsConnectedToServer && SelectedContainer != null;
-
     [RelayCommand]
     private void CopyScript()
         => TryCopyToClipboard(GeneratedScript, "Script copied to clipboard.");
@@ -1774,75 +1633,15 @@ public partial class RestoreViewModel : ViewModelBase
                 return;
             }
 
-            if (SelectedContainer != null)
+            // Everything about the server-side credential lives on the child (#115 seam 5),
+            // including the decision not to touch one. A refusal has written nothing, so there is
+            // nothing to unwind - and nothing to file in the history either.
+            var preflight = await Credential.PrepareForRestoreAsync(server, AppendLog);
+            if (!preflight.CanProceed)
             {
-                var sasToken = _credentialStore.GetSasToken(SelectedContainer);
-                if (!string.IsNullOrEmpty(sasToken))
-                {
-                    // Only write to the server when the credential is genuinely missing or is not
-                    // a SAS credential. This used to drop and recreate on every single execute,
-                    // regardless of the status the panel above was displaying, which contradicted
-                    // the UI's own "creating it is optional" wording and briefly removed a
-                    // credential that other sessions may have been using.
-                    //
-                    // A credential that exists and is SAS is left alone. Its secret could still be
-                    // a rotated SAS that no longer works - that is unknowable from here, since the
-                    // secret cannot be read back - so the fix for that case is the explicit
-                    // refresh button, not silently rewriting server state on every run.
-                    //
-                    // A managed identity is left alone for a stronger reason: it restores perfectly
-                    // well, this app cannot create one, and ALTER would reset the identity. Reading
-                    // "not SAS" as "broken" is what silently converted somebody's working managed
-                    // identity into a SAS token here, taking every other job on that container with
-                    // it, under the log line "Credential updated on the server" (#145).
-                    var credential = await _sqlService.CredentialExistsAsync(server, SqlCredentialName);
-                    if (credential.CanRestoreFromUrl)
-                    {
-                        AppendLog(credential.Kind == BlobCredentialIdentity.ManagedIdentity
-                            ? $"Using the existing SQL credential [{SqlCredentialName}] (Managed Identity). Server state not modified."
-                            : $"Using the existing SQL credential [{SqlCredentialName}]. Server state not modified.");
-                    }
-                    else if (credential.Exists)
-                    {
-                        // Neither usable nor ours to reinterpret. Converting it is a real option -
-                        // it is what the button on the panel does - but it must be a decision
-                        // somebody made, not a side effect of pressing Execute. Stopping here costs
-                        // a restore that was about to fail on blob access anyway.
-                        attempted = false;
-                        var message =
-                            $"Credential [{SqlCredentialName}] exists with identity " +
-                            $"'{credential.Identity}', which a restore from URL cannot use. Left " +
-                            "untouched: replacing it with the stored SAS token is what " +
-                            "\"Create credential on server\" does, so that it is a deliberate change.";
-                        AppendLog(message);
-                        SetError(message);
-                        return;
-                    }
-                    else
-                    {
-                        AppendLog($"Credential [{SqlCredentialName}] is missing - creating it...");
-
-                        // This statement carries the SAS token to the server. It is the one moment
-                        // in a restore where a secret crosses the wire, so if the connection is
-                        // encrypted but unverified, say so here rather than only in settings (#17).
-                        if (server.TrustServerCertificate)
-                            AppendLog(
-                                "  Note: this connection trusts the server certificate without validating it, " +
-                                "and the SAS token is sent over it.");
-
-                        var change = await _sqlService.EnsureCredentialExistsAsync(
-                            server, SqlCredentialName, SelectedContainer.ContainerUrl, sasToken);
-
-                        AppendLog(change == CredentialChange.Created
-                            ? "Credential created on the server."
-                            : "Credential updated on the server.");
-
-                        // Changing a credential is a change to shared state on someone's instance.
-                        // It belongs in the file, not only in a console that closes with the app.
-                        _log.ServerChange(server.ServerName,
-                            $"credential [{SqlCredentialName}] {change.ToString().ToLowerInvariant()}");
-                    }
-                }
+                attempted = false;
+                SetError(preflight.Refusal!);
+                return;
             }
 
             _log.ServerChange(server.ServerName,

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -789,7 +789,8 @@ public partial class RestoreViewModel : ViewModelBase
             var progress = new Progress<int>(n => LoadProgressText = $"Scanned {n:N0} blobs...");
 
             _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer, scope, progress, ct);
-            _allSets = _blobService.GroupIntoBackupSets(_allBackups);
+            _allSets = _blobService.GroupIntoBackupSets(
+                _allBackups, SelectedContainer?.BackupServerTimeZoneId);
 
             var servers = _blobService.GetDiscoveredServers(_allBackups);
             DiscoveredServers = new ObservableCollection<string>(servers);

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -74,32 +74,12 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _targetDatabaseName = string.Empty;
 
-    // Restore points (replaces continuous slider)
-    [ObservableProperty]
-    private ObservableCollection<RestorePoint> _restorePoints = [];
-
-    [ObservableProperty]
-    private RestorePoint? _selectedRestorePoint;
-
-    [ObservableProperty]
-    private bool _hasRestorePoints;
-
-    [ObservableProperty]
-    private string _restoreWindowText = string.Empty;
-
     /// <summary>
-    /// Left-hand label under the timeline. A plain property rather than the old
-    /// {Binding RestorePoints[0].Timestamp}, which threw an index error into WPF's binding trace
-    /// on every layout while the collection was empty.
+    /// The restore-point timeline: the points, the filters over them, the layout and the
+    /// selection (#115 seam 2). Its selection is the one everything downstream hangs off, so this
+    /// class watches it in the constructor.
     /// </summary>
-    [ObservableProperty]
-    private string _timelineStartText = string.Empty;
-
-    [ObservableProperty]
-    private ObservableCollection<TimelineTick> _timelineTicks = [];
-
-    [ObservableProperty]
-    private int _timelineHeight = 60;
+    public RestoreTimelineViewModel Timeline { get; } = new();
 
     // Restore chain
     [ObservableProperty]
@@ -312,37 +292,6 @@ public partial class RestoreViewModel : ViewModelBase
 
     public bool IsBusyWithAnything => BusyDescription.Length > 0;
 
-    // ── restore point filters (#27) ─────────────────────────────────────────────
-
-    /// <summary>True when the container holds any restore points at all.</summary>
-    [ObservableProperty]
-    private bool _hasVisiblePoints;
-
-    [ObservableProperty]
-    private string _pointCountText = string.Empty;
-
-    [ObservableProperty]
-    private bool _showFullPoints = true;
-
-    [ObservableProperty]
-    private bool _showDiffPoints = true;
-
-    [ObservableProperty]
-    private bool _showLogPoints = true;
-
-    [ObservableProperty]
-    private string _pointsFromText = string.Empty;
-
-    [ObservableProperty]
-    private string _pointsToText = string.Empty;
-
-    /// <summary>Parsed from the text boxes; null means no bound on that end.</summary>
-    [ObservableProperty]
-    private DateTime? _pointsFrom;
-
-    [ObservableProperty]
-    private DateTime? _pointsTo;
-
     /// <summary>Per-set RESTORE VERIFYONLY results for the selected chain.</summary>
     public ObservableCollection<ChainVerifyResult> ChainVerifyResults { get; } = [];
 
@@ -461,7 +410,6 @@ public partial class RestoreViewModel : ViewModelBase
         _allBackups = [];
         _allSets = [];
         _dbSets = [];
-        _allPoints = [];
 
         BackupsLoaded = false;
         DiscoveredServers = [];
@@ -469,17 +417,9 @@ public partial class RestoreViewModel : ViewModelBase
         SelectedServerName = null;
         SelectedDatabaseName = null;
 
-        RestorePoints = [];
-        HasRestorePoints = false;
-        HasVisiblePoints = false;
-        PointCountText = string.Empty;
-        RestoreWindowText = string.Empty;
-        TimelineTicks.Clear();
-        TimelineHeight = 50;
-
-        // Assigning null runs the selection handler, which clears the chain, the script, the
-        // verification results and the inventory findings.
-        SelectedRestorePoint = null;
+        // Clearing the timeline drops its selection, which runs the selection handler below and
+        // clears the chain, the script, the verification results and the inventory findings.
+        Timeline.Clear();
 
         // Disarm. An armed Execute that survives a container change is an armed Execute aimed at
         // something the user is no longer looking at.
@@ -661,6 +601,14 @@ public partial class RestoreViewModel : ViewModelBase
                 RefreshCheckState();
         };
 
+        // The selection now lives on the timeline (#115 seam 2), which is a different object, so
+        // this is a subscription rather than a generated partial hook.
+        Timeline.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(RestoreTimelineViewModel.SelectedPoint))
+                OnSelectedRestorePointChanged(Timeline.SelectedPoint);
+        };
+
         RefreshContainers();
     }
 
@@ -740,19 +688,21 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void SelectRestorePoint(RestorePoint? point)
-    {
-        if (point != null)
-            SelectedRestorePoint = point;
-    }
-
-    [RelayCommand]
     private void ToggleChainDetails()
     {
         ShowChainDetails = !ShowChainDetails;
     }
 
-    partial void OnSelectedRestorePointChanged(RestorePoint? value)
+    /// <summary>
+    /// Everything downstream of the timeline: the chain, the script, the point-in-time window and
+    /// the verification results all belong to the selected point, and are rebuilt or thrown away
+    /// when it moves.
+    ///
+    /// A plain PropertyChanged subscription rather than a partial hook - the property now lives on
+    /// <see cref="Timeline"/>, and a partial hook can only be written for a property the same class
+    /// declares.
+    /// </summary>
+    private void OnSelectedRestorePointChanged(RestorePoint? value)
     {
         ShowChainDetails = false;
 
@@ -935,14 +885,11 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Every computed restore point, before the view's filters. The timeline and the list both
-    /// show a subset of this (#27).
+    /// Works out which points this database can be restored to, and hands them to the timeline.
     /// </summary>
-    private List<RestorePoint> _allPoints = [];
-
     private void ComputeAndDisplayRestorePoints()
     {
-        _allPoints = _chainBuilder.ComputeRestorePoints(_dbSets);
+        var points = _chainBuilder.ComputeRestorePoints(_dbSets);
 
         // Inventory-level findings: backups that exist but can never be offered. These belong to
         // the discovered set rather than to any one chain, so they are held separately and survive
@@ -952,286 +899,18 @@ public partial class RestoreViewModel : ViewModelBase
         // orphaned logs and "no full backup at all" were being computed nowhere and shown nowhere.
         InventoryIssues = new ObservableCollection<ChainIssue>(
             _chainValidator.ValidateInventory(_dbSets)
-                .Concat(_chainValidator.ValidateReachability(_dbSets, _allPoints)));
+                .Concat(_chainValidator.ValidateReachability(_dbSets, points)));
         HasInventoryIssues = InventoryIssues.Count > 0;
 
-        // A fresh load starts wide open. Carrying a previous database's date range over would
-        // silently hide points that have nothing to do with it.
-        _suppressPointFilterRefresh = true;
-        ShowFullPoints = ShowDiffPoints = ShowLogPoints = true;
-        PointsFromText = string.Empty;
-        PointsToText = string.Empty;
-        _suppressPointFilterRefresh = false;
+        Timeline.Load(points);
 
-        HasRestorePoints = _allPoints.Count > 0;
-
-        if (_allPoints.Count == 0)
+        if (points.Count == 0)
         {
-            RestorePoints = [];
-            HasVisiblePoints = false;
-            RestoreWindowText = string.Empty;
-            PointCountText = string.Empty;
-            TimelineTicks.Clear();
-            TimelineHeight = 50;
             SetError("No valid restore points found. Ensure there is at least one full backup.");
             return;
         }
 
-        ApplyPointFilters(selectLatest: true);
         ClearStatus();
-    }
-
-    /// <summary>
-    /// Narrows the timeline and the list to the points the filters allow, then lays the timeline
-    /// out over just those.
-    ///
-    /// Laying out over the VISIBLE set rather than all of them is what makes the date range behave
-    /// like a zoom: narrow to a two-hour window and those points spread across the whole track
-    /// instead of staying bunched in the sliver they occupied before (#27).
-    /// </summary>
-    private void ApplyPointFilters(bool selectLatest = false)
-    {
-        var previous = SelectedRestorePoint;
-        var visible = _allPoints.Where(PointMatchesFilters).ToList();
-
-        LayOutTimeline(visible);
-
-        RestorePoints = new ObservableCollection<RestorePoint>(visible);
-        HasVisiblePoints = visible.Count > 0;
-
-        PointCountText = visible.Count == _allPoints.Count
-            ? $"{_allPoints.Count} restore point(s)"
-            : $"Showing {visible.Count} of {_allPoints.Count} restore point(s)";
-
-        if (visible.Count == 0)
-        {
-            RestoreWindowText = string.Empty;
-            return;
-        }
-
-        // Keep the selection when it survives the filter - changing a type toggle should not throw
-        // away the point someone had already chosen.
-        SelectedRestorePoint = !selectLatest && previous != null && visible.Contains(previous)
-            ? previous
-            : visible[^1];
-    }
-
-    private bool PointMatchesFilters(RestorePoint p)
-    {
-        var typeAllowed = p.Type switch
-        {
-            BackupType.Full => ShowFullPoints,
-            BackupType.Differential => ShowDiffPoints,
-            BackupType.TransactionLog => ShowLogPoints,
-            _ => true
-        };
-        if (!typeAllowed) return false;
-
-        if (PointsFrom.HasValue && p.Timestamp < PointsFrom.Value) return false;
-        if (PointsTo.HasValue && p.Timestamp > PointsTo.Value) return false;
-
-        return true;
-    }
-
-    private void LayOutTimeline(List<RestorePoint> points)
-    {
-        if (points.Count > 1)
-        {
-            var minTicks = points[0].Timestamp.Ticks;
-            var maxTicks = points[^1].Timestamp.Ticks;
-            var range = (double)(maxTicks - minTicks);
-            foreach (var p in points)
-                p.TimelinePosition = range > 0 ? (p.Timestamp.Ticks - minTicks) / range : 0.5;
-        }
-        else if (points.Count == 1)
-        {
-            points[0].TimelinePosition = 0.5;
-        }
-
-        // Vertical stacking, so points too close together to draw side by side are not drawn on
-        // top of each other.
-        ComputeRows(points);
-
-        if (points.Count == 0)
-        {
-            TimelineTicks.Clear();
-            TimelineHeight = 50;
-            return;
-        }
-
-        var first = points[0].Timestamp;
-        var last = points[^1].Timestamp;
-        RestoreWindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
-        TimelineStartText = $"{first:yyyy-MM-dd HH:mm}";
-
-        TimelineTicks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));
-
-        int maxRow = points.Max(p => p.Row);
-        TimelineHeight = Math.Max(50, 30 + (maxRow + 1) * 18);
-    }
-
-    /// <summary>Set while the filters are being reset in bulk, so each one does not re-filter.</summary>
-    private bool _suppressPointFilterRefresh;
-
-    private void OnPointFilterChanged()
-    {
-        if (_suppressPointFilterRefresh || _allPoints.Count == 0) return;
-        ApplyPointFilters();
-    }
-
-    partial void OnShowFullPointsChanged(bool value) => OnPointFilterChanged();
-    partial void OnShowDiffPointsChanged(bool value) => OnPointFilterChanged();
-    partial void OnShowLogPointsChanged(bool value) => OnPointFilterChanged();
-
-    partial void OnPointsFromTextChanged(string value)
-    {
-        PointsFrom = ParseFilterDate(value);
-        OnPointFilterChanged();
-    }
-
-    partial void OnPointsToTextChanged(string value)
-    {
-        PointsTo = ParseFilterDate(value);
-        OnPointFilterChanged();
-    }
-
-    /// <summary>
-    /// Invariant, and forgiving about how much of a timestamp was typed - "2026-01-10" is a
-    /// perfectly reasonable thing to enter into a date box. Unparsable means no bound rather than
-    /// an error, so half-typed input does not blank the timeline mid-keystroke.
-    /// </summary>
-    private static DateTime? ParseFilterDate(string? text)
-    {
-        if (string.IsNullOrWhiteSpace(text)) return null;
-
-        return DateTime.TryParse(
-            text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
-            ? parsed
-            : null;
-    }
-
-    /// <summary>Back to every point, without reloading anything from the container.</summary>
-    [RelayCommand]
-    private void ResetPointFilters()
-    {
-        _suppressPointFilterRefresh = true;
-        ShowFullPoints = ShowDiffPoints = ShowLogPoints = true;
-        PointsFromText = string.Empty;
-        PointsToText = string.Empty;
-        _suppressPointFilterRefresh = false;
-
-        if (_allPoints.Count > 0) ApplyPointFilters();
-    }
-
-    /// <summary>
-    /// Narrows the range to the day the selected point falls on. A week of 15-minute logs is
-    /// roughly 670 points; picking one precisely means getting to a day first, and doing that by
-    /// typing two timestamps is a chore when the answer is nearly always "the day it broke".
-    /// </summary>
-    [RelayCommand]
-    private void ZoomToSelectedDay()
-    {
-        if (SelectedRestorePoint == null) return;
-
-        var day = SelectedRestorePoint.Timestamp.Date;
-
-        _suppressPointFilterRefresh = true;
-        PointsFromText = day.ToString("yyyy-MM-dd HH:mm:ss");
-        PointsToText = day.AddDays(1).AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss");
-        _suppressPointFilterRefresh = false;
-
-        ApplyPointFilters();
-    }
-
-    private static void ComputeRows(List<RestorePoint> points)
-    {
-        const double minSeparation = 0.025;
-        var rows = new List<List<double>>();
-
-        foreach (var p in points)
-        {
-            bool placed = false;
-            for (int row = 0; row < rows.Count; row++)
-            {
-                bool overlaps = rows[row].Any(pos => Math.Abs(pos - p.TimelinePosition) < minSeparation);
-                if (!overlaps)
-                {
-                    p.Row = row;
-                    rows[row].Add(p.TimelinePosition);
-                    placed = true;
-                    break;
-                }
-            }
-            if (!placed)
-            {
-                p.Row = rows.Count;
-                rows.Add([p.TimelinePosition]);
-            }
-        }
-    }
-
-    private static List<TimelineTick> ComputeTicks(DateTime first, DateTime last)
-    {
-        var ticks = new List<TimelineTick>();
-        var range = last - first;
-        var totalTicks = (double)(last.Ticks - first.Ticks);
-        if (totalTicks <= 0) return ticks;
-
-        // Choose interval based on range
-        TimeSpan interval;
-        string format;
-        if (range.TotalDays > 60)
-        {
-            interval = TimeSpan.FromDays(14);
-            format = "MMM dd";
-        }
-        else if (range.TotalDays > 14)
-        {
-            interval = TimeSpan.FromDays(7);
-            format = "MMM dd";
-        }
-        else if (range.TotalDays > 3)
-        {
-            interval = TimeSpan.FromDays(1);
-            format = "MMM dd";
-        }
-        else if (range.TotalHours > 12)
-        {
-            interval = TimeSpan.FromHours(6);
-            format = "HH:mm";
-        }
-        else
-        {
-            interval = TimeSpan.FromHours(1);
-            format = "HH:mm";
-        }
-
-        // Round start to the next clean interval boundary
-        var cursor = RoundUp(first, interval);
-
-        while (cursor < last)
-        {
-            double pos = (cursor.Ticks - first.Ticks) / totalTicks;
-            if (pos >= 0.02 && pos <= 0.98)
-            {
-                ticks.Add(new TimelineTick { Position = pos, Label = cursor.ToString(format) });
-            }
-            cursor += interval;
-        }
-
-        return ticks;
-    }
-
-    private static DateTime RoundUp(DateTime dt, TimeSpan interval)
-    {
-        if (interval.TotalDays >= 1)
-        {
-            var next = dt.Date.AddDays(1);
-            while (next <= dt) next = next.AddDays((int)interval.TotalDays);
-            return next;
-        }
-        var ticks = (dt.Ticks + interval.Ticks - 1) / interval.Ticks * interval.Ticks;
-        return new DateTime(ticks);
     }
 
     private void AutoPopulateMoveDefaults()
@@ -1315,8 +994,8 @@ public partial class RestoreViewModel : ViewModelBase
 
         if (EffectiveStopAt is DateTime stopAt)
             parts.Add($"Stop at {stopAt:yyyy-MM-dd HH:mm:ss} (point-in-time recovery).");
-        else if (SelectedRestorePoint != null && SelectedRestorePoint.Type == BackupType.TransactionLog)
-            parts.Add($"Restore to end of log backup at {SelectedRestorePoint.Timestamp:yyyy-MM-dd HH:mm:ss}.");
+        else if (Timeline.SelectedPoint is { Type: BackupType.TransactionLog } logPoint)
+            parts.Add($"Restore to end of log backup at {logPoint.Timestamp:yyyy-MM-dd HH:mm:ss}.");
 
         var optionsList = new List<string>();
 
@@ -2346,7 +2025,7 @@ public partial class RestoreViewModel : ViewModelBase
             TargetDatabase = TargetDatabaseName,
             ContainerName = SelectedContainer?.Name,
             SourceDatabase = SelectedDatabaseName,
-            RestorePointTimestamp = SelectedRestorePoint?.Timestamp,
+            RestorePointTimestamp = Timeline.SelectedPoint?.Timestamp,
             ChainSummary = RestoreChain?.Summary ?? "no chain",
             Outcome = outcome,
             ErrorMessage = failure,
@@ -2537,8 +2216,8 @@ public partial class RestoreViewModel : ViewModelBase
         header.AppendLine($"Target:     {TargetDatabaseName}");
         if (SelectedContainer != null)
             header.AppendLine($"Container:  {SelectedContainer.Name}");
-        if (SelectedRestorePoint != null)
-            header.AppendLine($"Point:      {SelectedRestorePoint.TimestampDisplay}");
+        if (Timeline.SelectedPoint != null)
+            header.AppendLine($"Point:      {Timeline.SelectedPoint.TimestampDisplay}");
         header.AppendLine($"Chain:      {RestoreChain?.Summary ?? "none"}");
         header.AppendLine($"Outcome:    {(ExecutionComplete ? (ExecutionSuccess ? "Succeeded" : "Did not succeed") : "Still running")}");
         header.AppendLine(new string('-', 60));

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -121,34 +121,11 @@ public partial class RestoreViewModel : ViewModelBase
     // 14:30. The target is bounded to within the selected log's window; to stop earlier the
     // user picks an earlier restore point, which keeps the generated chain correct.
 
-    /// <summary>True when the selected restore point is a log, so STOPAT applies.</summary>
-    [ObservableProperty]
-    private bool _canUsePointInTime;
-
-    [ObservableProperty]
-    private bool _usePointInTime;
-
-    /// <summary>User-entered target time, parsed into <see cref="StopAtDateTime"/>.</summary>
-    [ObservableProperty]
-    private string _stopAtText = string.Empty;
-
-    /// <summary>Parsed and validated target, or null when unusable.</summary>
-    [ObservableProperty]
-    private DateTime? _stopAtDateTime;
-
-    /// <summary>Exclusive lower bound: the end of the previous set in the chain.</summary>
-    [ObservableProperty]
-    private DateTime? _stopAtEarliest;
-
-    /// <summary>Inclusive upper bound: the end of the selected log backup.</summary>
-    [ObservableProperty]
-    private DateTime? _stopAtLatest;
-
-    [ObservableProperty]
-    private string _pointInTimeMessage = string.Empty;
-
-    [ObservableProperty]
-    private bool _hasPointInTimeError;
+    /// <summary>
+    /// The STOPAT target and the window it has to fall inside (#115 seam 3). The window itself is
+    /// chain reasoning, so this class works it out and hands it down.
+    /// </summary>
+    public PointInTimeViewModel PointInTime { get; } = new();
 
     // ── Chain gap detection ──────────────────────────────────────────────────────
     // Structural validation of the selected chain, run at selection time. The app otherwise
@@ -609,6 +586,14 @@ public partial class RestoreViewModel : ViewModelBase
                 OnSelectedRestorePointChanged(Timeline.SelectedPoint);
         };
 
+        // The STOPAT target feeds the generated script, so any change to it has to reach the
+        // script (#115 seam 3). Skipped while SetWindow is rewriting several properties at once -
+        // the caller updates once at the end rather than four times through a half-built state.
+        PointInTime.PropertyChanged += (_, _) =>
+        {
+            if (!PointInTime.IsUpdating) UpdateRestoreSummary();
+        };
+
         RefreshContainers();
     }
 
@@ -992,7 +977,7 @@ public partial class RestoreViewModel : ViewModelBase
         parts.Add($"Restore '{SelectedDatabaseName}' as '{TargetDatabaseName}'");
         parts.Add($"using {RestoreChain.Summary} ({RestoreChain.FileCount} files total).");
 
-        if (EffectiveStopAt is DateTime stopAt)
+        if (PointInTime.Effective is DateTime stopAt)
             parts.Add($"Stop at {stopAt:yyyy-MM-dd HH:mm:ss} (point-in-time recovery).");
         else if (Timeline.SelectedPoint is { Type: BackupType.TransactionLog } logPoint)
             parts.Add($"Restore to end of log backup at {logPoint.Timestamp:yyyy-MM-dd HH:mm:ss}.");
@@ -1026,35 +1011,15 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Recomputes the STOPAT window for the selected restore point. The window itself is
-    /// <see cref="BackupChain.StopAtWindow"/>; this only projects it onto the UI state.
+    /// Points the STOPAT box at the selected restore point's window, or turns it off.
+    ///
+    /// STOPAT only applies to a log restore, and only inside the LAST log's window - which is what
+    /// <see cref="BackupChain.StopAtWindow"/> works out. Deciding whether there is a window is
+    /// chain reasoning and stays here; validating against it does not.
     /// </summary>
     private void UpdatePointInTimeWindow(RestorePoint? point)
-    {
-        var window = point?.Type == BackupType.TransactionLog
-            ? RestoreChain?.StopAtWindow
-            : null;
-
-        if (window == null)
-        {
-            CanUsePointInTime = false;
-            UsePointInTime = false;
-            StopAtEarliest = null;
-            StopAtLatest = null;
-            StopAtText = string.Empty;
-            StopAtDateTime = null;
-            PointInTimeMessage = string.Empty;
-            HasPointInTimeError = false;
-            return;
-        }
-
-        CanUsePointInTime = true;
-        StopAtEarliest = window.Value.Earliest;
-        StopAtLatest = window.Value.Latest;
-        UsePointInTime = false;
-        StopAtText = window.Value.Latest.ToString(StopAtFormat);
-        ValidatePointInTime();
-    }
+        => PointInTime.SetWindow(
+            point?.Type == BackupType.TransactionLog ? RestoreChain?.StopAtWindow : null);
 
     /// <summary>
     /// Reads RESTORE HEADERONLY for every member of the selected chain and validates the LSN
@@ -1279,81 +1244,6 @@ public partial class RestoreViewModel : ViewModelBase
                 : $"{warnings} warning(s) about this chain";
     }
 
-    private const string StopAtFormat = "yyyy-MM-dd HH:mm:ss";
-
-    private static readonly string[] StopAtAcceptedFormats =
-    [
-        "yyyy-MM-dd HH:mm:ss",
-        "yyyy-MM-ddTHH:mm:ss",
-        "yyyy-MM-dd HH:mm",
-        "yyyy-MM-ddTHH:mm"
-    ];
-
-    private void ValidatePointInTime()
-    {
-        if (!CanUsePointInTime)
-        {
-            StopAtDateTime = null;
-            PointInTimeMessage = string.Empty;
-            HasPointInTimeError = false;
-            return;
-        }
-
-        if (!DateTime.TryParseExact(
-                StopAtText?.Trim(), StopAtAcceptedFormats,
-                CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
-        {
-            StopAtDateTime = null;
-            HasPointInTimeError = UsePointInTime;
-            PointInTimeMessage = $"Enter a time as {StopAtFormat}.";
-            UpdateRestoreSummary();
-            return;
-        }
-
-        // Exclusive lower bound: at exactly the previous set's time nothing from this log has
-        // been applied yet, which is the earlier restore point, not this one.
-        if (parsed <= StopAtEarliest)
-        {
-            StopAtDateTime = null;
-            HasPointInTimeError = UsePointInTime;
-            PointInTimeMessage =
-                $"Must be after {StopAtEarliest:yyyy-MM-dd HH:mm:ss} — to stop earlier, " +
-                "select an earlier restore point on the timeline.";
-            UpdateRestoreSummary();
-            return;
-        }
-
-        if (parsed > StopAtLatest)
-        {
-            StopAtDateTime = null;
-            HasPointInTimeError = UsePointInTime;
-            PointInTimeMessage =
-                $"Must be at or before {StopAtLatest:yyyy-MM-dd HH:mm:ss} — to stop later, " +
-                "select a later restore point on the timeline.";
-            UpdateRestoreSummary();
-            return;
-        }
-
-        StopAtDateTime = parsed;
-        HasPointInTimeError = false;
-        PointInTimeMessage = UsePointInTime
-            ? $"Recovery will stop at {parsed:yyyy-MM-dd HH:mm:ss}; later transactions in this log are discarded."
-            : $"Valid range: after {StopAtEarliest:yyyy-MM-dd HH:mm:ss} up to {StopAtLatest:yyyy-MM-dd HH:mm:ss}.";
-        UpdateRestoreSummary();
-    }
-
-    /// <summary>The STOPAT value to generate, or null to restore the whole log chain.</summary>
-    private DateTime? EffectiveStopAt =>
-        CanUsePointInTime && UsePointInTime && !HasPointInTimeError ? StopAtDateTime : null;
-
-    partial void OnStopAtTextChanged(string value) => ValidatePointInTime();
-
-    partial void OnUsePointInTimeChanged(bool value)
-    {
-        ValidatePointInTime();
-        UpdateRestoreSummary();
-    }
-
     partial void OnWithReplaceChanged(bool value) => UpdateRestoreSummary();
     partial void OnDisconnectSessionsChanged(bool value) => UpdateRestoreSummary();
     partial void OnRecoveryModeChanged(RecoveryMode oldValue, RecoveryMode newValue)
@@ -1469,9 +1359,9 @@ public partial class RestoreViewModel : ViewModelBase
 
         // Refuse to silently fall back to a full-chain restore when the user asked to stop at a
         // time we could not use - that would replay exactly the transactions they meant to skip.
-        if (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null)
+        if (PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null)
         {
-            SetError($"Point-in-time target is not valid. {PointInTimeMessage}");
+            SetError($"Point-in-time target is not valid. {PointInTime.Message}");
             return;
         }
 
@@ -1556,7 +1446,7 @@ public partial class RestoreViewModel : ViewModelBase
 
         if (RestoreChain == null
             || string.IsNullOrWhiteSpace(TargetDatabaseName)
-            || (UsePointInTime && CanUsePointInTime && EffectiveStopAt == null)
+            || (PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null)
             || !HasStandbyFileIfNeeded)
         {
             GeneratedScript = string.Empty;
@@ -1574,7 +1464,7 @@ public partial class RestoreViewModel : ViewModelBase
             StandbyFilePath = string.IsNullOrWhiteSpace(StandbyFilePath) ? null : StandbyFilePath,
             DisconnectSessions = DisconnectSessions,
             StatsPercent = StatsPercent,
-            StopAt = EffectiveStopAt,
+            StopAt = PointInTime.Effective,
             KeepReplication = KeepReplication,
             EnableBroker = EnableBroker,
             NewBroker = NewBroker,
@@ -1942,7 +1832,7 @@ public partial class RestoreViewModel : ViewModelBase
             _log.ServerChange(server.ServerName,
                 $"restore starting: target [{TargetDatabaseName}], " +
                 $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={WithReplace}, " +
-                $"recovery={RecoveryMode}, stopAt={EffectiveStopAt?.ToString("s") ?? "none"}");
+                $"recovery={RecoveryMode}, stopAt={PointInTime.Effective?.ToString("s") ?? "none"}");
 
             AppendLog("Beginning restore execution...\n");
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -257,6 +257,37 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isVerifyingChain;
 
+    // ── restore point filters (#27) ─────────────────────────────────────────────
+
+    /// <summary>True when the container holds any restore points at all.</summary>
+    [ObservableProperty]
+    private bool _hasVisiblePoints;
+
+    [ObservableProperty]
+    private string _pointCountText = string.Empty;
+
+    [ObservableProperty]
+    private bool _showFullPoints = true;
+
+    [ObservableProperty]
+    private bool _showDiffPoints = true;
+
+    [ObservableProperty]
+    private bool _showLogPoints = true;
+
+    [ObservableProperty]
+    private string _pointsFromText = string.Empty;
+
+    [ObservableProperty]
+    private string _pointsToText = string.Empty;
+
+    /// <summary>Parsed from the text boxes; null means no bound on that end.</summary>
+    [ObservableProperty]
+    private DateTime? _pointsFrom;
+
+    [ObservableProperty]
+    private DateTime? _pointsTo;
+
     /// <summary>Per-set RESTORE VERIFYONLY results for the selected chain.</summary>
     public ObservableCollection<ChainVerifyResult> ChainVerifyResults { get; } = [];
 
@@ -526,7 +557,17 @@ public partial class RestoreViewModel : ViewModelBase
             SelectedDatabaseName = DiscoveredDatabases[0];
     }
 
-    partial void OnSelectedDatabaseNameChanged(string? value)
+    partial void OnSelectedDatabaseNameChanged(string? value) => RefreshSelectedDatabase(value);
+
+    /// <summary>
+    /// Rebuilds the working set and the restore points for the chosen database.
+    ///
+    /// Called on selection change AND at the end of every load. Relying on the change alone meant
+    /// a reload with the same server and database still selected - the natural thing to do after
+    /// taking a fresh backup - raised no property change at all, so the sets and the timeline kept
+    /// the PREVIOUS scan's contents and the new backup never appeared.
+    /// </summary>
+    private void RefreshSelectedDatabase(string? value)
     {
         if (value == null || _allSets.Count == 0) return;
 
@@ -665,6 +706,10 @@ public partial class RestoreViewModel : ViewModelBase
                 ComputeAndDisplayRestorePoints();
             }
 
+
+            // Unconditionally, not just when the selection changed - see RefreshSelectedDatabase.
+            RefreshSelectedDatabase(SelectedDatabaseName);
+
             // Only when nothing above went wrong. Selecting the first server or database runs the
             // whole filter-and-compute cascade, which can end in "no valid restore points found" -
             // and painting a success line over that left an empty timeline with the status bar
@@ -722,9 +767,15 @@ public partial class RestoreViewModel : ViewModelBase
         SetStatus("Cancelling...");
     }
 
+    /// <summary>
+    /// Every computed restore point, before the view's filters. The timeline and the list both
+    /// show a subset of this (#27).
+    /// </summary>
+    private List<RestorePoint> _allPoints = [];
+
     private void ComputeAndDisplayRestorePoints()
     {
-        var points = _chainBuilder.ComputeRestorePoints(_dbSets);
+        _allPoints = _chainBuilder.ComputeRestorePoints(_dbSets);
 
         // Inventory-level findings: backups that exist but can never be offered. These belong to
         // the discovered set rather than to any one chain, so they are held separately and survive
@@ -734,14 +785,93 @@ public partial class RestoreViewModel : ViewModelBase
         // orphaned logs and "no full backup at all" were being computed nowhere and shown nowhere.
         InventoryIssues = new ObservableCollection<ChainIssue>(
             _chainValidator.ValidateInventory(_dbSets)
-                .Concat(_chainValidator.ValidateReachability(_dbSets, points)));
+                .Concat(_chainValidator.ValidateReachability(_dbSets, _allPoints)));
         HasInventoryIssues = InventoryIssues.Count > 0;
 
-        // Compute timeline positions (0-1)
+        // A fresh load starts wide open. Carrying a previous database's date range over would
+        // silently hide points that have nothing to do with it.
+        _suppressPointFilterRefresh = true;
+        ShowFullPoints = ShowDiffPoints = ShowLogPoints = true;
+        PointsFromText = string.Empty;
+        PointsToText = string.Empty;
+        _suppressPointFilterRefresh = false;
+
+        HasRestorePoints = _allPoints.Count > 0;
+
+        if (_allPoints.Count == 0)
+        {
+            RestorePoints = [];
+            HasVisiblePoints = false;
+            RestoreWindowText = string.Empty;
+            PointCountText = string.Empty;
+            TimelineTicks.Clear();
+            TimelineHeight = 50;
+            SetError("No valid restore points found. Ensure there is at least one full backup.");
+            return;
+        }
+
+        ApplyPointFilters(selectLatest: true);
+        ClearStatus();
+    }
+
+    /// <summary>
+    /// Narrows the timeline and the list to the points the filters allow, then lays the timeline
+    /// out over just those.
+    ///
+    /// Laying out over the VISIBLE set rather than all of them is what makes the date range behave
+    /// like a zoom: narrow to a two-hour window and those points spread across the whole track
+    /// instead of staying bunched in the sliver they occupied before (#27).
+    /// </summary>
+    private void ApplyPointFilters(bool selectLatest = false)
+    {
+        var previous = SelectedRestorePoint;
+        var visible = _allPoints.Where(PointMatchesFilters).ToList();
+
+        LayOutTimeline(visible);
+
+        RestorePoints = new ObservableCollection<RestorePoint>(visible);
+        HasVisiblePoints = visible.Count > 0;
+
+        PointCountText = visible.Count == _allPoints.Count
+            ? $"{_allPoints.Count} restore point(s)"
+            : $"Showing {visible.Count} of {_allPoints.Count} restore point(s)";
+
+        if (visible.Count == 0)
+        {
+            RestoreWindowText = string.Empty;
+            return;
+        }
+
+        // Keep the selection when it survives the filter - changing a type toggle should not throw
+        // away the point someone had already chosen.
+        SelectedRestorePoint = !selectLatest && previous != null && visible.Contains(previous)
+            ? previous
+            : visible[^1];
+    }
+
+    private bool PointMatchesFilters(RestorePoint p)
+    {
+        var typeAllowed = p.Type switch
+        {
+            BackupType.Full => ShowFullPoints,
+            BackupType.Differential => ShowDiffPoints,
+            BackupType.TransactionLog => ShowLogPoints,
+            _ => true
+        };
+        if (!typeAllowed) return false;
+
+        if (PointsFrom.HasValue && p.Timestamp < PointsFrom.Value) return false;
+        if (PointsTo.HasValue && p.Timestamp > PointsTo.Value) return false;
+
+        return true;
+    }
+
+    private void LayOutTimeline(List<RestorePoint> points)
+    {
         if (points.Count > 1)
         {
-            var minTicks = points.First().Timestamp.Ticks;
-            var maxTicks = points.Last().Timestamp.Ticks;
+            var minTicks = points[0].Timestamp.Ticks;
+            var maxTicks = points[^1].Timestamp.Ticks;
             var range = (double)(maxTicks - minTicks);
             foreach (var p in points)
                 p.TimelinePosition = range > 0 ? (p.Timestamp.Ticks - minTicks) / range : 0.5;
@@ -751,36 +881,99 @@ public partial class RestoreViewModel : ViewModelBase
             points[0].TimelinePosition = 0.5;
         }
 
-        // Compute vertical stacking rows to avoid horizontal overlap
+        // Vertical stacking, so points too close together to draw side by side are not drawn on
+        // top of each other.
         ComputeRows(points);
 
-        RestorePoints = new ObservableCollection<RestorePoint>(points);
-        HasRestorePoints = points.Count > 0;
-
-        if (points.Count > 0)
+        if (points.Count == 0)
         {
-            var first = points.First().Timestamp;
-            var last = points.Last().Timestamp;
-            RestoreWindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
-            TimelineStartText = $"{first:yyyy-MM-dd HH:mm}";
-
-            // Compute time-interval tick marks
-            TimelineTicks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));
-
-            // Timeline height based on max row
-            int maxRow = points.Max(p => p.Row);
-            TimelineHeight = Math.Max(50, 30 + (maxRow + 1) * 18);
-
-            SelectedRestorePoint = points.Last();
-            ClearStatus();
-        }
-        else
-        {
-            RestoreWindowText = string.Empty;
             TimelineTicks.Clear();
             TimelineHeight = 50;
-            SetError("No valid restore points found. Ensure there is at least one full backup.");
+            return;
         }
+
+        var first = points[0].Timestamp;
+        var last = points[^1].Timestamp;
+        RestoreWindowText = $"{first:yyyy-MM-dd HH:mm} to {last:yyyy-MM-dd HH:mm}";
+        TimelineStartText = $"{first:yyyy-MM-dd HH:mm}";
+
+        TimelineTicks = new ObservableCollection<TimelineTick>(ComputeTicks(first, last));
+
+        int maxRow = points.Max(p => p.Row);
+        TimelineHeight = Math.Max(50, 30 + (maxRow + 1) * 18);
+    }
+
+    /// <summary>Set while the filters are being reset in bulk, so each one does not re-filter.</summary>
+    private bool _suppressPointFilterRefresh;
+
+    private void OnPointFilterChanged()
+    {
+        if (_suppressPointFilterRefresh || _allPoints.Count == 0) return;
+        ApplyPointFilters();
+    }
+
+    partial void OnShowFullPointsChanged(bool value) => OnPointFilterChanged();
+    partial void OnShowDiffPointsChanged(bool value) => OnPointFilterChanged();
+    partial void OnShowLogPointsChanged(bool value) => OnPointFilterChanged();
+
+    partial void OnPointsFromTextChanged(string value)
+    {
+        PointsFrom = ParseFilterDate(value);
+        OnPointFilterChanged();
+    }
+
+    partial void OnPointsToTextChanged(string value)
+    {
+        PointsTo = ParseFilterDate(value);
+        OnPointFilterChanged();
+    }
+
+    /// <summary>
+    /// Invariant, and forgiving about how much of a timestamp was typed - "2026-01-10" is a
+    /// perfectly reasonable thing to enter into a date box. Unparsable means no bound rather than
+    /// an error, so half-typed input does not blank the timeline mid-keystroke.
+    /// </summary>
+    private static DateTime? ParseFilterDate(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+
+        return DateTime.TryParse(
+            text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    /// <summary>Back to every point, without reloading anything from the container.</summary>
+    [RelayCommand]
+    private void ResetPointFilters()
+    {
+        _suppressPointFilterRefresh = true;
+        ShowFullPoints = ShowDiffPoints = ShowLogPoints = true;
+        PointsFromText = string.Empty;
+        PointsToText = string.Empty;
+        _suppressPointFilterRefresh = false;
+
+        if (_allPoints.Count > 0) ApplyPointFilters();
+    }
+
+    /// <summary>
+    /// Narrows the range to the day the selected point falls on. A week of 15-minute logs is
+    /// roughly 670 points; picking one precisely means getting to a day first, and doing that by
+    /// typing two timestamps is a chore when the answer is nearly always "the day it broke".
+    /// </summary>
+    [RelayCommand]
+    private void ZoomToSelectedDay()
+    {
+        if (SelectedRestorePoint == null) return;
+
+        var day = SelectedRestorePoint.Timestamp.Date;
+
+        _suppressPointFilterRefresh = true;
+        PointsFromText = day.ToString("yyyy-MM-dd HH:mm:ss");
+        PointsToText = day.AddDays(1).AddSeconds(-1).ToString("yyyy-MM-dd HH:mm:ss");
+        _suppressPointFilterRefresh = false;
+
+        ApplyPointFilters();
     }
 
     private static void ComputeRows(List<RestorePoint> points)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -100,19 +100,12 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private ObservableCollection<BackupSet> _chainSets = [];
 
-    // Options
-    [ObservableProperty]
-    private bool _withReplace = true;
-
-    [ObservableProperty]
-    private RecoveryMode _recoveryMode = RecoveryMode.Recovery;
-
-    public bool IsStandbyMode => RecoveryMode == RecoveryMode.Standby;
-
-    // OnRecoveryModeChanged is defined later to also update restore summary
-
-    [ObservableProperty]
-    private string _standbyFilePath = string.Empty;
+    /// <summary>
+    /// The RESTORE options, and the one place they become a <see cref="RestoreOptions"/>
+    /// (#115 seam 7). One subscription in the constructor keeps the script in step with all of
+    /// them, whatever gets added later.
+    /// </summary>
+    public RestoreOptionsViewModel Options { get; } = new();
 
     // ── Point-in-time (STOPAT) ───────────────────────────────────────────────────
     // Only meaningful for a transaction-log restore point. Without this the granularity of a
@@ -278,26 +271,6 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _hasVerifyFailures;
 
-    [ObservableProperty]
-    private bool _disconnectSessions = true;
-
-    [ObservableProperty]
-    private int _statsPercent = 10;
-
-    [ObservableProperty]
-    private bool _keepReplication;
-
-    [ObservableProperty]
-    private bool _enableBroker;
-
-    [ObservableProperty]
-    private bool _newBroker;
-
-    [ObservableProperty]
-    private bool _withChecksum;
-
-    [ObservableProperty]
-    private bool _continueAfterError;
 
     [ObservableProperty]
     private bool _useWithMove;
@@ -593,6 +566,11 @@ public partial class RestoreViewModel : ViewModelBase
         {
             if (!PointInTime.IsUpdating) UpdateRestoreSummary();
         };
+
+        // One subscription in place of a one-line change handler per option (#115 seam 7). An
+        // option added later is kept in step with the script by existing, rather than by whoever
+        // adds it remembering to write a handler - which is what #110 was.
+        Options.PropertyChanged += (_, _) => UpdateRestoreSummary();
 
         RefreshContainers();
     }
@@ -984,14 +962,14 @@ public partial class RestoreViewModel : ViewModelBase
 
         var optionsList = new List<string>();
 
-        if (WithReplace)
+        if (Options.WithReplace)
             optionsList.Add("overwrite existing database (WITH REPLACE)");
-        if (DisconnectSessions)
+        if (Options.DisconnectSessions)
             optionsList.Add("disconnect active sessions");
         if (UseWithMove)
             optionsList.Add($"relocate data files (WITH MOVE)");
 
-        var recoveryDesc = RecoveryMode switch
+        var recoveryDesc = Options.RecoveryMode switch
         {
             RecoveryMode.Recovery => "brought online for use (RECOVERY)",
             RecoveryMode.NoRecovery => "left in restoring state (NORECOVERY)",
@@ -1000,9 +978,9 @@ public partial class RestoreViewModel : ViewModelBase
         };
         optionsList.Add($"database will be {recoveryDesc}");
 
-        if (KeepReplication) optionsList.Add("preserve replication settings");
-        if (EnableBroker) optionsList.Add("enable Service Broker");
-        if (NewBroker) optionsList.Add("create new Service Broker ID");
+        if (Options.KeepReplication) optionsList.Add("preserve replication settings");
+        if (Options.EnableBroker) optionsList.Add("enable Service Broker");
+        if (Options.NewBroker) optionsList.Add("create new Service Broker ID");
 
         if (optionsList.Count > 0)
             parts.Add("Options: " + string.Join("; ", optionsList) + ".");
@@ -1131,7 +1109,7 @@ public partial class RestoreViewModel : ViewModelBase
 
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 var result = await _sqlService.RestoreVerifyOnlyAsync(
-                    ConnectedServer, urls, WithChecksum, fileMoves, ct);
+                    ConnectedServer, urls, Options.WithChecksum, fileMoves, ct);
 
                 ChainVerifyResults.Add(new ChainVerifyResult { Set = set, Result = result });
                 HasVerifyResults = true;
@@ -1244,28 +1222,15 @@ public partial class RestoreViewModel : ViewModelBase
                 : $"{warnings} warning(s) about this chain";
     }
 
-    partial void OnWithReplaceChanged(bool value) => UpdateRestoreSummary();
-    partial void OnDisconnectSessionsChanged(bool value) => UpdateRestoreSummary();
-    partial void OnRecoveryModeChanged(RecoveryMode oldValue, RecoveryMode newValue)
-    {
-        OnPropertyChanged(nameof(IsStandbyMode));
-        UpdateRestoreSummary();
-    }
-    partial void OnKeepReplicationChanged(bool value) => UpdateRestoreSummary();
-    partial void OnEnableBrokerChanged(bool value) => UpdateRestoreSummary();
-    partial void OnNewBrokerChanged(bool value) => UpdateRestoreSummary();
-    partial void OnWithChecksumChanged(bool value) => UpdateRestoreSummary();
-    partial void OnContinueAfterErrorChanged(bool value) => UpdateRestoreSummary();
-
-    // These four are typed into text boxes rather than ticked, and every one of them was missing
-    // its handler - so the script on screen did not change when they did. That is the exact
+    // The WITH MOVE paths are typed into text boxes rather than ticked, and both were missing
+    // their handler - so the script on screen did not change when they did. That is the exact
     // failure RegenerateScript exists to prevent: typing a new data-file path, watching the box
-    // update, and running a script that still had the old one - or, for WITH MOVE, no MOVE clause
-    // at all, sending the restore to the file paths baked into the backup.
+    // update, and running a script that still had the old one - or no MOVE clause at all, sending
+    // the restore to the file paths baked into the backup. The rest of that class of bug is gone
+    // structurally with #115 seam 7; these two are still here because the moves are worked out from
+    // the chain and the server rather than being options.
     partial void OnMoveDataFilePathChanged(string value) => UpdateRestoreSummary();
     partial void OnMoveLogFilePathChanged(string value) => UpdateRestoreSummary();
-    partial void OnStandbyFilePathChanged(string value) => UpdateRestoreSummary();
-    partial void OnStatsPercentChanged(int value) => UpdateRestoreSummary();
 
     // Verification opens its own connection and reads whole backups. Letting it start while a
     // restore is running would put a second heavy reader on the same server at the worst moment.
@@ -1330,15 +1295,6 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// STANDBY needs somewhere to put its undo file. Blank produced <c>STANDBY = ''</c>, which
-    /// SQL Server rejects - as the LAST statement of the chain, so it failed after SET SINGLE_USER
-    /// and WITH REPLACE had already dropped and overwritten the target, leaving it in RESTORING
-    /// and single-user with nothing to show for it.
-    /// </summary>
-    private bool HasStandbyFileIfNeeded =>
-        RecoveryMode != RecoveryMode.Standby || !string.IsNullOrWhiteSpace(StandbyFilePath);
-
-    /// <summary>
     /// Explicit Generate. Same work as the live rebuild, but it says why nothing was produced -
     /// the live path stays silent because reporting an error on every keystroke would be noise.
     /// </summary>
@@ -1365,7 +1321,7 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        if (!HasStandbyFileIfNeeded)
+        if (!Options.HasStandbyFileIfNeeded)
         {
             SetError("STANDBY needs an undo file path. Without one the script would end in " +
                      "STANDBY = '', which fails after the database has already been overwritten.");
@@ -1447,31 +1403,17 @@ public partial class RestoreViewModel : ViewModelBase
         if (RestoreChain == null
             || string.IsNullOrWhiteSpace(TargetDatabaseName)
             || (PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null)
-            || !HasStandbyFileIfNeeded)
+            || !Options.HasStandbyFileIfNeeded)
         {
             GeneratedScript = string.Empty;
             HasScript = false;
             return;
         }
 
-        var fileMoves = BuildFileMoves();
-
-        var options = new RestoreOptions
-        {
-            TargetDatabaseName = TargetDatabaseName,
-            WithReplace = WithReplace,
-            RecoveryMode = RecoveryMode,
-            StandbyFilePath = string.IsNullOrWhiteSpace(StandbyFilePath) ? null : StandbyFilePath,
-            DisconnectSessions = DisconnectSessions,
-            StatsPercent = StatsPercent,
-            StopAt = PointInTime.Effective,
-            KeepReplication = KeepReplication,
-            EnableBroker = EnableBroker,
-            NewBroker = NewBroker,
-            WithChecksum = WithChecksum,
-            ContinueAfterError = ContinueAfterError,
-            FileMoves = fileMoves
-        };
+        // The three things that are not options: which database, where the point-in-time target
+        // ended up, and where the files land - each worked out somewhere that knows about the
+        // chain or the server.
+        var options = Options.Build(TargetDatabaseName, PointInTime.Effective, BuildFileMoves());
 
         GeneratedScript = _scriptGenerator.Generate(RestoreChain, options);
         HasScript = true;
@@ -1831,8 +1773,8 @@ public partial class RestoreViewModel : ViewModelBase
 
             _log.ServerChange(server.ServerName,
                 $"restore starting: target [{TargetDatabaseName}], " +
-                $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={WithReplace}, " +
-                $"recovery={RecoveryMode}, stopAt={PointInTime.Effective?.ToString("s") ?? "none"}");
+                $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={Options.WithReplace}, " +
+                $"recovery={Options.RecoveryMode}, stopAt={PointInTime.Effective?.ToString("s") ?? "none"}");
 
             AppendLog("Beginning restore execution...\n");
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1423,6 +1423,12 @@ public partial class RestoreViewModel : ViewModelBase
         ChainVerifyResults.Clear();
         HasVerifyResults = false;
 
+        // The same MOVE clauses the restore would use. Without them VERIFYONLY checks the paths
+        // recorded inside the backup - the SOURCE server's - and reports directory-lookup failures
+        // for a restore that was never going to touch them (#129).
+        var fileMoves = BuildFileMoves();
+        VerifiedWithMove = fileMoves.Count > 0;
+
         try
         {
             var sets = RestoreChain.AllSets;
@@ -1433,7 +1439,7 @@ public partial class RestoreViewModel : ViewModelBase
 
                 var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 var result = await _sqlService.RestoreVerifyOnlyAsync(
-                    ConnectedServer, urls, WithChecksum, ct);
+                    ConnectedServer, urls, WithChecksum, fileMoves, ct);
 
                 ChainVerifyResults.Add(new ChainVerifyResult { Set = set, Result = result });
                 HasVerifyResults = true;
@@ -1442,9 +1448,13 @@ public partial class RestoreViewModel : ViewModelBase
             var failed = ChainVerifyResults.Count(r => !r.IsValid);
             HasVerifyFailures = failed > 0;
 
+            UpdateTargetPathWarning();
+
             SetStatus(failed > 0
                 ? $"{failed} of {ChainVerifyResults.Count} backup(s) failed verification - see below. Do not rely on this chain."
-                : $"All {ChainVerifyResults.Count} backup(s) in the chain verified.");
+                : HasTargetPathProblem
+                    ? $"All {ChainVerifyResults.Count} backup(s) read back intact, but the restore will fail - see below."
+                    : $"All {ChainVerifyResults.Count} backup(s) in the chain verified.");
         }
         catch (OperationCanceledException)
         {
@@ -1465,11 +1475,47 @@ public partial class RestoreViewModel : ViewModelBase
     private bool CanVerifyChain() =>
         IsConnectedToServer && RestoreChain != null && !IsVerifyingChain && !IsExecuting;
 
+    /// <summary>
+    /// Turns SQL Server's directory-lookup complaint into something that says what to do about it.
+    ///
+    /// Backups can read back perfectly and still be certain to fail on restore, because the
+    /// directories they would be written to do not exist on this server. VERIFYONLY reports that
+    /// as an informational message next to "the backup set is valid", which is four lines of grey
+    /// text under a green tick - so it gets said properly here instead (#129).
+    /// </summary>
+    private void UpdateTargetPathWarning()
+    {
+        HasTargetPathProblem = ChainVerifyResults.Any(r => r.Result.TargetPathsMissing);
+
+        TargetPathProblemMessage = !HasTargetPathProblem
+            ? string.Empty
+            : VerifiedWithMove
+                ? "The target directories do not exist on this server. Create them, or change the "
+                  + "file paths above - as it stands the restore will fail once it has already "
+                  + "dropped the target database."
+                : "The file paths recorded inside these backups do not exist on this server, and "
+                  + "no WITH MOVE is set - so the restore will fail once it has already dropped "
+                  + "the target database. Tick WITH MOVE and give it paths that exist here.";
+    }
+
+    /// <summary>True when the last verification found directories a restore could not write to.</summary>
+    [ObservableProperty]
+    private bool _hasTargetPathProblem;
+
+    [ObservableProperty]
+    private string _targetPathProblemMessage = string.Empty;
+
+    /// <summary>Whether the last verification was given MOVE clauses, which changes what to say.</summary>
+    [ObservableProperty]
+    private bool _verifiedWithMove;
+
     private void ClearVerifyResults()
     {
         ChainVerifyResults.Clear();
         HasVerifyResults = false;
         HasVerifyFailures = false;
+        HasTargetPathProblem = false;
+        TargetPathProblemMessage = string.Empty;
     }
 
     private void UpdateChainIssues(BackupChain? chain, IReadOnlyList<ChainHeader>? headers = null)
@@ -1705,6 +1751,58 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// The WITH MOVE clauses the restore would use, or an empty list when it is not moving files.
+    ///
+    /// Shared with the verification, which passes the same list to RESTORE VERIFYONLY - otherwise
+    /// VERIFYONLY checks the paths recorded inside the backup, which belong to the SOURCE server,
+    /// and reports directory-lookup failures for a restore that was never going to use them (#129).
+    /// </summary>
+    private List<FileMoveOption> BuildFileMoves()
+    {
+        var fileMoves = new List<FileMoveOption>();
+        if (!UseWithMove) return fileMoves;
+
+        if (HasFetchedFileMoves && FetchedFileMoves.Count > 0)
+        {
+            foreach (var m in FetchedFileMoves)
+            {
+                if (!string.IsNullOrWhiteSpace(m.NewPhysicalName))
+                {
+                    fileMoves.Add(new FileMoveOption
+                    {
+                        LogicalName = m.LogicalName,
+                        PhysicalName = m.PhysicalName,
+                        NewPhysicalName = m.NewPhysicalName,
+                        Type = m.Type
+                    });
+                }
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(MoveDataFilePath))
+        {
+            // Guessed logical names. Wrong for a renamed database or one with secondary files,
+            // which is what Get file names exists to fix.
+            var sourceDbName = SelectedDatabaseName ?? TargetDatabaseName;
+            fileMoves.Add(new FileMoveOption
+            {
+                LogicalName = sourceDbName,
+                PhysicalName = string.Empty,
+                NewPhysicalName = MoveDataFilePath,
+                Type = "ROWS"
+            });
+            fileMoves.Add(new FileMoveOption
+            {
+                LogicalName = sourceDbName + "_log",
+                PhysicalName = string.Empty,
+                NewPhysicalName = MoveLogFilePath,
+                Type = "LOG"
+            });
+        }
+
+        return fileMoves;
+    }
+
+    /// <summary>
     /// Rebuilds the script from the current settings, silently.
     ///
     /// Called from UpdateRestoreSummary, so every option change keeps the script in step. It used
@@ -1730,24 +1828,7 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        var fileMoves = new List<FileMoveOption>();
-        if (UseWithMove)
-        {
-            if (HasFetchedFileMoves && FetchedFileMoves.Count > 0)
-            {
-                foreach (var m in FetchedFileMoves)
-                {
-                    if (!string.IsNullOrWhiteSpace(m.NewPhysicalName))
-                        fileMoves.Add(new FileMoveOption { LogicalName = m.LogicalName, PhysicalName = m.PhysicalName, NewPhysicalName = m.NewPhysicalName, Type = m.Type });
-                }
-            }
-            else if (!string.IsNullOrWhiteSpace(MoveDataFilePath))
-            {
-                var sourceDbName = SelectedDatabaseName ?? TargetDatabaseName;
-                fileMoves.Add(new FileMoveOption { LogicalName = sourceDbName, PhysicalName = string.Empty, NewPhysicalName = MoveDataFilePath, Type = "ROWS" });
-                fileMoves.Add(new FileMoveOption { LogicalName = sourceDbName + "_log", PhysicalName = string.Empty, NewPhysicalName = MoveLogFilePath, Type = "LOG" });
-            }
-        }
+        var fileMoves = BuildFileMoves();
 
         var options = new RestoreOptions
         {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -254,6 +254,18 @@ public partial class RestoreViewModel : ViewModelBase
     private bool _isValidatingChain;
 
     [ObservableProperty]
+    private bool _isVerifyingChain;
+
+    /// <summary>Per-set RESTORE VERIFYONLY results for the selected chain.</summary>
+    public ObservableCollection<ChainVerifyResult> ChainVerifyResults { get; } = [];
+
+    [ObservableProperty]
+    private bool _hasVerifyResults;
+
+    [ObservableProperty]
+    private bool _hasVerifyFailures;
+
+    [ObservableProperty]
     private bool _disconnectSessions = true;
 
     [ObservableProperty]
@@ -267,6 +279,12 @@ public partial class RestoreViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _newBroker;
+
+    [ObservableProperty]
+    private bool _withChecksum;
+
+    [ObservableProperty]
+    private bool _continueAfterError;
 
     [ObservableProperty]
     private bool _useWithMove;
@@ -535,6 +553,11 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnSelectedRestorePointChanged(RestorePoint? value)
     {
         ShowChainDetails = false;
+
+        // Verification belongs to the chain that was verified. Leaving the results on screen
+        // after the selection moves would show a green tick against backups nothing has read.
+        ClearVerifyResults();
+
         if (value == null)
         {
             RestoreChain = null;
@@ -566,6 +589,7 @@ public partial class RestoreViewModel : ViewModelBase
         ChainLsnVerified = false;
         UpdateChainIssues(chain);
         ValidateChainCommand.NotifyCanExecuteChanged();
+        VerifyChainCommand.NotifyCanExecuteChanged();
         UpdateRestoreSummary();
         FetchLogicalNamesCommand.NotifyCanExecuteChanged();
         InspectBackupMetadataCommand.NotifyCanExecuteChanged();
@@ -1024,6 +1048,72 @@ public partial class RestoreViewModel : ViewModelBase
     private bool CanValidateChain() =>
         IsConnectedToServer && RestoreChain != null && !IsValidatingChain;
 
+    /// <summary>
+    /// Runs RESTORE VERIFYONLY over every set in the chain: does each backup actually read back,
+    /// before an hour is spent finding out that it does not.
+    ///
+    /// This asks a different question from Validate chain. That one reads headers and checks the
+    /// LSNs line up - whether these backups belong together. This one reads the whole backup and
+    /// checks it is intact - whether they are usable at all. A truncated or half-uploaded blob
+    /// passes the first and fails this.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanVerifyChain))]
+    private async Task VerifyChainAsync()
+    {
+        if (RestoreChain == null || ConnectedServer == null) return;
+
+        IsVerifyingChain = true;
+        ClearStatus();
+        ChainVerifyResults.Clear();
+        HasVerifyResults = false;
+
+        try
+        {
+            var sets = RestoreChain.AllSets;
+            for (int i = 0; i < sets.Count; i++)
+            {
+                var set = sets[i];
+                SetStatus($"Verifying {i + 1} of {sets.Count}: {set.TypeDisplay} {set.SetId}...");
+
+                var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+                var result = await _sqlService.RestoreVerifyOnlyAsync(
+                    ConnectedServer, urls, WithChecksum);
+
+                ChainVerifyResults.Add(new ChainVerifyResult { Set = set, Result = result });
+                HasVerifyResults = true;
+            }
+
+            var failed = ChainVerifyResults.Count(r => !r.IsValid);
+            HasVerifyFailures = failed > 0;
+
+            SetStatus(failed > 0
+                ? $"{failed} of {ChainVerifyResults.Count} backup(s) failed verification - see below. Do not rely on this chain."
+                : $"All {ChainVerifyResults.Count} backup(s) in the chain verified.");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Verification cancelled.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Verification could not run: {ex.Message}");
+        }
+        finally
+        {
+            IsVerifyingChain = false;
+        }
+    }
+
+    private bool CanVerifyChain() =>
+        IsConnectedToServer && RestoreChain != null && !IsVerifyingChain && !IsExecuting;
+
+    private void ClearVerifyResults()
+    {
+        ChainVerifyResults.Clear();
+        HasVerifyResults = false;
+        HasVerifyFailures = false;
+    }
+
     private void UpdateChainIssues(BackupChain? chain, IReadOnlyList<ChainHeader>? headers = null)
     {
         var issues = _chainValidator.Validate(chain);
@@ -1135,6 +1225,12 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnKeepReplicationChanged(bool value) => UpdateRestoreSummary();
     partial void OnEnableBrokerChanged(bool value) => UpdateRestoreSummary();
     partial void OnNewBrokerChanged(bool value) => UpdateRestoreSummary();
+    partial void OnWithChecksumChanged(bool value) => UpdateRestoreSummary();
+    partial void OnContinueAfterErrorChanged(bool value) => UpdateRestoreSummary();
+
+    // Verification opens its own connection and reads whole backups. Letting it start while a
+    // restore is running would put a second heavy reader on the same server at the worst moment.
+    partial void OnIsExecutingChanged(bool value) => VerifyChainCommand.NotifyCanExecuteChanged();
     partial void OnTargetDatabaseNameChanged(string value) => UpdateRestoreSummary();
 
     partial void OnIsConnectedToServerChanged(bool value)
@@ -1146,6 +1242,7 @@ public partial class RestoreViewModel : ViewModelBase
         HasConnectedServerTags = ConnectedServerTags.Count > 0;
 
         ValidateChainCommand.NotifyCanExecuteChanged();
+        VerifyChainCommand.NotifyCanExecuteChanged();
         FetchLogicalNamesCommand.NotifyCanExecuteChanged();
         InspectBackupMetadataCommand.NotifyCanExecuteChanged();
         CopyFileListOnlyCommandCommand.NotifyCanExecuteChanged();
@@ -1243,6 +1340,8 @@ public partial class RestoreViewModel : ViewModelBase
             KeepReplication = KeepReplication,
             EnableBroker = EnableBroker,
             NewBroker = NewBroker,
+            WithChecksum = WithChecksum,
+            ContinueAfterError = ContinueAfterError,
             SqlCredentialName = SqlCredentialName,
             SasToken = sasToken,
             StorageAccountUrl = SelectedContainer?.ContainerUrl,

--- a/src/NineLives/ViewModels/ServerCredentialViewModel.cs
+++ b/src/NineLives/ViewModels/ServerCredentialViewModel.cs
@@ -1,0 +1,340 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// Whether the connected instance can reach the container, and what to do when it cannot.
+///
+/// Fifth seam out of RestoreViewModel (#115). Small, but it was spread across four places that had
+/// to agree: the panel's status text, the button's label, what Execute does before it runs, and the
+/// sequencing that keeps a slow check from answering for a container the user has already left.
+/// They disagreed - #145 was the panel calling a managed identity broken and Execute then acting on
+/// that, which are two of those four places.
+///
+/// RESTORE FROM URL authenticates through a credential on the SERVER, named for the container URL
+/// and matched by prefix. Nothing here is about how this app reaches the container: that is the SAS
+/// token or Entra sign-in on the container config, and the two are independent - browsing with
+/// Entra while the instance restores with its own managed identity is an ordinary pairing.
+/// </summary>
+public partial class ServerCredentialViewModel : ObservableObject
+{
+    private readonly ISqlServerService _sql;
+    private readonly ICredentialStore _store;
+    private readonly OperationLog _log;
+
+    /// <summary>
+    /// Shared with the parent's other server calls, so the Stop button stops a credential write
+    /// too (#111). It is the parent's object: these are mutually exclusive buttons, and starting
+    /// one while another runs should stop the first.
+    /// </summary>
+    private readonly OperationCancellation _writeCancellation;
+
+    /// <summary>
+    /// The background check has its own source. It is not user-initiated, has no Stop button, and
+    /// races itself: two overlapping checks would leave the panel showing whichever finished last,
+    /// which could be the container the user just moved away from - and that panel is what someone
+    /// reads before deciding whether to create a credential (#111).
+    /// </summary>
+    private readonly OperationCancellation _checkCancellation = new();
+
+    public ServerCredentialViewModel(
+        ISqlServerService sql, ICredentialStore store, OperationLog log,
+        OperationCancellation writeCancellation)
+    {
+        _sql = sql;
+        _store = store;
+        _log = log;
+        _writeCancellation = writeCancellation;
+    }
+
+    /// <summary>
+    /// Something the user should see on the app's status line; true when it is an error.
+    ///
+    /// An event rather than a call back into the parent, so this type can be exercised without one.
+    /// <see cref="PrepareForRestoreAsync"/> deliberately does NOT raise it - a refusal there stops
+    /// the restore, and the execute path reports it alongside everything else it has to unwind.
+    /// </summary>
+    public event Action<string, bool>? Reported;
+
+    /// <summary>The instance the panel is describing, or null when not connected.</summary>
+    [ObservableProperty]
+    private ServerConnection? _server;
+
+    /// <summary>The container whose URL names the credential.</summary>
+    [ObservableProperty]
+    private BlobContainerConfig? _container;
+
+    /// <summary>
+    /// The credential name, which is the container URL by default and editable free text on screen.
+    /// Editable because the credential may already exist under a name somebody else chose.
+    /// </summary>
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    /// <summary>Null until a check has run, so "not checked yet" does not render as "missing".</summary>
+    [ObservableProperty]
+    private bool? _existsOnServer;
+
+    // What the credential of that name actually authenticates as. The three views below are derived
+    // rather than stored: they used to be one bool that conflated "not a SAS credential" with
+    // "unusable", which is how a managed identity came to be treated as damage (#145).
+    [ObservableProperty]
+    private BlobCredentialIdentity _identityKind = BlobCredentialIdentity.Missing;
+
+    /// <summary>A restore can authenticate with what is on the server as it stands.</summary>
+    public bool IsUsable =>
+        IdentityKind is BlobCredentialIdentity.SharedAccessSignature
+            or BlobCredentialIdentity.ManagedIdentity;
+
+    /// <summary>The credential holds a SAS, so the stored token is the thing that can go stale.</summary>
+    public bool IsSharedAccessSignature =>
+        IdentityKind == BlobCredentialIdentity.SharedAccessSignature;
+
+    /// <summary>The instance authenticates to storage as itself, and this app must not touch it.</summary>
+    public bool IsManagedIdentity => IdentityKind == BlobCredentialIdentity.ManagedIdentity;
+
+    partial void OnIdentityKindChanged(BlobCredentialIdentity value)
+    {
+        OnPropertyChanged(nameof(IsUsable));
+        OnPropertyChanged(nameof(IsSharedAccessSignature));
+        OnPropertyChanged(nameof(IsManagedIdentity));
+    }
+
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    [ObservableProperty]
+    private bool _isChecking;
+
+    /// <summary>The panel only means anything once a container is selected.</summary>
+    [ObservableProperty]
+    private bool _sectionVisible;
+
+    /// <summary>
+    /// Point this at a container: the credential is named for its URL, and everything on the panel
+    /// belongs to it. Clears the previous container's answer before asking about the new one, so a
+    /// stale verdict is never on screen under a different container's name.
+    /// </summary>
+    public Task PointAtAsync(BlobContainerConfig? container)
+    {
+        Container = container;
+        SectionVisible = container != null;
+        if (container != null) Name = container.ContainerUrl;
+        return RefreshAsync();
+    }
+
+    /// <summary>Call when the connected server or the selected container changes.</summary>
+    public async Task RefreshAsync()
+    {
+        SectionVisible = Container != null;
+        if (Server == null || Container == null)
+        {
+            ExistsOnServer = null;
+            StatusMessage = string.Empty;
+            IdentityKind = BlobCredentialIdentity.Missing;
+            return;
+        }
+
+        // Cancels any check already in flight. See _checkCancellation.
+        var ct = _checkCancellation.Begin();
+
+        IsChecking = true;
+        StatusMessage = "Checking...";
+        var server = Server;
+        try
+        {
+            var credential = await _sql.CredentialExistsAsync(server, Name, ct);
+            ExistsOnServer = credential.Exists;
+            IdentityKind = credential.Kind;
+            StatusMessage = Describe(credential);
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer check - which is about to write its own answer here. Saying
+            // anything would just be the older check having the last word again.
+            return;
+        }
+        catch (Exception ex)
+        {
+            ExistsOnServer = null;
+            IdentityKind = BlobCredentialIdentity.Missing;
+            StatusMessage = $"Could not check credential: {ex.Message}";
+        }
+        finally
+        {
+            // Only when this check is still the current one. Ending the newer check's source, or
+            // clearing its "Checking..." state, is how the previous version left the panel
+            // reporting the container the user had already moved away from.
+            if (!ct.IsCancellationRequested)
+            {
+                _checkCancellation.End();
+                IsChecking = false;
+                CreateOnServerCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The panel's one line about what is on the server. An unusable credential is named rather
+    /// than just rejected: "not a SAS credential" was the same sentence for a managed identity
+    /// that would have restored perfectly well and for a Windows account that never could (#145).
+    /// </summary>
+    internal static string Describe(BlobCredentialStatus credential) => credential.Kind switch
+    {
+        BlobCredentialIdentity.SharedAccessSignature =>
+            "Credential is present and valid (SHARED ACCESS SIGNATURE).",
+        BlobCredentialIdentity.ManagedIdentity =>
+            "Credential is present and valid (Managed Identity). The restore authenticates as the " +
+            "instance's own identity, so no SAS token is involved and this app will not modify it.",
+        BlobCredentialIdentity.Other =>
+            $"Credential exists with identity '{credential.Identity}', which a restore from URL " +
+            "cannot use. Replace it below, or point at a different credential.",
+        _ => "Credential is not present on this server. Restore will fail unless you create it."
+    };
+
+    /// <summary>Create or update the credential with the container's stored SAS token.</summary>
+    [RelayCommand(CanExecute = nameof(CanCreate))]
+    private async Task CreateOnServerAsync()
+    {
+        if (Server == null || Container == null) return;
+
+        var sasToken = _store.GetSasToken(Container);
+        if (string.IsNullOrEmpty(sasToken))
+        {
+            Reported?.Invoke(
+                "No SAS token stored for this container. Add or refresh the token in Blob Storage config.",
+                true);
+            return;
+        }
+
+        // What is about to be overwritten, read before the write. This is the only route by which
+        // a managed identity gets replaced by a SAS token, and it should say so afterwards rather
+        // than reporting a routine "updated" for a change to how the instance authenticates (#145).
+        var replaced = IdentityKind;
+
+        try
+        {
+            var change = await _sql.EnsureCredentialExistsAsync(
+                Server, Name, Container.ContainerUrl, sasToken, _writeCancellation.Begin());
+            await RefreshAsync();
+            Reported?.Invoke(change switch
+            {
+                CredentialChange.Created => "Credential created on server.",
+                _ when replaced == BlobCredentialIdentity.ManagedIdentity =>
+                    "Credential replaced on server: it authenticated as the instance's managed " +
+                    "identity and now holds the stored SAS token.",
+                _ => "Credential updated on server with the stored SAS token."
+            }, false);
+
+            if (replaced == BlobCredentialIdentity.ManagedIdentity)
+                _log.ServerChange(Server.ServerName,
+                    $"credential [{Name}] identity changed from Managed Identity to SAS");
+        }
+        catch (Exception ex)
+        {
+            Reported?.Invoke($"Failed to create credential: {ex.Message}", true);
+        }
+    }
+
+    // Deliberately available even when the credential is present and valid. SQL Server will not
+    // hand back a credential's secret, so "present and SAS" says nothing about whether the token
+    // inside it still works - a SAS that was rotated or has expired looks identical from here.
+    // Since Execute no longer rewrites the credential on every run, this button is the only way
+    // to push a fresh token, and hiding it left users with no route at all.
+    private bool CanCreate() => Server != null && Container != null;
+
+    partial void OnServerChanged(ServerConnection? value) => CreateOnServerCommand.NotifyCanExecuteChanged();
+    partial void OnContainerChanged(BlobContainerConfig? value) => CreateOnServerCommand.NotifyCanExecuteChanged();
+
+    /// <summary>
+    /// What the execute path should do about the credential before it starts, and everything it
+    /// should say about it. Writes to the server only when there is nothing of that name.
+    /// </summary>
+    public async Task<CredentialPreflight> PrepareForRestoreAsync(
+        ServerConnection server, Action<string> appendLog)
+    {
+        if (Container == null) return CredentialPreflight.Proceed;
+
+        // No stored token means nothing this app could write anyway - an Entra container has none
+        // by design. Whatever is on the server is what the restore will use, and it is not this
+        // app's to guess at.
+        var sasToken = _store.GetSasToken(Container);
+        if (string.IsNullOrEmpty(sasToken)) return CredentialPreflight.Proceed;
+
+        // Only write when the credential is genuinely missing. This used to drop and recreate on
+        // every single execute, regardless of the status the panel was displaying, which
+        // contradicted the UI's own "creating it is optional" wording and briefly removed a
+        // credential that other sessions may have been using (#10).
+        //
+        // A credential that exists and is SAS is left alone. Its secret could still be a rotated
+        // SAS that no longer works - unknowable from here, since the secret cannot be read back -
+        // so the fix for that case is the explicit button, not rewriting server state on every run.
+        //
+        // A managed identity is left alone for a stronger reason: it restores perfectly well, this
+        // app cannot create one, and ALTER would reset the identity. Reading "not SAS" as "broken"
+        // is what silently converted somebody's working managed identity into a SAS token here,
+        // taking every other job on that container with it, under the log line "Credential updated
+        // on the server" (#145).
+        var credential = await _sql.CredentialExistsAsync(server, Name);
+
+        if (credential.CanRestoreFromUrl)
+        {
+            appendLog(credential.Kind == BlobCredentialIdentity.ManagedIdentity
+                ? $"Using the existing SQL credential [{Name}] (Managed Identity). Server state not modified."
+                : $"Using the existing SQL credential [{Name}]. Server state not modified.");
+            return CredentialPreflight.Proceed;
+        }
+
+        if (credential.Exists)
+        {
+            // Neither usable nor ours to reinterpret. Converting it is a real option - it is what
+            // the button on the panel does - but it must be a decision somebody made, not a side
+            // effect of pressing Execute. Stopping costs a restore that was about to fail on blob
+            // access anyway.
+            var refusal =
+                $"Credential [{Name}] exists with identity '{credential.Identity}', which a " +
+                "restore from URL cannot use. Left untouched: replacing it with the stored SAS " +
+                "token is what \"Create credential on server\" does, so that it is a deliberate change.";
+            appendLog(refusal);
+            return CredentialPreflight.Stop(refusal);
+        }
+
+        appendLog($"Credential [{Name}] is missing - creating it...");
+
+        // This statement carries the SAS token to the server. It is the one moment in a restore
+        // where a secret crosses the wire, so if the connection is encrypted but unverified, say so
+        // here rather than only in settings (#17).
+        if (server.TrustServerCertificate)
+            appendLog(
+                "  Note: this connection trusts the server certificate without validating it, " +
+                "and the SAS token is sent over it.");
+
+        var written = await _sql.EnsureCredentialExistsAsync(
+            server, Name, Container.ContainerUrl, sasToken);
+
+        appendLog(written == CredentialChange.Created
+            ? "Credential created on the server."
+            : "Credential updated on the server.");
+
+        // Changing a credential is a change to shared state on someone's instance. It belongs in
+        // the file, not only in a console that closes with the app.
+        _log.ServerChange(server.ServerName,
+            $"credential [{Name}] {written.ToString().ToLowerInvariant()}");
+
+        return CredentialPreflight.Proceed;
+    }
+}
+
+/// <summary>
+/// Whether a restore may start, and what to say when it may not. A refusal here has touched
+/// nothing, so the caller has nothing to unwind.
+/// </summary>
+public readonly record struct CredentialPreflight(bool CanProceed, string? Refusal)
+{
+    public static CredentialPreflight Proceed => new(true, null);
+
+    public static CredentialPreflight Stop(string reason) => new(false, reason);
+}

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -33,9 +33,28 @@ public partial class ServerManagerViewModel : ViewModelBase
     [ObservableProperty]
     private AuthMode _editAuthMode = AuthMode.WindowsAuth;
 
+    /// <summary>Whether to show the password box. Only SQL auth has a password to hold (#30).</summary>
     public bool IsSqlAuth => EditAuthMode == AuthMode.SqlAuth;
 
-    partial void OnEditAuthModeChanged(AuthMode value) => OnPropertyChanged(nameof(IsSqlAuth));
+    /// <summary>
+    /// Whether to show the username box. Interactive Entra takes one as an optional hint that
+    /// pre-selects the account, which is worth having on a machine signed in to several.
+    /// </summary>
+    public bool ShowsUsername => EditAuthMode.AcceptsUsername();
+
+    public bool IsEntraAuth => EditAuthMode.IsEntra();
+
+    public string UsernameLabel => EditAuthMode == AuthMode.EntraInteractive
+        ? "USERNAME (OPTIONAL - PRE-SELECTS THE ACCOUNT)"
+        : "USERNAME";
+
+    partial void OnEditAuthModeChanged(AuthMode value)
+    {
+        OnPropertyChanged(nameof(IsSqlAuth));
+        OnPropertyChanged(nameof(ShowsUsername));
+        OnPropertyChanged(nameof(IsEntraAuth));
+        OnPropertyChanged(nameof(UsernameLabel));
+    }
 
     [ObservableProperty]
     private string _editUsername = string.Empty;
@@ -225,7 +244,7 @@ public partial class ServerManagerViewModel : ViewModelBase
             return;
         }
 
-        if (EditAuthMode == AuthMode.SqlAuth && string.IsNullOrWhiteSpace(EditUsername))
+        if (EditAuthMode.RequiresUsername() && string.IsNullOrWhiteSpace(EditUsername))
         {
             SetError("Username is required for SQL Authentication.");
             return;
@@ -262,7 +281,9 @@ public partial class ServerManagerViewModel : ViewModelBase
         ReplaceTags(server.Tags, TagPalette.ParseTags(EditTags));
         server.ServerName = EditServerName;
         server.AuthMode = EditAuthMode;
-        server.Username = EditAuthMode == AuthMode.SqlAuth ? EditUsername : null;
+        server.Username = EditAuthMode.AcceptsUsername() && !string.IsNullOrWhiteSpace(EditUsername)
+            ? EditUsername
+            : null;
         server.ConnectionTimeoutSeconds = EditTimeout;
         server.TrustServerCertificate = EditTrustServerCert;
         server.Encrypt = EditEncrypt;
@@ -283,17 +304,31 @@ public partial class ServerManagerViewModel : ViewModelBase
             return;
         }
 
-        if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
+        if (EditAuthMode.NeedsStoredPassword())
         {
-            try
+            if (!string.IsNullOrWhiteSpace(EditPassword))
             {
-                _credentialStore.SaveSqlPassword(server, EditPassword);
+                try
+                {
+                    _credentialStore.SaveSqlPassword(server, EditPassword);
+                }
+                catch (Exception ex)
+                {
+                    SetError($"The server was saved, but the password could not be stored: {ex.Message}");
+                    return;
+                }
             }
-            catch (Exception ex)
-            {
-                SetError($"The server was saved, but the password could not be stored: {ex.Message}");
-                return;
-            }
+        }
+        else
+        {
+            // Switching away from SQL auth used to leave the password in Credential Manager - a
+            // live secret for a login nothing uses any more, outliving the only reason it was
+            // stored. Moving to Entra is usually done precisely to stop tools holding passwords,
+            // so leaving one behind defeats the point of the switch.
+            //
+            // After the config write, for the same reason Delete does it in that order: the
+            // password is only redundant once the mode change has actually landed on disk.
+            _credentialStore.DeleteSecret(server.CredentialKey);
         }
 
         SelectedServer = server;
@@ -308,7 +343,7 @@ public partial class ServerManagerViewModel : ViewModelBase
 
         // Same reasoning as deleting a container: a stored SQL password is removed from Credential
         // Manager and the app never displays it, so a single click should not be enough (#42).
-        var secretNote = SelectedServer.AuthMode == AuthMode.SqlAuth
+        var secretNote = SelectedServer.AuthMode.NeedsStoredPassword()
             ? "\n\nIts stored SQL password will be deleted from Windows Credential Manager."
             : string.Empty;
 
@@ -332,7 +367,7 @@ public partial class ServerManagerViewModel : ViewModelBase
             return;
         }
 
-        if (removed.AuthMode == AuthMode.SqlAuth)
+        if (removed.AuthMode.NeedsStoredPassword())
             _credentialStore.DeleteSecret(removed.CredentialKey);
 
         if (IsConnected && ConnectedServerDisplay == removed.DisplayText)
@@ -487,9 +522,9 @@ public partial class ServerManagerViewModel : ViewModelBase
             // In memory only. This used to call SaveSqlPassword, which is a durable write to
             // Credential Manager - so testing a mistyped password overwrote the working one
             // before the user had agreed to anything, and Cancel could not undo it (#12).
-            if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
+            if (EditAuthMode.NeedsStoredPassword() && !string.IsNullOrWhiteSpace(EditPassword))
                 server.UnsavedPassword = EditPassword;
-            else if (EditAuthMode == AuthMode.SqlAuth && !IsNew)
+            else if (EditAuthMode.NeedsStoredPassword() && !IsNew)
                 // No new password typed: test against the one already saved for this entry.
                 server.Id = SelectedServer?.Id;
 

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -9,8 +9,8 @@ namespace Blackcat.NineLives.ViewModels;
 
 public partial class ServerManagerViewModel : ViewModelBase
 {
-    private readonly CredentialStore _credentialStore;
-    private readonly SqlServerService _sqlService;
+    private readonly ICredentialStore _credentialStore;
+    private readonly ISqlServerService _sqlService;
 
     public event EventHandler<ServerConnectionChangedEventArgs>? ConnectionChanged;
 
@@ -73,7 +73,7 @@ public partial class ServerManagerViewModel : ViewModelBase
     [ObservableProperty]
     private string _connectedServerDisplay = string.Empty;
 
-    public ServerManagerViewModel(CredentialStore credentialStore, SqlServerService sqlService)
+    public ServerManagerViewModel(ICredentialStore credentialStore, ISqlServerService sqlService)
     {
         _credentialStore = credentialStore;
         _sqlService = sqlService;

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -42,8 +42,6 @@ public partial class ServerManagerViewModel : ViewModelBase
     /// </summary>
     public bool ShowsUsername => EditAuthMode.AcceptsUsername();
 
-    public bool IsEntraAuth => EditAuthMode.IsEntra();
-
     public string UsernameLabel => EditAuthMode == AuthMode.EntraInteractive
         ? "USERNAME (OPTIONAL - PRE-SELECTS THE ACCOUNT)"
         : "USERNAME";
@@ -52,7 +50,6 @@ public partial class ServerManagerViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(IsSqlAuth));
         OnPropertyChanged(nameof(ShowsUsername));
-        OnPropertyChanged(nameof(IsEntraAuth));
         OnPropertyChanged(nameof(UsernameLabel));
     }
 

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -338,6 +338,7 @@ public partial class ServerManagerViewModel : ViewModelBase
         if (IsConnected && ConnectedServerDisplay == removed.DisplayText)
         {
             IsConnected = false;
+            MarkConnected(null);
             ConnectedServerDisplay = string.Empty;
             ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs
             {
@@ -427,6 +428,7 @@ public partial class ServerManagerViewModel : ViewModelBase
 
             IsConnected = true;
             ConnectedServerDisplay = SelectedServer.DisplayText;
+            MarkConnected(SelectedServer);
             ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs
             {
                 IsConnected = true,
@@ -445,11 +447,21 @@ public partial class ServerManagerViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Exactly one server carries the connected marker, so the list can never show two.
+    /// </summary>
+    private void MarkConnected(ServerConnection? connected)
+    {
+        foreach (var server in Servers)
+            server.IsConnectedServer = ReferenceEquals(server, connected);
+    }
+
     [RelayCommand]
     private void Disconnect()
     {
         IsConnected = false;
         ConnectedServerDisplay = string.Empty;
+        MarkConnected(null);
         ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs
         {
             IsConnected = false,

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -87,6 +87,34 @@ public partial class ServerManagerViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Captures a server's persisted fields and returns the action that puts them back. Used to
+    /// undo an in-place edit when the config write is refused.
+    /// </summary>
+    private static Action Snapshot(ServerConnection server)
+    {
+        var name = server.Name;
+        var serverName = server.ServerName;
+        var authMode = server.AuthMode;
+        var username = server.Username;
+        var timeout = server.ConnectionTimeoutSeconds;
+        var trust = server.TrustServerCertificate;
+        var encrypt = server.Encrypt;
+        var tags = server.Tags.ToList();
+
+        return () =>
+        {
+            server.Name = name;
+            server.ServerName = serverName;
+            server.AuthMode = authMode;
+            server.Username = username;
+            server.ConnectionTimeoutSeconds = timeout;
+            server.TrustServerCertificate = trust;
+            server.Encrypt = encrypt;
+            ReplaceTags(server.Tags, tags);
+        };
+    }
+
+    /// <summary>
     /// Persists the server list. Returns false and sets the error when the write failed, so
     /// callers do not go on to report success - the config save used to swallow everything and
     /// the UI said "saved successfully" whether or not anything reached the disk.
@@ -204,6 +232,10 @@ public partial class ServerManagerViewModel : ViewModelBase
         }
 
         ServerConnection server;
+
+        // Undoes the edit if the save is refused. Null for a new server, which is removed instead.
+        Action? restore = null;
+
         if (IsNew)
         {
             if (Servers.Any(s => s.Name.Equals(EditName, StringComparison.OrdinalIgnoreCase)))
@@ -218,6 +250,10 @@ public partial class ServerManagerViewModel : ViewModelBase
         else
         {
             server = SelectedServer!;
+
+            // Snapshot before mutating, so a refused save can put the model back rather than
+            // leaving it showing values that were never persisted.
+            restore = Snapshot(server);
         }
 
         server.Name = EditName;
@@ -231,17 +267,33 @@ public partial class ServerManagerViewModel : ViewModelBase
         server.TrustServerCertificate = EditTrustServerCert;
         server.Encrypt = EditEncrypt;
 
-        if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
-        {
-            _credentialStore.SaveSqlPassword(server, EditPassword);
-        }
-
+        // Config FIRST, password second.
+        //
+        // The other order wrote the password to Credential Manager and then found the config could
+        // not be saved. Change a login's username and password together with config.json briefly
+        // locked, and the vault holds the NEW password while the file still has the OLD username -
+        // so every connection fails auth, and the form never shows a stored password, so nothing
+        // on screen says why. Delete already follows this rule.
         if (!SaveServers())
         {
             // Nothing reached the disk, so do not leave the list showing a server that is not
             // really there. Stay in the edit form so the save can be retried.
             if (IsNew) Servers.Remove(server);
+            else restore?.Invoke();
             return;
+        }
+
+        if (EditAuthMode == AuthMode.SqlAuth && !string.IsNullOrWhiteSpace(EditPassword))
+        {
+            try
+            {
+                _credentialStore.SaveSqlPassword(server, EditPassword);
+            }
+            catch (Exception ex)
+            {
+                SetError($"The server was saved, but the password could not be stored: {ex.Message}");
+                return;
+            }
         }
 
         SelectedServer = server;

--- a/src/NineLives/Views/AboutView.xaml
+++ b/src/NineLives/Views/AboutView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.AboutView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.AboutView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
@@ -14,18 +14,18 @@
                 <TextBlock Style="{StaticResource LogoWordmark}"
                            FontSize="26"
                            Margin="0,0,0,12">
-                    <Run Text="N I N E" Foreground="{StaticResource PrimaryTextBrush}" />
+                    <Run Text="N I N E" Foreground="{DynamicResource PrimaryTextBrush}" />
                     <Run Text="  " />
-                    <Run Text="L I V E S" Foreground="#3B83E9" />
+                    <Run Text="L I V E S" Foreground="{DynamicResource AccentBrush}" />
                 </TextBlock>
 
                 <TextBlock Text="{Binding Version}"
                            FontSize="14"
-                           Foreground="{StaticResource SecondaryTextBrush}"
+                           Foreground="{DynamicResource SecondaryTextBrush}"
                            HorizontalAlignment="Center"
                            Margin="0,0,0,20" />
 
-                <Border Height="1" Background="{StaticResource CardBorderBrush}" Margin="0,0,0,20" />
+                <Border Height="1" Background="{DynamicResource CardBorderBrush}" Margin="0,0,0,20" />
 
                 <TextBlock Text="{Binding Description}"
                            Style="{StaticResource BodyText}"
@@ -33,12 +33,12 @@
                            TextAlignment="Center"
                            Margin="0,0,0,24" />
 
-                <Border Height="1" Background="{StaticResource CardBorderBrush}" Margin="0,0,0,20" />
+                <Border Height="1" Background="{DynamicResource CardBorderBrush}" Margin="0,0,0,20" />
 
                 <TextBlock Text="AUTHOR" Style="{StaticResource LabelText}" HorizontalAlignment="Center" />
                 <TextBlock Text="{Binding Author}"
                            FontSize="15" FontWeight="SemiBold"
-                           Foreground="{StaticResource PrimaryTextBrush}"
+                           Foreground="{DynamicResource PrimaryTextBrush}"
                            HorizontalAlignment="Center"
                            Margin="0,0,0,4" />
                 <TextBlock Text="{Binding Company}"
@@ -48,11 +48,29 @@
                 <TextBlock HorizontalAlignment="Center" Margin="0,0,0,20">
                     <Hyperlink NavigateUri="{Binding Website}"
                                RequestNavigate="Hyperlink_RequestNavigate"
-                               Foreground="{StaticResource AccentBrush}"
+                               Foreground="{DynamicResource AccentBrush}"
                                TextDecorations="None">
                         <Run Text="{Binding Website, Mode=OneWay}" />
                     </Hyperlink>
                 </TextBlock>
+
+                <Border Height="1" Background="{DynamicResource CardBorderBrush}" Margin="0,0,0,20" />
+
+                <TextBlock Text="APPEARANCE" Style="{StaticResource LabelText}" HorizontalAlignment="Center" />
+                <ComboBox ItemsSource="{Binding Themes}"
+                          DisplayMemberPath="Name"
+                          SelectedValuePath="Value"
+                          SelectedValue="{Binding SelectedTheme}"
+                          Style="{StaticResource DarkComboBox}"
+                          Width="200"
+                          HorizontalAlignment="Center"
+                          Margin="0,0,0,6"
+                          ToolTip="Dark is the default. High contrast is pure black and white with saturated status colours, for anyone who needs it." />
+                <TextBlock Text="Applies straight away, and is remembered."
+                           Style="{StaticResource SecondaryText}"
+                           FontSize="11"
+                           HorizontalAlignment="Center"
+                           Margin="0,0,0,20" />
 
                 <!-- The logs are what someone attaches to a bug report, so there has to be a way
                      to find them that is not "know where LocalAppData lives" (#40). -->

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -219,7 +219,7 @@
                                             HorizontalAlignment="Left"
                                             Opacity="0.85">
                                         <TextBlock Text="{Binding TypeDisplay}"
-                                                   Foreground="White"
+                                                   Foreground="{StaticResource BadgeTextBrush}"
                                                    FontSize="11"
                                                    FontWeight="SemiBold" />
                                     </Border>

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.BlobBrowserView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.BlobBrowserView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
@@ -111,7 +111,7 @@
                     <StackPanel Grid.Column="0" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.TotalSets}"
                                    FontSize="20" FontWeight="Bold"
-                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                   Foreground="{DynamicResource PrimaryTextBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Total Sets" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -119,7 +119,7 @@
                     <StackPanel Grid.Column="1" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.FullBackups}"
                                    FontSize="20" FontWeight="Bold"
-                                   Foreground="{StaticResource AccentBrush}"
+                                   Foreground="{DynamicResource AccentBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Full" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -127,7 +127,7 @@
                     <StackPanel Grid.Column="2" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.DiffBackups}"
                                    FontSize="20" FontWeight="Bold"
-                                   Foreground="{StaticResource WarningBrush}"
+                                   Foreground="{DynamicResource WarningBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Diff" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -135,7 +135,7 @@
                     <StackPanel Grid.Column="3" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.LogBackups}"
                                    FontSize="20" FontWeight="Bold"
-                                   Foreground="{StaticResource SuccessBrush}"
+                                   Foreground="{DynamicResource SuccessBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Log" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -143,7 +143,7 @@
                     <StackPanel Grid.Column="4" HorizontalAlignment="Center">
                         <TextBlock Text="{Binding Summary.TotalSizeDisplay}"
                                    FontSize="14" FontWeight="Bold"
-                                   Foreground="{StaticResource PrimaryTextBrush}"
+                                   Foreground="{DynamicResource PrimaryTextBrush}"
                                    HorizontalAlignment="Center" />
                         <TextBlock Text="Size" Style="{StaticResource SecondaryText}"
                                    HorizontalAlignment="Center" />
@@ -184,7 +184,7 @@
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"
                             Visibility="{Binding HasFiles, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                     <TextBlock Text="&#x1F4C2;" FontSize="48" HorizontalAlignment="Center"
-                               Foreground="{StaticResource SecondaryTextBrush}" Margin="0,0,0,12" />
+                               Foreground="{DynamicResource SecondaryTextBrush}" Margin="0,0,0,12" />
                     <TextBlock Text="No backup files loaded"
                                Style="{StaticResource BodyText}"
                                HorizontalAlignment="Center" />
@@ -236,7 +236,7 @@
                 </DataGrid>
 
                 <!-- Loading -->
-                <Border Background="#80000000"
+                <Border Background="{DynamicResource OverlayBrush}"
                         CornerRadius="6"
                         Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}">
                     <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -438,7 +438,7 @@
                                                     <Border CornerRadius="4" Padding="10,5" Cursor="Hand"
                                                             Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                         <StackPanel Orientation="Horizontal">
-                                                            <TextBlock Text="{Binding DisplayName}" Foreground="White"
+                                                            <TextBlock Text="{Binding DisplayName}" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}"
                                                                        FontSize="12" FontWeight="SemiBold"
                                                                        VerticalAlignment="Center" />
                                                             <Button Content="  x" Foreground="{DynamicResource PrimaryTextBrush}" FontSize="11"
@@ -481,9 +481,9 @@
                                                             BorderBrush="{DynamicResource CardBorderBrush}"
                                                             Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                         <StackPanel Orientation="Horizontal">
-                                                            <TextBlock Text="+" Foreground="White" FontWeight="Bold"
+                                                            <TextBlock Text="+" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}" FontWeight="Bold"
                                                                        FontSize="12" Margin="0,0,4,0" />
-                                                            <TextBlock Text="{Binding DisplayName}" Foreground="White"
+                                                            <TextBlock Text="{Binding DisplayName}" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}"
                                                                        FontSize="12" />
                                                         </StackPanel>
                                                     </Border>
@@ -549,7 +549,7 @@
                                                             <Border CornerRadius="4" Padding="10,5" Cursor="Hand"
                                                                     Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                                 <StackPanel Orientation="Horizontal">
-                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="White"
+                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}"
                                                                                FontSize="12" FontWeight="SemiBold"
                                                                                VerticalAlignment="Center" />
                                                                     <Button Content="  x" Foreground="{DynamicResource PrimaryTextBrush}" FontSize="11"
@@ -590,9 +590,9 @@
                                                                     BorderBrush="{DynamicResource CardBorderBrush}"
                                                                     Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                                 <StackPanel Orientation="Horizontal">
-                                                                    <TextBlock Text="+" Foreground="White" FontWeight="Bold"
+                                                                    <TextBlock Text="+" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}" FontWeight="Bold"
                                                                                FontSize="12" Margin="0,0,4,0" />
-                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="White"
+                                                                    <TextBlock Text="{Binding DisplayName}" Foreground="{Binding HexColor, Converter={StaticResource ContrastingText}}"
                                                                                FontSize="12" />
                                                                 </StackPanel>
                                                             </Border>

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -360,9 +360,9 @@
                                     Visibility="{Binding IsEntraAuth, Converter={StaticResource BoolToVis}}">
                                 <StackPanel>
                                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
-                                               Text="Entra sign-in is built but has not been tested against a real tenant - there is no Entra-enabled storage account to develop it against. Test Connection will tell you honestly whether it works. Please report what happens either way." />
+                                               Text="Your account needs the Storage Blob Data Reader role on this container. Owner or Contributor is NOT enough - blob data access is a separate set of roles from the ones that administer the account, which is the usual reason a permission error appears against an account that can plainly see the container in the portal." />
                                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,8,0,0"
-                                               Text="Your account needs the Storage Blob Data Reader role on this container - Owner or Contributor on the subscription is not enough on its own. This covers browsing only: the RESTORE itself runs on SQL Server, which needs its own credential for the container URL." />
+                                               Text="This covers browsing only: the RESTORE itself runs on SQL Server, which needs its own credential for the container URL. Test Connection names the account it signed in as, which is worth checking first if the permission looks right." />
                                 </StackPanel>
                             </Border>
 

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -372,6 +372,20 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
 
+                            <!-- The only thing that genuinely reconciles the two clocks a backup
+                                 time can come from: a filename is the backup server's local time,
+                                 a blob's LastModified is UTC. Optional, and "not known" behaves
+                                 exactly as the app did before it existed (#102). -->
+                            <TextBlock Text="BACKUP SERVER TIME ZONE" Style="{StaticResource LabelText}" />
+                            <TextBlock Text="Only needed when some backups here have no timestamp in their filename. Setting it lets those be sorted correctly against the rest instead of being marked approximate."
+                                       Style="{StaticResource SecondaryText}"
+                                       FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap" />
+                            <ComboBox ItemsSource="{Binding TimeZones}"
+                                      SelectedItem="{Binding EditBackupServerTimeZone}"
+                                      DisplayMemberPath="Name"
+                                      Style="{StaticResource DarkComboBox}"
+                                      Margin="0,0,0,16" />
+
                             <TextBlock>
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock" BasedOn="{StaticResource LabelText}">

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -9,6 +9,9 @@
         <converters:HexToBrushConverter x:Key="HexToBrush" />
         <converters:BoolToEyeIconConverter x:Key="BoolToEyeIcon" />
         <converters:BackupSourceTypeToDisplayConverter x:Key="BackupSourceTypeDisplay" />
+        <converters:EnumToBoolConverter x:Key="EnumToBool" />
+        <converters:BlobAuthModeToDisplayConverter x:Key="BlobAuthModeDisplay" />
+        <converters:BlobAuthModeIsSasConverter x:Key="BlobAuthModeIsSas" />
     </UserControl.Resources>
 
     <Grid>
@@ -172,10 +175,19 @@
                                            Style="{StaticResource BodyText}"
                                            Margin="0,0,0,12" />
 
-                                <TextBlock Text="SAS TOKEN STATUS" Style="{StaticResource LabelText}" />
-                                <TextBlock Text="{Binding SasExpiryText}"
+                                <TextBlock Text="AUTHENTICATION" Style="{StaticResource LabelText}" />
+                                <TextBlock Text="{Binding SelectedContainer.AuthMode, Converter={StaticResource BlobAuthModeDisplay}}"
                                            Style="{StaticResource BodyText}"
                                            Margin="0,0,0,12" />
+
+                                <!-- Only under SAS. An expiry line against a container that has no
+                                     token of ours would send someone hunting for the wrong thing. -->
+                                <StackPanel Visibility="{Binding SelectedContainer.AuthMode, Converter={StaticResource BlobAuthModeIsSas}}">
+                                    <TextBlock Text="SAS TOKEN STATUS" Style="{StaticResource LabelText}" />
+                                    <TextBlock Text="{Binding SasExpiryText}"
+                                               Style="{StaticResource BodyText}"
+                                               Margin="0,0,0,12" />
+                                </StackPanel>
 
                                 <TextBlock Text="BACKUPS AT THIS LOCATION" Style="{StaticResource LabelText}" />
                                 <TextBlock Margin="0,0,0,12">
@@ -317,6 +329,44 @@
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,16" />
 
+                            <TextBlock Text="AUTHENTICATION" Style="{StaticResource LabelText}" />
+                            <StackPanel Margin="0,4,0,16">
+                                <RadioButton Content="SAS token"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=SasToken}"
+                                             Margin="0,0,0,8"
+                                             GroupName="BlobAuthMode"
+                                             ToolTip="A shared access signature stored in Windows Credential Manager." />
+                                <RadioButton Content="Entra ID - interactive (MFA)"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraInteractive}"
+                                             Margin="0,0,0,8"
+                                             GroupName="BlobAuthMode"
+                                             ToolTip="Opens a browser to sign in. Nothing is stored - the sign-in lasts for as long as the app is running." />
+                                <RadioButton Content="Entra ID - default"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraDefault}"
+                                             GroupName="BlobAuthMode"
+                                             ToolTip="Environment, then managed identity, then the Azure CLI or Visual Studio sign-in, then a prompt. The one to pick when this app runs on an Azure VM." />
+                            </StackPanel>
+
+                            <!-- Untested against a real tenant - see the note in the README. Said
+                                 here rather than only in the docs, because the person who finds out
+                                 is the one standing in front of this screen. -->
+                            <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                    BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                    BorderThickness="1" CornerRadius="4" Padding="10"
+                                    Margin="0,0,0,16"
+                                    Visibility="{Binding IsEntraAuth, Converter={StaticResource BoolToVis}}">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
+                                               Text="Entra sign-in is built but has not been tested against a real tenant - there is no Entra-enabled storage account to develop it against. Test Connection will tell you honestly whether it works. Please report what happens either way." />
+                                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,8,0,0"
+                                               Text="Your account needs the Storage Blob Data Reader role on this container - Owner or Contributor on the subscription is not enough on its own. This covers browsing only: the RESTORE itself runs on SQL Server, which needs its own credential for the container URL." />
+                                </StackPanel>
+                            </Border>
+
+                            <StackPanel Visibility="{Binding IsSasAuth, Converter={StaticResource BoolToVis}}">
                             <TextBlock Text="SAS TOKEN" Style="{StaticResource LabelText}" />
                             <TextBlock Text="Token is stored securely and cannot be displayed. Enter a new token below to replace it."
                                        Style="{StaticResource SecondaryText}" FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap"
@@ -356,6 +406,7 @@
                                             Cursor="Hand" ToolTip="Show/hide SAS token" />
                                 </Grid>
                             </Grid>
+                            </StackPanel>
 
                             <TextBlock Text="BACKUPS AT THIS LOCATION" Style="{StaticResource LabelText}" />
                             <TextBlock Text="Choose whether this container holds standalone instance backups, Availability Group backups (Ola default naming), or both."

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.BlobConfigView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.BlobConfigView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
@@ -51,7 +51,7 @@
                              SelectedItem="{Binding SelectedContainer}"
                              Background="Transparent"
                              BorderThickness="0"
-                             Foreground="{StaticResource PrimaryTextBrush}"
+                             Foreground="{DynamicResource PrimaryTextBrush}"
                              HorizontalContentAlignment="Stretch"
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -61,12 +61,12 @@
                                 <StackPanel Margin="4,6">
                                     <StackPanel Orientation="Horizontal">
                                         <Ellipse Width="8" Height="8"
-                                                 Fill="{StaticResource SuccessBrush}"
+                                                 Fill="{DynamicResource SuccessBrush}"
                                                  VerticalAlignment="Center"
                                                  Margin="0,0,8,0" />
                                         <TextBlock Text="{Binding Name}"
                                                    FontWeight="SemiBold"
-                                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                                                   Foreground="{DynamicResource PrimaryTextBrush}" />
                                     </StackPanel>
                                     <TextBlock Text="{Binding ContainerUrl}"
                                                Style="{StaticResource SecondaryText}"
@@ -96,11 +96,11 @@
                                             <ControlTemplate.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
                                                     <Setter TargetName="border" Property="Background"
-                                                            Value="{StaticResource SidebarItemHoverBrush}" />
+                                                            Value="{DynamicResource SidebarItemHoverBrush}" />
                                                 </Trigger>
                                                 <Trigger Property="IsSelected" Value="True">
                                                     <Setter TargetName="border" Property="Background"
-                                                            Value="{StaticResource SidebarItemActiveBrush}" />
+                                                            Value="{DynamicResource SidebarItemActiveBrush}" />
                                                 </Trigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
@@ -116,18 +116,18 @@
             <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto">
                 <StackPanel>
                     <!-- SAS Expiry Warning -->
-                    <Border Background="{StaticResource DangerBackgroundBrush}"
+                    <Border Background="{DynamicResource DangerBackgroundBrush}"
                             CornerRadius="6"
                             Padding="16,12"
                             Margin="0,0,0,16"
                             Visibility="{Binding IsSasExpired, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
                             <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="&#x26A0;" FontSize="16" Foreground="{StaticResource ErrorBrush}"
+                                <TextBlock Text="&#x26A0;" FontSize="16" Foreground="{DynamicResource ErrorBrush}"
                                            VerticalAlignment="Center" Margin="0,0,8,0" />
                                 <TextBlock Text="SAS Token Expired"
                                            FontWeight="SemiBold"
-                                           Foreground="{StaticResource ErrorBrush}" />
+                                           Foreground="{DynamicResource ErrorBrush}" />
                             </StackPanel>
                             <TextBlock Text="{Binding SasExpiryText}"
                                        Style="{StaticResource SecondaryText}"
@@ -217,7 +217,7 @@
                                 </StackPanel>
 
                                 <!-- Test Result -->
-                                <Border Background="{StaticResource InputBackgroundBrush}"
+                                <Border Background="{DynamicResource InputBackgroundBrush}"
                                         CornerRadius="4"
                                         Padding="12,8"
                                         Margin="0,16,0,0"
@@ -241,7 +241,7 @@
                                         <StackPanel Grid.Column="0" HorizontalAlignment="Center">
                                             <TextBlock Text="{Binding ContainerSummary.FullBackups}"
                                                        FontSize="24" FontWeight="Bold"
-                                                       Foreground="{StaticResource AccentBrush}"
+                                                       Foreground="{DynamicResource AccentBrush}"
                                                        HorizontalAlignment="Center" />
                                             <TextBlock Text="Full" Style="{StaticResource SecondaryText}"
                                                        HorizontalAlignment="Center" />
@@ -249,7 +249,7 @@
                                         <StackPanel Grid.Column="1" HorizontalAlignment="Center">
                                             <TextBlock Text="{Binding ContainerSummary.DiffBackups}"
                                                        FontSize="24" FontWeight="Bold"
-                                                       Foreground="{StaticResource WarningBrush}"
+                                                       Foreground="{DynamicResource WarningBrush}"
                                                        HorizontalAlignment="Center" />
                                             <TextBlock Text="Diff" Style="{StaticResource SecondaryText}"
                                                        HorizontalAlignment="Center" />
@@ -257,7 +257,7 @@
                                         <StackPanel Grid.Column="2" HorizontalAlignment="Center">
                                             <TextBlock Text="{Binding ContainerSummary.LogBackups}"
                                                        FontSize="24" FontWeight="Bold"
-                                                       Foreground="{StaticResource SuccessBrush}"
+                                                       Foreground="{DynamicResource SuccessBrush}"
                                                        HorizontalAlignment="Center" />
                                             <TextBlock Text="Log" Style="{StaticResource SecondaryText}"
                                                        HorizontalAlignment="Center" />
@@ -265,7 +265,7 @@
                                         <StackPanel Grid.Column="3" HorizontalAlignment="Center">
                                             <TextBlock Text="{Binding ContainerSummary.TotalSizeDisplay}"
                                                        FontSize="18" FontWeight="Bold"
-                                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                                       Foreground="{DynamicResource PrimaryTextBrush}"
                                                        HorizontalAlignment="Center" />
                                             <TextBlock Text="Total" Style="{StaticResource SecondaryText}"
                                                        HorizontalAlignment="Center" />
@@ -338,13 +338,13 @@
                                              TextWrapping="Wrap" AcceptsReturn="False" MaxHeight="80"
                                              VerticalScrollBarVisibility="Auto"
                                              Visibility="{Binding ShowSasToken, Converter={StaticResource BoolToVis}}" />
-                                    <Border Background="{StaticResource InputBackgroundBrush}"
+                                    <Border Background="{DynamicResource InputBackgroundBrush}"
                                             CornerRadius="4" Padding="10,8"
-                                            BorderBrush="{StaticResource CardBorderBrush}"
+                                            BorderBrush="{DynamicResource CardBorderBrush}"
                                             BorderThickness="1" MinHeight="36"
                                             Visibility="{Binding ShowSasToken, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                                         <TextBlock Text="••••••••••••••••••••••••••••••••••••••••••••••••"
-                                                   Foreground="{StaticResource SecondaryTextBrush}"
+                                                   Foreground="{DynamicResource SecondaryTextBrush}"
                                                    VerticalAlignment="Center" FontSize="14" />
                                     </Border>
                                     <Button Content="{Binding ShowSasToken, Converter={StaticResource BoolToEyeIcon}}"
@@ -352,7 +352,7 @@
                                             HorizontalAlignment="Right" VerticalAlignment="Top"
                                             Margin="0,4,4,0" Padding="6,2" FontSize="14"
                                             Background="Transparent" BorderThickness="0"
-                                            Foreground="{StaticResource SecondaryTextBrush}"
+                                            Foreground="{DynamicResource SecondaryTextBrush}"
                                             Cursor="Hand" ToolTip="Show/hide SAS token" />
                                 </Grid>
                             </Grid>
@@ -389,7 +389,7 @@
                                        FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap" />
 
                             <!-- Draggable active path elements -->
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="8,6" Margin="0,0,0,6"
                                     MinHeight="40" AllowDrop="True"
                                     DragOver="PathDragOver" Drop="PathDrop">
@@ -427,7 +427,7 @@
                                                             <TextBlock Text="{Binding DisplayName}" Foreground="White"
                                                                        FontSize="12" FontWeight="SemiBold"
                                                                        VerticalAlignment="Center" />
-                                                            <Button Content="  x" Foreground="#CCFFFFFF" FontSize="11"
+                                                            <Button Content="  x" Foreground="{DynamicResource PrimaryTextBrush}" FontSize="11"
                                                                     FontWeight="Bold" Cursor="Hand"
                                                                     Background="Transparent" BorderThickness="0"
                                                                     VerticalAlignment="Center" Padding="0"
@@ -437,7 +437,7 @@
                                                                     ToolTip="Remove this element" />
                                                         </StackPanel>
                                                     </Border>
-                                                    <TextBlock Text="/" Foreground="{StaticResource SecondaryTextBrush}"
+                                                    <TextBlock Text="/" Foreground="{DynamicResource SecondaryTextBrush}"
                                                                FontSize="14" VerticalAlignment="Center" Margin="4,0,0,0" />
                                                 </StackPanel>
                                             </DataTemplate>
@@ -464,7 +464,7 @@
                                                 <ControlTemplate TargetType="Button">
                                                     <Border x:Name="bd" CornerRadius="4" Padding="10,5"
                                                             Opacity="0.5" BorderThickness="1"
-                                                            BorderBrush="{StaticResource CardBorderBrush}"
+                                                            BorderBrush="{DynamicResource CardBorderBrush}"
                                                             Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                         <StackPanel Orientation="Horizontal">
                                                             <TextBlock Text="+" Foreground="White" FontWeight="Bold"
@@ -492,14 +492,14 @@
 
                             <!-- AG path structure (when AG or Mixed) - drag/drop same as standalone -->
                             <Border Visibility="{Binding IsAgPathSectionVisible, Converter={StaticResource BoolToVis}}"
-                                    Background="{StaticResource InputBackgroundBrush}"
+                                    Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="12" Margin="0,0,0,16">
                                 <StackPanel>
                                     <TextBlock Text="AG PATH STRUCTURE" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
                                     <TextBlock Text="Drag the coloured elements to define how AG backup paths are structured (e.g. BackupType/ClusterName$AGName/DatabaseName/FileName). Leave default to also support Ola flat filenames."
                                                Style="{StaticResource SecondaryText}"
                                                FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap" />
-                                    <Border Background="{StaticResource CardBorderBrush}"
+                                    <Border Background="{DynamicResource CardBorderBrush}"
                                             CornerRadius="4" Padding="8,6" Margin="0,0,0,6"
                                             MinHeight="40" AllowDrop="True"
                                             BorderThickness="1"
@@ -538,7 +538,7 @@
                                                                     <TextBlock Text="{Binding DisplayName}" Foreground="White"
                                                                                FontSize="12" FontWeight="SemiBold"
                                                                                VerticalAlignment="Center" />
-                                                                    <Button Content="  x" Foreground="#CCFFFFFF" FontSize="11"
+                                                                    <Button Content="  x" Foreground="{DynamicResource PrimaryTextBrush}" FontSize="11"
                                                                             FontWeight="Bold" Cursor="Hand"
                                                                             Background="Transparent" BorderThickness="0"
                                                                             VerticalAlignment="Center" Padding="0"
@@ -548,7 +548,7 @@
                                                                             ToolTip="Remove this element" />
                                                                 </StackPanel>
                                                             </Border>
-                                                            <TextBlock Text="/" Foreground="{StaticResource SecondaryTextBrush}"
+                                                            <TextBlock Text="/" Foreground="{DynamicResource SecondaryTextBrush}"
                                                                        FontSize="14" VerticalAlignment="Center" Margin="4,0,0,0" />
                                                         </StackPanel>
                                                     </DataTemplate>
@@ -573,7 +573,7 @@
                                                         <ControlTemplate TargetType="Button">
                                                             <Border x:Name="bd" CornerRadius="4" Padding="10,5"
                                                                     Opacity="0.5" BorderThickness="1"
-                                                                    BorderBrush="{StaticResource CardBorderBrush}"
+                                                                    BorderBrush="{DynamicResource CardBorderBrush}"
                                                                     Background="{Binding HexColor, Converter={StaticResource HexToBrush}}">
                                                                 <StackPanel Orientation="Horizontal">
                                                                     <TextBlock Text="+" Foreground="White" FontWeight="Bold"
@@ -600,7 +600,7 @@
 
                             <!-- Error display -->
                             <TextBlock Text="{Binding ErrorMessage}"
-                                       Foreground="{StaticResource ErrorBrush}"
+                                       Foreground="{DynamicResource ErrorBrush}"
                                        Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
                                        Margin="0,0,0,12"
                                        TextWrapping="Wrap" />
@@ -624,14 +624,14 @@
                                         Command="{Binding CancelEditCommand}"
                                         Margin="0,0,12,0" />
                                 <TextBlock Text="You have unsaved changes"
-                                           Foreground="{StaticResource WarningBrush}"
+                                           Foreground="{DynamicResource WarningBrush}"
                                            FontSize="12" FontStyle="Italic"
                                            VerticalAlignment="Center"
                                            Visibility="{Binding HasUnsavedChanges, Converter={StaticResource BoolToVis}}" />
                             </StackPanel>
 
                             <!-- Test Result in Edit Mode -->
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4"
                                     Padding="12,8"
                                     Margin="0,16,0,0"
@@ -644,7 +644,7 @@
                     </Border>
 
                     <!-- Loading Overlay -->
-                    <Border Background="#80000000"
+                    <Border Background="{DynamicResource OverlayBrush}"
                             CornerRadius="6"
                             Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"
                             Margin="0,16,0,0">

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -73,7 +73,12 @@
                             <Button Content="Copy output"
                                     Command="{Binding CopyConsoleCommand}"
                                     Style="{StaticResource SecondaryButton}"
-                                    Padding="8,2" FontSize="11" />
+                                    Padding="8,2" FontSize="11" Margin="0,0,8,0" />
+                            <Button Content="Save output"
+                                    Command="{Binding SaveConsoleCommand}"
+                                    Style="{StaticResource SecondaryButton}"
+                                    Padding="8,2" FontSize="11"
+                                    ToolTip="Writes the console to a file, with a header naming the server, the target database and the outcome." />
                         </StackPanel>
                     </Grid>
                 </Border>

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -66,7 +66,7 @@
                                        FontSize="11" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                            <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
+                            <TextBlock Text="{Binding Console.Lines.Count, StringFormat='{}{0} lines'}"
                                        Foreground="{DynamicResource ConsoleMutedBrush}"
                                        FontFamily="{StaticResource ConsoleFont}"
                                        FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0" />
@@ -87,7 +87,7 @@
                      unbounded height realises every row and virtualisation silently does nothing.
                      A ListBox brings its own virtualising scroll viewer. -->
                 <ListBox Grid.Row="1" x:Name="ConsoleList"
-                         ItemsSource="{Binding ConsoleLines}"
+                         ItemsSource="{Binding Console.Lines}"
                          Style="{StaticResource ConsoleListBox}" />
             </Grid>
         </Border>

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="Blackcat.NineLives.Views.ExecutionWindow"
+﻿<Window x:Class="Blackcat.NineLives.Views.ExecutionWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
@@ -7,7 +7,7 @@
         MinWidth="640" MinHeight="380"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
-        Background="{StaticResource WindowBackgroundBrush}"
+        Background="{DynamicResource WindowBackgroundBrush}"
         Closing="OnClosing">
 
     <Window.Resources>
@@ -31,8 +31,8 @@
         </StackPanel>
 
         <Border Grid.Row="1" CornerRadius="6"
-                Background="{StaticResource ConsoleBackgroundBrush}"
-                BorderBrush="{StaticResource ConsoleBorderBrush}"
+                Background="{DynamicResource ConsoleBackgroundBrush}"
+                BorderBrush="{DynamicResource ConsoleBorderBrush}"
                 BorderThickness="1">
             <Grid>
                 <Grid.RowDefinitions>
@@ -41,9 +41,9 @@
                 </Grid.RowDefinitions>
 
                 <Border Grid.Row="0"
-                        Background="{StaticResource ConsoleChromeBrush}"
+                        Background="{DynamicResource ConsoleChromeBrush}"
                         CornerRadius="5,5,0,0"
-                        BorderBrush="{StaticResource ConsoleBorderBrush}"
+                        BorderBrush="{DynamicResource ConsoleBorderBrush}"
                         BorderThickness="0,0,0,1"
                         Padding="12,7">
                     <Grid>
@@ -51,23 +51,23 @@
                             <Ellipse Width="9" Height="9" Margin="0,0,7,0">
                                 <Ellipse.Style>
                                     <Style TargetType="Ellipse">
-                                        <Setter Property="Fill" Value="{StaticResource ConsoleMutedBrush}" />
+                                        <Setter Property="Fill" Value="{DynamicResource ConsoleMutedBrush}" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsExecuting}" Value="True">
-                                                <Setter Property="Fill" Value="{StaticResource ConsoleSuccessBrush}" />
+                                                <Setter Property="Fill" Value="{DynamicResource ConsoleSuccessBrush}" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
                                 </Ellipse.Style>
                             </Ellipse>
                             <TextBlock Text="restore console"
-                                       Foreground="{StaticResource ConsoleMutedBrush}"
+                                       Foreground="{DynamicResource ConsoleMutedBrush}"
                                        FontFamily="{StaticResource ConsoleFont}"
                                        FontSize="11" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                             <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
-                                       Foreground="{StaticResource ConsoleMutedBrush}"
+                                       Foreground="{DynamicResource ConsoleMutedBrush}"
                                        FontFamily="{StaticResource ConsoleFont}"
                                        FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0" />
                             <Button Content="Copy output"
@@ -94,7 +94,7 @@
 
         <!-- What a failed or cancelled restore left behind (#14). -->
         <Border Grid.Row="2" CornerRadius="4" Padding="12" Margin="0,12,0,0"
-                Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1"
+                Background="{DynamicResource DangerPanelBackgroundBrush}" BorderBrush="{DynamicResource DangerPanelBorderBrush}" BorderThickness="1"
                 Visibility="{Binding HasRecoveryActions, Converter={StaticResource BoolToVis}}">
             <StackPanel>
                 <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
@@ -105,11 +105,11 @@
                 <ItemsControl ItemsSource="{Binding RecoveryActions}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="10" Margin="0,0,0,8">
                                 <StackPanel>
                                     <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
-                                               Foreground="{StaticResource PrimaryTextBrush}"
+                                               Foreground="{DynamicResource PrimaryTextBrush}"
                                                TextWrapping="Wrap" />
                                     <TextBox Text="{Binding Sql, Mode=OneWay}"
                                              Style="{StaticResource DarkTextBox}"

--- a/src/NineLives/Views/ExecutionWindow.xaml.cs
+++ b/src/NineLives/Views/ExecutionWindow.xaml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
@@ -27,9 +27,9 @@ public partial class ExecutionWindow : Window
         InitializeComponent();
         DataContext = _viewModel = viewModel;
 
-        viewModel.ConsoleLines.CollectionChanged += OnConsoleLinesChanged;
+        viewModel.Console.Lines.CollectionChanged += OnConsoleLinesChanged;
         ConsoleList.Loaded += (_, _) => HookScroller();
-        Closed += (_, _) => viewModel.ConsoleLines.CollectionChanged -= OnConsoleLinesChanged;
+        Closed += (_, _) => viewModel.Console.Lines.CollectionChanged -= OnConsoleLinesChanged;
     }
 
     private void HookScroller()

--- a/src/NineLives/Views/HistoryView.xaml
+++ b/src/NineLives/Views/HistoryView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.HistoryView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.HistoryView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
@@ -46,32 +46,30 @@
             <Border Grid.Column="0" Style="{StaticResource CardBorder}" Margin="0,0,12,0">
                 <ListBox ItemsSource="{Binding Entries}"
                          SelectedItem="{Binding SelectedEntry}"
-                         Background="Transparent"
-                         BorderThickness="0"
-                         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                         Style="{StaticResource CardListBox}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
-                            <StackPanel Margin="0,4,0,8">
+                            <StackPanel>
                                 <TextBlock Text="{Binding StartedDisplay}"
                                            Style="{StaticResource SecondaryText}"
                                            FontSize="11" />
                                 <TextBlock TextWrapping="Wrap" FontWeight="SemiBold" Margin="0,2,0,0">
                                     <Run Text="{Binding TargetDatabase, Mode=OneWay}" />
-                                    <Run Text=" on " Foreground="{StaticResource SecondaryTextBrush}" />
+                                    <Run Text=" on " Foreground="{DynamicResource SecondaryTextBrush}" />
                                     <Run Text="{Binding ServerName, Mode=OneWay}"
-                                         Foreground="{StaticResource SecondaryTextBrush}" />
+                                         Foreground="{DynamicResource SecondaryTextBrush}" />
                                 </TextBlock>
                                 <TextBlock Margin="0,2,0,0" FontSize="11">
                                     <Run Text="{Binding OutcomeDisplay, Mode=OneWay}">
                                         <Run.Style>
                                             <Style TargetType="Run">
-                                                <Setter Property="Foreground" Value="{StaticResource SuccessBrush}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
                                                 <Style.Triggers>
                                                     <DataTrigger Binding="{Binding Outcome}" Value="Failed">
-                                                        <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                                        <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding Outcome}" Value="Cancelled">
-                                                        <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                                        <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
@@ -79,7 +77,7 @@
                                     </Run>
                                     <Run Text="  " />
                                     <Run Text="{Binding DurationDisplay, Mode=OneWay}"
-                                         Foreground="{StaticResource SecondaryTextBrush}" />
+                                         Foreground="{DynamicResource SecondaryTextBrush}" />
                                 </TextBlock>
                             </StackPanel>
                         </DataTemplate>
@@ -105,7 +103,7 @@
                                        Margin="0,4,0,12" />
 
                             <TextBlock Text="{Binding SelectedEntry.ErrorMessage}"
-                                       Foreground="{StaticResource ErrorBrush}"
+                                       Foreground="{DynamicResource ErrorBrush}"
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,12"
                                        Visibility="{Binding SelectedEntry.ErrorMessage, Converter={StaticResource NullToVis}}" />
@@ -127,13 +125,13 @@
                             </StackPanel>
 
                             <TextBlock Text="SCRIPT" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="10" Margin="0,0,0,12">
                                 <TextBox Text="{Binding SelectedEntry.Script, Mode=OneWay}"
                                          IsReadOnly="True"
                                          Background="Transparent"
                                          BorderThickness="0"
-                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                         Foreground="{DynamicResource PrimaryTextBrush}"
                                          FontFamily="Cascadia Code, Consolas, Courier New"
                                          FontSize="11"
                                          MaxHeight="220"
@@ -142,13 +140,13 @@
                             </Border>
 
                             <TextBlock Text="EXECUTION LOG" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="10">
                                 <TextBox Text="{Binding SelectedEntry.Log, Mode=OneWay}"
                                          IsReadOnly="True"
                                          Background="Transparent"
                                          BorderThickness="0"
-                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                         Foreground="{DynamicResource PrimaryTextBrush}"
                                          FontFamily="Cascadia Code, Consolas, Courier New"
                                          FontSize="11"
                                          MaxHeight="260"
@@ -194,7 +192,7 @@
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding IsClearArmed}" Value="True">
                                         <Setter Property="Text" Value="Confirm clear" />
-                                        <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                        <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>

--- a/src/NineLives/Views/HistoryView.xaml
+++ b/src/NineLives/Views/HistoryView.xaml
@@ -1,0 +1,207 @@
+<UserControl x:Class="Blackcat.NineLives.Views.HistoryView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,16">
+            <TextBlock Text="Restore History" Style="{StaticResource HeaderText}" />
+            <TextBlock Text="Every restore this app has run, kept so it can go in a change ticket or an incident write-up."
+                       Style="{StaticResource SecondaryText}"
+                       Margin="0,4,0,0" />
+        </StackPanel>
+
+        <!-- Filter + refresh -->
+        <Grid Grid.Row="1" Margin="0,0,0,12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBox Grid.Column="0"
+                     Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                     Style="{StaticResource DarkTextBox}"
+                     ToolTip="Filter by database, server, container or outcome." />
+
+            <Button Grid.Column="1" Content="Refresh"
+                    Command="{Binding RefreshCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Padding="12,6" Margin="8,0,0,0" />
+        </Grid>
+
+        <!-- List + detail -->
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="360" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource CardBorder}" Margin="0,0,12,0">
+                <ListBox ItemsSource="{Binding Entries}"
+                         SelectedItem="{Binding SelectedEntry}"
+                         Background="Transparent"
+                         BorderThickness="0"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel Margin="0,4,0,8">
+                                <TextBlock Text="{Binding StartedDisplay}"
+                                           Style="{StaticResource SecondaryText}"
+                                           FontSize="11" />
+                                <TextBlock TextWrapping="Wrap" FontWeight="SemiBold" Margin="0,2,0,0">
+                                    <Run Text="{Binding TargetDatabase, Mode=OneWay}" />
+                                    <Run Text=" on " Foreground="{StaticResource SecondaryTextBrush}" />
+                                    <Run Text="{Binding ServerName, Mode=OneWay}"
+                                         Foreground="{StaticResource SecondaryTextBrush}" />
+                                </TextBlock>
+                                <TextBlock Margin="0,2,0,0" FontSize="11">
+                                    <Run Text="{Binding OutcomeDisplay, Mode=OneWay}">
+                                        <Run.Style>
+                                            <Style TargetType="Run">
+                                                <Setter Property="Foreground" Value="{StaticResource SuccessBrush}" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Outcome}" Value="Failed">
+                                                        <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Outcome}" Value="Cancelled">
+                                                        <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Run.Style>
+                                    </Run>
+                                    <Run Text="  " />
+                                    <Run Text="{Binding DurationDisplay, Mode=OneWay}"
+                                         Foreground="{StaticResource SecondaryTextBrush}" />
+                                </TextBlock>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Border>
+
+            <Border Grid.Column="1" Style="{StaticResource CardBorder}">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <TextBlock Text="Select a restore to see what it did."
+                                   Style="{StaticResource SecondaryText}"
+                                   Visibility="{Binding SelectedEntry, Converter={StaticResource NullToVis}, ConverterParameter=Invert}" />
+
+                        <StackPanel Visibility="{Binding SelectedEntry, Converter={StaticResource NullToVis}}">
+                            <TextBlock Text="{Binding SelectedEntry.Summary}"
+                                       Style="{StaticResource HeaderText}"
+                                       FontSize="18"
+                                       TextWrapping="Wrap" />
+                            <TextBlock Text="{Binding SelectedEntry.Detail}"
+                                       Style="{StaticResource SecondaryText}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,4,0,12" />
+
+                            <TextBlock Text="{Binding SelectedEntry.ErrorMessage}"
+                                       Foreground="{StaticResource ErrorBrush}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,12"
+                                       Visibility="{Binding SelectedEntry.ErrorMessage, Converter={StaticResource NullToVis}}" />
+
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                                <Button Content="Copy script"
+                                        Command="{Binding CopyScriptCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,5" Margin="0,0,8,0" />
+                                <Button Content="Copy log"
+                                        Command="{Binding CopyLogCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,5" Margin="0,0,8,0" />
+                                <Button Content="Save as file"
+                                        Command="{Binding SaveEntryCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,5"
+                                        ToolTip="Writes the whole record - details, script and execution log - to a text file." />
+                            </StackPanel>
+
+                            <TextBlock Text="SCRIPT" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
+                            <Border Background="{StaticResource InputBackgroundBrush}"
+                                    CornerRadius="4" Padding="10" Margin="0,0,0,12">
+                                <TextBox Text="{Binding SelectedEntry.Script, Mode=OneWay}"
+                                         IsReadOnly="True"
+                                         Background="Transparent"
+                                         BorderThickness="0"
+                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                         FontFamily="Cascadia Code, Consolas, Courier New"
+                                         FontSize="11"
+                                         MaxHeight="220"
+                                         VerticalScrollBarVisibility="Auto"
+                                         HorizontalScrollBarVisibility="Auto" />
+                            </Border>
+
+                            <TextBlock Text="EXECUTION LOG" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
+                            <Border Background="{StaticResource InputBackgroundBrush}"
+                                    CornerRadius="4" Padding="10">
+                                <TextBox Text="{Binding SelectedEntry.Log, Mode=OneWay}"
+                                         IsReadOnly="True"
+                                         Background="Transparent"
+                                         BorderThickness="0"
+                                         Foreground="{StaticResource PrimaryTextBrush}"
+                                         FontFamily="Cascadia Code, Consolas, Courier New"
+                                         FontSize="11"
+                                         MaxHeight="260"
+                                         VerticalScrollBarVisibility="Auto"
+                                         HorizontalScrollBarVisibility="Auto" />
+                            </Border>
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
+        </Grid>
+
+        <!-- Status + clear -->
+        <Grid Grid.Row="3" Margin="0,12,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Column="0"
+                       Text="{Binding StatusMessage}"
+                       Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap"
+                       VerticalAlignment="Center" />
+
+            <Button Grid.Column="1" Content="Keep it"
+                    Command="{Binding CancelClearCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Padding="12,6" Margin="0,0,8,0"
+                    Visibility="{Binding IsClearArmed, Converter={StaticResource BoolToVis}}" />
+
+            <Button Grid.Column="2"
+                    Command="{Binding ClearHistoryCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Padding="12,6"
+                    ToolTip="Deletes every recorded restore. Takes two presses.">
+                <Button.Content>
+                    <TextBlock>
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Text" Value="Clear history" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsClearArmed}" Value="True">
+                                        <Setter Property="Text" Value="Confirm clear" />
+                                        <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Button.Content>
+            </Button>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/NineLives/Views/HistoryView.xaml.cs
+++ b/src/NineLives/Views/HistoryView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class HistoryView : UserControl
+{
+    public HistoryView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -158,9 +158,72 @@
                     <TextBlock Text="2. SELECT RESTORE POINT"
                                Style="{StaticResource SubHeaderText}"
                                Margin="0,0,0,4" />
-                    <TextBlock Text="Click a point on the timeline or select from the list below."
+                    <TextBlock Text="Click a point on the timeline, or pick one from the list below."
                                Style="{StaticResource SecondaryText}"
                                Margin="0,0,0,12" />
+
+                    <!-- Narrowing controls. A week of 15-minute logs is roughly 670 points, which
+                         no timeline can draw legibly - so the range and the type toggles are the
+                         way to get from "everything" down to something you can click (#27). -->
+                    <Border Background="{StaticResource InputBackgroundBrush}"
+                            CornerRadius="6" Padding="12,10" Margin="0,0,0,12">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                                <CheckBox Content="Full" IsChecked="{Binding ShowFullPoints}"
+                                          Style="{StaticResource DarkCheckBox}" Margin="0,0,12,0" />
+                                <CheckBox Content="Diff" IsChecked="{Binding ShowDiffPoints}"
+                                          Style="{StaticResource DarkCheckBox}" Margin="0,0,12,0" />
+                                <CheckBox Content="Log" IsChecked="{Binding ShowLogPoints}"
+                                          Style="{StaticResource DarkCheckBox}" Margin="0,0,20,0" />
+
+                                <TextBlock Text="From" Style="{StaticResource SecondaryText}"
+                                           VerticalAlignment="Center" Margin="0,0,6,0" />
+                                <TextBox Text="{Binding PointsFromText, UpdateSourceTrigger=PropertyChanged}"
+                                         Style="{StaticResource DarkTextBox}"
+                                         Width="150" Margin="0,0,12,0"
+                                         ToolTip="yyyy-MM-dd or yyyy-MM-dd HH:mm:ss. Leave empty for no lower bound." />
+
+                                <TextBlock Text="To" Style="{StaticResource SecondaryText}"
+                                           VerticalAlignment="Center" Margin="0,0,6,0" />
+                                <TextBox Text="{Binding PointsToText, UpdateSourceTrigger=PropertyChanged}"
+                                         Style="{StaticResource DarkTextBox}"
+                                         Width="150"
+                                         ToolTip="yyyy-MM-dd or yyyy-MM-dd HH:mm:ss. Leave empty for no upper bound." />
+                            </StackPanel>
+
+                            <TextBlock Grid.Column="1" Text="{Binding PointCountText}"
+                                       Style="{StaticResource SecondaryText}"
+                                       VerticalAlignment="Center"
+                                       HorizontalAlignment="Right"
+                                       Margin="12,0,12,0" />
+
+                            <StackPanel Grid.Column="2" Orientation="Horizontal">
+                                <Button Content="Zoom to day"
+                                        Command="{Binding ZoomToSelectedDayCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,4" FontSize="11" Margin="0,0,8,0"
+                                        ToolTip="Narrows the range to the day the selected point falls on." />
+                                <Button Content="Reset"
+                                        Command="{Binding ResetPointFiltersCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,4" FontSize="11"
+                                        ToolTip="Show every restore point again." />
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+
+                    <TextBlock Text="No restore point matches these filters. Widen the range or switch a type back on."
+                               Style="{StaticResource SecondaryText}"
+                               Foreground="{StaticResource WarningBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,12"
+                               Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
 
                     <!-- ========== VISUAL TIMELINE ========== -->
                     <Border Background="{StaticResource InputBackgroundBrush}"
@@ -313,6 +376,61 @@
                             </Grid>
                         </Grid>
                     </Border>
+
+                    <!-- The list the header has always promised. The timeline is good for seeing
+                         the shape of what is available; it is hopeless for picking one point out
+                         of hundreds, which is what someone doing a point-in-time restore is
+                         actually trying to do. Sortable, and its selection is the same selection
+                         as the timeline's (#27). -->
+                    <TextBlock Text="RESTORE POINTS" Style="{StaticResource LabelText}" Margin="0,4,0,4"
+                               Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}}" />
+                    <DataGrid ItemsSource="{Binding RestorePoints}"
+                              SelectedItem="{Binding SelectedRestorePoint}"
+                              Style="{StaticResource DarkDataGrid}"
+                              MaxHeight="240"
+                              Margin="0,0,0,12"
+                              CanUserSortColumns="True"
+                              ScrollViewer.CanContentScroll="True"
+                              EnableRowVirtualization="True"
+                              Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Point in time" Width="180"
+                                                SortMemberPath="Timestamp"
+                                                Binding="{Binding TimestampDisplay}">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="ToolTip" Value="{Binding TimestampNote}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsTimestampApproximate}" Value="True">
+                                                <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+
+                            <DataGridTemplateColumn Header="Type" Width="90" SortMemberPath="Type">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <Border Background="{Binding Type, Converter={StaticResource TypeToColor}}"
+                                                CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Opacity="0.85">
+                                            <TextBlock Text="{Binding Type}" Foreground="White"
+                                                       FontSize="11" FontWeight="SemiBold" />
+                                        </Border>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+
+                            <DataGridTextColumn Header="Restores" Width="*"
+                                                Binding="{Binding TypeDisplay}" />
+                            <DataGridTextColumn Header="Files" Width="60"
+                                                SortMemberPath="TotalFiles"
+                                                Binding="{Binding TotalFiles}" />
+                            <DataGridTextColumn Header="Size" Width="90"
+                                                SortMemberPath="TotalSizeBytes"
+                                                Binding="{Binding SizeDisplay}" />
+                        </DataGrid.Columns>
+                    </DataGrid>
 
                     <!-- Restore Chain Backup Sets (for selected restore point) -->
                     <DataGrid ItemsSource="{Binding ChainSets}"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1075,7 +1075,7 @@
                                      Margin="0,0,0,16" />
 
                             <TextBlock Text="SQL CREDENTIAL NAME" Style="{StaticResource LabelText}" />
-                            <TextBox Text="{Binding SqlCredentialName, UpdateSourceTrigger=PropertyChanged}"
+                            <TextBox Text="{Binding Credential.Name, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,8"
                                      ToolTip="Defaults to the container URL. The credential on the server must match this name (container URL) for RESTORE FROM URL." />
@@ -1083,7 +1083,7 @@
                             <!-- Blob credential: when not connected, prompt to connect to verify; when connected, show status and optional Create -->
                             <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="12,10" Margin="0,0,0,16"
-                                    Visibility="{Binding CredentialSectionVisible, Converter={StaticResource BoolToVis}}">
+                                    Visibility="{Binding Credential.SectionVisible, Converter={StaticResource BoolToVis}}">
                                 <StackPanel>
                                     <TextBlock Text="BLOB CREDENTIAL ON SERVER" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
                                     <!-- Not connected: verify credential by connecting -->
@@ -1101,14 +1101,14 @@
                                                     <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
                                                     <Setter Property="BorderThickness" Value="0" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CredentialIsUsable}" Value="True">
+                                                        <DataTrigger Binding="{Binding Credential.IsUsable}" Value="True">
                                                             <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
                                                             <Setter Property="CornerRadius" Value="4" />
                                                             <Setter Property="Padding" Value="8,6,8,6" />
                                                         </DataTrigger>
-                                                        <DataTrigger Binding="{Binding CredentialExistsOnServer}" Value="False">
+                                                        <DataTrigger Binding="{Binding Credential.ExistsOnServer}" Value="False">
                                                             <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
@@ -1117,8 +1117,8 @@
                                                         </DataTrigger>
                                                         <MultiDataTrigger>
                                                             <MultiDataTrigger.Conditions>
-                                                                <Condition Binding="{Binding CredentialExistsOnServer}" Value="True" />
-                                                                <Condition Binding="{Binding CredentialIsUsable}" Value="False" />
+                                                                <Condition Binding="{Binding Credential.ExistsOnServer}" Value="True" />
+                                                                <Condition Binding="{Binding Credential.IsUsable}" Value="False" />
                                                             </MultiDataTrigger.Conditions>
                                                             <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource WarningBrush}" />
@@ -1129,11 +1129,11 @@
                                                     </Style.Triggers>
                                                 </Style>
                                             </Border.Style>
-                                            <TextBlock Text="{Binding CredentialStatusMessage}"
+                                            <TextBlock Text="{Binding Credential.StatusMessage}"
                                                        Style="{StaticResource SecondaryText}"
                                                        TextWrapping="Wrap" />
                                         </Border>
-                                        <TextBlock Visibility="{Binding CredentialIsUsable, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                        <TextBlock Visibility="{Binding Credential.IsUsable, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
                                             <Run Text="Restore from URL needs a SQL credential for the container, holding either a SHARED ACCESS SIGNATURE or - on SQL Server 2022 and later - the instance's Managed Identity. You can create the SAS kind from here, or create either on the server yourself before running the script. Execute will create one for you only if there is nothing of that name: a credential that already exists is never rewritten behind your back. The SAS token is never included in the generated script." />
                                         </TextBlock>
@@ -1141,18 +1141,18 @@
                                              credential of that name exists. SQL Server will not return its secret, so a
                                              rotated or expired token is indistinguishable from a working one, and this is
                                              the only way to push a fresh one. -->
-                                        <TextBlock Visibility="{Binding CredentialIsSharedAccessSignature, Converter={StaticResource BoolToVis}}"
+                                        <TextBlock Visibility="{Binding Credential.IsSharedAccessSignature, Converter={StaticResource BoolToVis}}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
                                             <Run Text="Execute will leave this credential alone. If the SAS token has been rotated or has expired since the credential was created, the restore will fail on blob access - refresh it below to push the token currently stored for this container." />
                                         </TextBlock>
                                         <!-- A managed identity is somebody else's deliberate setup: this app cannot create
                                              one, and the button below would ALTER it into a SAS credential, which is a
                                              change to how the whole instance authenticates to that container (#145). -->
-                                        <TextBlock Visibility="{Binding CredentialIsManagedIdentity, Converter={StaticResource BoolToVis}}"
+                                        <TextBlock Visibility="{Binding Credential.IsManagedIdentity, Converter={StaticResource BoolToVis}}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
                                             <Run Text="Execute will leave this credential alone and no SAS token is sent to the server. The instance authenticates to the container as itself, so the restore depends on its identity holding a role on the storage account rather than on anything stored here. The button below would replace that with a SAS credential - which would also change how anything else on this instance reaches the same container." />
                                         </TextBlock>
-                                        <Button Command="{Binding CreateCredentialOnServerCommand}"
+                                        <Button Command="{Binding Credential.CreateOnServerCommand}"
                                                 Margin="0,0,0,0" Padding="10,6"
                                                 ToolTip="Creates the SQL Server credential for this blob container URL, or updates an existing one with the SAS token currently stored for the container, so that RESTORE FROM URL can access the backups. An existing credential is altered in place, never dropped. The SAS token is not included in the generated script."
                                                 HorizontalAlignment="Left">
@@ -1160,13 +1160,13 @@
                                                 <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
                                                     <Setter Property="Content" Value="Create credential on server" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CredentialIsSharedAccessSignature}" Value="True">
+                                                        <DataTrigger Binding="{Binding Credential.IsSharedAccessSignature}" Value="True">
                                                             <Setter Property="Content" Value="Refresh credential with stored SAS token" />
                                                         </DataTrigger>
                                                         <!-- Says what the press would actually do. The same button under the
                                                              old label read as a harmless refresh while it converted the
                                                              instance's managed identity to a SAS token (#145). -->
-                                                        <DataTrigger Binding="{Binding CredentialIsManagedIdentity}" Value="True">
+                                                        <DataTrigger Binding="{Binding Credential.IsManagedIdentity}" Value="True">
                                                             <Setter Property="Content" Value="Replace Managed Identity with stored SAS token" />
                                                         </DataTrigger>
                                                     </Style.Triggers>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1164,7 +1164,13 @@
                                                 Command="{Binding CopyConsoleCommand}"
                                                 Style="{StaticResource SecondaryButton}"
                                                 Padding="8,2" FontSize="11"
+                                                Margin="0,0,8,0"
                                                 ToolTip="Copies the whole console, which is what to attach to a bug report." />
+                                        <Button Content="Save output"
+                                                Command="{Binding SaveConsoleCommand}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="8,2" FontSize="11"
+                                                ToolTip="Writes the console to a file, with a header naming the server, the target database and the outcome - for a change ticket or an incident write-up." />
                                     </StackPanel>
                                 </Grid>
                             </Border>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -508,25 +508,29 @@
                                 Padding="12,6" Margin="0,0,8,0"
                                 ToolTip="Do these backups belong together? Reads each backup's header and compares the LSNs. Takes seconds. Requires a connected server.">
                             <Button.Content>
-                                <TextBlock>
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="Check chain (HEADERONLY)" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsValidatingChain}" Value="True">
-                                                    <Setter Property="Text" Value="Checking..." />
-                                                </DataTrigger>
-                                                <MultiDataTrigger>
-                                                    <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding ChainLsnVerified}" Value="True" />
-                                                        <Condition Binding="{Binding HasChainIssues}" Value="False" />
-                                                    </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Text" Value="Chain checked" />
-                                                </MultiDataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
+                                <StackPanel Orientation="Horizontal">
+                                    <ContentControl Template="{StaticResource BusySpinner}"
+                                                    Width="13" Height="13" Margin="0,0,6,0"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{Binding IsValidatingChain, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock Style="{StaticResource PassedTick}"
+                                               Visibility="{Binding ChainCheckPassed, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value="Check chain (HEADERONLY)" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsValidatingChain}" Value="True">
+                                                        <Setter Property="Text" Value="Checking..." />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding ChainCheckPassed}" Value="True">
+                                                        <Setter Property="Text" Value="Chain checked" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
                             </Button.Content>
                         </Button>
 
@@ -540,26 +544,29 @@
                                 Padding="12,6" Margin="0,0,8,0"
                                 ToolTip="Is each backup actually readable? Runs RESTORE VERIFYONLY over every backup in the chain, reading every byte - this can take as long as the restore itself. Requires a connected server.">
                             <Button.Content>
-                                <TextBlock>
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="Verify backups (VERIFYONLY)" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsVerifyingChain}" Value="True">
-                                                    <Setter Property="Text" Value="Verifying..." />
-                                                </DataTrigger>
-                                                <MultiDataTrigger>
-                                                    <MultiDataTrigger.Conditions>
-                                                        <Condition Binding="{Binding HasVerifyResults}" Value="True" />
-                                                        <Condition Binding="{Binding HasVerifyFailures}" Value="False" />
-                                                        <Condition Binding="{Binding IsVerifyingChain}" Value="False" />
-                                                    </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Text" Value="Backups verified" />
-                                                </MultiDataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
+                                <StackPanel Orientation="Horizontal">
+                                    <ContentControl Template="{StaticResource BusySpinner}"
+                                                    Width="13" Height="13" Margin="0,0,6,0"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{Binding IsVerifyingChain, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock Style="{StaticResource PassedTick}"
+                                               Visibility="{Binding VerifyPassed, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value="Verify backups (VERIFYONLY)" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsVerifyingChain}" Value="True">
+                                                        <Setter Property="Text" Value="Verifying..." />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding VerifyPassed}" Value="True">
+                                                        <Setter Property="Text" Value="Backups verified" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
                             </Button.Content>
                         </Button>
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -366,6 +366,7 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
@@ -406,7 +407,39 @@
                             </Button.Content>
                         </Button>
 
+                        <!-- A different question from Validate Chain: that one reads headers and
+                             checks the LSNs line up, this one reads each backup end to end and
+                             checks it is intact. A truncated blob passes the first and fails this. -->
                         <Button Grid.Column="2"
+                                Style="{StaticResource SecondaryButton}"
+                                Command="{Binding VerifyChainCommand}"
+                                Padding="12,6" Margin="0,0,8,0"
+                                ToolTip="Run RESTORE VERIFYONLY over every backup in the chain to check each one reads back intact, before committing to the restore. Requires a connected server.">
+                            <Button.Content>
+                                <TextBlock>
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Text" Value="Verify Backups" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsVerifyingChain}" Value="True">
+                                                    <Setter Property="Text" Value="Verifying..." />
+                                                </DataTrigger>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding HasVerifyResults}" Value="True" />
+                                                        <Condition Binding="{Binding HasVerifyFailures}" Value="False" />
+                                                        <Condition Binding="{Binding IsVerifyingChain}" Value="False" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <Setter Property="Text" Value="Backups Verified" />
+                                                </MultiDataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Button.Content>
+                        </Button>
+
+                        <Button Grid.Column="3"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding ToggleChainDetailsCommand}"
                                 Padding="12,6">
@@ -426,6 +459,59 @@
                             </Button.Content>
                         </Button>
                     </Grid>
+
+                    <!-- Per-set VERIFYONLY results. Green while everything reads back, red the
+                         moment one does not - a failed member here means the chain cannot restore,
+                         whatever the timeline and the LSNs say about it. -->
+                    <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                            Visibility="{Binding HasVerifyResults, Converter={StaticResource BoolToVis}}">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Background" Value="#1A2A1E" />
+                                <Setter Property="BorderBrush" Value="{StaticResource SuccessBrush}" />
+                                <Setter Property="BorderThickness" Value="1" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasVerifyFailures}" Value="True">
+                                        <Setter Property="Background" Value="#3A1E1E" />
+                                        <Setter Property="BorderBrush" Value="#A33F3F" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <StackPanel>
+                            <TextBlock Text="RESTORE VERIFYONLY" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                            <ItemsControl ItemsSource="{Binding ChainVerifyResults}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Margin="0,0,0,8">
+                                            <TextBlock TextWrapping="Wrap" FontWeight="SemiBold">
+                                                <Run Text="{Binding TypeDisplay, Mode=OneWay}" />
+                                                <Run Text=" " />
+                                                <Run Text="{Binding SetId, Mode=OneWay}" />
+                                                <Run Text="  " />
+                                                <Run Text="{Binding StatusDisplay, Mode=OneWay}">
+                                                    <Run.Style>
+                                                        <Style TargetType="Run">
+                                                            <Setter Property="Foreground" Value="{StaticResource SuccessBrush}" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsValid}" Value="False">
+                                                                    <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </Run.Style>
+                                                </Run>
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding Message}"
+                                                       Style="{StaticResource SecondaryText}"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,2,0,0" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Border>
 
                     <!-- Chain gap detection: always visible when something is wrong, so a missing
                          stripe or a hole in the log sequence is seen BEFORE the script is run,
@@ -577,6 +663,25 @@
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Creates a new Service Broker identifier." />
+
+                            <CheckBox Content="CHECKSUM"
+                                      IsChecked="{Binding WithChecksum}"
+                                      Style="{StaticResource DarkCheckBox}"
+                                      Margin="0,0,0,12"
+                                      ToolTip="Verify backup checksums while restoring. Only works if the backup was taken WITH CHECKSUM - against one that was not, SQL Server fails the restore rather than skipping the check." />
+
+                            <CheckBox Content="CONTINUE_AFTER_ERROR"
+                                      IsChecked="{Binding ContinueAfterError}"
+                                      Style="{StaticResource DarkCheckBox}"
+                                      Margin="0,0,0,4"
+                                      ToolTip="Keep restoring past a damaged page or a failed checksum instead of stopping. The database this produces may be corrupt." />
+
+                            <TextBlock Style="{StaticResource SecondaryText}"
+                                       FontSize="10" TextWrapping="Wrap"
+                                       Foreground="{StaticResource WarningBrush}"
+                                       Margin="0,0,0,12"
+                                       Visibility="{Binding ContinueAfterError, Converter={StaticResource BoolToVis}}"
+                                       Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
 
                             <CheckBox Content="WITH MOVE (relocate files)"
                                       IsChecked="{Binding UseWithMove}"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -108,7 +108,7 @@
                             <Run Text="{Binding SetCount, Mode=OneWay}" FontWeight="SemiBold" />
                             <Run Text=" total sets" />
                         </TextBlock>
-                        <TextBlock Grid.Column="4" Text="{Binding RestoreWindowText}"
+                        <TextBlock Grid.Column="4" Text="{Binding Timeline.WindowText}"
                                    Style="{StaticResource SecondaryText}"
                                    VerticalAlignment="Center" HorizontalAlignment="Right" />
                     </Grid>
@@ -153,7 +153,7 @@
 
             <!-- Step 2: Restore Point Selection -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
-                    Visibility="{Binding HasRestorePoints, Converter={StaticResource BoolToVis}}">
+                    Visibility="{Binding Timeline.HasPoints, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
                     <TextBlock Text="2. SELECT RESTORE POINT"
                                Style="{StaticResource SubHeaderText}"
@@ -175,29 +175,29 @@
                             </Grid.ColumnDefinitions>
 
                             <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
-                                <CheckBox Content="Full" IsChecked="{Binding ShowFullPoints}"
+                                <CheckBox Content="Full" IsChecked="{Binding Timeline.ShowFull}"
                                           Style="{StaticResource DarkCheckBox}" Margin="0,0,12,0" />
-                                <CheckBox Content="Diff" IsChecked="{Binding ShowDiffPoints}"
+                                <CheckBox Content="Diff" IsChecked="{Binding Timeline.ShowDiff}"
                                           Style="{StaticResource DarkCheckBox}" Margin="0,0,12,0" />
-                                <CheckBox Content="Log" IsChecked="{Binding ShowLogPoints}"
+                                <CheckBox Content="Log" IsChecked="{Binding Timeline.ShowLog}"
                                           Style="{StaticResource DarkCheckBox}" Margin="0,0,20,0" />
 
                                 <TextBlock Text="From" Style="{StaticResource SecondaryText}"
                                            VerticalAlignment="Center" Margin="0,0,6,0" />
-                                <TextBox Text="{Binding PointsFromText, UpdateSourceTrigger=PropertyChanged}"
+                                <TextBox Text="{Binding Timeline.FromText, UpdateSourceTrigger=PropertyChanged}"
                                          Style="{StaticResource DarkTextBox}"
                                          Width="150" Margin="0,0,12,0"
                                          ToolTip="yyyy-MM-dd or yyyy-MM-dd HH:mm:ss. Leave empty for no lower bound." />
 
                                 <TextBlock Text="To" Style="{StaticResource SecondaryText}"
                                            VerticalAlignment="Center" Margin="0,0,6,0" />
-                                <TextBox Text="{Binding PointsToText, UpdateSourceTrigger=PropertyChanged}"
+                                <TextBox Text="{Binding Timeline.ToText, UpdateSourceTrigger=PropertyChanged}"
                                          Style="{StaticResource DarkTextBox}"
                                          Width="150"
                                          ToolTip="yyyy-MM-dd or yyyy-MM-dd HH:mm:ss. Leave empty for no upper bound." />
                             </StackPanel>
 
-                            <TextBlock Grid.Column="1" Text="{Binding PointCountText}"
+                            <TextBlock Grid.Column="1" Text="{Binding Timeline.CountText}"
                                        Style="{StaticResource SecondaryText}"
                                        VerticalAlignment="Center"
                                        HorizontalAlignment="Right"
@@ -205,12 +205,12 @@
 
                             <StackPanel Grid.Column="2" Orientation="Horizontal">
                                 <Button Content="Zoom to day"
-                                        Command="{Binding ZoomToSelectedDayCommand}"
+                                        Command="{Binding Timeline.ZoomToSelectedDayCommand}"
                                         Style="{StaticResource SecondaryButton}"
                                         Padding="10,4" FontSize="11" Margin="0,0,8,0"
                                         ToolTip="Narrows the range to the day the selected point falls on." />
                                 <Button Content="Reset"
-                                        Command="{Binding ResetPointFiltersCommand}"
+                                        Command="{Binding Timeline.ResetFiltersCommand}"
                                         Style="{StaticResource SecondaryButton}"
                                         Padding="10,4" FontSize="11"
                                         ToolTip="Show every restore point again." />
@@ -223,7 +223,7 @@
                                Foreground="{DynamicResource WarningBrush}"
                                TextWrapping="Wrap"
                                Margin="0,0,0,12"
-                               Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+                               Visibility="{Binding Timeline.HasVisiblePoints, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
 
                     <!-- ========== VISUAL TIMELINE ========== -->
                     <Border Background="{DynamicResource InputBackgroundBrush}"
@@ -247,9 +247,9 @@
                             </StackPanel>
 
                             <!-- Dots area (stacked vertically) -->
-                            <Grid Grid.Row="1" Height="{Binding TimelineHeight}" Margin="7,0">
+                            <Grid Grid.Row="1" Height="{Binding Timeline.TrackHeight}" Margin="7,0">
                                 <!-- Vertical guide lines at tick positions -->
-                                <ItemsControl ItemsSource="{Binding TimelineTicks}" IsHitTestVisible="False">
+                                <ItemsControl ItemsSource="{Binding Timeline.Ticks}" IsHitTestVisible="False">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
                                             <Grid />
@@ -271,7 +271,7 @@
                                 </ItemsControl>
 
                                 <!-- Clickable restore point dots -->
-                                <ItemsControl ItemsSource="{Binding RestorePoints}"
+                                <ItemsControl ItemsSource="{Binding Timeline.Points}"
                                               x:Name="TimelineDots">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
@@ -282,7 +282,7 @@
                                         <DataTemplate>
                                             <Button HorizontalAlignment="Left" VerticalAlignment="Bottom"
                                                     Cursor="Hand"
-                                                    Command="{Binding DataContext.SelectRestorePointCommand,
+                                                    Command="{Binding DataContext.Timeline.SelectPointCommand,
                                                               RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                     CommandParameter="{Binding}">
                                                 <Button.Template>
@@ -334,7 +334,7 @@
                                         VerticalAlignment="Top" CornerRadius="1.5" />
 
                                 <!-- Tick marks with labels -->
-                                <ItemsControl ItemsSource="{Binding TimelineTicks}">
+                                <ItemsControl ItemsSource="{Binding Timeline.Ticks}">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
                                             <Grid />
@@ -363,12 +363,16 @@
                             <!-- Start/End date labels -->
                             <Grid Grid.Row="3" Margin="7,2,7,0">
                                 <TextBlock Style="{StaticResource SecondaryText}" HorizontalAlignment="Left"
-                                           Text="{Binding TimelineStartText}"
+                                           Text="{Binding Timeline.StartText}"
                                            FontSize="10" />
+                                <!-- The END of the range, not the whole range: this label sits at
+                                     the right-hand end of the track and was showing "start to end",
+                                     so the start time appeared twice and the end was buried in it.
+                                     The full range is in the header above (#115 seam 2). -->
                                 <TextBlock Style="{StaticResource SecondaryText}" HorizontalAlignment="Right"
                                            FontSize="10">
                                     <TextBlock.Text>
-                                        <Binding Path="RestoreWindowText"
+                                        <Binding Path="Timeline.EndText"
                                                  FallbackValue=""
                                                  TargetNullValue="" />
                                     </TextBlock.Text>
@@ -383,16 +387,16 @@
                          actually trying to do. Sortable, and its selection is the same selection
                          as the timeline's (#27). -->
                     <TextBlock Text="RESTORE POINTS" Style="{StaticResource LabelText}" Margin="0,4,0,4"
-                               Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}}" />
-                    <DataGrid ItemsSource="{Binding RestorePoints}"
-                              SelectedItem="{Binding SelectedRestorePoint}"
+                               Visibility="{Binding Timeline.HasVisiblePoints, Converter={StaticResource BoolToVis}}" />
+                    <DataGrid ItemsSource="{Binding Timeline.Points}"
+                              SelectedItem="{Binding Timeline.SelectedPoint}"
                               Style="{StaticResource DarkDataGrid}"
                               MaxHeight="240"
                               Margin="0,0,0,12"
                               CanUserSortColumns="True"
                               ScrollViewer.CanContentScroll="True"
                               EnableRowVirtualization="True"
-                              Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}}">
+                              Visibility="{Binding Timeline.HasVisiblePoints, Converter={StaticResource BoolToVis}}">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="Point in time" Width="180"
                                                 SortMemberPath="Timestamp"
@@ -490,7 +494,7 @@
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
                             <Run Text="Selected: " Foreground="{DynamicResource SecondaryTextBrush}" />
-                            <Run Text="{Binding SelectedRestorePoint.TimestampDisplay, Mode=OneWay}"
+                            <Run Text="{Binding Timeline.SelectedPoint.TimestampDisplay, Mode=OneWay}"
                                  FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}" />
                             <Run Text="  |  " Foreground="{DynamicResource SecondaryTextBrush}" />
                             <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{DynamicResource SecondaryTextBrush}" />

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1301,7 +1301,7 @@
                                 <Style.Triggers>
                                     <MultiDataTrigger>
                                         <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding HasConsoleOutput}" Value="True" />
+                                            <Condition Binding="{Binding Console.HasOutput}" Value="True" />
                                             <Condition Binding="{Binding IsConsoleDetached}" Value="False" />
                                             <!-- Belt and braces. While a restore runs the console
                                                  is always in its own window, so the inline one
@@ -1350,7 +1350,7 @@
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                        <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
+                                        <TextBlock Text="{Binding Console.Lines.Count, StringFormat='{}{0} lines'}"
                                                    Foreground="{DynamicResource ConsoleMutedBrush}"
                                                    FontFamily="{StaticResource ConsoleFont}"
                                                    FontSize="11"
@@ -1374,7 +1374,7 @@
                             <!-- Virtualised so a long restore stays responsive. Auto-follows the
                                  last line unless the user has scrolled up to read something. -->
                             <ListBox Grid.Row="1" x:Name="ConsoleList"
-                                     ItemsSource="{Binding ConsoleLines}"
+                                     ItemsSource="{Binding Console.Lines}"
                                      Style="{StaticResource ConsoleListBox}"
                                      MaxHeight="360" />
                         </Grid>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1138,7 +1138,7 @@
                         <Button Content="{Binding ExecuteButtonText}"
                                 Style="{StaticResource DangerButton}"
                                 Command="{Binding ExecuteScriptCommand}"
-                                IsEnabled="{Binding IsConnectedToServer}"
+                                IsEnabled="{Binding CanPressExecute}"
                                 MinWidth="140" />
 
                         <!-- Only while a restore is actually running. Until now the only way to
@@ -1152,6 +1152,15 @@
                                 MinWidth="110"
                                 ToolTip="Asks SQL Server to abort the statement in flight. It rolls that statement back, but the target database is left mid-restore and will need recovering - the app will tell you how." />
                     </StackPanel>
+
+                    <!-- Why Execute is greyed out. Not connected, no script and a chain that cannot
+                         restore all looked identical - one disabled button, three different
+                         problems, and the answer already sitting in the viewmodel unshown. -->
+                    <TextBlock Text="{Binding ExecuteBlockedReason}"
+                               Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,8"
+                               Visibility="{Binding IsExecuteBlocked, Converter={StaticResource BoolToVis}}" />
 
                     <!-- Execute armed warning. The server's tags appear here deliberately: this is
                          the last thing between the user and an irreversible overwrite, and a

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -87,19 +87,19 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Orientation="Horizontal">
                             <Border Background="{DynamicResource AccentBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
-                                <TextBlock Text="{Binding FullCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
+                                <TextBlock Text="{Binding FullCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Full Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
                             <Border Background="{DynamicResource WarningBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
-                                <TextBlock Text="{Binding DiffCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
+                                <TextBlock Text="{Binding DiffCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Diff Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="2" Orientation="Horizontal">
                             <Border Background="{DynamicResource SuccessBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
-                                <TextBlock Text="{Binding LogCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
+                                <TextBlock Text="{Binding LogCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Log Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
@@ -414,7 +414,7 @@
                                     <DataTemplate>
                                         <Border Background="{Binding Type, Converter={StaticResource TypeToColor}}"
                                                 CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Opacity="0.85">
-                                            <TextBlock Text="{Binding Type}" Foreground="White"
+                                            <TextBlock Text="{Binding Type}" Foreground="{StaticResource BadgeTextBrush}"
                                                        FontSize="11" FontWeight="SemiBold" />
                                         </Border>
                                     </DataTemplate>
@@ -443,7 +443,7 @@
                                     <DataTemplate>
                                         <Border Background="{Binding Type, Converter={StaticResource TypeToColor}}"
                                                 CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Opacity="0.85">
-                                            <TextBlock Text="{Binding TypeDisplay}" Foreground="White"
+                                            <TextBlock Text="{Binding TypeDisplay}" Foreground="{StaticResource BadgeTextBrush}"
                                                        FontSize="11" FontWeight="SemiBold" />
                                         </Border>
                                     </DataTemplate>
@@ -740,7 +740,7 @@
                                             </Grid.ColumnDefinitions>
                                             <Border Background="{Binding Type, Converter={StaticResource TypeToColor}}"
                                                     CornerRadius="3" Padding="6,2" HorizontalAlignment="Left" Opacity="0.85">
-                                                <TextBlock Text="{Binding TypeDisplay}" Foreground="White"
+                                                <TextBlock Text="{Binding TypeDisplay}" Foreground="{StaticResource BadgeTextBrush}"
                                                            FontSize="11" FontWeight="SemiBold" HorizontalAlignment="Center" />
                                             </Border>
                                             <TextBlock Grid.Column="1" Text="{Binding BlobName}"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.RestoreView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.RestoreView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
@@ -86,19 +86,19 @@
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Orientation="Horizontal">
-                            <Border Background="{StaticResource AccentBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
+                            <Border Background="{DynamicResource AccentBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
                                 <TextBlock Text="{Binding FullCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Full Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
-                            <Border Background="{StaticResource WarningBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
+                            <Border Background="{DynamicResource WarningBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
                                 <TextBlock Text="{Binding DiffCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Diff Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="2" Orientation="Horizontal">
-                            <Border Background="{StaticResource SuccessBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
+                            <Border Background="{DynamicResource SuccessBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
                                 <TextBlock Text="{Binding LogCount}" Foreground="White" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Log Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
@@ -123,12 +123,12 @@
                  the case where there are no restore points, so the user got an empty screen and no
                  explanation. A XAML load test caught that. -->
             <Border CornerRadius="4" Padding="12" Margin="0,0,0,16"
-                    Background="#332B1A" BorderBrush="#8A6D2F" BorderThickness="1"
+                    Background="{DynamicResource WarningPanelBackgroundBrush}" BorderBrush="{DynamicResource WarningPanelBorderBrush}" BorderThickness="1"
                     Visibility="{Binding HasInventoryIssues, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
                     <TextBlock Text="About the backups found in this container"
                                FontWeight="SemiBold"
-                               Foreground="{StaticResource PrimaryTextBrush}"
+                               Foreground="{DynamicResource PrimaryTextBrush}"
                                TextWrapping="Wrap"
                                Margin="0,0,0,8" />
                     <ItemsControl ItemsSource="{Binding InventoryIssues}">
@@ -165,7 +165,7 @@
                     <!-- Narrowing controls. A week of 15-minute logs is roughly 670 points, which
                          no timeline can draw legibly - so the range and the type toggles are the
                          way to get from "everything" down to something you can click (#27). -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="6" Padding="12,10" Margin="0,0,0,12">
                         <Grid>
                             <Grid.ColumnDefinitions>
@@ -220,13 +220,13 @@
 
                     <TextBlock Text="No restore point matches these filters. Widen the range or switch a type back on."
                                Style="{StaticResource SecondaryText}"
-                               Foreground="{StaticResource WarningBrush}"
+                               Foreground="{DynamicResource WarningBrush}"
                                TextWrapping="Wrap"
                                Margin="0,0,0,12"
                                Visibility="{Binding HasVisiblePoints, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
 
                     <!-- ========== VISUAL TIMELINE ========== -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="6" Padding="16,12" Margin="0,0,0,12">
                         <Grid>
                             <Grid.RowDefinitions>
@@ -238,11 +238,11 @@
 
                             <!-- Legend -->
                             <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
-                                <Ellipse Width="10" Height="10" Fill="{StaticResource AccentBrush}" Margin="0,0,4,0" />
+                                <Ellipse Width="10" Height="10" Fill="{DynamicResource AccentBrush}" Margin="0,0,4,0" />
                                 <TextBlock Text="Full" Style="{StaticResource SecondaryText}" Margin="0,0,16,0" VerticalAlignment="Center" />
-                                <Ellipse Width="10" Height="10" Fill="{StaticResource WarningBrush}" Margin="0,0,4,0" />
+                                <Ellipse Width="10" Height="10" Fill="{DynamicResource WarningBrush}" Margin="0,0,4,0" />
                                 <TextBlock Text="Diff" Style="{StaticResource SecondaryText}" Margin="0,0,16,0" VerticalAlignment="Center" />
-                                <Ellipse Width="10" Height="10" Fill="{StaticResource SuccessBrush}" Margin="0,0,4,0" />
+                                <Ellipse Width="10" Height="10" Fill="{DynamicResource SuccessBrush}" Margin="0,0,4,0" />
                                 <TextBlock Text="Log" Style="{StaticResource SecondaryText}" VerticalAlignment="Center" />
                             </StackPanel>
 
@@ -258,7 +258,7 @@
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
                                             <Border HorizontalAlignment="Left" VerticalAlignment="Stretch"
-                                                    Width="1" Background="{StaticResource CardBorderBrush}" Opacity="0.25">
+                                                    Width="1" Background="{DynamicResource CardBorderBrush}" Opacity="0.25">
                                                 <Border.Margin>
                                                     <MultiBinding Converter="{StaticResource TickPos}">
                                                         <Binding Path="Position" />
@@ -314,9 +314,9 @@
                                                             <Run Text="{Binding TimestampDisplay, Mode=OneWay}" />
                                                         </TextBlock>
                                                         <TextBlock Text="{Binding ChainDescription}"
-                                                                   Foreground="{StaticResource SecondaryTextBrush}" TextWrapping="Wrap" />
+                                                                   Foreground="{DynamicResource SecondaryTextBrush}" TextWrapping="Wrap" />
                                                         <TextBlock Text="{Binding TimestampNote}"
-                                                                   Foreground="{StaticResource WarningBrush}" TextWrapping="Wrap"
+                                                                   Foreground="{DynamicResource WarningBrush}" TextWrapping="Wrap"
                                                                    Margin="0,4,0,0"
                                                                    Visibility="{Binding IsTimestampApproximate, Converter={StaticResource BoolToVis}}" />
                                                     </StackPanel>
@@ -330,7 +330,7 @@
                             <!-- Track line + tick marks (time scale axis) -->
                             <Grid Grid.Row="2" Height="32" Margin="7,0">
                                 <!-- Track line -->
-                                <Border Height="3" Background="{StaticResource CardBorderBrush}"
+                                <Border Height="3" Background="{DynamicResource CardBorderBrush}"
                                         VerticalAlignment="Top" CornerRadius="1.5" />
 
                                 <!-- Tick marks with labels -->
@@ -350,9 +350,9 @@
                                                     </MultiBinding>
                                                 </StackPanel.Margin>
                                                 <Border Width="1" Height="12"
-                                                        Background="{StaticResource SecondaryTextBrush}" Opacity="0.6" />
+                                                        Background="{DynamicResource SecondaryTextBrush}" Opacity="0.6" />
                                                 <TextBlock Text="{Binding Label}" FontSize="10"
-                                                           Foreground="{StaticResource SecondaryTextBrush}"
+                                                           Foreground="{DynamicResource SecondaryTextBrush}"
                                                            Margin="-16,2,0,0" />
                                             </StackPanel>
                                         </DataTemplate>
@@ -402,7 +402,7 @@
                                         <Setter Property="ToolTip" Value="{Binding TimestampNote}" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsTimestampApproximate}" Value="True">
-                                                <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -462,7 +462,7 @@
                                         <Setter Property="ToolTip" Value="{Binding TimestampNote}" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsTimestampApproximate}" Value="True">
-                                                <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                                <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
                                             </DataTrigger>
                                         </Style.Triggers>
                                     </Style>
@@ -488,11 +488,11 @@
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
-                            <Run Text="Selected: " Foreground="{StaticResource SecondaryTextBrush}" />
+                            <Run Text="Selected: " Foreground="{DynamicResource SecondaryTextBrush}" />
                             <Run Text="{Binding SelectedRestorePoint.TimestampDisplay, Mode=OneWay}"
-                                 FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}" />
-                            <Run Text="  |  " Foreground="{StaticResource SecondaryTextBrush}" />
-                            <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{StaticResource SecondaryTextBrush}" />
+                                 FontWeight="SemiBold" Foreground="{DynamicResource AccentBrush}" />
+                            <Run Text="  |  " Foreground="{DynamicResource SecondaryTextBrush}" />
+                            <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{DynamicResource SecondaryTextBrush}" />
                         </TextBlock>
 
                         <!-- On-demand LSN verification: one RESTORE HEADERONLY per chain member,
@@ -585,13 +585,13 @@
                             Visibility="{Binding HasVerifyResults, Converter={StaticResource BoolToVis}}">
                         <Border.Style>
                             <Style TargetType="Border">
-                                <Setter Property="Background" Value="#1A2A1E" />
-                                <Setter Property="BorderBrush" Value="{StaticResource SuccessBrush}" />
+                                <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                 <Setter Property="BorderThickness" Value="1" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasVerifyFailures}" Value="True">
-                                        <Setter Property="Background" Value="#3A1E1E" />
-                                        <Setter Property="BorderBrush" Value="#A33F3F" />
+                                        <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
+                                        <Setter Property="BorderBrush" Value="{DynamicResource DangerPanelBorderBrush}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -610,10 +610,10 @@
                                                 <Run Text="{Binding StatusDisplay, Mode=OneWay}">
                                                     <Run.Style>
                                                         <Style TargetType="Run">
-                                                            <Setter Property="Foreground" Value="{StaticResource SuccessBrush}" />
+                                                            <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
                                                             <Style.Triggers>
                                                                 <DataTrigger Binding="{Binding IsValid}" Value="False">
-                                                                    <Setter Property="Foreground" Value="{StaticResource ErrorBrush}" />
+                                                                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
                                                                 </DataTrigger>
                                                             </Style.Triggers>
                                                         </Style>
@@ -638,13 +638,13 @@
                             Visibility="{Binding HasChainIssues, Converter={StaticResource BoolToVis}}">
                         <Border.Style>
                             <Style TargetType="Border">
-                                <Setter Property="Background" Value="#332B1A" />
-                                <Setter Property="BorderBrush" Value="#8A6D2F" />
+                                <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource WarningPanelBorderBrush}" />
                                 <Setter Property="BorderThickness" Value="1" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasChainErrors}" Value="True">
-                                        <Setter Property="Background" Value="#3A1E1E" />
-                                        <Setter Property="BorderBrush" Value="#A33F3F" />
+                                        <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
+                                        <Setter Property="BorderBrush" Value="{DynamicResource DangerPanelBorderBrush}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -652,7 +652,7 @@
                         <StackPanel>
                             <TextBlock Text="{Binding ChainIssueSummary}"
                                        FontWeight="SemiBold"
-                                       Foreground="{StaticResource PrimaryTextBrush}"
+                                       Foreground="{DynamicResource PrimaryTextBrush}"
                                        TextWrapping="Wrap"
                                        Margin="0,0,0,8" />
                             <ItemsControl ItemsSource="{Binding ChainIssues}">
@@ -680,7 +680,7 @@
                          point. Shown whether or not a point is selected, because they explain why
                          the timeline has fewer entries than the browse list has files (#46). -->
                     <!-- Restore Chain Detail (togglable) -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="12" Margin="0,12,0,0"
                             Visibility="{Binding ShowChainDetails, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
@@ -796,7 +796,7 @@
 
                             <TextBlock Style="{StaticResource SecondaryText}"
                                        FontSize="10" TextWrapping="Wrap"
-                                       Foreground="{StaticResource WarningBrush}"
+                                       Foreground="{DynamicResource WarningBrush}"
                                        Margin="0,0,0,12"
                                        Visibility="{Binding ContinueAfterError, Converter={StaticResource BoolToVis}}"
                                        Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
@@ -814,10 +814,10 @@
                                 <Border CornerRadius="4" Padding="10,6" Margin="0,0,0,10">
                                     <Border.Style>
                                         <Style TargetType="Border">
-                                            <Setter Property="Background" Value="#30F39C12" />
+                                            <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding PathsFromServer}" Value="True">
-                                                    <Setter Property="Background" Value="#1A27AE60" />
+                                                    <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -831,10 +831,10 @@
                                         <Ellipse Grid.Column="0" Width="8" Height="8" VerticalAlignment="Center" Margin="0,0,8,0">
                                             <Ellipse.Style>
                                                 <Style TargetType="Ellipse">
-                                                    <Setter Property="Fill" Value="{StaticResource WarningBrush}" />
+                                                    <Setter Property="Fill" Value="{DynamicResource WarningBrush}" />
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding PathsFromServer}" Value="True">
-                                                            <Setter Property="Fill" Value="{StaticResource SuccessBrush}" />
+                                                            <Setter Property="Fill" Value="{DynamicResource SuccessBrush}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
@@ -900,7 +900,7 @@
                                 </StackPanel>
 
                                 <Border Visibility="{Binding HasFetchedFileMoves, Converter={StaticResource BoolToVis}}"
-                                        Background="{StaticResource InputBackgroundBrush}"
+                                        Background="{DynamicResource InputBackgroundBrush}"
                                         CornerRadius="4" Padding="8" Margin="0,0,0,8">
                                     <StackPanel>
                                         <TextBlock Text="Logical files (from RESTORE FILELISTONLY)" Style="{StaticResource LabelText}" Margin="0,0,0,6" />
@@ -920,7 +920,7 @@
                                 </Border>
 
                                 <Border Visibility="{Binding BackupMetadataSummary, Converter={StaticResource NullToVis}}"
-                                        Background="{StaticResource InputBackgroundBrush}"
+                                        Background="{DynamicResource InputBackgroundBrush}"
                                         CornerRadius="4" Padding="10" Margin="0,0,0,8">
                                     <StackPanel>
                                         <TextBlock Text="Backup metadata (RESTORE HEADERONLY)" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
@@ -995,7 +995,7 @@
                                      ToolTip="Defaults to the container URL. The credential on the server must match this name (container URL) for RESTORE FROM URL." />
 
                             <!-- Blob credential: when not connected, prompt to connect to verify; when connected, show status and optional Create -->
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="12,10" Margin="0,0,0,16"
                                     Visibility="{Binding CredentialSectionVisible, Converter={StaticResource BoolToVis}}">
                                 <StackPanel>
@@ -1012,19 +1012,19 @@
                                         <Border Padding="0,0,0,8">
                                             <Border.Style>
                                                 <Style TargetType="Border">
-                                                    <Setter Property="Background" Value="{StaticResource InputBackgroundBrush}" />
+                                                    <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
                                                     <Setter Property="BorderThickness" Value="0" />
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding CredentialIsValidSas}" Value="True">
-                                                            <Setter Property="Background" Value="#1A27AE60" />
-                                                            <Setter Property="BorderBrush" Value="{StaticResource SuccessBrush}" />
+                                                            <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
                                                             <Setter Property="CornerRadius" Value="4" />
                                                             <Setter Property="Padding" Value="8,6,8,6" />
                                                         </DataTrigger>
                                                         <DataTrigger Binding="{Binding CredentialExistsOnServer}" Value="False">
-                                                            <Setter Property="Background" Value="#30E74C3C" />
-                                                            <Setter Property="BorderBrush" Value="{StaticResource ErrorBrush}" />
+                                                            <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
                                                             <Setter Property="CornerRadius" Value="4" />
                                                             <Setter Property="Padding" Value="8,6,8,6" />
@@ -1034,8 +1034,8 @@
                                                                 <Condition Binding="{Binding CredentialExistsOnServer}" Value="True" />
                                                                 <Condition Binding="{Binding CredentialIsValidSas}" Value="False" />
                                                             </MultiDataTrigger.Conditions>
-                                                            <Setter Property="Background" Value="#30E67E22" />
-                                                            <Setter Property="BorderBrush" Value="{StaticResource WarningBrush}" />
+                                                            <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
+                                                            <Setter Property="BorderBrush" Value="{DynamicResource WarningBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
                                                             <Setter Property="CornerRadius" Value="4" />
                                                             <Setter Property="Padding" Value="8,6,8,6" />
@@ -1089,7 +1089,7 @@
                     <TextBlock Text="RESTORE SUMMARY"
                                Style="{StaticResource SubHeaderText}"
                                Margin="0,0,0,8" />
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="12,10">
                         <TextBlock Text="{Binding RestoreSummaryText}"
                                    Style="{StaticResource BodyText}"
@@ -1144,7 +1144,7 @@
                          the last thing between the user and an irreversible overwrite, and a
                          hostname alone is a weak signal - blackcatsvr01 and blackcatsvr02 differ
                          by one character. A red PROD pill is read before the sentence is. -->
-                    <Border Background="#30E74C3C" CornerRadius="4" Padding="12,8" Margin="0,0,0,12"
+                    <Border Background="{DynamicResource DangerPanelBackgroundBrush}" CornerRadius="4" Padding="12,8" Margin="0,0,0,12"
                             Visibility="{Binding IsExecuteArmed, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
                             <ItemsControl ItemsSource="{Binding ConnectedServerTags}"
@@ -1152,37 +1152,37 @@
                                           Margin="0,0,0,6"
                                           Visibility="{Binding HasConnectedServerTags, Converter={StaticResource BoolToVis}}" />
                             <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap">
-                                <Run Text="&#x26A0;" Foreground="{StaticResource ErrorBrush}" FontSize="14" />
+                                <Run Text="&#x26A0;" Foreground="{DynamicResource ErrorBrush}" FontSize="14" />
                                 <Run Text=" Click again to execute restore against" />
-                                <Run Text="{Binding ConnectedServerName, Mode=OneWay}" FontWeight="SemiBold" Foreground="{StaticResource ErrorBrush}" />
+                                <Run Text="{Binding ConnectedServerName, Mode=OneWay}" FontWeight="SemiBold" Foreground="{DynamicResource ErrorBrush}" />
                                 <Run Text=". Target:" />
                                 <Run Text="{Binding TargetDatabaseName, Mode=OneWay}" FontWeight="SemiBold" />
                                 <Run Text="(" />
                                 <Run Text="{Binding ChainSummary, Mode=OneWay}" />
-                                <Run Text="). This operation cannot be undone." Foreground="{StaticResource ErrorBrush}" />
+                                <Run Text="). This operation cannot be undone." Foreground="{DynamicResource ErrorBrush}" />
                             </TextBlock>
                         </StackPanel>
                     </Border>
 
                     <!-- Not connected warning -->
-                    <Border Background="{StaticResource DangerBackgroundBrush}"
+                    <Border Background="{DynamicResource DangerBackgroundBrush}"
                             CornerRadius="4" Padding="12,8" Margin="0,0,0,12"
                             Visibility="{Binding IsConnectedToServer, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                         <TextBlock Style="{StaticResource SecondaryText}">
-                            <Run Text="&#x26A0;" Foreground="{StaticResource WarningBrush}" />
+                            <Run Text="&#x26A0;" Foreground="{DynamicResource WarningBrush}" />
                             <Run Text=" Connect to a SQL Server instance (SQL Servers tab) to enable script execution." />
                         </TextBlock>
                     </Border>
 
                     <TextBlock Text="{Binding ErrorMessage}"
-                               Foreground="{StaticResource ErrorBrush}"
+                               Foreground="{DynamicResource ErrorBrush}"
                                Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
                                Margin="0,0,0,12" TextWrapping="Wrap" />
 
                     <!-- The generated script. Stays visible during and after execution: it used to
                          be hidden the moment Execute was pressed, so the script and the console
                          shared one slot and you could not see what was running while it ran. -->
-                    <Border Background="{StaticResource InputBackgroundBrush}"
+                    <Border Background="{DynamicResource InputBackgroundBrush}"
                             CornerRadius="4" Padding="0"
                             Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
@@ -1201,7 +1201,7 @@
                                                     FontFamily="{StaticResource ConsoleFont}"
                                                     FontSize="12"
                                                     TextWrapping="NoWrap"
-                                                    Foreground="{StaticResource ConsoleTextBrush}" />
+                                                    Foreground="{DynamicResource ConsoleTextBrush}" />
                             </ScrollViewer>
                         </StackPanel>
                     </Border>
@@ -1212,8 +1212,8 @@
                          growing string: appending to a bound string re-rendered the whole control
                          on every message, which is why progress arrived in bursts. -->
                     <Border CornerRadius="6" Margin="0,12,0,0"
-                            Background="{StaticResource ConsoleBackgroundBrush}"
-                            BorderBrush="{StaticResource ConsoleBorderBrush}"
+                            Background="{DynamicResource ConsoleBackgroundBrush}"
+                            BorderBrush="{DynamicResource ConsoleBorderBrush}"
                             BorderThickness="1">
                         <!-- Shown only when the console is NOT in its own window - the two are
                              mutually exclusive, so the output is never rendered twice. -->
@@ -1245,9 +1245,9 @@
 
                             <!-- Chrome strip: title, live indicator, copy. -->
                             <Border Grid.Row="0"
-                                    Background="{StaticResource ConsoleChromeBrush}"
+                                    Background="{DynamicResource ConsoleChromeBrush}"
                                     CornerRadius="5,5,0,0"
-                                    BorderBrush="{StaticResource ConsoleBorderBrush}"
+                                    BorderBrush="{DynamicResource ConsoleBorderBrush}"
                                     BorderThickness="0,0,0,1"
                                     Padding="12,7">
                                 <Grid>
@@ -1255,17 +1255,17 @@
                                         <Ellipse Width="9" Height="9" Margin="0,0,7,0">
                                             <Ellipse.Style>
                                                 <Style TargetType="Ellipse">
-                                                    <Setter Property="Fill" Value="{StaticResource ConsoleMutedBrush}" />
+                                                    <Setter Property="Fill" Value="{DynamicResource ConsoleMutedBrush}" />
                                                     <Style.Triggers>
                                                         <DataTrigger Binding="{Binding IsExecuting}" Value="True">
-                                                            <Setter Property="Fill" Value="{StaticResource ConsoleSuccessBrush}" />
+                                                            <Setter Property="Fill" Value="{DynamicResource ConsoleSuccessBrush}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
                                             </Ellipse.Style>
                                         </Ellipse>
                                         <TextBlock Text="restore console"
-                                                   Foreground="{StaticResource ConsoleMutedBrush}"
+                                                   Foreground="{DynamicResource ConsoleMutedBrush}"
                                                    FontFamily="{StaticResource ConsoleFont}"
                                                    FontSize="11"
                                                    VerticalAlignment="Center" />
@@ -1273,7 +1273,7 @@
 
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                                         <TextBlock Text="{Binding ConsoleLines.Count, StringFormat='{}{0} lines'}"
-                                                   Foreground="{StaticResource ConsoleMutedBrush}"
+                                                   Foreground="{DynamicResource ConsoleMutedBrush}"
                                                    FontFamily="{StaticResource ConsoleFont}"
                                                    FontSize="11"
                                                    VerticalAlignment="Center"
@@ -1308,7 +1308,7 @@
                          worst moment to be left working that out from a raw SQL error. Each action
                          shows the exact statement before it runs. -->
                     <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
-                            Background="#3A1E1E" BorderBrush="#A33F3F" BorderThickness="1">
+                            Background="{DynamicResource DangerPanelBackgroundBrush}" BorderBrush="{DynamicResource DangerPanelBorderBrush}" BorderThickness="1">
                         <!-- Same rule as the console: not while it is showing in its own window,
                              where the recovery actions already appear. -->
                         <Border.Style>
@@ -1334,12 +1334,12 @@
                             <ItemsControl ItemsSource="{Binding RecoveryActions}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Border Background="{StaticResource InputBackgroundBrush}"
+                                        <Border Background="{DynamicResource InputBackgroundBrush}"
                                                 CornerRadius="4" Padding="10" Margin="0,0,0,8">
                                             <StackPanel>
                                                 <TextBlock Text="{Binding Title}"
                                                            FontWeight="SemiBold"
-                                                           Foreground="{StaticResource PrimaryTextBrush}"
+                                                           Foreground="{DynamicResource PrimaryTextBrush}"
                                                            TextWrapping="Wrap" />
                                                 <TextBox Text="{Binding Sql, Mode=OneWay}"
                                                          Style="{StaticResource DarkTextBox}"
@@ -1374,7 +1374,7 @@
             </Border>
 
             <!-- Loading -->
-            <Border Background="#80000000" CornerRadius="6"
+            <Border Background="{DynamicResource OverlayBrush}" CornerRadius="6"
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}" Padding="20">
                 <StackPanel HorizontalAlignment="Center">
                     <TextBlock Text="Loading..." Style="{StaticResource BodyText}" HorizontalAlignment="Center" />

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1101,7 +1101,7 @@
                                                     <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
                                                     <Setter Property="BorderThickness" Value="0" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CredentialIsValidSas}" Value="True">
+                                                        <DataTrigger Binding="{Binding CredentialIsUsable}" Value="True">
                                                             <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                                             <Setter Property="BorderThickness" Value="1" />
@@ -1118,7 +1118,7 @@
                                                         <MultiDataTrigger>
                                                             <MultiDataTrigger.Conditions>
                                                                 <Condition Binding="{Binding CredentialExistsOnServer}" Value="True" />
-                                                                <Condition Binding="{Binding CredentialIsValidSas}" Value="False" />
+                                                                <Condition Binding="{Binding CredentialIsUsable}" Value="False" />
                                                             </MultiDataTrigger.Conditions>
                                                             <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
                                                             <Setter Property="BorderBrush" Value="{DynamicResource WarningBrush}" />
@@ -1133,17 +1133,24 @@
                                                        Style="{StaticResource SecondaryText}"
                                                        TextWrapping="Wrap" />
                                         </Border>
-                                        <TextBlock Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                        <TextBlock Visibility="{Binding CredentialIsUsable, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
-                                            <Run Text="Restore from URL requires a SQL credential (SHARED ACCESS SIGNATURE) for the container. You can create it from here, or create it on the server yourself before running the script. Execute will create it for you if it is missing. The SAS token is never included in the generated script." />
+                                            <Run Text="Restore from URL needs a SQL credential for the container, holding either a SHARED ACCESS SIGNATURE or - on SQL Server 2022 and later - the instance's Managed Identity. You can create the SAS kind from here, or create either on the server yourself before running the script. Execute will create one for you only if there is nothing of that name: a credential that already exists is never rewritten behind your back. The SAS token is never included in the generated script." />
                                         </TextBlock>
                                         <!-- Stays available once the credential is valid, because "valid" only means a SAS
                                              credential of that name exists. SQL Server will not return its secret, so a
                                              rotated or expired token is indistinguishable from a working one, and this is
                                              the only way to push a fresh one. -->
-                                        <TextBlock Visibility="{Binding CredentialIsValidSas, Converter={StaticResource BoolToVis}}"
+                                        <TextBlock Visibility="{Binding CredentialIsSharedAccessSignature, Converter={StaticResource BoolToVis}}"
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
                                             <Run Text="Execute will leave this credential alone. If the SAS token has been rotated or has expired since the credential was created, the restore will fail on blob access - refresh it below to push the token currently stored for this container." />
+                                        </TextBlock>
+                                        <!-- A managed identity is somebody else's deliberate setup: this app cannot create
+                                             one, and the button below would ALTER it into a SAS credential, which is a
+                                             change to how the whole instance authenticates to that container (#145). -->
+                                        <TextBlock Visibility="{Binding CredentialIsManagedIdentity, Converter={StaticResource BoolToVis}}"
+                                                   Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
+                                            <Run Text="Execute will leave this credential alone and no SAS token is sent to the server. The instance authenticates to the container as itself, so the restore depends on its identity holding a role on the storage account rather than on anything stored here. The button below would replace that with a SAS credential - which would also change how anything else on this instance reaches the same container." />
                                         </TextBlock>
                                         <Button Command="{Binding CreateCredentialOnServerCommand}"
                                                 Margin="0,0,0,0" Padding="10,6"
@@ -1153,8 +1160,14 @@
                                                 <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
                                                     <Setter Property="Content" Value="Create credential on server" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding CredentialIsValidSas}" Value="True">
+                                                        <DataTrigger Binding="{Binding CredentialIsSharedAccessSignature}" Value="True">
                                                             <Setter Property="Content" Value="Refresh credential with stored SAS token" />
+                                                        </DataTrigger>
+                                                        <!-- Says what the press would actually do. The same button under the
+                                                             old label read as a harmless refresh while it converted the
+                                                             instance's managed identity to a SAS token (#145). -->
+                                                        <DataTrigger Binding="{Binding CredentialIsManagedIdentity}" Value="True">
+                                                            <Setter Property="Content" Value="Replace Managed Identity with stored SAS token" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -621,6 +621,12 @@
                                 <Setter Property="BorderBrush" Value="{DynamicResource SuccessBrush}" />
                                 <Setter Property="BorderThickness" Value="1" />
                                 <Style.Triggers>
+                                    <!-- Amber, not green: every backup read back, but the restore
+                                         will still fail because it has nowhere to write. -->
+                                    <DataTrigger Binding="{Binding HasTargetPathProblem}" Value="True">
+                                        <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
+                                        <Setter Property="BorderBrush" Value="{DynamicResource WarningPanelBorderBrush}" />
+                                    </DataTrigger>
                                     <DataTrigger Binding="{Binding HasVerifyFailures}" Value="True">
                                         <Setter Property="Background" Value="{DynamicResource DangerPanelBackgroundBrush}" />
                                         <Setter Property="BorderBrush" Value="{DynamicResource DangerPanelBorderBrush}" />
@@ -630,6 +636,25 @@
                         </Border.Style>
                         <StackPanel>
                             <TextBlock Text="RESTORE VERIFYONLY" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+
+                            <!-- SQL Server reports this as an informational line next to "the
+                                 backup set is valid", which is four lines of grey text under a
+                                 green tick. Said properly here instead (#129). -->
+                            <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                    BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                    BorderThickness="1" CornerRadius="4"
+                                    Padding="10" Margin="0,0,0,10"
+                                    Visibility="{Binding HasTargetPathProblem, Converter={StaticResource BoolToVis}}">
+                                <StackPanel>
+                                    <TextBlock Text="The restore will fail as it stands"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource WarningBrush}"
+                                               Margin="0,0,0,4" />
+                                    <TextBlock Text="{Binding TargetPathProblemMessage}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap" />
+                                </StackPanel>
+                            </Border>
                             <ItemsControl ItemsSource="{Binding ChainVerifyResults}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1037,22 +1037,35 @@
 
                             <!-- Point-in-time (STOPAT): only shown for a log restore point, where
                                  stopping partway through the log is meaningful. -->
-                            <StackPanel Visibility="{Binding CanUsePointInTime, Converter={StaticResource BoolToVis}}">
+                            <StackPanel Visibility="{Binding PointInTime.CanUse, Converter={StaticResource BoolToVis}}">
                                 <TextBlock Text="POINT IN TIME" Style="{StaticResource LabelText}" />
                                 <CheckBox Content="Stop at a specific time (STOPAT)"
-                                          IsChecked="{Binding UsePointInTime}"
+                                          IsChecked="{Binding PointInTime.Use}"
                                           Style="{StaticResource DarkCheckBox}"
                                           Margin="0,4,0,8"
                                           ToolTip="Recover to an exact moment inside the selected log backup instead of restoring the whole log." />
-                                <TextBox Text="{Binding StopAtText, UpdateSourceTrigger=PropertyChanged}"
+                                <TextBox Text="{Binding PointInTime.StopAtText, UpdateSourceTrigger=PropertyChanged}"
                                          Style="{StaticResource DarkTextBox}"
-                                         IsEnabled="{Binding UsePointInTime}"
+                                         IsEnabled="{Binding PointInTime.Use}"
                                          Width="180" HorizontalAlignment="Left"
                                          ToolTip="yyyy-MM-dd HH:mm:ss" />
-                                <TextBlock Text="{Binding PointInTimeMessage}"
-                                           Style="{StaticResource SecondaryText}"
+                                <!-- "Must be after 14:15" is a rejection, not a hint, and it was
+                                     drawn in the same muted grey as "Valid range: ...". Execute is
+                                     already blocked at that point, so the message is the only thing
+                                     saying why. -->
+                                <TextBlock Text="{Binding PointInTime.Message}"
                                            TextWrapping="Wrap"
-                                           Margin="0,4,0,16" />
+                                           Margin="0,4,0,16">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding PointInTime.HasError}" Value="True">
+                                                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                             </StackPanel>
 
                             <TextBlock Text="STATS PERCENT" Style="{StaticResource LabelText}" />

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -496,28 +496,32 @@
                             <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{DynamicResource SecondaryTextBrush}" />
                         </TextBlock>
 
-                        <!-- On-demand LSN verification: one RESTORE HEADERONLY per chain member,
-                             so it is a deliberate action rather than automatic on selection. -->
+                        <!-- On-demand: one RESTORE HEADERONLY per chain member, so it is a
+                             deliberate action rather than automatic on selection.
+
+                             Named for the question it answers rather than for the word "validate".
+                             Two of the buttons on this screen used to say "verify" and mean
+                             different things, and a third said it while verifying nothing. -->
                         <Button Grid.Column="1"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding ValidateChainCommand}"
                                 Padding="12,6" Margin="0,0,8,0"
-                                ToolTip="Read each backup's header and verify the LSN chain is unbroken. Requires a connected server.">
+                                ToolTip="Do these backups belong together? Reads each backup's header and compares the LSNs. Takes seconds. Requires a connected server.">
                             <Button.Content>
                                 <TextBlock>
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="Validate Chain" />
+                                            <Setter Property="Text" Value="Check chain (HEADERONLY)" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsValidatingChain}" Value="True">
-                                                    <Setter Property="Text" Value="Validating..." />
+                                                    <Setter Property="Text" Value="Checking..." />
                                                 </DataTrigger>
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding ChainLsnVerified}" Value="True" />
                                                         <Condition Binding="{Binding HasChainIssues}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Text" Value="Chain Verified" />
+                                                    <Setter Property="Text" Value="Chain checked" />
                                                 </MultiDataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -526,19 +530,20 @@
                             </Button.Content>
                         </Button>
 
-                        <!-- A different question from Validate Chain: that one reads headers and
+                        <!-- A different question from Check chain: that one reads headers and
                              checks the LSNs line up, this one reads each backup end to end and
-                             checks it is intact. A truncated blob passes the first and fails this. -->
+                             checks it is intact. A truncated blob passes the first and fails this.
+                             It is also the only one here that costs real time. -->
                         <Button Grid.Column="2"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding VerifyChainCommand}"
                                 Padding="12,6" Margin="0,0,8,0"
-                                ToolTip="Run RESTORE VERIFYONLY over every backup in the chain to check each one reads back intact, before committing to the restore. Requires a connected server.">
+                                ToolTip="Is each backup actually readable? Runs RESTORE VERIFYONLY over every backup in the chain, reading every byte - this can take as long as the restore itself. Requires a connected server.">
                             <Button.Content>
                                 <TextBlock>
                                     <TextBlock.Style>
                                         <Style TargetType="TextBlock">
-                                            <Setter Property="Text" Value="Verify Backups" />
+                                            <Setter Property="Text" Value="Verify backups (VERIFYONLY)" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsVerifyingChain}" Value="True">
                                                     <Setter Property="Text" Value="Verifying..." />
@@ -549,7 +554,7 @@
                                                         <Condition Binding="{Binding HasVerifyFailures}" Value="False" />
                                                         <Condition Binding="{Binding IsVerifyingChain}" Value="False" />
                                                     </MultiDataTrigger.Conditions>
-                                                    <Setter Property="Text" Value="Backups Verified" />
+                                                    <Setter Property="Text" Value="Backups verified" />
                                                 </MultiDataTrigger>
                                             </Style.Triggers>
                                         </Style>
@@ -590,6 +595,20 @@
                             </Button.Content>
                         </Button>
                     </Grid>
+
+                    <!-- The pair above are the genuinely subtle one: both act on the whole chain
+                         and both sound like the same thing. The difference that matters when you
+                         are deciding whether to press one is how long it takes. -->
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               FontSize="11" TextWrapping="Wrap"
+                               Margin="0,6,0,0"
+                               Visibility="{Binding HasValidChain, Converter={StaticResource BoolToVis}}">
+                        <Run Text="Check chain" FontWeight="SemiBold" />
+                        <Run Text="reads each header and compares the LSNs - do these backups belong together? Seconds." />
+                        <LineBreak />
+                        <Run Text="Verify backups" FontWeight="SemiBold" />
+                        <Run Text="reads every byte of every backup - is each one actually readable? Can take as long as the restore." />
+                    </TextBlock>
 
                     <!-- Per-set VERIFYONLY results. Green while everything reads back, red the
                          moment one does not - a failed member here means the chain cannot restore,
@@ -883,34 +902,39 @@
                                 <TextBlock Style="{StaticResource SecondaryText}"
                                            FontSize="10" TextWrapping="Wrap"
                                            Margin="0,0,0,4"
-                                           Text="Logical file names are inferred by default. Use Verify backup to get actual names from the backup (RESTORE FILELISTONLY) for correct WITH MOVE." />
+                                           Text="Logical file names are guessed from the database name by default, which is wrong for a database that has been renamed or has secondary files. Get file names reads the real ones out of the backup." />
 
-                                <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
-                                    <Button Content="Verify backup (FILELISTONLY)"
+                                <!-- Wraps rather than clips. Four buttons on one line runs off the
+                                     edge of the panel at anything less than a wide window, and a
+                                     StackPanel does not wrap - it just hides the last one. -->
+                                <WrapPanel Orientation="Horizontal" Margin="0,8,0,8">
+                                    <!-- Was "Verify backup (FILELISTONLY)", which verified nothing:
+                                         it reads the logical file names so WITH MOVE can name them
+                                         correctly instead of guessing. Opening the backup to list
+                                         them does incidentally prove the credential works, which is
+                                         probably where the old name came from. -->
+                                    <Button Content="Get file names (FILELISTONLY)"
                                             Style="{StaticResource SecondaryButton}"
                                             Command="{Binding FetchLogicalNamesCommand}"
-                                            Padding="8,4" FontSize="11"
-                                            ToolTip="Run RESTORE FILELISTONLY on the full backup to get logical file names for WITH MOVE."
-                                            Margin="0,0,8,0" />
+                                            Padding="8,4" FontSize="11" Margin="0,0,8,6"
+                                            ToolTip="Reads the logical file names out of the full backup, so WITH MOVE can name them correctly rather than guessing from the database name. Reads this one backup, not the chain." />
                                     <Button Content="Copy FILELISTONLY command"
                                             Style="{StaticResource SecondaryButton}"
                                             Command="{Binding CopyFileListOnlyCommandCommand}"
-                                            Padding="8,4" FontSize="11"
-                                            ToolTip="Copy the RESTORE FILELISTONLY T-SQL to clipboard to run in SSMS (e.g. when you get error 13)."
-                                            Margin="0,0,8,0" />
-                                    <Button Content="View metadata (HEADERONLY)"
+                                            Padding="8,4" FontSize="11" Margin="0,0,8,6"
+                                            ToolTip="Copy the RESTORE FILELISTONLY T-SQL to clipboard to run in SSMS (e.g. when you get error 13)." />
+                                    <Button Content="Read header (HEADERONLY)"
                                             Style="{StaticResource SecondaryButton}"
                                             Command="{Binding InspectBackupMetadataCommand}"
-                                            Padding="8,4" FontSize="11"
-                                            ToolTip="Run RESTORE HEADERONLY to inspect backup set metadata."
-                                            Margin="0,0,8,0" />
+                                            Padding="8,4" FontSize="11" Margin="0,0,8,6"
+                                            ToolTip="Shows what the full backup says about itself - database, type, when it was taken, LSNs. Reads this one backup, not the chain." />
                                     <Button Content="Copy HEADERONLY command"
                                             Style="{StaticResource SecondaryButton}"
                                             Command="{Binding CopyHeaderOnlyCommandCommand}"
-                                            Padding="8,4" FontSize="11"
+                                            Padding="8,4" FontSize="11" Margin="0,0,8,6"
                                             ToolTip="Copy the RESTORE HEADERONLY T-SQL to clipboard to run in SSMS (e.g. when you get error 13)."
-                                            Margin="0,0,8,0" />
-                                </StackPanel>
+                                            />
+                                </WrapPanel>
 
                                 <Border Visibility="{Binding HasFetchedFileMoves, Converter={StaticResource BoolToVis}}"
                                         Background="{DynamicResource InputBackgroundBrush}"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -248,10 +248,14 @@
                                                         <TextBlock FontWeight="SemiBold">
                                                             <Run Text="{Binding TypeDisplay, Mode=OneWay}" />
                                                             <Run Text=" — " />
-                                                            <Run Text="{Binding Timestamp, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}', Mode=OneWay}" />
+                                                            <Run Text="{Binding TimestampDisplay, Mode=OneWay}" />
                                                         </TextBlock>
                                                         <TextBlock Text="{Binding ChainDescription}"
                                                                    Foreground="{StaticResource SecondaryTextBrush}" TextWrapping="Wrap" />
+                                                        <TextBlock Text="{Binding TimestampNote}"
+                                                                   Foreground="{StaticResource WarningBrush}" TextWrapping="Wrap"
+                                                                   Margin="0,4,0,0"
+                                                                   Visibility="{Binding IsTimestampApproximate, Converter={StaticResource BoolToVis}}" />
                                                     </StackPanel>
                                                 </Button.ToolTip>
                                             </Button>
@@ -330,8 +334,22 @@
 
                             <DataGridTextColumn Header="Set ID" Width="160"
                                                 Binding="{Binding SetId}" />
+                            <!-- Sorts on the underlying value, not the display string, so a "~"
+                                 prefix cannot push approximate sets to one end of the grid. -->
                             <DataGridTextColumn Header="Timestamp" Width="150"
-                                                Binding="{Binding Timestamp, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}" />
+                                                SortMemberPath="Timestamp"
+                                                Binding="{Binding TimestampDisplay}">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="ToolTip" Value="{Binding TimestampNote}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsTimestampApproximate}" Value="True">
+                                                <Setter Property="Foreground" Value="{StaticResource WarningBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
                             <DataGridTextColumn Header="Files" Width="55"
                                                 Binding="{Binding FileCount}" />
                             <DataGridTextColumn Header="Striped" Width="60"
@@ -352,7 +370,7 @@
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
                             <Run Text="Selected: " Foreground="{StaticResource SecondaryTextBrush}" />
-                            <Run Text="{Binding SelectedRestorePoint.Timestamp, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}', Mode=OneWay}"
+                            <Run Text="{Binding SelectedRestorePoint.TimestampDisplay, Mode=OneWay}"
                                  FontWeight="SemiBold" Foreground="{StaticResource AccentBrush}" />
                             <Run Text="  |  " Foreground="{StaticResource SecondaryTextBrush}" />
                             <Run Text="{Binding ChainSummary, Mode=OneWay}" Foreground="{StaticResource SecondaryTextBrush}" />
@@ -496,7 +514,8 @@
                                             <TextBlock Grid.Column="2" Text="{Binding SizeDisplay}"
                                                        Style="{StaticResource SecondaryText}" VerticalAlignment="Center" />
                                             <TextBlock Grid.Column="3"
-                                                       Text="{Binding EffectiveDate, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}"
+                                                       Text="{Binding EffectiveDateDisplay}"
+                                                       ToolTip="{Binding EffectiveDateNote}"
                                                        Style="{StaticResource SecondaryText}" VerticalAlignment="Center" />
                                         </Grid>
                                     </DataTemplate>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -821,43 +821,43 @@
                                      ToolTip="The name of the database to restore to." />
 
                             <CheckBox Content="WITH REPLACE"
-                                      IsChecked="{Binding WithReplace}"
+                                      IsChecked="{Binding Options.WithReplace}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Overwrite the existing database even if it already exists." />
 
                             <CheckBox Content="Disconnect Sessions"
-                                      IsChecked="{Binding DisconnectSessions}"
+                                      IsChecked="{Binding Options.DisconnectSessions}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="SET SINGLE_USER WITH ROLLBACK IMMEDIATE before restore." />
 
                             <CheckBox Content="KEEP_REPLICATION"
-                                      IsChecked="{Binding KeepReplication}"
+                                      IsChecked="{Binding Options.KeepReplication}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Preserves replication settings during restore." />
 
                             <CheckBox Content="ENABLE_BROKER"
-                                      IsChecked="{Binding EnableBroker}"
+                                      IsChecked="{Binding Options.EnableBroker}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Enables Service Broker with the existing contract." />
 
                             <CheckBox Content="NEW_BROKER"
-                                      IsChecked="{Binding NewBroker}"
+                                      IsChecked="{Binding Options.NewBroker}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Creates a new Service Broker identifier." />
 
                             <CheckBox Content="CHECKSUM"
-                                      IsChecked="{Binding WithChecksum}"
+                                      IsChecked="{Binding Options.WithChecksum}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
                                       ToolTip="Verify backup checksums while restoring. Only works if the backup was taken WITH CHECKSUM - against one that was not, SQL Server fails the restore rather than skipping the check." />
 
                             <CheckBox Content="CONTINUE_AFTER_ERROR"
-                                      IsChecked="{Binding ContinueAfterError}"
+                                      IsChecked="{Binding Options.ContinueAfterError}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,4"
                                       ToolTip="Keep restoring past a damaged page or a failed checksum instead of stopping. The database this produces may be corrupt." />
@@ -866,7 +866,7 @@
                                        FontSize="10" TextWrapping="Wrap"
                                        Foreground="{DynamicResource WarningBrush}"
                                        Margin="0,0,0,12"
-                                       Visibility="{Binding ContinueAfterError, Converter={StaticResource BoolToVis}}"
+                                       Visibility="{Binding Options.ContinueAfterError, Converter={StaticResource BoolToVis}}"
                                        Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
 
                             <CheckBox Content="WITH MOVE (relocate files)"
@@ -1013,27 +1013,27 @@
                             <StackPanel Margin="0,4,0,16">
                                 <RadioButton Content="RECOVERY"
                                              Style="{StaticResource DarkRadioButton}"
-                                             IsChecked="{Binding RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=Recovery}"
+                                             IsChecked="{Binding Options.RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=Recovery}"
                                              Margin="0,0,0,6" GroupName="RecoveryMode"
                                              ToolTip="Database is fully recovered and ready for use." />
                                 <RadioButton Content="NORECOVERY"
                                              Style="{StaticResource DarkRadioButton}"
-                                             IsChecked="{Binding RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=NoRecovery}"
+                                             IsChecked="{Binding Options.RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=NoRecovery}"
                                              Margin="0,0,0,6" GroupName="RecoveryMode"
                                              ToolTip="Leaves database in restoring state for additional restores." />
                                 <RadioButton Content="STANDBY"
                                              Style="{StaticResource DarkRadioButton}"
-                                             IsChecked="{Binding RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=Standby}"
+                                             IsChecked="{Binding Options.RecoveryMode, Converter={StaticResource EnumToBool}, ConverterParameter=Standby}"
                                              GroupName="RecoveryMode"
                                              ToolTip="Read-only with undo file." />
                             </StackPanel>
 
                             <TextBlock Text="STANDBY FILE PATH" Style="{StaticResource LabelText}"
-                                       Visibility="{Binding IsStandbyMode, Converter={StaticResource BoolToVis}}" />
-                            <TextBox Text="{Binding StandbyFilePath, UpdateSourceTrigger=PropertyChanged}"
+                                       Visibility="{Binding Options.IsStandbyMode, Converter={StaticResource BoolToVis}}" />
+                            <TextBox Text="{Binding Options.StandbyFilePath, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,16"
-                                     Visibility="{Binding IsStandbyMode, Converter={StaticResource BoolToVis}}" />
+                                     Visibility="{Binding Options.IsStandbyMode, Converter={StaticResource BoolToVis}}" />
 
                             <!-- Point-in-time (STOPAT): only shown for a log restore point, where
                                  stopping partway through the log is meaningful. -->
@@ -1069,7 +1069,7 @@
                             </StackPanel>
 
                             <TextBlock Text="STATS PERCENT" Style="{StaticResource LabelText}" />
-                            <TextBox Text="{Binding StatsPercent, UpdateSourceTrigger=PropertyChanged}"
+                            <TextBox Text="{Binding Options.StatsPercent, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Width="80" HorizontalAlignment="Left"
                                      Margin="0,0,0,16" />

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -485,6 +485,7 @@
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <TextBlock Grid.Column="0" VerticalAlignment="Center">
@@ -557,7 +558,19 @@
                             </Button.Content>
                         </Button>
 
+                        <!-- Only while something is running. RESTORE VERIFYONLY reads every byte
+                             of every backup in the chain at CommandTimeout = 0, so on a large
+                             chain this is the difference between waiting and killing the app. -->
                         <Button Grid.Column="3"
+                                Content="Stop"
+                                Command="{Binding CancelQueryCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="12,6" Margin="0,0,8,0"
+                                Foreground="{DynamicResource WarningBrush}"
+                                Visibility="{Binding CanCancelQuery, Converter={StaticResource BoolToVis}}"
+                                ToolTip="Stop the server query that is running." />
+
+                        <Button Grid.Column="4"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding ToggleChainDetailsCommand}"
                                 Padding="12,6">

--- a/src/NineLives/Views/RestoreView.xaml.cs
+++ b/src/NineLives/Views/RestoreView.xaml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
@@ -33,7 +33,7 @@ public partial class RestoreView : UserControl
         if (e.NewValue is RestoreViewModel vm)
         {
             _viewModel = vm;
-            _observedLines = vm.ConsoleLines;
+            _observedLines = vm.Console.Lines;
             _observedLines.CollectionChanged += OnConsoleLinesChanged;
             vm.PropertyChanged += OnViewModelPropertyChanged;
         }

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -303,18 +303,6 @@
                                              ToolTip="Lets the driver choose: environment, then managed identity, then the signed-in account, then a prompt. The one to pick for SQL Server on an Azure VM." />
                             </StackPanel>
 
-                            <!-- Untested against a real tenant - see the note in the README. Said
-                                 here rather than only in the docs, because the person who finds out
-                                 is the one standing in front of this screen. -->
-                            <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
-                                    BorderBrush="{DynamicResource WarningPanelBorderBrush}"
-                                    BorderThickness="1" CornerRadius="4" Padding="10"
-                                    Margin="0,0,0,16"
-                                    Visibility="{Binding IsEntraAuth, Converter={StaticResource BoolToVis}}">
-                                <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
-                                           Text="Entra sign-in is built but has not been tested against a real tenant - there is no Entra-enabled instance to develop it against. The connection string is what Microsoft documents, and Test Connection will tell you honestly whether it works. Please report what happens either way." />
-                            </Border>
-
                             <!-- Username: required for SQL auth, an optional account hint for
                                  interactive Entra. Password: SQL auth only - the Entra modes have
                                  no secret for the app to hold, which is the point of using them. -->

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -60,23 +60,53 @@
                             <DataTemplate>
                                 <StackPanel Margin="4,6">
                                     <StackPanel Orientation="Horizontal">
+                                        <!-- Green while this is the connected server, so the list
+                                             says which one is live rather than only the banner at
+                                             the top of the window (#127). -->
                                         <TextBlock Text="&#x26C1;" FontSize="14" Margin="0,0,8,0"
-                                                   VerticalAlignment="Center"
-                                                   Foreground="{DynamicResource SecondaryTextBrush}" />
+                                                   VerticalAlignment="Center">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsConnectedServer}" Value="True">
+                                                            <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+
+                                        <!-- Now that the row is width-constrained (no horizontal
+                                             scrolling), a long name would be cut mid-character
+                                             rather than scrolled - so trim it explicitly. -->
                                         <TextBlock Text="{Binding Name}"
                                                    FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource PrimaryTextBrush}" />
+                                                   TextTrimming="CharacterEllipsis"
+                                                   Foreground="{DynamicResource PrimaryTextBrush}"
+                                                   VerticalAlignment="Center" />
+
+                                        <Border Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                                                BorderBrush="{DynamicResource SuccessBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="8"
+                                                Padding="6,0" Margin="8,0,0,0"
+                                                VerticalAlignment="Center"
+                                                Visibility="{Binding IsConnectedServer, Converter={StaticResource BoolToVis}}">
+                                            <TextBlock Text="connected"
+                                                       FontSize="10" FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource SuccessBrush}" />
+                                        </Border>
                                     </StackPanel>
-                                    <!-- Now that the row is width-constrained (no horizontal
-                                         scrolling), a long name would be cut mid-character
-                                         rather than scrolled - so trim it explicitly. -->
-                                    <TextBlock Text="{Binding DisplayText}"
-                                               Style="{StaticResource SecondaryText}"
-                                               TextTrimming="CharacterEllipsis"
-                                               Margin="22,2,0,0" />
+
+                                    <!-- The server name and auth mode used to be repeated here.
+                                         Neither is what gets scanned for in a list whose job is
+                                         "which server do I want", and the auth mode only matters
+                                         when editing or when a connection fails - both of which
+                                         are the detail pane's job (#127). -->
                                     <ItemsControl ItemsSource="{Binding TagChips}"
                                                   Style="{StaticResource TagChipList}"
-                                                  Margin="22,2,0,0" />
+                                                  Margin="22,4,0,0" />
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
@@ -88,9 +118,15 @@
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="ListBoxItem">
+                                            <!-- A border at rest, not only when selected. Without
+                                                 one the list reads as a single undifferentiated
+                                                 column of text (#127). -->
                                             <Border x:Name="border"
                                                     Background="{TemplateBinding Background}"
+                                                    BorderBrush="{DynamicResource CardBorderBrush}"
+                                                    BorderThickness="1"
                                                     CornerRadius="4"
+                                                    Margin="0,0,0,6"
                                                     Padding="{TemplateBinding Padding}">
                                                 <ContentPresenter />
                                             </Border>
@@ -103,6 +139,13 @@
                                                     <Setter TargetName="border" Property="Background"
                                                             Value="{DynamicResource SidebarItemActiveBrush}" />
                                                 </Trigger>
+                                                <!-- Last, so it wins over selection: selecting a
+                                                     different server must not take the marker off
+                                                     the one that is actually live. -->
+                                                <DataTrigger Binding="{Binding IsConnectedServer}" Value="True">
+                                                    <Setter TargetName="border" Property="BorderBrush"
+                                                            Value="{DynamicResource SuccessBrush}" />
+                                                </DataTrigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
                                     </Setter.Value>

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.ServerManagerView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.ServerManagerView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
@@ -55,17 +55,17 @@
                              BorderThickness="0"
                              HorizontalContentAlignment="Stretch"
                              ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                             Foreground="{StaticResource PrimaryTextBrush}">
+                             Foreground="{DynamicResource PrimaryTextBrush}">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Margin="4,6">
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="&#x26C1;" FontSize="14" Margin="0,0,8,0"
                                                    VerticalAlignment="Center"
-                                                   Foreground="{StaticResource SecondaryTextBrush}" />
+                                                   Foreground="{DynamicResource SecondaryTextBrush}" />
                                         <TextBlock Text="{Binding Name}"
                                                    FontWeight="SemiBold"
-                                                   Foreground="{StaticResource PrimaryTextBrush}" />
+                                                   Foreground="{DynamicResource PrimaryTextBrush}" />
                                     </StackPanel>
                                     <!-- Now that the row is width-constrained (no horizontal
                                          scrolling), a long name would be cut mid-character
@@ -97,11 +97,11 @@
                                             <ControlTemplate.Triggers>
                                                 <Trigger Property="IsMouseOver" Value="True">
                                                     <Setter TargetName="border" Property="Background"
-                                                            Value="{StaticResource SidebarItemHoverBrush}" />
+                                                            Value="{DynamicResource SidebarItemHoverBrush}" />
                                                 </Trigger>
                                                 <Trigger Property="IsSelected" Value="True">
                                                     <Setter TargetName="border" Property="Background"
-                                                            Value="{StaticResource SidebarItemActiveBrush}" />
+                                                            Value="{DynamicResource SidebarItemActiveBrush}" />
                                                 </Trigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
@@ -117,17 +117,17 @@
             <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto">
                 <StackPanel>
                     <!-- Connected Banner -->
-                    <Border Background="#1A3D1F"
+                    <Border Background="{DynamicResource SuccessPanelBackgroundBrush}"
                             CornerRadius="6"
                             Padding="16,10"
                             Margin="0,0,0,16"
                             Visibility="{Binding IsConnected, Converter={StaticResource BoolToVis}}">
                         <StackPanel Orientation="Horizontal">
                             <Ellipse Width="10" Height="10"
-                                     Fill="{StaticResource SuccessBrush}"
+                                     Fill="{DynamicResource SuccessBrush}"
                                      VerticalAlignment="Center" Margin="0,0,10,0" />
                             <TextBlock Text="{Binding ConnectedServerDisplay, StringFormat='Connected to {0}'}"
-                                       Foreground="{StaticResource SuccessBrush}"
+                                       Foreground="{DynamicResource SuccessBrush}"
                                        FontWeight="SemiBold" VerticalAlignment="Center" />
                             <Button Content="Disconnect"
                                     Style="{StaticResource SecondaryButton}"
@@ -184,7 +184,7 @@
                                             Command="{Binding DeleteCommand}" />
                                 </StackPanel>
 
-                                <Border Background="{StaticResource InputBackgroundBrush}"
+                                <Border Background="{DynamicResource InputBackgroundBrush}"
                                         CornerRadius="4"
                                         Padding="12,8"
                                         Margin="0,16,0,0"
@@ -302,7 +302,7 @@
                                      Margin="0,0,0,16" />
 
                             <TextBlock Text="{Binding ErrorMessage}"
-                                       Foreground="{StaticResource ErrorBrush}"
+                                       Foreground="{DynamicResource ErrorBrush}"
                                        Visibility="{Binding HasError, Converter={StaticResource BoolToVis}}"
                                        Margin="0,0,0,12"
                                        TextWrapping="Wrap" />
@@ -321,7 +321,7 @@
                                         Command="{Binding CancelEditCommand}" />
                             </StackPanel>
 
-                            <Border Background="{StaticResource InputBackgroundBrush}"
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4"
                                     Padding="12,8"
                                     Margin="0,16,0,0"
@@ -333,7 +333,7 @@
                         </StackPanel>
                     </Border>
 
-                    <Border Background="#80000000"
+                    <Border Background="{DynamicResource OverlayBrush}"
                             CornerRadius="6"
                             Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"
                             Margin="0,16,0,0">

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -282,16 +282,50 @@
                                 <RadioButton Content="SQL Server Authentication"
                                              Style="{StaticResource DarkRadioButton}"
                                              IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=SqlAuth}"
+                                             Margin="0,0,0,8"
                                              GroupName="AuthMode" />
+                                <RadioButton Content="Entra ID - interactive (MFA)"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraInteractive}"
+                                             Margin="0,0,0,8"
+                                             GroupName="AuthMode"
+                                             ToolTip="Opens a browser to sign in. The mode that satisfies multi-factor authentication. Nothing is stored." />
+                                <RadioButton Content="Entra ID - integrated"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraIntegrated}"
+                                             Margin="0,0,0,8"
+                                             GroupName="AuthMode"
+                                             ToolTip="Uses the Windows account you are already signed in with, without a prompt. Needs the machine joined to the directory." />
+                                <RadioButton Content="Entra ID - default"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditAuthMode, Converter={StaticResource EnumToBool}, ConverterParameter=EntraDefault}"
+                                             GroupName="AuthMode"
+                                             ToolTip="Lets the driver choose: environment, then managed identity, then the signed-in account, then a prompt. The one to pick for SQL Server on an Azure VM." />
                             </StackPanel>
 
-                            <!-- SQL Auth Fields -->
-                            <StackPanel Visibility="{Binding IsSqlAuth, Converter={StaticResource BoolToVis}}">
-                                <TextBlock Text="USERNAME" Style="{StaticResource LabelText}" />
+                            <!-- Untested against a real tenant - see the note in the README. Said
+                                 here rather than only in the docs, because the person who finds out
+                                 is the one standing in front of this screen. -->
+                            <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                    BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                    BorderThickness="1" CornerRadius="4" Padding="10"
+                                    Margin="0,0,0,16"
+                                    Visibility="{Binding IsEntraAuth, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
+                                           Text="Entra sign-in is built but has not been tested against a real tenant - there is no Entra-enabled instance to develop it against. The connection string is what Microsoft documents, and Test Connection will tell you honestly whether it works. Please report what happens either way." />
+                            </Border>
+
+                            <!-- Username: required for SQL auth, an optional account hint for
+                                 interactive Entra. Password: SQL auth only - the Entra modes have
+                                 no secret for the app to hold, which is the point of using them. -->
+                            <StackPanel Visibility="{Binding ShowsUsername, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Text="{Binding UsernameLabel}" Style="{StaticResource LabelText}" />
                                 <TextBox Text="{Binding EditUsername, UpdateSourceTrigger=PropertyChanged}"
                                          Style="{StaticResource DarkTextBox}"
                                          Margin="0,0,0,16" />
+                            </StackPanel>
 
+                            <StackPanel Visibility="{Binding IsSqlAuth, Converter={StaticResource BoolToVis}}">
                                 <TextBlock Text="PASSWORD" Style="{StaticResource LabelText}" />
                                 <PasswordBox x:Name="PasswordInput"
                                              Style="{StaticResource DarkPasswordBox}"

--- a/src/NineLives/packages.lock.json
+++ b/src/NineLives/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     "net10.0-windows7.0": {
+      "Azure.Identity": {
+        "type": "Direct",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Azure.Storage.Blobs": {
         "type": "Direct",
         "requested": "[12.29.1, )",

--- a/src/NineLives/packages.lock.json
+++ b/src/NineLives/packages.lock.json
@@ -43,6 +43,21 @@
           "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)"
         }
       },
+      "Microsoft.Data.SqlClient.Extensions.Azure": {
+        "type": "Direct",
+        "requested": "[7.0.2, )",
+        "resolved": "7.0.2",
+        "contentHash": "mJhONie3MuVXvSfBbtqGQAOGgeQDbOTfO5d0ZYo3KE4Vb7mua4O23lPJrsTYzvWn5od2CPAh0dHMZEWtJXcpxQ==",
+        "dependencies": {
+          "Azure.Core": "1.51.1",
+          "Azure.Identity": "1.18.0",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.Broker": "4.84.2"
+        }
+      },
       "Azure.Core": {
         "type": "Transitive",
         "resolved": "1.55.0",
@@ -180,10 +195,19 @@
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
-        "resolved": "4.83.1",
-        "contentHash": "jOLIrZ3cynoqHLLO1cXplFFabrhrMEYs/EuKHvmCyrOm1axqiVFT6nCSnHxk7w5+d2BeQfCdM12Yf/0X7OeS1g==",
+        "resolved": "4.84.2",
+        "contentHash": "Va9FjmABSgj/lcUfHH0pBNQkmS7SNyepz2ERV7Yynp6QgEYpFdSqR6Vzy1WWipN8GS5pBHuXoZbqaDWuARCrHQ==",
         "dependencies": {
           "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Broker": {
+        "type": "Transitive",
+        "resolved": "4.84.2",
+        "contentHash": "928ySLeGz1xtvydwq6h9tv7TbxrtA4ZzavLKUqRJh0PW6BGcEJwpI8W8vf2PlQdYemGm/oyGjdzYzdY/I8r/4A==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.NativeInterop": "0.20.6"
         }
       },
       "Microsoft.Identity.Client.Extensions.Msal": {
@@ -193,6 +217,11 @@
         "dependencies": {
           "Microsoft.Identity.Client": "4.83.1"
         }
+      },
+      "Microsoft.Identity.Client.NativeInterop": {
+        "type": "Transitive",
+        "resolved": "0.20.6",
+        "contentHash": "noyfdMfVxyWpM6xUDmlW6gUvZ5ci24z7Qoy15JvynTQfZV5vTD2NEdsnT5Gy4ngViwgdIp5iRjRy10jAKXFAgw=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -298,6 +327,11 @@
         "type": "Transitive",
         "resolved": "6.0.2",
         "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.Identity.Client.NativeInterop": {
+        "type": "Transitive",
+        "resolved": "0.20.6",
+        "contentHash": "noyfdMfVxyWpM6xUDmlW6gUvZ5ci24z7Qoy15JvynTQfZV5vTD2NEdsnT5Gy4ngViwgdIp5iRjRy10jAKXFAgw=="
       }
     }
   }


### PR DESCRIPTION
@
Release **v1.3.0**. `check-version-bump.yml` gates this on `<Version>` having moved, which it has: 1.2.0 → 1.3.0.

Authentication that does not need a SAS token, and the restore screen taken apart from the inside. **953 tests**, up from 587 at 1.2.0.

## Added

- **Entra ID for blob containers**, as an alternative to a SAS token, for organisations that prohibit long-lived SAS. A permission failure names the account that was refused and the role it is missing, which Azures own 403 does not (#29)
- **Entra MFA for SQL Server connections**, with the sign-in prompt parented to the app window (#30)
- Per-container **backup server time zone**, so backups with no timestamp in the filename sort correctly instead of being marked approximate (#102)
- **Verify Backups** (`RESTORE VERIFYONLY`), `CHECKSUM` and `CONTINUE_AFTER_ERROR` (#26)
- **Restore history**, a sortable restore-point list, light and high-contrast themes, busy indicators, a Stop button for server queries

## The two that matter most

- **A Managed Identity blob credential is no longer converted to SAS by running a restore** (#145). The check reduced every identity to "is it a SAS credential", so a credential authenticating as the instances own identity was reported broken and then altered — changing how anything else on that instance reached the same container.
- **The app no longer freezes while the Entra sign-in browser is open** (#152). Found and fixed after this release was already prepared, which is exactly why it is in it: shipping a release whose headline feature freezes the app would have been worse than not shipping the feature.

## Verified

- Entra browsing confirmed working end to end against a real container, including the freeze fix.
- Live SQL credential tests run against a local instance (5/5), including a managed-identity credential read back from `sys.credentials`.
- Full suite green on CI.

Once merged: tag `v1.3.0` and publish the release, which builds and attaches `NineLives.exe` with checksums and a provenance attestation.
@