### PR TITLE
Finish off #117 item 8

### DIFF
--- a/src/NineLives.Tests/RestoreHistoryTests.cs
+++ b/src/NineLives.Tests/RestoreHistoryTests.cs
@@ -230,3 +230,36 @@ public class RestoreHistoryTests : IDisposable
         Assert.Single(store.Load());
     }
 }
+
+/// <summary>
+/// The saved-file affordance on the History screen (#117 item 8).
+///
+/// "Save as file" existed; opening what it wrote did not, so the record of a restore was written
+/// and then had to be gone and found.
+/// </summary>
+public class HistorySavedFileTests
+{
+    private static HistoryViewModel New() => new(new FakeRestoreHistoryStore());
+
+    [Fact]
+    public void NothingIsOfferedToOpenUntilSomethingHasBeenSaved()
+    {
+        var vm = New();
+
+        Assert.Null(vm.LastSavedPath);
+    }
+
+    /// <summary>
+    /// Asked to open nothing, it does nothing - rather than throwing out of a command, which on a
+    /// synchronous handler takes the process with it (#13).
+    /// </summary>
+    [Fact]
+    public void OpeningWithNothingSavedIsHarmless()
+    {
+        var vm = New();
+
+        vm.OpenSavedFileCommand.Execute(null);
+
+        Assert.False(vm.HasError);
+    }
+}

--- a/src/NineLives/ViewModels/HistoryViewModel.cs
+++ b/src/NineLives/ViewModels/HistoryViewModel.cs
@@ -1,4 +1,5 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -111,11 +112,35 @@ public partial class HistoryViewModel : ViewModelBase
         try
         {
             File.WriteAllText(dialog.FileName, Format(SelectedEntry));
+            LastSavedPath = dialog.FileName;
             SetStatus($"Saved to {dialog.FileName}");
         }
         catch (Exception ex)
         {
             SetError($"Could not save: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The file the last save wrote, so it can be opened without going and finding it (#117 item 8).
+    /// Saving the record of a restore and then having to hunt for it is a strange place to stop.
+    /// </summary>
+    [ObservableProperty]
+    private string? _lastSavedPath;
+
+    [RelayCommand]
+    private void OpenSavedFile()
+    {
+        if (string.IsNullOrEmpty(LastSavedPath)) return;
+
+        try
+        {
+            Process.Start(new ProcessStartInfo(LastSavedPath) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            // Whatever is registered for .txt failing is not this app's problem to crash over.
+            SetError($"Could not open {LastSavedPath}: {ex.Message}");
         }
     }
 

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -43,7 +43,10 @@
                                Style="{StaticResource SubHeaderText}"
                                Margin="0,0,0,12" />
 
-                    <StackPanel DockPanel.Dock="Bottom" Margin="0,12,0,0">
+                    <!-- Docked TOP, not bottom. On a fresh install this is the only thing to click and it
+                         was the furthest thing from the eye, at the foot of a tall empty
+                         list (#117 item 8). -->
+                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,12">
                         <Button Content="+ Add Container"
                                 Style="{StaticResource PrimaryButton}"
                                 Command="{Binding AddNewCommand}"

--- a/src/NineLives/Views/HistoryView.xaml
+++ b/src/NineLives/Views/HistoryView.xaml
@@ -1,4 +1,5 @@
 ﻿<UserControl x:Class="Blackcat.NineLives.Views.HistoryView"
+             Loaded="OnLoaded"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
@@ -44,7 +45,11 @@
             </Grid.ColumnDefinitions>
 
             <Border Grid.Column="0" Style="{StaticResource CardBorder}" Margin="0,0,12,0">
-                <ListBox ItemsSource="{Binding Entries}"
+                <!-- Named and focused on arrival so the arrow keys work without a click first.
+                     A ListBox is arrow-navigable already; nothing was ever giving it focus, which
+                     is what "no keyboard navigation" actually amounted to (#117 item 8). -->
+                <ListBox x:Name="EntriesList"
+                         ItemsSource="{Binding Entries}"
                          SelectedItem="{Binding SelectedEntry}"
                          Style="{StaticResource CardListBox}">
                     <ListBox.ItemTemplate>
@@ -120,8 +125,17 @@
                                 <Button Content="Save as file"
                                         Command="{Binding SaveEntryCommand}"
                                         Style="{StaticResource SecondaryButton}"
-                                        Padding="10,5"
+                                        Padding="10,5" Margin="0,0,8,0"
                                         ToolTip="Writes the whole record - details, script and execution log - to a text file." />
+                                <!-- Appears once something has been written. Saving the record of a
+                                     restore and then having to go and find it is a strange place to
+                                     stop (#117 item 8). -->
+                                <Button Content="Open saved file"
+                                        Command="{Binding OpenSavedFileCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="10,5"
+                                        ToolTip="{Binding LastSavedPath}"
+                                        Visibility="{Binding LastSavedPath, Converter={StaticResource NullToVis}}" />
                             </StackPanel>
 
                             <TextBlock Text="SCRIPT" Style="{StaticResource LabelText}" Margin="0,0,0,4" />

--- a/src/NineLives/Views/HistoryView.xaml.cs
+++ b/src/NineLives/Views/HistoryView.xaml.cs
@@ -1,3 +1,4 @@
+﻿using System.Windows;
 using System.Windows.Controls;
 
 namespace Blackcat.NineLives.Views;
@@ -8,4 +9,13 @@ public partial class HistoryView : UserControl
     {
         InitializeComponent();
     }
+
+    /// <summary>
+    /// Puts focus on the list so the arrow keys work on arrival (#117 item 8).
+    ///
+    /// A ListBox is arrow-navigable already - nothing was ever giving it focus, which is what "no
+    /// keyboard navigation" amounted to. Focusing the list rather than an item leaves the current
+    /// selection alone; pressing an arrow then moves from wherever it is.
+    /// </summary>
+    private void OnLoaded(object sender, RoutedEventArgs e) => EntriesList.Focus();
 }

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -39,7 +39,10 @@
                                Style="{StaticResource SubHeaderText}"
                                Margin="0,0,0,12" />
 
-                    <StackPanel DockPanel.Dock="Bottom" Margin="0,12,0,0">
+                    <!-- Docked TOP, not bottom. On a fresh install this is the only thing to click and it
+                         was the furthest thing from the eye, at the foot of a tall empty
+                         list (#117 item 8). -->
+                    <StackPanel DockPanel.Dock="Top" Margin="0,0,0,12">
                         <Button Content="+ Add Server"
                                 Style="{StaticResource PrimaryButton}"
                                 Command="{Binding AddNewCommand}"


### PR DESCRIPTION
@
The last three points in #117, and the smallest. **977 passing, 24 skipped** (1,001 total).

- **Opening a saved log.** "Save as file" existed, so the record of a restore was written and then had to be gone and found. An **Open saved file** button appears once something has been saved.
- **History keyboard navigation.** Worth looking before building anything: the list is already a `ListBox` and therefore arrow-navigable — **nothing was giving it focus**, which is all "no keyboard navigation" ever amounted to. It takes focus on arrival now. Focusing the list rather than an item leaves the current selection alone, so an arrow press moves from wherever it already is.
- **`+ Add Server` and `+ Add Container`** moved from the foot of a tall empty list to the top of it. On a fresh install that button is the only thing to click and it was the furthest thing from the eye — and #117 item 7s guidance panel now sits beside it rather than opposite it.

Rendered the servers screen to check the button reads as the first thing rather than the last.

**This closes #117**: items 2, 3, 5, 6, 7 and 8 are all done.
@