### PR TITLE
Lift the container listing out of RestoreViewModel (#115 seam 4)

### DIFF
--- a/src/NineLives.Tests/BackupInventorySeamTests.cs
+++ b/src/NineLives.Tests/BackupInventorySeamTests.cs
@@ -1,0 +1,148 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The inventory seam (#115 seam 4).
+///
+/// Its point is not the line count: the loaded backups now carry the container they came FROM, so
+/// nothing downstream has to assume that whatever is loaded belongs to whatever is selected above
+/// it. That assumption produced #112 - changing the container left the previous one's chain and
+/// script armed and executable - and, when the preselection was removed, a working set that fell
+/// back to every backup in the container.
+/// </summary>
+public class BackupInventorySeamTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupFileInfo File(string db, string server, BackupType type, DateTime at) => new()
+    {
+        BlobName = $"{type}/{server}/{db}/{at:yyyyMMdd_HHmmss}.bak",
+        BlobUrl = $"https://acct/backups/{type}/{server}/{db}/{at:yyyyMMdd_HHmmss}.bak",
+        Type = type,
+        InferredServerName = server,
+        InferredDatabaseName = db,
+        SizeBytes = 1000,
+        LastModified = new DateTimeOffset(at, TimeSpan.Zero)
+    };
+
+    private static BlobContainerConfig Container(string name = "backups") => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = name,
+        ContainerUrl = $"https://acct/{name}"
+    };
+
+    private static (BackupInventoryViewModel vm, FakeBlobStorageService blob) New()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                File("MyDb", "SRV01", BackupType.Full, T0),
+                File("MyDb", "SRV01", BackupType.TransactionLog, T0.AddHours(1)),
+                File("OtherDb", "SRV01", BackupType.Full, T0)
+            ]
+        };
+        return (new BackupInventoryViewModel(blob), blob);
+    }
+
+    [Fact]
+    public async Task ALoadRecordsWhichContainerItCameFrom()
+    {
+        var (vm, _) = New();
+        var container = Container("prod-backups");
+
+        await vm.LoadAsync(container);
+
+        Assert.Same(container, vm.LoadedFrom);
+        Assert.True(vm.BackupsLoaded);
+    }
+
+    /// <summary>
+    /// The lists are offered, not answered - and until one is answered the working set is EMPTY,
+    /// not everything. Falling back to every set drew a timeline of every backup of every database
+    /// on every server.
+    /// </summary>
+    [Fact]
+    public async Task NothingIsChosenAndNothingIsWorkedFromUntilItIs()
+    {
+        var (vm, _) = New();
+
+        await vm.LoadAsync(Container());
+
+        Assert.Null(vm.SelectedServerName);
+        Assert.Null(vm.SelectedDatabaseName);
+        Assert.Empty(vm.WorkingSet);
+        Assert.Equal(0, vm.SetCount);
+        Assert.NotEmpty(vm.DiscoveredDatabases);
+    }
+
+    [Fact]
+    public async Task ChoosingADatabaseNarrowsTheWorkingSetToIt()
+    {
+        var (vm, _) = New();
+        await vm.LoadAsync(Container());
+
+        vm.SelectedDatabaseName = "MyDb";
+
+        Assert.Equal(2, vm.SetCount);
+        Assert.Equal(1, vm.FullCount);
+        Assert.Equal(1, vm.LogCount);
+        Assert.All(vm.WorkingSet, s => Assert.Equal("MyDb", s.DatabaseName));
+    }
+
+    /// <summary>Clearing forgets where it came from, so nothing can be shown under a container it
+    /// did not come from - the shape of #112.</summary>
+    [Fact]
+    public async Task ClearingForgetsTheContainerAndEverythingFromIt()
+    {
+        var (vm, _) = New();
+        await vm.LoadAsync(Container());
+        vm.SelectedDatabaseName = "MyDb";
+
+        vm.Clear();
+
+        Assert.Null(vm.LoadedFrom);
+        Assert.False(vm.BackupsLoaded);
+        Assert.Empty(vm.WorkingSet);
+        Assert.Empty(vm.DiscoveredDatabases);
+        Assert.Null(vm.SelectedDatabaseName);
+    }
+
+    [Fact]
+    public async Task TheWorkingSetChangeIsAnnouncedSoTheChainCanFollow()
+    {
+        var (vm, _) = New();
+        await vm.LoadAsync(Container());
+
+        var announced = 0;
+        vm.WorkingSetChanged += () => announced++;
+
+        vm.SelectedDatabaseName = "MyDb";
+
+        Assert.True(announced > 0);
+    }
+
+    /// <summary>
+    /// A second load scopes down to what is already chosen, instead of walking the whole container
+    /// again - about 1,075ms unscoped versus 233ms for one database on a real container (#28).
+    /// </summary>
+    [Fact]
+    public async Task AReloadWithADatabaseChosenScopesTheListing()
+    {
+        var (vm, blob) = New();
+        await vm.LoadAsync(Container());
+        Assert.Null(blob.LastScope);
+
+        vm.SelectedServerName = "SRV01";
+        vm.SelectedDatabaseName = "MyDb";
+        await vm.LoadAsync(Container());
+
+        Assert.NotNull(blob.LastScope);
+        Assert.Equal("MyDb", blob.LastScope!.DatabaseName);
+        Assert.Equal("SRV01", blob.LastScope.ServerName);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -269,7 +269,7 @@ internal static class RestoreSetup
 {
     public static void ChooseADatabaseAndAPoint(RestoreViewModel vm)
     {
-        vm.SelectedDatabaseName ??= vm.DiscoveredDatabases.FirstOrDefault();
+        vm.Inventory.SelectedDatabaseName ??= vm.Inventory.DiscoveredDatabases.FirstOrDefault();
         vm.Timeline.SelectedPoint ??= vm.Timeline.Points.LastOrDefault();
     }
 }

--- a/src/NineLives.Tests/KeyboardShortcutTests.cs
+++ b/src/NineLives.Tests/KeyboardShortcutTests.cs
@@ -44,7 +44,7 @@ public class KeyboardShortcutTests
         vm.ReloadCommand.Execute(null);
 
         Assert.False(vm.Restore.IsBusy);
-        Assert.False(vm.Restore.BackupsLoaded);
+        Assert.False(vm.Restore.Inventory.BackupsLoaded);
     }
 
     [Fact]

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -87,11 +87,11 @@ public class RestoreViewModelTests
 
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        Assert.True(vm.BackupsLoaded);
-        Assert.NotEmpty(vm.DiscoveredDatabases);
+        Assert.True(vm.Inventory.BackupsLoaded);
+        Assert.NotEmpty(vm.Inventory.DiscoveredDatabases);
 
-        Assert.Null(vm.SelectedServerName);
-        Assert.Null(vm.SelectedDatabaseName);
+        Assert.Null(vm.Inventory.SelectedServerName);
+        Assert.Null(vm.Inventory.SelectedDatabaseName);
         Assert.Null(vm.Timeline.SelectedPoint);
 
         // And NOTHING is drawn. This is the part that bit hardest: with no database chosen the
@@ -100,7 +100,7 @@ public class RestoreViewModelTests
         // of them meaningful, because a restore chain only exists within one database.
         Assert.False(vm.Timeline.HasPoints);
         Assert.Empty(vm.Timeline.Points);
-        Assert.Equal(0, vm.SetCount);
+        Assert.Equal(0, vm.Inventory.SetCount);
 
         // And nothing downstream has been built from a choice nobody made.
         Assert.Null(vm.RestoreChain);
@@ -120,14 +120,14 @@ public class RestoreViewModelTests
         vm.SelectedContainer = Container();
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
-        vm.SelectedDatabaseName = "MyDb";
+        vm.Inventory.SelectedDatabaseName = "MyDb";
         Assert.True(vm.Timeline.HasPoints);
 
-        vm.SelectedDatabaseName = null;
+        vm.Inventory.SelectedDatabaseName = null;
 
         Assert.False(vm.Timeline.HasPoints);
         Assert.Empty(vm.Timeline.Points);
-        Assert.Equal(0, vm.SetCount);
+        Assert.Equal(0, vm.Inventory.SetCount);
     }
 
     [Fact]
@@ -142,7 +142,7 @@ public class RestoreViewModelTests
         // Nothing is preselected any more, so the test makes the choices a user would.
         RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
-        Assert.True(vm.BackupsLoaded);
+        Assert.True(vm.Inventory.BackupsLoaded);
         Assert.True(vm.Timeline.HasPoints);
 
         // A full plus three logs: the full itself, then one point per log.
@@ -245,20 +245,20 @@ public class RestoreViewModelTests
         RestoreSetup.ChooseADatabaseAndAPoint(vm);
         vm.TargetDatabaseName = "MyDb_Restored";
 
-        Assert.True(vm.BackupsLoaded);
+        Assert.True(vm.Inventory.BackupsLoaded);
         Assert.NotEmpty(vm.Timeline.Points);
         Assert.NotEmpty(vm.GeneratedScript);
 
         vm.SelectedContainer = Container();   // a different container
 
-        Assert.False(vm.BackupsLoaded);
+        Assert.False(vm.Inventory.BackupsLoaded);
         Assert.Empty(vm.Timeline.Points);
         Assert.False(vm.Timeline.HasPoints);
         Assert.Null(vm.Timeline.SelectedPoint);
         Assert.Null(vm.RestoreChain);
         Assert.Empty(vm.GeneratedScript);
         Assert.False(vm.HasScript);
-        Assert.Empty(vm.DiscoveredDatabases);
+        Assert.Empty(vm.Inventory.DiscoveredDatabases);
     }
 
     [Fact]
@@ -405,7 +405,7 @@ public class RestoreViewModelTests
         Assert.NotEmpty(vm.GeneratedScript);
 
         // OtherDb has logs but no full, so there is nothing it can be restored to.
-        vm.SelectedDatabaseName = "OtherDb";
+        vm.Inventory.SelectedDatabaseName = "OtherDb";
 
         Assert.Empty(vm.Timeline.Points);
         Assert.Null(vm.Timeline.SelectedPoint);
@@ -493,8 +493,8 @@ public class RestoreViewModelTests
 
         // The server as well as the database: the scope is built from both, and the load no longer
         // picks either.
-        vm.SelectedServerName = "SRV01";
-        vm.SelectedDatabaseName = "MyDb";
+        vm.Inventory.SelectedServerName = "SRV01";
+        vm.Inventory.SelectedDatabaseName = "MyDb";
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
         // Nothing is preselected any more, so the test makes the choices a user would.
@@ -517,8 +517,8 @@ public class RestoreViewModelTests
 
         // Nothing is preselected any more, so the test makes the choices a user would.
         RestoreSetup.ChooseADatabaseAndAPoint(vm);
-        vm.SelectedServerName = @"SRV01\PROD";
-        vm.SelectedDatabaseName = "MyDb";
+        vm.Inventory.SelectedServerName = @"SRV01\PROD";
+        vm.Inventory.SelectedDatabaseName = "MyDb";
         await vm.LoadBackupsCommand.ExecuteAsync(null);
 
         // Nothing is preselected any more, so the test makes the choices a user would.
@@ -540,7 +540,7 @@ public class RestoreViewModelTests
         // Nothing is preselected any more, so the test makes the choices a user would.
         RestoreSetup.ChooseADatabaseAndAPoint(vm);
 
-        Assert.False(vm.BackupsLoaded);
+        Assert.False(vm.Inventory.BackupsLoaded);
         Assert.Contains("No SAS token found.", vm.StatusMessage);
     }
 }

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -346,7 +346,7 @@ public class XamlLoadTests(WpfFixture wpf)
             var vm = NewRestoreViewModel();
             // The execute card only exists once backups are loaded, which is correct - there is
             // no script to run before then.
-            vm.BackupsLoaded = true;
+            vm.Inventory.BackupsLoaded = true;
             vm.HasScript = true;
             vm.IsConnectedToServer = true;
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
@@ -376,7 +376,7 @@ public class XamlLoadTests(WpfFixture wpf)
         {
             var vm = NewRestoreViewModel();
             vm.IsBusy = true;
-            vm.CanCancelLoad = true;
+            vm.Inventory.CanCancelLoad = true;
 
             // Step 4 holds all of this and is collapsed by default (#117 item 3): a collapsed
             // parent never measures, so its item containers are never generated to be found.
@@ -423,7 +423,7 @@ public class XamlLoadTests(WpfFixture wpf)
         wpf.Invoke(() =>
         {
             var vm = NewRestoreViewModel();
-            vm.BackupsLoaded = true;
+            vm.Inventory.BackupsLoaded = true;
             vm.HasScript = true;
             vm.GeneratedScript = "RESTORE DATABASE [MyDb] FROM URL = N'https://acct/backups/x.bak'";
             vm.Execution.Console.Lines =
@@ -479,7 +479,7 @@ public class XamlLoadTests(WpfFixture wpf)
         wpf.Invoke(() =>
         {
             var vm = NewRestoreViewModel();
-            vm.BackupsLoaded = true;
+            vm.Inventory.BackupsLoaded = true;
             vm.Execution.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
             vm.Execution.Console.HasOutput = true;
 
@@ -511,7 +511,7 @@ public class XamlLoadTests(WpfFixture wpf)
         wpf.Invoke(() =>
         {
             var vm = NewRestoreViewModel();
-            vm.BackupsLoaded = true;
+            vm.Inventory.BackupsLoaded = true;
             vm.Execution.Console.Lines = [new ConsoleLine("Beginning restore execution...")];
             vm.Execution.Console.HasOutput = true;
             vm.IsConsoleDetached = false;   // as if the wiring failed

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -1,0 +1,287 @@
+﻿using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// What a container holds, and which server and database within it is being looked at.
+///
+/// Fourth seam out of RestoreViewModel (#115). Its point is not the line count: it is that the
+/// loaded backups now carry the container they came FROM, as a field, instead of everything on the
+/// screen assuming that whatever is loaded belongs to whatever is currently selected above it.
+///
+/// That assumption has produced real bugs twice. #112: changing the container left the previous
+/// one's chain and script armed and executable, so Execute ran against blob URLs from a container
+/// nobody was looking at. And when the preselection was removed, the working set silently fell
+/// back to EVERY set in the container, drawing a timeline of every backup of every database on
+/// every server. Both are the same mistake - data whose provenance is implied rather than stated.
+/// </summary>
+public partial class BackupInventoryViewModel : ViewModelBase
+{
+    private readonly IBlobStorageService _blob;
+    private readonly OperationCancellation _loadCancellation = new();
+
+    public BackupInventoryViewModel(IBlobStorageService blob)
+    {
+        _blob = blob;
+    }
+
+    /// <summary>Raised when the working set changes, so the chain and timeline can be rebuilt.</summary>
+    public event Action? WorkingSetChanged;
+
+    /// <summary>Raised when the cancel state changes, so the parent's Stop button can follow.</summary>
+    public event Action? CancelStateChanged;
+
+    // ── what was loaded, and where from ─────────────────────────────────────────
+
+    private List<BackupFileInfo> _allBackups = [];
+    private List<BackupSet> _allSets = [];
+
+    /// <summary>
+    /// The container these backups were listed from.
+    ///
+    /// The whole reason this type exists. Anything derived from the inventory - a chain, a script,
+    /// a restore point - belongs to THIS container, and can be checked against the one currently
+    /// selected rather than assumed to match it.
+    /// </summary>
+    [ObservableProperty]
+    private BlobContainerConfig? _loadedFrom;
+
+    /// <summary>The sets for the chosen server and database: what a chain can actually be built from.</summary>
+    public List<BackupSet> WorkingSet { get; private set; } = [];
+
+    /// <summary>Every set in the container, for the inventory findings that look wider than one database.</summary>
+    public List<BackupSet> AllSets => _allSets;
+
+    [ObservableProperty]
+    private bool _backupsLoaded;
+
+    [ObservableProperty]
+    private string _loadProgressText = string.Empty;
+
+    [ObservableProperty]
+    private bool _canCancelLoad;
+
+    // ── what is being looked at within it ───────────────────────────────────────
+
+    [ObservableProperty]
+    private ObservableCollection<string> _discoveredServers = [];
+
+    [ObservableProperty]
+    private ObservableCollection<string> _discoveredDatabases = [];
+
+    [ObservableProperty]
+    private string? _selectedServerName;
+
+    [ObservableProperty]
+    private string? _selectedDatabaseName;
+
+    [ObservableProperty]
+    private int _fullCount;
+
+    [ObservableProperty]
+    private int _diffCount;
+
+    [ObservableProperty]
+    private int _logCount;
+
+    [ObservableProperty]
+    private int _setCount;
+
+    partial void OnSelectedServerNameChanged(string? value)
+    {
+        if (_allSets.Count == 0) return;
+
+        // Compare the FULL server identity. Matching on the host alone made selecting
+        // SQLHOST\PROD also match SQLHOST\TEST, so the database list offered databases that only
+        // exist on the other instance.
+        var dbs = _allSets
+            .Where(s => s.MatchesServer(value))
+            .Where(s => !string.IsNullOrEmpty(s.DatabaseName))
+            .Select(s => s.DatabaseName!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        DiscoveredDatabases = new ObservableCollection<string>(dbs);
+
+        // Nothing is chosen for the user. Picking the first database alphabetically is a decision
+        // about WHICH DATABASE TO RESTORE, made silently, and the rest of the screen then fills in
+        // around it as though somebody had asked for it. On a screen whose last button overwrites a
+        // database, the app does not get to guess.
+        RebuildWorkingSet();
+    }
+
+    partial void OnSelectedDatabaseNameChanged(string? value) => RebuildWorkingSet();
+
+    /// <summary>
+    /// Narrows the loaded sets to the chosen server and database.
+    ///
+    /// With no database chosen the working set is EMPTY, not everything. Falling back to every set
+    /// in the container produced a timeline of every backup of every database on every server -
+    /// thousands of points on a real container, none of them meaningful, because a restore chain
+    /// only exists within one database.
+    /// </summary>
+    private void RebuildWorkingSet()
+    {
+        if (string.IsNullOrEmpty(SelectedDatabaseName) || _allSets.Count == 0)
+        {
+            WorkingSet = [];
+            FullCount = DiffCount = LogCount = SetCount = 0;
+            WorkingSetChanged?.Invoke();
+            return;
+        }
+
+        var sets = _allSets
+            .Where(s => string.Equals(s.DatabaseName, SelectedDatabaseName, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        // Full server identity again - this is the filter that decides which sets reach
+        // BackupChainBuilder, so a host-only match let one instance's full pair with another
+        // instance's differentials and logs.
+        if (!string.IsNullOrEmpty(SelectedServerName))
+            sets = sets.Where(s => s.MatchesServer(SelectedServerName)).ToList();
+
+        WorkingSet = sets;
+        FullCount = sets.Count(s => s.Type == BackupType.Full);
+        DiffCount = sets.Count(s => s.Type == BackupType.Differential);
+        LogCount = sets.Count(s => s.Type == BackupType.TransactionLog);
+        SetCount = sets.Count;
+
+        WorkingSetChanged?.Invoke();
+    }
+
+    // ── loading ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Lists a container and works out what is in it.
+    /// </summary>
+    public async Task LoadAsync(BlobContainerConfig container)
+    {
+        var ct = _loadCancellation.Begin();
+        IsBusy = true;
+        LoadProgressText = "Scanning container...";
+        RaiseCancelStateChanged();
+        ClearStatus();
+
+        try
+        {
+            // If a database is already chosen - a reload after taking a fresh backup, say - push
+            // that down to Azure as a prefix instead of walking the whole container and discarding
+            // most of it. Measured on a real 4,440-blob container: about 1,075 ms unscoped versus
+            // about 233 ms for one database (#28).
+            //
+            // The FIRST load has no selection yet and stays a full scan, which it has to be: the
+            // server and database lists are built from what it finds.
+            var scope = BuildListingScope();
+            var progress = new Progress<int>(n => LoadProgressText = $"Scanned {n:N0} blobs...");
+
+            var files = await _blob.ListBackupFilesAsync(container, scope, progress, ct);
+            var sets = _blob.GroupIntoBackupSets(files, container.BackupServerTimeZoneId);
+
+            _allBackups = files;
+            _allSets = sets;
+
+            // Stated, not assumed: everything derived from here belongs to THIS container.
+            LoadedFrom = container;
+
+            DiscoveredServers = new ObservableCollection<string>(_blob.GetDiscoveredServers(files));
+            DiscoveredDatabases = new ObservableCollection<string>(_blob.GetDiscoveredDatabases(files));
+            BackupsLoaded = files.Count > 0;
+
+            // The lists are offered, not answered - and until one IS answered there is nothing to
+            // show.
+            RebuildWorkingSet();
+
+            // Only when nothing above went wrong. The filter-and-compute cascade can end in "no
+            // valid restore points found", and painting a success line over that left an empty
+            // timeline with the status bar cheerfully reporting how many files had loaded.
+            if (!HasError)
+                SetStatus($"Loaded {files.Count} files in {sets.Count} backup set(s) across " +
+                          $"{DiscoveredDatabases.Count} database(s).");
+        }
+        catch (OperationCanceledException)
+        {
+            // Asked for, not a failure. Nothing was written anywhere - listing is read-only - so
+            // there is nothing to explain beyond saying it stopped.
+            SetStatus("Loading cancelled.");
+            BackupsLoaded = false;
+        }
+        catch (Exception ex)
+        {
+            SetError($"Failed to load backups: {ex.Message}");
+            BackupsLoaded = false;
+        }
+        finally
+        {
+            _loadCancellation.End();
+            IsBusy = false;
+            LoadProgressText = string.Empty;
+            RaiseCancelStateChanged();
+        }
+    }
+
+    /// <summary>
+    /// The scope to push down to Azure, or null to scan everything.
+    ///
+    /// Only offered when a database is chosen. A server on its own narrows far less and the
+    /// database list is built from the previous scan anyway, so scoping to a server alone would
+    /// mostly re-fetch what is already in memory.
+    /// </summary>
+    private BlobListingScope? BuildListingScope()
+    {
+        if (string.IsNullOrWhiteSpace(SelectedDatabaseName)) return null;
+
+        // ServerName here is the identity used in the PATH, which for an instance is the host
+        // part - "SRV01\PROD" lives under "SRV01". ServerIdentity knows how to split it.
+        var pathServer = string.IsNullOrWhiteSpace(SelectedServerName)
+            ? null
+            : SelectedServerName.Split('\\')[0];
+
+        return new BlobListingScope(pathServer, SelectedDatabaseName);
+    }
+
+    /// <summary>Stops an in-progress listing.</summary>
+    [RelayCommand]
+    private void CancelLoad()
+    {
+        if (!_loadCancellation.CanCancel) return;
+
+        _loadCancellation.Cancel();
+        RaiseCancelStateChanged();
+        SetStatus("Stopping the scan...");
+    }
+
+    /// <summary>
+    /// Drops everything the previous container produced.
+    ///
+    /// Called when the container changes, so what is on screen always belongs to the container
+    /// named above it - the failure #112 was, where the previous container's chain and script
+    /// stayed armed and executable against blob URLs nobody was looking at any more.
+    /// </summary>
+    public void Clear()
+    {
+        _allBackups = [];
+        _allSets = [];
+        WorkingSet = [];
+        LoadedFrom = null;
+
+        BackupsLoaded = false;
+        DiscoveredServers = [];
+        DiscoveredDatabases = [];
+        SelectedServerName = null;
+        SelectedDatabaseName = null;
+        FullCount = DiffCount = LogCount = SetCount = 0;
+
+        WorkingSetChanged?.Invoke();
+    }
+
+    private void RaiseCancelStateChanged()
+    {
+        CanCancelLoad = _loadCancellation.CanCancel;
+        CancelStateChanged?.Invoke();
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -21,9 +21,8 @@ public partial class RestoreViewModel : ViewModelBase
     private readonly BackupChainValidator _chainValidator = new();
     private readonly ICredentialStore _credentialStore;
 
-    private List<BackupFileInfo> _allBackups = [];
-    private List<BackupSet> _allSets = [];
-    private List<BackupSet> _dbSets = [];
+    // The loaded backups, what was found in them and which container they came from all live on
+    // the inventory seam (#115 seam 4).
 
     // Two separate operations, two separate sources: browsing a container and running a restore
     // can both be in flight, and cancelling one must not touch the other (#25).
@@ -52,6 +51,13 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     public RestoreExecutionViewModel Execution { get; }
 
+    /// <summary>
+    /// What the selected container holds, and which server and database within it is being looked
+    /// at - carrying the container it was loaded FROM, so nothing downstream has to assume (#115
+    /// seam 4).
+    /// </summary>
+    public BackupInventoryViewModel Inventory { get; }
+
     #region Observable Properties
 
     [ObservableProperty]
@@ -59,21 +65,6 @@ public partial class RestoreViewModel : ViewModelBase
 
     [ObservableProperty]
     private BlobContainerConfig? _selectedContainer;
-
-    [ObservableProperty]
-    private bool _backupsLoaded;
-
-    [ObservableProperty]
-    private ObservableCollection<string> _discoveredServers = [];
-
-    [ObservableProperty]
-    private string? _selectedServerName;
-
-    [ObservableProperty]
-    private ObservableCollection<string> _discoveredDatabases = [];
-
-    [ObservableProperty]
-    private string? _selectedDatabaseName;
 
     [ObservableProperty]
     private string _targetDatabaseName = string.Empty;
@@ -166,10 +157,6 @@ public partial class RestoreViewModel : ViewModelBase
 
     // ── Cancellation (#25) ──────────────────────────────────────────────────────
 
-    /// <summary>True while a backup listing is running and has not been asked to stop.</summary>
-    [ObservableProperty]
-    private bool _canCancelLoad;
-
     /// <summary>True while a server query is running and has not been asked to stop (#111).</summary>
     [ObservableProperty]
     private bool _canCancelQuery;
@@ -177,13 +164,6 @@ public partial class RestoreViewModel : ViewModelBase
     /// <summary>True between asking to stop and the operation actually unwinding.</summary>
     [ObservableProperty]
     private bool _isCancelling;
-
-    /// <summary>
-    /// Running count during a listing. A container of any size takes long enough that "Loading..."
-    /// on its own gives no sense of whether it is progressing or hung (#28).
-    /// </summary>
-    [ObservableProperty]
-    private string _loadProgressText = string.Empty;
 
     // ── Execution console ───────────────────────────────────────────────────────
 
@@ -200,7 +180,7 @@ public partial class RestoreViewModel : ViewModelBase
     /// <summary>Pushes the cancellation sources' state onto the bound properties.</summary>
     private void RefreshCancelState()
     {
-        CanCancelLoad = _loadCancellation.CanCancel;
+        Inventory.CanCancelLoad = _loadCancellation.CanCancel;
 
         CanCancelQuery = _queryCancellation.CanCancel;
         IsCancelling = _loadCancellation.IsCancelling
@@ -343,23 +323,12 @@ public partial class RestoreViewModel : ViewModelBase
 
     /// <summary>
     /// Drops everything derived from a container's contents. Called when the container changes and
-    /// when a load is abandoned, so what is on screen always belongs to the container named above
-    /// it.
+    /// when a load is abandoned, so what is on screen always belongs to the container named above it.
     /// </summary>
     private void ClearLoadedBackups()
     {
-        _allBackups = [];
-        _allSets = [];
-        _dbSets = [];
+        Inventory.Clear();
 
-        BackupsLoaded = false;
-        DiscoveredServers = [];
-        DiscoveredDatabases = [];
-        SelectedServerName = null;
-        SelectedDatabaseName = null;
-
-        // Clearing the timeline drops its selection, which runs the selection handler below and
-        // clears the chain, the script, the verification results and the inventory findings.
         Timeline.Clear();
 
         // Disarm. An armed Execute that survives a container change is an armed Execute aimed at
@@ -423,18 +392,6 @@ public partial class RestoreViewModel : ViewModelBase
     public bool IsExecuting => Execution.IsExecuting;
 
     // Backup summary
-    [ObservableProperty]
-    private int _fullCount;
-
-    [ObservableProperty]
-    private int _diffCount;
-
-    [ObservableProperty]
-    private int _logCount;
-
-    [ObservableProperty]
-    private int _setCount;
-
     #endregion
 
     public RestoreViewModel(
@@ -458,6 +415,46 @@ public partial class RestoreViewModel : ViewModelBase
         // without it, running the execute path in a test appends real restore lines to the user's
         // actual log file, which is the same class of side effect this whole change is about.
         _log = log ?? App.Log;
+
+        Inventory = new BackupInventoryViewModel(blobService);
+
+        // The chain and the timeline are built from whatever the inventory currently holds, so a
+        // change there is the one signal that rebuilds them.
+        Inventory.WorkingSetChanged += ComputeAndDisplayRestorePoints;
+        Inventory.CancelStateChanged += RefreshCancelState;
+        Inventory.PropertyChanged += (_, e) =>
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(BackupInventoryViewModel.StatusMessage) when !Inventory.HasError:
+                    SetStatus(Inventory.StatusMessage);
+                    break;
+                case nameof(BackupInventoryViewModel.ErrorMessage) when Inventory.HasError:
+                    SetError(Inventory.ErrorMessage);
+                    break;
+                case nameof(BackupInventoryViewModel.IsBusy):
+                    IsBusy = Inventory.IsBusy;
+                    break;
+                case nameof(BackupInventoryViewModel.SelectedDatabaseName):
+                    // The target defaults to the source name, and the MOVE paths follow from it.
+                    // Both belong to the screen rather than to the inventory - they describe where
+                    // the restore is GOING, not what the container holds.
+                    if (!string.IsNullOrEmpty(Inventory.SelectedDatabaseName))
+                    {
+                        TargetDatabaseName = Inventory.SelectedDatabaseName!;
+                        AutoPopulateMoveDefaults();
+                    }
+                    RefreshSteps();
+                    RefreshCheckState();
+                    break;
+
+                case nameof(BackupInventoryViewModel.BackupsLoaded):
+                case nameof(BackupInventoryViewModel.SelectedServerName):
+                    RefreshSteps();
+                    RefreshCheckState();
+                    break;
+            }
+        };
 
         Execution = new RestoreExecutionViewModel(sqlService, _history, _log, _queryCancellation);
 
@@ -496,8 +493,8 @@ public partial class RestoreViewModel : ViewModelBase
             if (e.PropertyName is nameof(IsBusy) or nameof(TargetDatabaseName))
                 RefreshCheckState();
 
-            if (e.PropertyName is nameof(BackupsLoaded) or nameof(SelectedDatabaseName)
-                or nameof(SelectedServerName) or nameof(SelectedContainer)
+            if (e.PropertyName is nameof(Inventory.BackupsLoaded) or nameof(Inventory.SelectedDatabaseName)
+                or nameof(Inventory.SelectedServerName) or nameof(SelectedContainer)
                 or nameof(TargetDatabaseName))
                 RefreshSteps();
         };
@@ -551,80 +548,7 @@ public partial class RestoreViewModel : ViewModelBase
             SelectedContainer = Containers[0];
     }
 
-    partial void OnSelectedServerNameChanged(string? value)
-    {
-        if (_allSets.Count == 0) return;
 
-        // Compare the FULL server identity. Matching on the host alone made selecting
-        // SQLHOST\PROD also match SQLHOST\TEST, so the database list offered databases that
-        // only exist on the other instance.
-        var filtered = _allSets.Where(s => s.MatchesServer(value));
-
-        var dbs = filtered
-            .Where(s => !string.IsNullOrEmpty(s.DatabaseName))
-            .Select(s => s.DatabaseName!)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        DiscoveredDatabases = new ObservableCollection<string>(dbs);
-
-        // Nothing is chosen for the user. Picking the first database alphabetically is a decision
-        // about WHICH DATABASE TO RESTORE, made silently, and the rest of the screen then fills in
-        // around it as though somebody had asked for it - a chain, a restore point, a target name.
-        // On a screen whose last button overwrites a database, the app does not get to guess.
-    }
-
-    partial void OnSelectedDatabaseNameChanged(string? value) => RefreshSelectedDatabase(value);
-
-    /// <summary>
-    /// Rebuilds the working set and the restore points for the chosen database.
-    ///
-    /// Called on selection change AND at the end of every load. Relying on the change alone meant
-    /// a reload with the same server and database still selected - the natural thing to do after
-    /// taking a fresh backup - raised no property change at all, so the sets and the timeline kept
-    /// the PREVIOUS scan's contents and the new backup never appeared.
-    /// </summary>
-    private void RefreshSelectedDatabase(string? value)
-    {
-        // No database chosen: nothing to compute a chain from, so show nothing rather than
-        // everything. Returning early used to be safe because something was always selected.
-        // No database chosen: nothing to compute a chain from, so show nothing rather than
-        // everything. Returning early used to be safe because something was always selected.
-        if (string.IsNullOrEmpty(value) || _allSets.Count == 0)
-        {
-            _dbSets = [];
-            FullCount = DiffCount = LogCount = SetCount = 0;
-            Timeline.Clear();
-            return;
-        }
-
-        _dbSets = _allSets
-            .Where(s => string.Equals(s.DatabaseName, value, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        // Full server identity again - this is the filter that decides which sets reach
-        // BackupChainBuilder, so a host-only match let one instance's full pair with another
-        // instance's differentials and logs.
-        if (!string.IsNullOrEmpty(SelectedServerName))
-            _dbSets = _dbSets.Where(s => s.MatchesServer(SelectedServerName)).ToList();
-
-        FullCount = _dbSets.Count(s => s.Type == BackupType.Full);
-        DiffCount = _dbSets.Count(s => s.Type == BackupType.Differential);
-        LogCount = _dbSets.Count(s => s.Type == BackupType.TransactionLog);
-        SetCount = _dbSets.Count;
-
-        TargetDatabaseName = value;
-        AutoPopulateMoveDefaults();
-
-        ComputeAndDisplayRestorePoints();
-    }
-
-    [RelayCommand]
-    private void ToggleChainDetails()
-    {
-        ShowChainDetails = !ShowChainDetails;
-    }
 
     /// <summary>
     /// Everything downstream of the timeline: the chain, the script, the point-in-time window and
@@ -691,6 +615,7 @@ public partial class RestoreViewModel : ViewModelBase
         CopyHeaderOnlyCommandCommand.NotifyCanExecuteChanged();
     }
 
+    /// <summary>Lists the selected container. Everything it finds lives on the inventory seam.</summary>
     [RelayCommand]
     private async Task LoadBackupsAsync()
     {
@@ -700,87 +625,9 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        var ct = _loadCancellation.Begin();
-        IsBusy = true;
-        LoadProgressText = "Scanning container...";
-        RefreshCancelState();
-        ClearStatus();
-        try
-        {
-            // If a database is already chosen - a reload after taking a fresh backup, say - push
-            // that down to Azure as a prefix instead of walking the whole container and discarding
-            // most of it. Measured on a real 4,440-blob container: about 1,075 ms unscoped versus
-            // about 233 ms for one database (#28).
-            //
-            // The FIRST load has no selection yet and stays a full scan, which it has to be: the
-            // server and database lists are built from what it finds.
-            var scope = BuildListingScope();
-            var progress = new Progress<int>(n => LoadProgressText = $"Scanned {n:N0} blobs...");
-
-            _allBackups = await _blobService.ListBackupFilesAsync(SelectedContainer, scope, progress, ct);
-            _allSets = _blobService.GroupIntoBackupSets(
-                _allBackups, SelectedContainer?.BackupServerTimeZoneId);
-
-            var servers = _blobService.GetDiscoveredServers(_allBackups);
-            DiscoveredServers = new ObservableCollection<string>(servers);
-
-            var dbs = _blobService.GetDiscoveredDatabases(_allBackups);
-            DiscoveredDatabases = new ObservableCollection<string>(dbs);
-            BackupsLoaded = _allBackups.Count > 0;
-
-            // The lists are offered, not answered - and until one IS answered there is nothing to
-            // show. Falling back to every set in the container meant a timeline of every backup of
-            // every database on every server: on a real container that is thousands of points, all
-            // of them meaningless, because a restore chain only exists within one database.
-            RefreshSelectedDatabase(SelectedDatabaseName);
-
-            // Only when nothing above went wrong. Selecting the first server or database runs the
-            // whole filter-and-compute cascade, which can end in "no valid restore points found" -
-            // and painting a success line over that left an empty timeline with the status bar
-            // cheerfully reporting how many files had loaded. Found by the first ViewModel test.
-            if (!HasError)
-                SetStatus($"Loaded {_allBackups.Count} files in {_allSets.Count} backup set(s) across {dbs.Count} database(s).");
-        }
-        catch (OperationCanceledException)
-        {
-            // Asked for, not a failure. Nothing was written anywhere - listing is read-only - so
-            // there is nothing to explain beyond saying it stopped.
-            SetStatus("Loading cancelled.");
-            BackupsLoaded = false;
-        }
-        catch (Exception ex)
-        {
-            SetError($"Failed to load backups: {ex.Message}");
-            BackupsLoaded = false;
-        }
-        finally
-        {
-            _loadCancellation.End();
-            IsBusy = false;
-            LoadProgressText = string.Empty;
-            RefreshCancelState();
-        }
+        await Inventory.LoadAsync(SelectedContainer);
     }
 
-    /// <summary>
-    /// The scope to push down to Azure, or null to scan everything.
-    ///
-    /// Only offered when a database is chosen. A server on its own narrows far less and the
-    /// database list is built from the previous scan anyway, so scoping to a server alone would
-    /// mostly re-fetch what is already in memory.
-    /// </summary>
-    private BlobListingScope? BuildListingScope()
-    {
-        if (string.IsNullOrWhiteSpace(SelectedDatabaseName)) return null;
-
-        // ServerName here is the identity used in the PATH, which for an instance is the host
-        // part - "SRV01\PROD" lives under "SRV01". ServerIdentity knows how to split it.
-        var pathServer = string.IsNullOrWhiteSpace(SelectedServerName)
-            ? null
-            : SelectedServerName.Split('\\')[0];
-
-        return new BlobListingScope(pathServer, SelectedDatabaseName);
-    }
 
     /// <summary>
     /// Stops whichever server query is running - verify, validate, a metadata read, or a recovery
@@ -798,11 +645,12 @@ public partial class RestoreViewModel : ViewModelBase
 
     /// <summary>Stops an in-progress backup listing.</summary>
     [RelayCommand]
-    private void CancelLoad()
+    private void CancelLoad() => Inventory.CancelLoadCommand.Execute(null);
+
+    [RelayCommand]
+    private void ToggleChainDetails()
     {
-        _loadCancellation.Cancel();
-        RefreshCancelState();
-        SetStatus("Cancelling...");
+        ShowChainDetails = !ShowChainDetails;
     }
 
     /// <summary>
@@ -810,7 +658,7 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     private void ComputeAndDisplayRestorePoints()
     {
-        var points = _chainBuilder.ComputeRestorePoints(_dbSets);
+        var points = _chainBuilder.ComputeRestorePoints(Inventory.WorkingSet);
 
         // Inventory-level findings: backups that exist but can never be offered. These belong to
         // the discovered set rather than to any one chain, so they are held separately and survive
@@ -819,8 +667,8 @@ public partial class RestoreViewModel : ViewModelBase
         // ValidateInventory was written for #62 and then never called, so orphaned differentials,
         // orphaned logs and "no full backup at all" were being computed nowhere and shown nowhere.
         InventoryIssues = new ObservableCollection<ChainIssue>(
-            _chainValidator.ValidateInventory(_dbSets)
-                .Concat(_chainValidator.ValidateReachability(_dbSets, points)));
+            _chainValidator.ValidateInventory(Inventory.WorkingSet)
+                .Concat(_chainValidator.ValidateReachability(Inventory.WorkingSet, points)));
         HasInventoryIssues = InventoryIssues.Count > 0;
 
         Timeline.Load(points);
@@ -912,7 +760,7 @@ public partial class RestoreViewModel : ViewModelBase
         }
 
         var parts = new List<string>();
-        parts.Add($"Restore '{SelectedDatabaseName}' as '{TargetDatabaseName}'");
+        parts.Add($"Restore '{Inventory.SelectedDatabaseName}' as '{TargetDatabaseName}'");
         parts.Add($"using {RestoreChain.Summary} ({RestoreChain.FileCount} files total).");
 
         if (PointInTime.Effective is DateTime stopAt)
@@ -960,7 +808,7 @@ public partial class RestoreViewModel : ViewModelBase
         // people out of the step before they could use them.
         Steps.Report(
             Steps.Source,
-            BackupsLoaded && !string.IsNullOrWhiteSpace(SelectedDatabaseName),
+            Inventory.BackupsLoaded && !string.IsNullOrWhiteSpace(Inventory.SelectedDatabaseName),
             DescribeSource());
 
         // Described, and confirmed by the user rather than by a click. Choosing a restore point is
@@ -985,11 +833,11 @@ public partial class RestoreViewModel : ViewModelBase
         if (SelectedContainer == null) return string.Empty;
 
         var parts = new List<string> { SelectedContainer.Name };
-        if (!string.IsNullOrWhiteSpace(SelectedDatabaseName))
+        if (!string.IsNullOrWhiteSpace(Inventory.SelectedDatabaseName))
         {
-            parts.Add(string.IsNullOrWhiteSpace(SelectedServerName)
-                ? SelectedDatabaseName!
-                : $"{SelectedDatabaseName} on {SelectedServerName}");
+            parts.Add(string.IsNullOrWhiteSpace(Inventory.SelectedServerName)
+                ? Inventory.SelectedDatabaseName!
+                : $"{Inventory.SelectedDatabaseName} on {Inventory.SelectedServerName}");
         }
 
         return string.Join(", ", parts);
@@ -1398,7 +1246,7 @@ public partial class RestoreViewModel : ViewModelBase
         {
             // Guessed logical names. Wrong for a renamed database or one with secondary files,
             // which is what Get file names exists to fix.
-            var sourceDbName = SelectedDatabaseName ?? TargetDatabaseName;
+            var sourceDbName = Inventory.SelectedDatabaseName ?? TargetDatabaseName;
             fileMoves.Add(new FileMoveOption
             {
                 LogicalName = sourceDbName,
@@ -1691,7 +1539,7 @@ public partial class RestoreViewModel : ViewModelBase
                 server,
                 GeneratedScript,
                 TargetDatabaseName,
-                SelectedDatabaseName,
+                Inventory.SelectedDatabaseName,
                 SelectedContainer?.Name,
                 RestoreChain?.Summary ?? "no chain",
                 Timeline.SelectedPoint?.Timestamp,

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -116,7 +116,7 @@
 
                     <!-- Server + Database selectors -->
                     <Grid Margin="0,12,0,0"
-                          Visibility="{Binding BackupsLoaded, Converter={StaticResource BoolToVis}}">
+                          Visibility="{Binding Inventory.BackupsLoaded, Converter={StaticResource BoolToVis}}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
@@ -124,22 +124,22 @@
 
                         <StackPanel Grid.Column="0" Margin="0,0,12,0">
                             <TextBlock Text="SERVER / INSTANCE" Style="{StaticResource LabelText}" />
-                            <ComboBox ItemsSource="{Binding DiscoveredServers}"
-                                      SelectedItem="{Binding SelectedServerName}"
+                            <ComboBox ItemsSource="{Binding Inventory.DiscoveredServers}"
+                                      SelectedItem="{Binding Inventory.SelectedServerName}"
                                       Style="{StaticResource DarkComboBox}" />
                         </StackPanel>
 
                         <StackPanel Grid.Column="1" Margin="0,0,12,0">
                             <TextBlock Text="DATABASE" Style="{StaticResource LabelText}" />
-                            <ComboBox ItemsSource="{Binding DiscoveredDatabases}"
-                                      SelectedItem="{Binding SelectedDatabaseName}"
+                            <ComboBox ItemsSource="{Binding Inventory.DiscoveredDatabases}"
+                                      SelectedItem="{Binding Inventory.SelectedDatabaseName}"
                                       Style="{StaticResource DarkComboBox}" />
                         </StackPanel>
                     </Grid>
 
                     <!-- Backup set summary (set counts, accounting for striping) -->
                     <Grid Margin="0,16,0,0"
-                          Visibility="{Binding BackupsLoaded, Converter={StaticResource BoolToVis}}">
+                          Visibility="{Binding Inventory.BackupsLoaded, Converter={StaticResource BoolToVis}}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
@@ -149,25 +149,25 @@
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Orientation="Horizontal">
                             <Border Background="{DynamicResource AccentBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
-                                <TextBlock Text="{Binding FullCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
+                                <TextBlock Text="{Binding Inventory.FullCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Full Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
                             <Border Background="{DynamicResource WarningBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
-                                <TextBlock Text="{Binding DiffCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
+                                <TextBlock Text="{Binding Inventory.DiffCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Diff Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <StackPanel Grid.Column="2" Orientation="Horizontal">
                             <Border Background="{DynamicResource SuccessBrush}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0">
-                                <TextBlock Text="{Binding LogCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
+                                <TextBlock Text="{Binding Inventory.LogCount}" Foreground="{StaticResource BadgeTextBrush}" FontWeight="Bold" FontSize="12" />
                             </Border>
                             <TextBlock Text="Log Sets" Style="{StaticResource BodyText}" VerticalAlignment="Center" />
                         </StackPanel>
                         <TextBlock Grid.Column="3" Style="{StaticResource SecondaryText}"
                                    VerticalAlignment="Center" Margin="8,0">
-                            <Run Text="{Binding SetCount, Mode=OneWay}" FontWeight="SemiBold" />
+                            <Run Text="{Binding Inventory.SetCount, Mode=OneWay}" FontWeight="SemiBold" />
                             <Run Text=" total sets" />
                         </TextBlock>
                         <TextBlock Grid.Column="4" Text="{Binding Timeline.WindowText}"
@@ -1365,7 +1365,7 @@
                                 <Run Text=" From:" />
                                 <Run Text="{Binding SelectedContainer.Name, Mode=OneWay}" FontWeight="SemiBold" />
                                 <Run Text="/" />
-                                <Run Text="{Binding SelectedDatabaseName, Mode=OneWay}" FontWeight="SemiBold" />
+                                <Run Text="{Binding Inventory.SelectedDatabaseName, Mode=OneWay}" FontWeight="SemiBold" />
                                 <Run Text=". This operation cannot be undone." Foreground="{DynamicResource ErrorBrush}" />
                             </TextBlock>
                         </StackPanel>
@@ -1583,14 +1583,14 @@
                     Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}" Padding="20">
                 <StackPanel HorizontalAlignment="Center">
                     <TextBlock Text="Loading..." Style="{StaticResource BodyText}" HorizontalAlignment="Center" />
-                    <TextBlock Text="{Binding LoadProgressText}"
+                    <TextBlock Text="{Binding Inventory.LoadProgressText}"
                                Style="{StaticResource SecondaryText}"
                                HorizontalAlignment="Center"
                                Margin="0,4,0,0" />
                     <Button Content="Cancel"
                             Style="{StaticResource SecondaryButton}"
                             Command="{Binding CancelLoadCommand}"
-                            Visibility="{Binding CanCancelLoad, Converter={StaticResource BoolToVis}}"
+                            Visibility="{Binding Inventory.CanCancelLoad, Converter={StaticResource BoolToVis}}"
                             Padding="10,6" Margin="0,10,0,0"
                             HorizontalAlignment="Center" />
                 </StackPanel>


### PR DESCRIPTION
@
The **last seam** of #115. `RestoreViewModel` **2,572 → 1,578 lines** across the six. **991 passing** (1,015 total).

`BackupInventoryViewModel` owns the listing, what was discovered in it, which server and database are being looked at, the counts, and the working set a chain is built from.

## Its point is not the line count

The loaded backups now carry the container they came **from**, as a field, instead of everything on the screen assuming that whatever is loaded belongs to whatever is selected above it.

That assumption has produced two real bugs already:

- **#112** — changing the container left the previous ones chain and script armed and executable, against blob URLs nobody was looking at.
- **The preselection removal** — with nothing selected the working set fell back to *every* set in the container, drawing a timeline of thousands of points that could never form a chain.

## And a third, found while doing it

Removing the parents copies of `SelectedDatabaseName` and the rest was not tidying. With the inventory holding the live values, the parents twins still **bound, compiled, and stayed null forever** — and `BuildFileMoves` reads `SelectedDatabaseName` to name the logical files. So the `MOVE` clause silently started naming the **target** database instead of the source:

```
expected: MOVE NMyDb          TO NE:\SQLData\MyDb_Restored.mdf
actual:   MOVE NMyDb_Restored TO NE:\SQLData\MyDb_Restored.mdf
```

A restore that moves the wrong logical name fails outright — but it is the same silent-wrong-value shape as #110, and it was caught by a test rather than by reading. Two properties with the same name and different lifetimes is exactly what this seam removes.

## Tests

Six on the seam directly: that a load records its container, that clearing forgets it, that nothing is chosen and nothing worked from until it is, that the working-set change is announced so the chain can follow, and that a reload with a database chosen scopes the listing rather than walking the container again (#28).

All 89 end-to-end restore, script, XAML-load and theme tests still pass.

## #115 is finished with this

All six seams done. What is left of `RestoreViewModel` is the coordinator the issue predicted: the chain, the script, and the wiring between six children.
@