### PR TITLE
Lift the execution out of RestoreViewModel (#115 seam 6)

### DIFF
--- a/src/NineLives.Tests/BusyFeedbackTests.cs
+++ b/src/NineLives.Tests/BusyFeedbackTests.cs
@@ -179,10 +179,10 @@ public class ChainCheckStateTests
         Assert.Equal("Verifying backups...", vm.BusyDescription);
 
         vm.IsVerifyingChain = false;
-        vm.IsExecuting = true;
+        vm.Execution.IsExecuting = true;
         Assert.Contains("MyDb_Restored", vm.BusyDescription);
 
-        vm.IsExecuting = false;
+        vm.Execution.IsExecuting = false;
         Assert.Empty(vm.BusyDescription);
     }
 
@@ -192,7 +192,7 @@ public class ChainCheckStateTests
         var vm = await Loaded();
 
         vm.IsBusy = true;
-        vm.IsExecuting = true;
+        vm.Execution.IsExecuting = true;
 
         // The one that matters is the one writing to a database.
         Assert.Contains("Restoring", vm.BusyDescription);
@@ -245,7 +245,7 @@ public class GlobalBusyTests
 
         vm.ServerManager.IsBusy = true;
         vm.Restore.TargetDatabaseName = "MyDb_Restored";
-        vm.Restore.IsExecuting = true;
+        vm.Restore.Execution.IsExecuting = true;
 
         Assert.Contains("Restoring", vm.BusyText);
     }

--- a/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
+++ b/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
@@ -123,7 +123,7 @@ public class ExecuteBlockedReasonTests
         var vm = await Loaded();
         vm.IsConnectedToServer = true;
         vm.TargetDatabaseName = "MyDb_Restored";
-        vm.IsExecuting = true;
+        vm.Execution.IsExecuting = true;
 
         // The button is doing its other job here; a "why not" line would be noise.
         Assert.Empty(vm.ExecuteBlockedReason);

--- a/src/NineLives.Tests/RestoreExecutionSeamTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionSeamTests.cs
@@ -1,0 +1,176 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The execution seam on its own (#115 seam 6).
+///
+/// This is the only code on the Restore screen that writes to somebody's database, and reaching it
+/// used to mean standing up a container, a listing, a chain and a connection. The rules that matter
+/// most - a cancelled restore is recorded as loudly as a failed one, the history records executions
+/// rather than button presses, the console is flushed before it is recorded - are now reachable
+/// directly.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class RestoreExecutionSeamTests
+{
+    private static OperationLog ThrowawayLog() => new(Path.Combine(
+        Path.GetTempPath(), "ninelives-exec-seam", Guid.NewGuid().ToString("n")));
+
+    private static ServerConnection Server() => new()
+    {
+        Id = ServerConnection.NewId(),
+        Name = "SRV01",
+        ServerName = "SRV01"
+    };
+
+    private static RestoreRun Run() => new(
+        Server(),
+        "RESTORE DATABASE [MyDb_Restored] FROM URL = 'https://acct/backups/full.bak'",
+        "MyDb_Restored",
+        "MyDb",
+        "backups",
+        "Full + 2 logs",
+        new DateTime(2026, 8, 1, 22, 9, 12),
+        "WITH REPLACE=True, recovery=Recovery, stopAt=none");
+
+    private static (RestoreExecutionViewModel vm, FakeSqlServerService sql, FakeRestoreHistoryStore history) New()
+    {
+        var sql = new FakeSqlServerService();
+        var history = new FakeRestoreHistoryStore();
+        var vm = new RestoreExecutionViewModel(sql, history, ThrowawayLog(), new OperationCancellation());
+        return (vm, sql, history);
+    }
+
+    private static Task<CredentialPreflight> Proceed(Action<string> _) => Task.FromResult(CredentialPreflight.Proceed);
+
+    // ── arming ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ArmingChangesTheButtonAndDisarmingPutsItBack()
+    {
+        var (vm, _, _) = New();
+
+        vm.Arm();
+        Assert.True(vm.IsArmed);
+        Assert.Equal(5, vm.Countdown);
+        Assert.Contains("Confirm", vm.ButtonText);
+
+        vm.Disarm();
+        Assert.False(vm.IsArmed);
+        Assert.Equal("Execute on Server", vm.ButtonText);
+    }
+
+    // ── running ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ASuccessfulRunIsRecordedWithEnoughToPutInATicket()
+    {
+        var (vm, _, history) = New();
+
+        await vm.RunAsync(Run(), Proceed);
+
+        Assert.True(vm.ExecutionSuccess);
+        Assert.True(vm.ExecutionComplete);
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(RestoreOutcome.Succeeded, entry.Outcome);
+        Assert.Equal("MyDb_Restored", entry.TargetDatabase);
+        Assert.Equal("MyDb", entry.SourceDatabase);
+        Assert.Equal("backups", entry.ContainerName);
+        Assert.Equal("Full + 2 logs", entry.ChainSummary);
+        Assert.NotEmpty(entry.Script);
+    }
+
+    [Fact]
+    public async Task AFailedRunIsRecordedAsFailedWithTheReason()
+    {
+        var (vm, sql, history) = New();
+        sql.ExecuteThrows = new InvalidOperationException("RESTORE terminating abnormally.");
+
+        await vm.RunAsync(Run(), Proceed);
+
+        Assert.False(vm.ExecutionSuccess);
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(RestoreOutcome.Failed, entry.Outcome);
+        Assert.Contains("terminating abnormally", entry.ErrorMessage);
+    }
+
+    /// <summary>
+    /// A refused credential has written nothing to the server, so nothing was attempted - and the
+    /// history records executions, not button presses.
+    /// </summary>
+    [Fact]
+    public async Task ARefusedPreflightRunsNothingAndFilesNothing()
+    {
+        var (vm, sql, history) = New();
+
+        await vm.RunAsync(Run(), _ => Task.FromResult(
+            CredentialPreflight.Stop("Credential exists with identity 'MYDOMAIN\\svc_sql'.")));
+
+        Assert.Empty(history.Entries);
+        Assert.Empty(sql.ExecutedScripts);
+        Assert.True(vm.HasError);
+        Assert.Contains("MYDOMAIN\\svc_sql", vm.ErrorMessage);
+    }
+
+    /// <summary>
+    /// The recorded log is the WHOLE console, not whatever had made it out of the batching buffer
+    /// when the run ended - which is why the flush happens before the history entry is written.
+    /// </summary>
+    [Fact]
+    public async Task TheRecordedLogIsTheWholeConsole()
+    {
+        var (vm, _, history) = New();
+
+        await vm.RunAsync(Run(), Proceed);
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Contains("Beginning restore execution", entry.Log);
+        Assert.Equal(vm.Console.Text, entry.Log);
+    }
+
+    [Fact]
+    public async Task TheRunIsAimedAtWhatItWasGiven()
+    {
+        var (vm, sql, _) = New();
+        var run = Run();
+
+        await vm.RunAsync(run, Proceed);
+
+        Assert.Same(run.Server, Assert.Single(sql.ExecutedAgainst));
+        Assert.Equal(run.Script, Assert.Single(sql.ExecutedScripts));
+    }
+
+    // ── cancelling ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CancellingWithNothingRunningDoesNothing()
+    {
+        var (vm, _, _) = New();
+
+        vm.CancelCommand.Execute(null);
+
+        Assert.False(vm.IsCancelling);
+        Assert.Equal(string.Empty, vm.Console.Text);
+    }
+
+    /// <summary>
+    /// Nothing is offered to stop before a run starts, and nothing is left offered after one ends.
+    /// The Stop button is the only way out of a restore aimed at the wrong server (#25).
+    /// </summary>
+    [Fact]
+    public async Task StoppingIsOfferedOnlyWhileSomethingIsRunning()
+    {
+        var (vm, _, _) = New();
+        Assert.False(vm.CanCancel);
+
+        await vm.RunAsync(Run(), Proceed);
+
+        Assert.False(vm.CanCancel);
+    }
+}

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -71,7 +71,7 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
 
         // The button arms on the first press and fires on the second.
         await vm.ExecuteScriptCommand.ExecuteAsync(null);
-        Assert.True(vm.IsExecuteArmed);
+        Assert.True(vm.Execution.IsArmed);
 
         return (vm, sql);
     }
@@ -148,7 +148,7 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
             store.SaveSasToken(vm.SelectedContainer!, "sv=2024-01-01&sig=x");
 
             await vm.ExecuteScriptCommand.ExecuteAsync(null);
-            log = vm.Console.Text;
+            log = vm.Execution.Console.Text;
         });
 
         Assert.Contains("Server state not modified", log);
@@ -190,7 +190,7 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
 
             await vm.ExecuteScriptCommand.ExecuteAsync(null);
 
-            log = vm.Console.Text;
+            log = vm.Execution.Console.Text;
             writes = sql.CredentialWrites;
             executed = sql.ExecutedScripts;
         });
@@ -234,7 +234,7 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
 
             await vm.ExecuteScriptCommand.ExecuteAsync(null);
 
-            log = vm.Console.Text;
+            log = vm.Execution.Console.Text;
             error = vm.ErrorMessage;
             writes = sql.CredentialWrites;
             executed = sql.ExecutedScripts;

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -281,11 +281,11 @@ public class RestoreViewModelTests
         };
 
         await vm.ExecuteScriptCommand.ExecuteAsync(null);
-        Assert.True(vm.IsExecuteArmed);
+        Assert.True(vm.Execution.IsArmed);
 
         vm.SelectedContainer = Container();
 
-        Assert.False(vm.IsExecuteArmed);
+        Assert.False(vm.Execution.IsArmed);
     }
 
     // ── point in time (#115 seam 3) ─────────────────────────────────────────────

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -218,14 +218,14 @@ public class XamlLoadTests(WpfFixture wpf)
         wpf.Invoke(() =>
         {
             var vm = NewRestoreViewModel();
-            vm.RecoveryStateMessage = "[MyDb] is in RESTORING state.";
-            vm.RecoveryActions =
+            vm.Execution.RecoveryStateMessage = "[MyDb] is in RESTORING state.";
+            vm.Execution.RecoveryActions =
             [
                 new RecoveryAction("Bring the database online", "RESTORE DATABASE [MyDb] WITH RECOVERY", "Ends the sequence."),
                 new RecoveryAction("Allow other connections again", "ALTER DATABASE [MyDb] SET MULTI_USER", "Safe at any point.")
             ];
-            vm.HasRecoveryActions = true;
-            vm.ExecutionComplete = true;
+            vm.Execution.HasRecoveryActions = true;
+            vm.Execution.ExecutionComplete = true;
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
@@ -356,11 +356,11 @@ public class XamlLoadTests(WpfFixture wpf)
             var view = new RestoreView { DataContext = vm };
 
             // Not running: nothing to stop, so the button must not be offered.
-            vm.CanCancelExecute = false;
+            vm.Execution.CanCancel = false;
             Realise(view);
             Assert.DoesNotContain(VisibleButtons(view), b => (b.Content as string) == "Stop restore");
 
-            vm.CanCancelExecute = true;
+            vm.Execution.CanCancel = true;
             Realise(view);
 
             var stop = Assert.Single(VisibleButtons(view), b => (b.Content as string) == "Stop restore");
@@ -426,15 +426,15 @@ public class XamlLoadTests(WpfFixture wpf)
             vm.BackupsLoaded = true;
             vm.HasScript = true;
             vm.GeneratedScript = "RESTORE DATABASE [MyDb] FROM URL = N'https://acct/backups/x.bak'";
-            vm.Console.Lines =
+            vm.Execution.Console.Lines =
             [
                 new ConsoleLine("Beginning restore execution...", ConsoleLineKind.Step),
                 new ConsoleLine("50 percent processed."),
                 new ConsoleLine("ERROR: something went wrong", ConsoleLineKind.Error)
             ];
-            vm.Console.HasOutput = true;
-            vm.IsExecuting = false;
-            vm.ExecutionComplete = true;
+            vm.Execution.Console.HasOutput = true;
+            vm.Execution.IsExecuting = false;
+            vm.Execution.ExecutionComplete = true;
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
@@ -480,8 +480,8 @@ public class XamlLoadTests(WpfFixture wpf)
         {
             var vm = NewRestoreViewModel();
             vm.BackupsLoaded = true;
-            vm.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
-            vm.Console.HasOutput = true;
+            vm.Execution.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
+            vm.Execution.Console.HasOutput = true;
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
@@ -512,10 +512,10 @@ public class XamlLoadTests(WpfFixture wpf)
         {
             var vm = NewRestoreViewModel();
             vm.BackupsLoaded = true;
-            vm.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
-            vm.Console.HasOutput = true;
+            vm.Execution.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
+            vm.Execution.Console.HasOutput = true;
             vm.IsConsoleDetached = false;   // as if the wiring failed
-            vm.IsExecuting = true;
+            vm.Execution.IsExecuting = true;
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -319,7 +319,7 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private void CancelCurrent()
     {
-        if (Restore.CancelExecuteCommand.CanExecute(null)) { Restore.CancelExecuteCommand.Execute(null); return; }
+        if (Restore.Execution.CancelCommand.CanExecute(null)) { Restore.Execution.CancelCommand.Execute(null); return; }
         if (Restore.CancelQueryCommand.CanExecute(null)) { Restore.CancelQueryCommand.Execute(null); return; }
         if (Restore.CancelLoadCommand.CanExecute(null)) Restore.CancelLoadCommand.Execute(null);
     }

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -1,0 +1,467 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Win32;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// Everything one execution needs to know, captured at the moment the confirm is pressed.
+///
+/// A record rather than a set of properties read as the run goes along: the restore takes minutes,
+/// the screen behind it stays live, and reading the target database name at the end of a run that
+/// started against a different one is the class of bug this whole seam exists to make impossible.
+/// </summary>
+public sealed record RestoreRun(
+    ServerConnection Server,
+    string Script,
+    string TargetDatabase,
+    string? SourceDatabase,
+    string? ContainerName,
+    string ChainSummary,
+    DateTime? RestorePointTimestamp,
+    string OptionsForLog);
+
+/// <summary>
+/// Running a restore: arming, the countdown, execution, cancellation, what to do when it fails,
+/// and filing the record afterwards.
+///
+/// Sixth seam out of RestoreViewModel (#115), and the one the issue called highest-stakes: it is
+/// the only code here that writes to somebody's database. It had no reason to sit next to timeline
+/// tick-mark maths, and the parts of it that matter - that a cancelled restore is reported as
+/// loudly as a failed one, that the history records executions rather than button presses, that
+/// the console is flushed before it is recorded - were reachable only by standing up a container,
+/// a listing, a chain and a connection.
+/// </summary>
+public partial class RestoreExecutionViewModel : ViewModelBase
+{
+    private readonly ISqlServerService _sql;
+    private readonly IRestoreHistoryStore _history;
+    private readonly OperationLog _log;
+
+    /// <summary>Its own source: the Stop button during a restore is not the same button as the
+    /// one that stops a verify, and the two must be able to be in different states.</summary>
+    private readonly OperationCancellation _executeCancellation = new();
+
+    /// <summary>
+    /// The parent's, shared with its other server calls, because a recovery action runs after the
+    /// restore has finished and belongs to the same Stop button as the rest of them (#111).
+    /// </summary>
+    private readonly OperationCancellation _queryCancellation;
+
+    public RestoreExecutionViewModel(
+        ISqlServerService sql,
+        IRestoreHistoryStore history,
+        OperationLog log,
+        OperationCancellation queryCancellation)
+    {
+        _sql = sql;
+        _history = history;
+        _log = log;
+        _queryCancellation = queryCancellation;
+
+        // Every console message is written to the log file as it arrives, so the file cannot drift
+        // from what was on screen.
+        Console = new ConsoleBuffer(message => _log.Info($"[execute] {message.Trim()}"));
+    }
+
+    /// <summary>
+    /// The execution console. Its batching and line handling live in ConsoleBuffer (#115 seam 1) -
+    /// this type only feeds it and shows it.
+    /// </summary>
+    public ConsoleBuffer Console { get; }
+
+    /// <summary>Raised whenever the cancel state changes, so the parent can refresh its own view of it.</summary>
+    public event Action? CancelStateChanged;
+
+    // ── arming ──────────────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private bool _isArmed;
+
+    [ObservableProperty]
+    private string _buttonText = "Execute on Server";
+
+    [ObservableProperty]
+    private int _countdown;
+
+    private CancellationTokenSource? _armTimeoutCts;
+
+    /// <summary>
+    /// Arms the button for five seconds.
+    ///
+    /// The countdown is not decoration: it is the gap in which somebody reads the confirmation
+    /// banner naming the server and the target, and it disarms itself so a button left armed
+    /// while attention moved elsewhere cannot be pressed later by accident.
+    /// </summary>
+    public void Arm()
+    {
+        IsArmed = true;
+        ButtonText = "Confirm Execute (5)";
+        Countdown = 5;
+
+        _armTimeoutCts?.Cancel();
+        _armTimeoutCts = new CancellationTokenSource();
+
+        _ = RunArmCountdownAsync(_armTimeoutCts.Token);
+    }
+
+    public void Disarm()
+    {
+        _armTimeoutCts?.Cancel();
+        IsArmed = false;
+        ButtonText = "Execute on Server";
+    }
+
+    private async Task RunArmCountdownAsync(CancellationToken ct)
+    {
+        try
+        {
+            for (var remaining = 5; remaining > 0; remaining--)
+            {
+                Countdown = remaining;
+                ButtonText = $"Confirm Execute ({remaining})";
+                await Task.Delay(1000, ct);
+            }
+
+            Disarm();
+        }
+        catch (OperationCanceledException)
+        {
+            // Either it was pressed, or something else disarmed it. Both are handled where they
+            // happen; there is nothing to do here.
+        }
+    }
+
+    // ── running ─────────────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private bool _isExecuting;
+
+    [ObservableProperty]
+    private bool _executionSuccess;
+
+    [ObservableProperty]
+    private bool _executionComplete;
+
+    /// <summary>
+    /// True while a restore is running and has not been asked to stop.
+    ///
+    /// Held rather than computed, as it was before this seam: the Stop button binds to it, and a
+    /// test has to be able to put the screen into the state where that button is offered without
+    /// standing up a whole restore to do it.
+    /// </summary>
+    [ObservableProperty]
+    private bool _canCancel;
+
+    [ObservableProperty]
+    private bool _isCancelling;
+
+    /// <summary>
+    /// Runs one restore, start to finish.
+    /// </summary>
+    /// <param name="run">What to execute, captured before anything started.</param>
+    /// <param name="preflight">
+    /// The server-side credential check (#115 seam 5). A refusal has written nothing, so the run is
+    /// abandoned without a history entry - it was never attempted.
+    /// </param>
+    public async Task RunAsync(RestoreRun run, Func<Action<string>, Task<CredentialPreflight>> preflight)
+    {
+        Disarm();
+
+        // The recovery steps that may follow must agree with the run that produced them, even if
+        // the screen behind has moved on to a different server or target since.
+        _lastServer = run.Server;
+        _lastTarget = run.TargetDatabase;
+
+        var startedAt = DateTime.Now;
+        var outcome = RestoreOutcome.Failed;
+        string? failure = null;
+
+        // Set false when the run is abandoned before anything was attempted, so the history
+        // records executions rather than button presses.
+        var attempted = true;
+
+        var executeToken = _executeCancellation.Begin();
+        IsExecuting = true;
+        Console.IsRunning = true;
+
+        // Reset alongside ExecutionComplete. Left over from a previous run it could combine with an
+        // early bail-out to show the success banner - and write "Outcome: Succeeded" into a saved
+        // log - for a restore that never ran.
+        ExecutionSuccess = false;
+        ExecutionComplete = false;
+        Console.Clear();
+        RecoveryActions = [];
+        HasRecoveryActions = false;
+        RaiseCancelStateChanged();
+
+        try
+        {
+            var check = await preflight(AppendLog);
+            if (!check.CanProceed)
+            {
+                attempted = false;
+                SetError(check.Refusal!);
+                return;
+            }
+
+            _log.ServerChange(run.Server.ServerName,
+                $"restore starting: target [{run.TargetDatabase}], {run.ChainSummary}, {run.OptionsForLog}");
+
+            AppendLog("Beginning restore execution...\n");
+
+            await _sql.ExecuteRestoreWithProgressAsync(
+                run.Server,
+                run.Script,
+                // InvokeAsync, not Invoke. This callback runs on the connection's thread when SQL
+                // Server sends an info message, and a synchronous Invoke BLOCKS that thread until
+                // the UI has finished handling it. With the UI busy re-rendering, progress backed
+                // up and then arrived in bursts - which is precisely what "not live" looked like.
+                msg => Application.Current.Dispatcher.InvokeAsync(() => AppendLog(msg)),
+                executeToken);
+
+            ExecutionSuccess = true;
+            outcome = RestoreOutcome.Succeeded;
+            AppendLog("\nRestore completed successfully!");
+            SetStatus("Restore execution completed successfully.");
+        }
+        catch (OperationCanceledException)
+        {
+            outcome = RestoreOutcome.Cancelled;
+            failure = "Cancelled by the user part-way through the chain.";
+
+            // Cancelling a restore is not the same as never having run it. SqlCommand.Cancel stops
+            // the client waiting and SQL Server rolls back the statement that was in flight, but
+            // the target stays mid-restore - so this must be as loud as a failure, and it goes
+            // through the same recovery guidance (#14, #25).
+            ExecutionSuccess = false;
+            AppendLog("\nCANCELLED. The statement in flight was rolled back by SQL Server, but the " +
+                      "restore stopped part-way through the chain.");
+
+            _log.ServerChange(run.Server.ServerName,
+                $"restore CANCELLED by user, target [{run.TargetDatabase}]");
+
+            SetError("Restore cancelled. The target database has been left mid-restore - see below.");
+
+            await ReportRecoveryStateAsync(run.Server, run.TargetDatabase);
+        }
+        catch (Exception ex)
+        {
+            ExecutionSuccess = false;
+            outcome = RestoreOutcome.Failed;
+            failure = ex.Message;
+            AppendLog($"\nERROR: {ex.Message}");
+            SetError($"Restore failed: {ex.Message}");
+
+            // The restore has stopped part-way and the target is almost certainly not usable. Find
+            // out exactly how, and say so, while the connection is still open (#14).
+            await ReportRecoveryStateAsync(run.Server, run.TargetDatabase);
+        }
+        finally
+        {
+            _executeCancellation.End();
+            IsExecuting = false;
+            Console.IsRunning = false;
+            ExecutionComplete = true;
+            Console.Flush();   // nothing buffered may outlive the run
+            RaiseCancelStateChanged();
+
+            // After the flush, so the recorded log is the whole console rather than whatever had
+            // made it out of the batching buffer. Recorded for every outcome including cancelled -
+            // "I stopped it" is exactly the kind of thing a change ticket needs to say.
+            if (attempted) RecordHistory(run, startedAt, outcome, failure);
+        }
+    }
+
+    /// <summary>
+    /// Files this execution in the history (#31). Never throws: the store swallows its own
+    /// failures, and a restore must not be reported as failed because a record could not be kept.
+    /// </summary>
+    private void RecordHistory(RestoreRun run, DateTime startedAt, RestoreOutcome outcome, string? failure)
+        => _history.Append(new RestoreHistoryEntry
+        {
+            StartedAt = startedAt,
+            CompletedAt = DateTime.Now,
+            ServerName = run.Server.ServerName,
+            TargetDatabase = run.TargetDatabase,
+            ContainerName = run.ContainerName,
+            SourceDatabase = run.SourceDatabase,
+            RestorePointTimestamp = run.RestorePointTimestamp,
+            ChainSummary = run.ChainSummary,
+            Outcome = outcome,
+            ErrorMessage = failure,
+            Script = run.Script,
+            Log = Console.Text
+        });
+
+    /// <summary>
+    /// Stops a running restore.
+    ///
+    /// Deliberately worded as a warning rather than a neutral action: stopping a restore part-way
+    /// leaves the target database in RESTORING, which is not a state anyone wants to discover by
+    /// accident. The recovery panel that appears afterwards explains how to get out of it.
+    /// </summary>
+    [RelayCommand]
+    private void Cancel()
+    {
+        if (!_executeCancellation.CanCancel) return;
+
+        _executeCancellation.Cancel();
+        RaiseCancelStateChanged();
+        AppendLog("\nCancellation requested - waiting for SQL Server to roll back the current statement...");
+    }
+
+    // ── afterwards ──────────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private ObservableCollection<RecoveryAction> _recoveryActions = [];
+
+    [ObservableProperty]
+    private bool _hasRecoveryActions;
+
+    [ObservableProperty]
+    private string _recoveryStateMessage = string.Empty;
+
+    /// <summary>
+    /// After a failed restore, works out what state the target database was left in and offers the
+    /// statements that put it right.
+    ///
+    /// This is the moment of maximum stress - a restore has failed mid-incident and the database is
+    /// now in a state that blocks other connections. Leaving somebody to work that out from a raw
+    /// SQL error, when the app is still holding the connection that could tell them, is the wrong
+    /// place to stop.
+    /// </summary>
+    private async Task ReportRecoveryStateAsync(ServerConnection server, string targetDatabase)
+    {
+        RecoveryActions = [];
+        HasRecoveryActions = false;
+        RecoveryStateMessage = string.Empty;
+
+        try
+        {
+            var state = await _sql.GetDatabaseRecoveryStateAsync(server, targetDatabase);
+            if (!state.NeedsAttention)
+            {
+                if (!state.Exists)
+                    AppendLog($"\n[{targetDatabase}] is not on the server - nothing was left behind.");
+                return;
+            }
+
+            RecoveryStateMessage = state.Explain(targetDatabase);
+            RecoveryActions = new ObservableCollection<RecoveryAction>(state.SuggestedActions(targetDatabase));
+            HasRecoveryActions = RecoveryActions.Count > 0;
+
+            AppendLog($"\n{RecoveryStateMessage}");
+            foreach (var action in RecoveryActions)
+                AppendLog($"\n  {action.Title}:  {action.Sql}");
+        }
+        catch (Exception ex)
+        {
+            // Best effort. The restore failure is the news; failing to describe the aftermath must
+            // not replace the error the user actually needs to read.
+            AppendLog($"\nCould not check the state of [{targetDatabase}]: {ex.Message}");
+        }
+    }
+
+    /// <summary>The server and target the last run used, so a recovery step knows where to go.</summary>
+    private ServerConnection? _lastServer;
+    private string _lastTarget = string.Empty;
+
+    /// <summary>Runs one remediation the user picked, then re-reads the state.</summary>
+    [RelayCommand]
+    private async Task RunRecoveryActionAsync(RecoveryAction? action)
+    {
+        if (action == null || _lastServer == null) return;
+
+        // Cancellable, and it needs it more than most: this runs when a restore has already failed,
+        // RESTORE ... WITH RECOVERY can take a long time on a large database, and it goes out at
+        // CommandTimeout = 0. Without a Stop the only way out was killing the process - at the
+        // exact moment the user is trying to get their database back.
+        var ct = _queryCancellation.Begin();
+        RaiseCancelStateChanged();
+
+        try
+        {
+            AppendLog($"\nRunning: {action.Sql}");
+            await _sql.ExecuteRecoveryActionAsync(_lastServer, action.Sql, ct);
+            AppendLog("Completed.");
+            await ReportRecoveryStateAsync(_lastServer, _lastTarget);
+
+            if (!HasRecoveryActions)
+                SetStatus($"[{_lastTarget}] is back to a usable state.");
+        }
+        catch (OperationCanceledException)
+        {
+            // SQL Server rolls back the statement that was in flight, so the database is where it
+            // was before this step - which is still whatever the failed restore left behind.
+            AppendLog("\nCancelled. The database is in the same state as before this step.");
+            SetStatus("Recovery step cancelled.");
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"\nERROR: {ex.Message}");
+            SetError($"Recovery step failed: {ex.Message}");
+        }
+        finally
+        {
+            _queryCancellation.End();
+            RaiseCancelStateChanged();
+        }
+    }
+
+    [RelayCommand]
+    private void CopyRecoveryAction(RecoveryAction? action)
+    {
+        if (action != null)
+            TryCopyToClipboard(action.Sql, "Recovery statement copied to clipboard.");
+    }
+
+    // ── the console's own actions ───────────────────────────────────────────────
+
+    [RelayCommand]
+    private void CopyConsole() => TryCopyToClipboard(Console.Text, "Execution log copied to clipboard.");
+
+    [RelayCommand]
+    private void SaveConsole()
+    {
+        if (string.IsNullOrEmpty(Console.Text)) return;
+
+        var dialog = new SaveFileDialog
+        {
+            Filter = "Text Files (*.txt)|*.txt|All Files (*.*)|*.*",
+            DefaultExt = ".txt",
+            FileName = $"ninelives_execution_{DateTime.Now:yyyyMMdd_HHmmss}.txt"
+        };
+
+        if (dialog.ShowDialog() != true) return;
+
+        try
+        {
+            File.WriteAllText(dialog.FileName, Console.Text);
+            SetStatus($"Execution log saved to {dialog.FileName}");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not save the log: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Appends to the on-screen console and to the log file at the same time, so the file cannot
+    /// drift from what the user was shown. Redaction happens inside the log, not here (#40).
+    /// </summary>
+    private void AppendLog(string message) => Console.Append(message);
+
+    private void RaiseCancelStateChanged()
+    {
+        CanCancel = _executeCancellation.CanCancel;
+        IsCancelling = _executeCancellation.IsCancelling;
+        CancelStateChanged?.Invoke();
+    }
+
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -28,8 +28,6 @@ public partial class RestoreViewModel : ViewModelBase
     // Two separate operations, two separate sources: browsing a container and running a restore
     // can both be in flight, and cancelling one must not touch the other (#25).
     private readonly OperationCancellation _loadCancellation = new();
-    private readonly OperationCancellation _executeCancellation = new();
-
     /// <summary>
     /// The server queries a user starts and might want to abandon: verify, validate, the two
     /// metadata reads, creating the credential, and the post-failure recovery actions (#111).
@@ -46,6 +44,13 @@ public partial class RestoreViewModel : ViewModelBase
     /// say about it, and what Execute should do before it runs (#115 seam 5).
     /// </summary>
     public ServerCredentialViewModel Credential { get; }
+
+    /// <summary>
+    /// Running the restore: arming, the countdown, execution, cancellation, the recovery guidance
+    /// afterwards and the history entry (#115 seam 6). The only code on this screen that writes to
+    /// somebody's database.
+    /// </summary>
+    public RestoreExecutionViewModel Execution { get; }
 
     #region Observable Properties
 
@@ -156,29 +161,14 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private bool _hasInventoryIssues;
 
-    // ── Aftermath of a failed restore (#14) ─────────────────────────────────────
-    // A chain that stops part-way leaves the target in RESTORING, and in SINGLE_USER too if
-    // Disconnect sessions was on, because the closing SET MULTI_USER never ran. Both block other
-    // connections, at the worst possible moment.
-
-    [ObservableProperty]
-    private string _recoveryStateMessage = string.Empty;
-
-    [ObservableProperty]
-    private ObservableCollection<RecoveryAction> _recoveryActions = [];
-
-    [ObservableProperty]
-    private bool _hasRecoveryActions;
+    // The aftermath of a failed restore (#14) lives on the execution seam with the run that
+    // produced it (#115 seam 6).
 
     // ── Cancellation (#25) ──────────────────────────────────────────────────────
 
     /// <summary>True while a backup listing is running and has not been asked to stop.</summary>
     [ObservableProperty]
     private bool _canCancelLoad;
-
-    /// <summary>True while a restore is running and has not been asked to stop.</summary>
-    [ObservableProperty]
-    private bool _canCancelExecute;
 
     /// <summary>True while a server query is running and has not been asked to stop (#111).</summary>
     [ObservableProperty]
@@ -211,10 +201,10 @@ public partial class RestoreViewModel : ViewModelBase
     private void RefreshCancelState()
     {
         CanCancelLoad = _loadCancellation.CanCancel;
-        CanCancelExecute = _executeCancellation.CanCancel;
+
         CanCancelQuery = _queryCancellation.CanCancel;
         IsCancelling = _loadCancellation.IsCancelling
-            || _executeCancellation.IsCancelling
+            || Execution.IsCancelling
             || _queryCancellation.IsCancelling;
     }
 
@@ -374,9 +364,7 @@ public partial class RestoreViewModel : ViewModelBase
 
         // Disarm. An armed Execute that survives a container change is an armed Execute aimed at
         // something the user is no longer looking at.
-        IsExecuteArmed = false;
-        ExecuteButtonText = "Execute on Server";
-        _armTimeoutCts?.Cancel();
+        Execution.Disarm();
     }
 
     [ObservableProperty]
@@ -428,25 +416,11 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _connectedServerName = string.Empty;
 
-    [ObservableProperty]
-    private bool _isExecuting;
-
-    [ObservableProperty]
-    private bool _executionComplete;
-
-    [ObservableProperty]
-    private bool _executionSuccess;
-
-    [ObservableProperty]
-    private bool _isExecuteArmed;
-
-    [ObservableProperty]
-    private int _executeCountdown;
-
-    [ObservableProperty]
-    private string _executeButtonText = "Execute on Server";
-
-    private CancellationTokenSource? _armTimeoutCts;
+    /// <summary>
+    /// Whether a restore is running. The state belongs to the execution seam; this reads it, so
+    /// the things on this screen that must not happen mid-restore still have one thing to ask.
+    /// </summary>
+    public bool IsExecuting => Execution.IsExecuting;
 
     // Backup summary
     [ObservableProperty]
@@ -485,9 +459,27 @@ public partial class RestoreViewModel : ViewModelBase
         // actual log file, which is the same class of side effect this whole change is about.
         _log = log ?? App.Log;
 
-        // Every console message is written to the log file as it arrives, so the file cannot drift
-        // from what was on screen.
-        Console = new ConsoleBuffer(message => _log.Info($"[execute] {message.Trim()}"));
+        Execution = new RestoreExecutionViewModel(sqlService, _history, _log, _queryCancellation);
+
+        // The run reports through the same status line as the rest of the screen, and its cancel
+        // state feeds the one Stop button that covers every server call here.
+        Execution.CancelStateChanged += RefreshCancelState;
+        Execution.PropertyChanged += (_, e) =>
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(ViewModelBase.StatusMessage):
+                    if (!Execution.HasError) SetStatus(Execution.StatusMessage);
+                    break;
+                case nameof(ViewModelBase.ErrorMessage) when Execution.HasError:
+                    SetError(Execution.ErrorMessage);
+                    break;
+                case nameof(RestoreExecutionViewModel.IsExecuting):
+                    OnExecutionRunningChanged();
+                    OnPropertyChanged(nameof(IsBusyWithAnything));
+                    break;
+            }
+        };
 
         // Shares _queryCancellation so the Stop button stops a credential write too (#111), and
         // reports through the same status line as everything else on this screen (#115 seam 5).
@@ -1274,8 +1266,10 @@ public partial class RestoreViewModel : ViewModelBase
 
     // Verification opens its own connection and reads whole backups. Letting it start while a
     // restore is running would put a second heavy reader on the same server at the worst moment.
-    partial void OnIsExecutingChanged(bool value)
+    // Called from the execution seam's own IsExecuting, which is where that state now lives.
+    private void OnExecutionRunningChanged()
     {
+        OnPropertyChanged(nameof(IsExecuting));
         VerifyChainCommand.NotifyCanExecuteChanged();
         RefreshExecuteBlockedReason();
         RefreshCheckState();
@@ -1637,6 +1631,14 @@ public partial class RestoreViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Arms the button, then hands the run to the execution seam (#115 seam 6).
+    ///
+    /// What stays here is what belongs to this screen rather than to the run: whether the script
+    /// on display is the one the options currently produce, and whether the chain can restore at
+    /// all. Both are checked on the CONFIRM press as well as when arming - validation can finish
+    /// during the five-second countdown and find an error that was not known when it was armed.
+    /// </summary>
     [RelayCommand]
     private async Task ExecuteScriptAsync()
     {
@@ -1651,355 +1653,56 @@ public partial class RestoreViewModel : ViewModelBase
         if (string.IsNullOrEmpty(GeneratedScript))
         {
             SetError("The current options do not produce a script. Check the settings above.");
-            IsExecuteArmed = false;
-            ExecuteButtonText = "Execute on Server";
+            Execution.Disarm();
             return;
         }
 
-        // Refuse to run when the chain cannot possibly restore. This is the last safe moment:
-        // once execution starts, WITH REPLACE drops the target database, and a chain that fails
-        // partway leaves nothing usable behind. Failing here costs the user a few seconds;
-        // failing mid-restore costs them the database they were restoring over.
-        //
-        // Checked on the confirm press as well as when arming: validation can finish during the
-        // five-second countdown and find an error that was not known when the button was armed.
+        // Once execution starts, WITH REPLACE drops the target database, and a chain that fails
+        // partway leaves nothing usable behind. Failing here costs a few seconds; failing
+        // mid-restore costs the database being restored over.
         if (HasChainErrors)
         {
             var first = ChainIssues.First(i => i.IsError);
             SetError($"Cannot execute: {first.Title}. {first.Detail}");
-            IsExecuteArmed = false;
-            ExecuteButtonText = "Execute on Server";
+            Execution.Disarm();
             return;
         }
 
-        if (!IsExecuteArmed)
+        if (!Execution.IsArmed)
         {
-            IsExecuteArmed = true;
-            ExecuteButtonText = "Confirm Execute (5)";
-            ExecuteCountdown = 5;
-
-            _armTimeoutCts?.Cancel();
-            _armTimeoutCts = new CancellationTokenSource();
-
-            _ = RunArmCountdownAsync(_armTimeoutCts.Token);
+            Execution.Arm();
             return;
         }
 
-        _armTimeoutCts?.Cancel();
-        IsExecuteArmed = false;
-        ExecuteButtonText = "Execute on Server";
-
-        var startedAt = DateTime.Now;
-        var outcome = RestoreOutcome.Failed;
-        string? failure = null;
-
-        // Set false when the run is abandoned before anything was attempted, so history records
-        // executions rather than button presses.
-        var attempted = true;
-
-        var executeToken = _executeCancellation.Begin();
-        IsExecuting = true;
-        Console.IsRunning = true;
-        // Reset alongside ExecutionComplete. Left over from a previous run it could combine with an
-        // early bail-out to show the success banner - and write "Outcome: Succeeded" into a saved
-        // log - for a restore that never ran.
-        ExecutionSuccess = false;
-        ExecutionComplete = false;
-        Console.Clear();
-        RecoveryActions = [];
-        HasRecoveryActions = false;
-        RefreshCancelState();
-
-        try
+        // Execute against the server we are actually connected to, not one looked up by name. This
+        // used to re-read config.json and take the first entry whose ServerName matched, which is a
+        // different object whenever two entries share a host and differ in auth, port or encryption
+        // - so the restore ran under credentials the user never connected with or tested.
+        var server = ConnectedServer;
+        if (server == null)
         {
-            // Execute against the server we are actually connected to, not one looked up by name.
-            // This used to re-read config.json and take the first entry whose ServerName matched,
-            // which is a different object whenever two entries share a host and differ in auth,
-            // port or encryption - a Windows-auth and a SQL-auth entry for the same box, say. The
-            // restore would then run under credentials the user never connected with or tested.
-            // Every other server call on this screen already uses ConnectedServer.
-            var server = ConnectedServer;
-            if (server == null)
-            {
-                attempted = false;
-                SetError("Not connected to a server.");
-                return;
-            }
+            Execution.Disarm();
+            SetError("Not connected to a server.");
+            return;
+        }
 
-            // Everything about the server-side credential lives on the child (#115 seam 5),
-            // including the decision not to touch one. A refusal has written nothing, so there is
-            // nothing to unwind - and nothing to file in the history either.
-            var preflight = await Credential.PrepareForRestoreAsync(server, AppendLog);
-            if (!preflight.CanProceed)
-            {
-                attempted = false;
-                SetError(preflight.Refusal!);
-                return;
-            }
-
-            _log.ServerChange(server.ServerName,
-                $"restore starting: target [{TargetDatabaseName}], " +
-                $"{RestoreChain?.Summary ?? "no chain"}, WITH REPLACE={Options.WithReplace}, " +
-                $"recovery={Options.RecoveryMode}, stopAt={PointInTime.Effective?.ToString("s") ?? "none"}");
-
-            AppendLog("Beginning restore execution...\n");
-
-            await _sqlService.ExecuteRestoreWithProgressAsync(
+        await Execution.RunAsync(
+            new RestoreRun(
                 server,
                 GeneratedScript,
-                // InvokeAsync, not Invoke. This callback runs on the connection's thread when SQL
-                // Server sends an info message, and a synchronous Invoke BLOCKS that thread until
-                // the UI has finished handling it. With the UI busy re-rendering, progress backed
-                // up and then arrived in bursts - which is precisely what "not live" looked like.
-                // Posting instead lets the restore keep streaming while the UI catches up.
-                msg => Application.Current.Dispatcher.InvokeAsync(() => AppendLog(msg)),
-                executeToken);
-
-            ExecutionSuccess = true;
-            outcome = RestoreOutcome.Succeeded;
-            AppendLog("\nRestore completed successfully!");
-            SetStatus("Restore execution completed successfully.");
-        }
-        catch (OperationCanceledException)
-        {
-            outcome = RestoreOutcome.Cancelled;
-            failure = "Cancelled by the user part-way through the chain.";
-            // Cancelling a restore is not the same as never having run it. SqlCommand.Cancel stops
-            // the client waiting and SQL Server rolls back the statement that was in flight, but
-            // the target stays mid-restore - so this must be as loud as a failure, and it goes
-            // through the same recovery guidance (#14, #25).
-            ExecutionSuccess = false;
-            AppendLog("\nCANCELLED. The statement in flight was rolled back by SQL Server, but the " +
-                      "restore stopped part-way through the chain.");
-
-            _log.ServerChange(ConnectedServer?.ServerName ?? "unknown",
-                $"restore CANCELLED by user, target [{TargetDatabaseName}]");
-
-            SetError("Restore cancelled. The target database has been left mid-restore - see below.");
-
-            if (ConnectedServer != null)
-                await ReportRecoveryStateAsync(ConnectedServer);
-        }
-        catch (Exception ex)
-        {
-            ExecutionSuccess = false;
-            outcome = RestoreOutcome.Failed;
-            failure = ex.Message;
-            AppendLog($"\nERROR: {ex.Message}");
-            SetError($"Restore failed: {ex.Message}");
-
-            // The restore has stopped part-way and the target is almost certainly not usable.
-            // Find out exactly how, and say so, while the connection is still open (#14).
-            if (ConnectedServer != null)
-                await ReportRecoveryStateAsync(ConnectedServer);
-        }
-        finally
-        {
-            _executeCancellation.End();
-            IsExecuting = false;
-            Console.IsRunning = false;
-            ExecutionComplete = true;
-            Console.Flush();   // nothing buffered may outlive the run
-            RefreshCancelState();
-
-            // After the flush, so the recorded log is the whole console rather than whatever had
-            // made it out of the batching buffer. Recorded for every outcome including cancelled -
-            // "I stopped it" is exactly the kind of thing a change ticket needs to say.
-            if (attempted) RecordHistory(startedAt, outcome, failure);
-        }
+                TargetDatabaseName,
+                SelectedDatabaseName,
+                SelectedContainer?.Name,
+                RestoreChain?.Summary ?? "no chain",
+                Timeline.SelectedPoint?.Timestamp,
+                $"WITH REPLACE={Options.WithReplace}, recovery={Options.RecoveryMode}, " +
+                $"stopAt={PointInTime.Effective?.ToString("s") ?? "none"}"),
+            appendLog => Credential.PrepareForRestoreAsync(server, appendLog));
     }
 
-    /// <summary>
-    /// Files this execution in the history (#31). Never throws: the store swallows its own
-    /// failures, and a restore must not be reported as failed because a record could not be kept.
-    /// </summary>
-    private void RecordHistory(DateTime startedAt, RestoreOutcome outcome, string? failure)
-    {
-        _history.Append(new RestoreHistoryEntry
-        {
-            StartedAt = startedAt,
-            CompletedAt = DateTime.Now,
-            ServerName = ConnectedServer?.ServerName ?? "unknown",
-            TargetDatabase = TargetDatabaseName,
-            ContainerName = SelectedContainer?.Name,
-            SourceDatabase = SelectedDatabaseName,
-            RestorePointTimestamp = Timeline.SelectedPoint?.Timestamp,
-            ChainSummary = RestoreChain?.Summary ?? "no chain",
-            Outcome = outcome,
-            ErrorMessage = failure,
-            Script = GeneratedScript,
-            Log = Console.Text
-        });
-    }
-
-    /// <summary>
-    /// Stops a running restore.
-    ///
-    /// Deliberately worded as a warning rather than a neutral action: stopping a restore part-way
-    /// leaves the target database in RESTORING, which is not a state anyone wants to discover by
-    /// accident. The recovery panel that appears afterwards explains how to get out of it.
-    /// </summary>
-    [RelayCommand]
-    private void CancelExecute()
-    {
-        if (!_executeCancellation.CanCancel) return;
-
-        _executeCancellation.Cancel();
-        RefreshCancelState();
-        AppendLog("\nCancellation requested - waiting for SQL Server to roll back the current statement...");
-    }
-
-    /// <summary>
-    /// After a failed restore, works out what state the target database was left in and offers the
-    /// statements that put it right.
-    ///
-    /// This is the moment of maximum stress - a restore has failed mid-incident and the database is
-    /// now in a state that blocks other connections. Leaving someone to work that out from a raw
-    /// SQL error, when the app is still holding the connection that could tell them, is the wrong
-    /// place to stop.
-    /// </summary>
-    private async Task ReportRecoveryStateAsync(ServerConnection server)
-    {
-        RecoveryActions = [];
-        HasRecoveryActions = false;
-        RecoveryStateMessage = string.Empty;
-
-        try
-        {
-            var state = await _sqlService.GetDatabaseRecoveryStateAsync(server, TargetDatabaseName);
-            if (!state.NeedsAttention)
-            {
-                if (!state.Exists)
-                    AppendLog($"\n[{TargetDatabaseName}] is not on the server - nothing was left behind.");
-                return;
-            }
-
-            RecoveryStateMessage = state.Explain(TargetDatabaseName);
-            RecoveryActions = new ObservableCollection<RecoveryAction>(
-                state.SuggestedActions(TargetDatabaseName));
-            HasRecoveryActions = RecoveryActions.Count > 0;
-
-            AppendLog($"\n{RecoveryStateMessage}");
-            foreach (var action in RecoveryActions)
-                AppendLog($"\n  {action.Title}:  {action.Sql}");
-        }
-        catch (Exception ex)
-        {
-            // Best effort. The restore failure is the news; failing to describe the aftermath must
-            // not replace the error the user actually needs to read.
-            AppendLog($"\nCould not check the state of [{TargetDatabaseName}]: {ex.Message}");
-        }
-    }
-
-    /// <summary>Runs one remediation the user picked, then re-reads the state.</summary>
-    [RelayCommand]
-    private async Task RunRecoveryActionAsync(RecoveryAction? action)
-    {
-        if (action == null || ConnectedServer == null) return;
-
-        // Cancellable, and it needs it more than most: this runs when a restore has already
-        // failed, RESTORE ... WITH RECOVERY can take a long time on a large database, and it goes
-        // out at CommandTimeout = 0. Without a Stop the only way out was killing the process - at
-        // the exact moment the user is trying to get their database back.
-        var ct = _queryCancellation.Begin();
-        RefreshCancelState();
-
-        try
-        {
-            AppendLog($"\nRunning: {action.Sql}");
-            await _sqlService.ExecuteRecoveryActionAsync(ConnectedServer, action.Sql, ct);
-            AppendLog("Completed.");
-            await ReportRecoveryStateAsync(ConnectedServer);
-
-            if (!HasRecoveryActions)
-                SetStatus($"[{TargetDatabaseName}] is back to a usable state.");
-        }
-        catch (OperationCanceledException)
-        {
-            // SQL Server rolls back the statement that was in flight, so the database is where it
-            // was before this step - which is still whatever the failed restore left behind.
-            AppendLog("\nCancelled. The database is in the same state as before this step.");
-            SetStatus("Recovery step cancelled.");
-        }
-        catch (Exception ex)
-        {
-            AppendLog($"\nERROR: {ex.Message}");
-            SetError($"Recovery step failed: {ex.Message}");
-        }
-        finally
-        {
-            _queryCancellation.End();
-            RefreshCancelState();
-        }
-    }
-
-    [RelayCommand]
-    private void CopyRecoveryAction(RecoveryAction? action)
-    {
-        if (action != null)
-            TryCopyToClipboard(action.Sql, "Recovery statement copied to clipboard.");
-    }
-
-    /// <summary>
-    /// Appends to the on-screen console and to the log file at the same time.
-    ///
-    /// One call rather than two so the file cannot drift from what the user was shown - and so a
-    /// restore that ends with the window being closed still leaves a record of how far it got.
-    /// Redaction happens inside the log, not here (#40).
-    /// </summary>
-    /// <summary>
-    /// The execution console. Its batching and line handling live in ConsoleBuffer (#115) - this
-    /// screen only feeds it and shows it.
-    /// </summary>
-    public ConsoleBuffer Console { get; }
-
-    /// <summary>
-    /// Appends to the on-screen console and to the log file at the same time, so the file cannot
-    /// drift from what the user was shown.
-    /// </summary>
-    private void AppendLog(string message) => Console.Append(message);
 
 
 
-    [RelayCommand]
-    private void CopyConsole()
-        => TryCopyToClipboard(Console.Text, "Execution log copied to clipboard.");
-
-    /// <summary>
-    /// Writes the console to a file, with a header saying what it was (#31). The clipboard is fine
-    /// for pasting into a chat window; a change ticket or an incident write-up wants a file, and
-    /// wants it to say which server and which database on its own.
-    /// </summary>
-    [RelayCommand]
-    private void SaveConsole()
-    {
-        if (string.IsNullOrEmpty(Console.Text))
-        {
-            SetError("There is no execution log to save yet.");
-            return;
-        }
-
-        var dialog = new SaveFileDialog
-        {
-            Filter = "Text Files (*.txt)|*.txt|Log Files (*.log)|*.log|All Files (*.*)|*.*",
-            DefaultExt = ".txt",
-            FileName = $"ninelives_{TargetDatabaseName}_{DateTime.Now:yyyyMMdd_HHmmss}.txt"
-        };
-
-        if (dialog.ShowDialog() != true) return;
-
-        try
-        {
-            File.WriteAllText(dialog.FileName, BuildSavedLog());
-            SetStatus($"Execution log saved to {dialog.FileName}");
-        }
-        catch (Exception ex)
-        {
-            // Read-only location, full disk, or a path the database name made invalid. Any of
-            // those used to take the whole app down from inside a synchronous command (#13).
-            SetError($"Could not save the execution log: {ex.Message}");
-        }
-    }
 
     /// <summary>
     /// The console plus the context needed to read it a week later. Redacted on the way out for
@@ -2017,33 +1720,11 @@ public partial class RestoreViewModel : ViewModelBase
         if (Timeline.SelectedPoint != null)
             header.AppendLine($"Point:      {Timeline.SelectedPoint.TimestampDisplay}");
         header.AppendLine($"Chain:      {RestoreChain?.Summary ?? "none"}");
-        header.AppendLine($"Outcome:    {(ExecutionComplete ? (ExecutionSuccess ? "Succeeded" : "Did not succeed") : "Still running")}");
+        header.AppendLine($"Outcome:    {(Execution.ExecutionComplete ? (Execution.ExecutionSuccess ? "Succeeded" : "Did not succeed") : "Still running")}");
         header.AppendLine(new string('-', 60));
         header.AppendLine();
 
-        return LogRedactor.Redact(header + Console.Text);
+        return LogRedactor.Redact(header + Execution.Console.Text);
     }
 
-    private async Task RunArmCountdownAsync(CancellationToken ct)
-    {
-        try
-        {
-            for (int i = 5; i >= 1; i--)
-            {
-                ct.ThrowIfCancellationRequested();
-                ExecuteCountdown = i;
-                ExecuteButtonText = $"Confirm Execute ({i})";
-                await Task.Delay(1000, ct);
-            }
-
-            Application.Current.Dispatcher.Invoke(() =>
-            {
-                IsExecuteArmed = false;
-                ExecuteButtonText = "Execute on Server";
-            });
-        }
-        catch (OperationCanceledException)
-        {
-        }
-    }
 }

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -53,7 +53,7 @@
                                     <Style TargetType="Ellipse">
                                         <Setter Property="Fill" Value="{DynamicResource ConsoleMutedBrush}" />
                                         <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsExecuting}" Value="True">
+                                            <DataTrigger Binding="{Binding Execution.IsExecuting}" Value="True">
                                                 <Setter Property="Fill" Value="{DynamicResource ConsoleSuccessBrush}" />
                                             </DataTrigger>
                                         </Style.Triggers>
@@ -66,16 +66,16 @@
                                        FontSize="11" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                            <TextBlock Text="{Binding Console.Lines.Count, StringFormat='{}{0} lines'}"
+                            <TextBlock Text="{Binding Execution.Console.Lines.Count, StringFormat='{}{0} lines'}"
                                        Foreground="{DynamicResource ConsoleMutedBrush}"
                                        FontFamily="{StaticResource ConsoleFont}"
                                        FontSize="11" VerticalAlignment="Center" Margin="0,0,12,0" />
                             <Button Content="Copy output"
-                                    Command="{Binding CopyConsoleCommand}"
+                                    Command="{Binding Execution.CopyConsoleCommand}"
                                     Style="{StaticResource SecondaryButton}"
                                     Padding="8,2" FontSize="11" Margin="0,0,8,0" />
                             <Button Content="Save output"
-                                    Command="{Binding SaveConsoleCommand}"
+                                    Command="{Binding Execution.SaveConsoleCommand}"
                                     Style="{StaticResource SecondaryButton}"
                                     Padding="8,2" FontSize="11"
                                     ToolTip="Writes the console to a file, with a header naming the server, the target database and the outcome." />
@@ -87,7 +87,7 @@
                      unbounded height realises every row and virtualisation silently does nothing.
                      A ListBox brings its own virtualising scroll viewer. -->
                 <ListBox Grid.Row="1" x:Name="ConsoleList"
-                         ItemsSource="{Binding Console.Lines}"
+                         ItemsSource="{Binding Execution.Console.Lines}"
                          Style="{StaticResource ConsoleListBox}" />
             </Grid>
         </Border>
@@ -95,14 +95,14 @@
         <!-- What a failed or cancelled restore left behind (#14). -->
         <Border Grid.Row="2" CornerRadius="4" Padding="12" Margin="0,12,0,0"
                 Background="{DynamicResource DangerPanelBackgroundBrush}" BorderBrush="{DynamicResource DangerPanelBorderBrush}" BorderThickness="1"
-                Visibility="{Binding HasRecoveryActions, Converter={StaticResource BoolToVis}}">
+                Visibility="{Binding Execution.HasRecoveryActions, Converter={StaticResource BoolToVis}}">
             <StackPanel>
                 <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
                            Style="{StaticResource LabelText}" Margin="0,0,0,8" />
-                <TextBlock Text="{Binding RecoveryStateMessage}"
+                <TextBlock Text="{Binding Execution.RecoveryStateMessage}"
                            Style="{StaticResource BodyText}"
                            TextWrapping="Wrap" Margin="0,0,0,10" />
-                <ItemsControl ItemsSource="{Binding RecoveryActions}">
+                <ItemsControl ItemsSource="{Binding Execution.RecoveryActions}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <Border Background="{DynamicResource InputBackgroundBrush}"
@@ -121,13 +121,13 @@
                                                TextWrapping="Wrap" Margin="0,0,0,8" />
                                     <StackPanel Orientation="Horizontal">
                                         <Button Content="Run this"
-                                                Command="{Binding DataContext.RunRecoveryActionCommand,
+                                                Command="{Binding DataContext.Execution.RunRecoveryActionCommand,
                                                           RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                 CommandParameter="{Binding}"
                                                 Style="{StaticResource SecondaryButton}"
                                                 Padding="10,6" Margin="0,0,8,0" />
                                         <Button Content="Copy"
-                                                Command="{Binding DataContext.CopyRecoveryActionCommand,
+                                                Command="{Binding DataContext.Execution.CopyRecoveryActionCommand,
                                                           RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                 CommandParameter="{Binding}"
                                                 Style="{StaticResource SecondaryButton}"
@@ -143,9 +143,9 @@
 
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
             <Button Content="Stop restore"
-                    Command="{Binding CancelExecuteCommand}"
+                    Command="{Binding Execution.CancelCommand}"
                     Style="{StaticResource DangerButton}"
-                    Visibility="{Binding CanCancelExecute, Converter={StaticResource BoolToVis}}"
+                    Visibility="{Binding Execution.CanCancel, Converter={StaticResource BoolToVis}}"
                     Padding="14,7" Margin="0,0,8,0"
                     ToolTip="Asks SQL Server to abort the statement in flight. It rolls that statement back, but the target database is left mid-restore." />
             <!-- Enabled only once it has finished. Closing mid-restore would hide the one thing
@@ -153,7 +153,7 @@
             <Button Content="Close"
                     Click="OnClose"
                     Style="{StaticResource SecondaryButton}"
-                    IsEnabled="{Binding ExecutionComplete}"
+                    IsEnabled="{Binding Execution.ExecutionComplete}"
                     Padding="20,7" MinWidth="90" />
         </StackPanel>
     </Grid>

--- a/src/NineLives/Views/ExecutionWindow.xaml.cs
+++ b/src/NineLives/Views/ExecutionWindow.xaml.cs
@@ -27,9 +27,9 @@ public partial class ExecutionWindow : Window
         InitializeComponent();
         DataContext = _viewModel = viewModel;
 
-        viewModel.Console.Lines.CollectionChanged += OnConsoleLinesChanged;
+        viewModel.Execution.Console.Lines.CollectionChanged += OnConsoleLinesChanged;
         ConsoleList.Loaded += (_, _) => HookScroller();
-        Closed += (_, _) => viewModel.Console.Lines.CollectionChanged -= OnConsoleLinesChanged;
+        Closed += (_, _) => viewModel.Execution.Console.Lines.CollectionChanged -= OnConsoleLinesChanged;
     }
 
     private void HookScroller()

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1311,7 +1311,7 @@
                                 Command="{Binding SaveScriptCommand}"
                                 IsEnabled="{Binding HasScript}"
                                 Margin="0,0,8,0" />
-                        <Button Content="{Binding ExecuteButtonText}"
+                        <Button Content="{Binding Execution.ButtonText}"
                                 Style="{StaticResource DangerButton}"
                                 Command="{Binding ExecuteScriptCommand}"
                                 IsEnabled="{Binding CanPressExecute}"
@@ -1322,8 +1322,8 @@
                              leaves the database mid-restore with nothing written down (#25). -->
                         <Button Content="Stop restore"
                                 Style="{StaticResource SecondaryButton}"
-                                Command="{Binding CancelExecuteCommand}"
-                                Visibility="{Binding CanCancelExecute, Converter={StaticResource BoolToVis}}"
+                                Command="{Binding Execution.CancelCommand}"
+                                Visibility="{Binding Execution.CanCancel, Converter={StaticResource BoolToVis}}"
                                 Margin="8,0,0,0"
                                 MinWidth="110"
                                 ToolTip="Asks SQL Server to abort the statement in flight. It rolls that statement back, but the target database is left mid-restore and will need recovering - the app will tell you how." />
@@ -1343,7 +1343,7 @@
                          hostname alone is a weak signal - blackcatsvr01 and blackcatsvr02 differ
                          by one character. A red PROD pill is read before the sentence is. -->
                     <Border Background="{DynamicResource DangerPanelBackgroundBrush}" CornerRadius="4" Padding="12,8" Margin="0,0,0,12"
-                            Visibility="{Binding IsExecuteArmed, Converter={StaticResource BoolToVis}}">
+                            Visibility="{Binding Execution.IsArmed, Converter={StaticResource BoolToVis}}">
                         <StackPanel>
                             <ItemsControl ItemsSource="{Binding ConnectedServerTags}"
                                           Style="{StaticResource TagChipList}"
@@ -1427,14 +1427,14 @@
                                 <Style.Triggers>
                                     <MultiDataTrigger>
                                         <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding Console.HasOutput}" Value="True" />
+                                            <Condition Binding="{Binding Execution.Console.HasOutput}" Value="True" />
                                             <Condition Binding="{Binding IsConsoleDetached}" Value="False" />
                                             <!-- Belt and braces. While a restore runs the console
                                                  is always in its own window, so the inline one
                                                  must be gone even if the detach flag never got
                                                  set - a wiring failure should not put two
                                                  consoles on screen. -->
-                                            <Condition Binding="{Binding IsExecuting}" Value="False" />
+                                            <Condition Binding="{Binding Execution.IsExecuting}" Value="False" />
                                         </MultiDataTrigger.Conditions>
                                         <Setter Property="Visibility" Value="Visible" />
                                     </MultiDataTrigger>
@@ -1461,7 +1461,7 @@
                                                 <Style TargetType="Ellipse">
                                                     <Setter Property="Fill" Value="{DynamicResource ConsoleMutedBrush}" />
                                                     <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding IsExecuting}" Value="True">
+                                                        <DataTrigger Binding="{Binding Execution.IsExecuting}" Value="True">
                                                             <Setter Property="Fill" Value="{DynamicResource ConsoleSuccessBrush}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
@@ -1476,20 +1476,20 @@
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                        <TextBlock Text="{Binding Console.Lines.Count, StringFormat='{}{0} lines'}"
+                                        <TextBlock Text="{Binding Execution.Console.Lines.Count, StringFormat='{}{0} lines'}"
                                                    Foreground="{DynamicResource ConsoleMutedBrush}"
                                                    FontFamily="{StaticResource ConsoleFont}"
                                                    FontSize="11"
                                                    VerticalAlignment="Center"
                                                    Margin="0,0,12,0" />
                                         <Button Content="Copy output"
-                                                Command="{Binding CopyConsoleCommand}"
+                                                Command="{Binding Execution.CopyConsoleCommand}"
                                                 Style="{StaticResource SecondaryButton}"
                                                 Padding="8,2" FontSize="11"
                                                 Margin="0,0,8,0"
                                                 ToolTip="Copies the whole console, which is what to attach to a bug report." />
                                         <Button Content="Save output"
-                                                Command="{Binding SaveConsoleCommand}"
+                                                Command="{Binding Execution.SaveConsoleCommand}"
                                                 Style="{StaticResource SecondaryButton}"
                                                 Padding="8,2" FontSize="11"
                                                 ToolTip="Writes the console to a file, with a header naming the server, the target database and the outcome - for a change ticket or an incident write-up." />
@@ -1500,7 +1500,7 @@
                             <!-- Virtualised so a long restore stays responsive. Auto-follows the
                                  last line unless the user has scrolled up to read something. -->
                             <ListBox Grid.Row="1" x:Name="ConsoleList"
-                                     ItemsSource="{Binding Console.Lines}"
+                                     ItemsSource="{Binding Execution.Console.Lines}"
                                      Style="{StaticResource ConsoleListBox}"
                                      MaxHeight="360" />
                         </Grid>
@@ -1521,7 +1521,7 @@
                                 <Style.Triggers>
                                     <MultiDataTrigger>
                                         <MultiDataTrigger.Conditions>
-                                            <Condition Binding="{Binding HasRecoveryActions}" Value="True" />
+                                            <Condition Binding="{Binding Execution.HasRecoveryActions}" Value="True" />
                                             <Condition Binding="{Binding IsConsoleDetached}" Value="False" />
                                         </MultiDataTrigger.Conditions>
                                         <Setter Property="Visibility" Value="Visible" />
@@ -1532,10 +1532,10 @@
                         <StackPanel>
                             <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
                                        Style="{StaticResource LabelText}" Margin="0,0,0,8" />
-                            <TextBlock Text="{Binding RecoveryStateMessage}"
+                            <TextBlock Text="{Binding Execution.RecoveryStateMessage}"
                                        Style="{StaticResource BodyText}"
                                        TextWrapping="Wrap" Margin="0,0,0,12" />
-                            <ItemsControl ItemsSource="{Binding RecoveryActions}">
+                            <ItemsControl ItemsSource="{Binding Execution.RecoveryActions}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
                                         <Border Background="{DynamicResource InputBackgroundBrush}"
@@ -1555,13 +1555,13 @@
                                                            TextWrapping="Wrap" Margin="0,0,0,8" />
                                                 <StackPanel Orientation="Horizontal">
                                                     <Button Content="Run this"
-                                                            Command="{Binding DataContext.RunRecoveryActionCommand,
+                                                            Command="{Binding DataContext.Execution.RunRecoveryActionCommand,
                                                                       RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                             CommandParameter="{Binding}"
                                                             Style="{StaticResource SecondaryButton}"
                                                             Padding="10,6" Margin="0,0,8,0" />
                                                     <Button Content="Copy"
-                                                            Command="{Binding DataContext.CopyRecoveryActionCommand,
+                                                            Command="{Binding DataContext.Execution.CopyRecoveryActionCommand,
                                                                       RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                                             CommandParameter="{Binding}"
                                                             Style="{StaticResource SecondaryButton}"

--- a/src/NineLives/Views/RestoreView.xaml.cs
+++ b/src/NineLives/Views/RestoreView.xaml.cs
@@ -33,7 +33,7 @@ public partial class RestoreView : UserControl
         if (e.NewValue is RestoreViewModel vm)
         {
             _viewModel = vm;
-            _observedLines = vm.Console.Lines;
+            _observedLines = vm.Execution.Console.Lines;
             _observedLines.CollectionChanged += OnConsoleLinesChanged;
             vm.PropertyChanged += OnViewModelPropertyChanged;
         }


### PR DESCRIPTION
@
Sixth seam of #115, and the one the issue called highest-stakes: the only code on this screen that writes to somebodys database. **2,049 → 1,730 lines**, and **985 passing** (1,009 total).

## What moved

`RestoreExecutionViewModel` owns arming, the countdown, the run itself, cancellation, the recovery guidance that follows a failure, and the history entry.

What stays behind is what belongs to the **screen** rather than to the run: whether the script on display is the one the options currently produce, and whether the chain can restore at all. Both are still checked on the *confirm* press as well as when arming, because validation can finish during the five-second countdown and find an error that was not known when the button was armed.

## A run is now a record, not a set of live properties

```csharp
public sealed record RestoreRun(
    ServerConnection Server, string Script, string TargetDatabase, string? SourceDatabase,
    string? ContainerName, string ChainSummary, DateTime? RestorePointTimestamp, string OptionsForLog);
```

Captured when confirm is pressed. That closes a real gap rather than just tidying: **a restore takes minutes, the screen behind it stays live**, and reading the target database name at the end of a run that started against a different one is exactly the class of bug this seam exists to make impossible. The recovery steps that follow a failure use the same captured server and target, for the same reason — they used to read `ConnectedServer` and `TargetDatabaseName` as they were *by then*.

## Cancellation keeps the split it had

Its own source for the restore; the parents for the recovery actions that follow it, because those belong to the same Stop button as the rest of the screens queries (#111). `CanCancel` is held rather than computed, as it was before — the Stop button binds to it and a test has to be able to reach that state.

## Tests

Eight, and the interesting ones previously needed a container, a listing, a chain and a connection to reach:

- a **refused credential runs nothing AND files nothing** — the history records executions, not button presses
- the **recorded log is the whole console**, not whatever escaped the batching buffer when the run ended, which is why the flush happens before the entry is written
- a failure is recorded with its reason; a cancellation is recorded as loudly as a failure
- the run is aimed at exactly what it was handed

The ten existing end-to-end execute tests still pass unchanged in behaviour, and all 55 XAML-load and theme tests pass, which covers the ~29 bindings repointed at the seam.

## Remaining on #115

Seam 4 (container listing and discovery, ~250 lines) is the last one.
@