### PR TITLE
Measure the header read (#130), and read backup history from msdb (#149)

### DIFF
--- a/src/NineLives.Tests/BackupHistoryTests.cs
+++ b/src/NineLives.Tests/BackupHistoryTests.cs
@@ -1,0 +1,136 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Reading what an instance recorded backing up, from msdb (#149).
+///
+/// The first half of restoring from a shared backup location: there is no container to list, but
+/// the instance that took the backups knows what it took, when, to which files, and at which LSNs.
+///
+/// It also answers #130 for this source without any of that issue's cost. Chains from blob storage
+/// infer type and database from the path and assemble by timestamp, consulting headers only on
+/// demand because each one is a round trip. Here the authoritative values are already in a table.
+/// </summary>
+public class BackupHistoryTests
+{
+    [Theory]
+    [InlineData("D", BackupType.Full)]
+    [InlineData("I", BackupType.Differential)]
+    [InlineData("L", BackupType.TransactionLog)]
+    public void TheThreeChainTypesAreRecognised(string msdb, BackupType expected)
+        => Assert.Equal(expected, SqlServerService.TypeFromMsdb(msdb));
+
+    /// <summary>
+    /// File, filegroup and partial backups are not chain members this app restores. Reporting them
+    /// as Unknown is the honest answer; mapping them onto Full because the letter is close would
+    /// put a backup in a chain that cannot restore it.
+    /// </summary>
+    [Theory]
+    [InlineData("F")]
+    [InlineData("G")]
+    [InlineData("P")]
+    [InlineData("Q")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void EverythingElseIsUnknownRatherThanGuessedAt(string? msdb)
+        => Assert.Equal(BackupType.Unknown, SqlServerService.TypeFromMsdb(msdb));
+
+    /// <summary>
+    /// msdb keeps history for backups whose files were deleted, archived or pruned by a retention
+    /// job long ago. "It is in the history" and "it is on disk" are different questions - which is
+    /// why #149 verifies the files separately, and on the target.
+    /// </summary>
+    [Fact]
+    public void AnEntryWithNoFilesKnowsItCannotBeRestoredFrom()
+    {
+        var entry = new BackupHistoryEntry { DatabaseName = "MyDb", Type = BackupType.Full };
+
+        Assert.False(entry.HasFiles);
+    }
+
+    [Fact]
+    public void AStripedBackupKeepsEveryFile()
+    {
+        var entry = new BackupHistoryEntry
+        {
+            DatabaseName = "MyDb",
+            Type = BackupType.Full,
+            Files = [@"\nas01\sql\MyDb_1.bak", @"\nas01\sql\MyDb_2.bak", @"\nas01\sql\MyDb_3.bak"]
+        };
+
+        Assert.True(entry.HasFiles);
+        Assert.Equal(3, entry.Files.Count);
+    }
+
+    /// <summary>
+    /// The relationship that makes this worth doing: a differential's DatabaseBackupLSN equals the
+    /// CheckpointLSN of the full it belongs to. Timestamps only suggest that; this settles it, and
+    /// it is the check #130 wants headers for - already answered here by the source instance.
+    /// </summary>
+    [Fact]
+    public void ADifferentialPointsAtItsFullByLsn()
+    {
+        var full = new BackupHistoryEntry
+        {
+            DatabaseName = "MyDb", Type = BackupType.Full, CheckpointLsn = 37000000012300001m
+        };
+        var diff = new BackupHistoryEntry
+        {
+            DatabaseName = "MyDb", Type = BackupType.Differential, DatabaseBackupLsn = 37000000012300001m
+        };
+        var strayDiff = new BackupHistoryEntry
+        {
+            DatabaseName = "MyDb", Type = BackupType.Differential, DatabaseBackupLsn = 99000000099900001m
+        };
+
+        Assert.Equal(full.CheckpointLsn, diff.DatabaseBackupLsn);
+        Assert.NotEqual(full.CheckpointLsn, strayDiff.DatabaseBackupLsn);
+    }
+
+    /// <summary>
+    /// The cap is a number somebody can read, not a silent truncation. Returning "the newest 500"
+    /// while looking like "everything" is how a backup gets concluded missing when it is simply
+    /// older than the limit.
+    /// </summary>
+    [Fact]
+    public void TheHistoryLimitIsStatedRatherThanImplied()
+        => Assert.True(SqlServerService.BackupHistoryLimit > 0);
+
+    // ── against a real instance ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Live proof that the query parses and its columns come back as expected, against whatever
+    /// history the instance happens to hold - including none, which is a valid answer and must not
+    /// throw. Skipped unless NINELIVES_TEST_SQL is set.
+    ///
+    /// Read-only: it touches nothing, creates nothing and takes no backups.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task TheHistoryQueryRunsAgainstARealInstance()
+    {
+        var service = new SqlServerService(new FakeCredentialStore());
+        var server = new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "test",
+            ServerName = SqlExecutionFailureTests.TestServerName!,
+            AuthMode = AuthMode.WindowsAuth,
+            TrustServerCertificate = true
+        };
+
+        var history = await service.ReadBackupHistoryAsync(server);
+
+        Assert.NotNull(history);
+        Assert.All(history, e =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(e.DatabaseName));
+            Assert.NotEqual(default, e.StartedAt);
+
+            // Every file this app would restore from is a real path, in stripe order.
+            Assert.All(e.Files, f => Assert.False(string.IsNullOrWhiteSpace(f)));
+        });
+    }
+}

--- a/src/NineLives.Tests/HeaderTimingTests.cs
+++ b/src/NineLives.Tests/HeaderTimingTests.cs
@@ -1,0 +1,38 @@
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The measurement #130 asks for before anything is designed around it.
+///
+/// That issue proposes building chains from backup headers rather than filenames, and every part
+/// of its suggested shape rests on an assumption nobody has tested: that one HEADERONLY read is
+/// slow enough that reading a whole container is out of the question. It even says so - "if it
+/// turns out to be ~20ms, the whole question changes shape".
+///
+/// Check chain already does exactly one read per chain member against real backups, so the number
+/// costs nothing to collect there.
+/// </summary>
+public class HeaderTimingTests
+{
+    /// <summary>
+    /// Per FILE, not per set. A striped set is several reads, and the question is what reading
+    /// every file in a container would cost.
+    /// </summary>
+    [Fact]
+    public void TheCostIsReportedPerFileBecauseThatIsWhatWouldScale()
+    {
+        var text = RestoreViewModel.DescribeHeaderTiming(
+            setCount: 3, fileCount: 6, elapsed: TimeSpan.FromMilliseconds(1200));
+
+        Assert.Contains("6 file(s)", text);
+        Assert.Contains("3 set(s)", text);
+        Assert.Contains("200 ms per file", text);
+    }
+
+    [Fact]
+    public void NothingReadIsNothingToReport()
+        => Assert.Equal(string.Empty,
+            RestoreViewModel.DescribeHeaderTiming(0, 0, TimeSpan.FromSeconds(1)));
+}

--- a/src/NineLives/Models/BackupHistoryEntry.cs
+++ b/src/NineLives/Models/BackupHistoryEntry.cs
@@ -1,0 +1,75 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// One backup as the source instance recorded it in <c>msdb</c>, with the files it was written to.
+///
+/// The first piece of #149: restores from a shared backup location, where the backups were never in
+/// blob storage and there is no container to list. What there IS, on the instance that took them,
+/// is a complete record of what was backed up, when, to which files, and - crucially - the LSNs.
+///
+/// That also answers #130 for this source without any of its cost. Chains from blob storage are
+/// built by inferring type and database from the path and assembling by timestamp, with headers
+/// consulted only on demand because reading them means a round trip per file. Here the authoritative
+/// values are already in a table: no filename convention to parse, no header to read, no guessing.
+/// </summary>
+public sealed class BackupHistoryEntry
+{
+    public string DatabaseName { get; init; } = string.Empty;
+
+    public BackupType Type { get; init; } = BackupType.Unknown;
+
+    /// <summary>When the backup STARTED, which is what the source instance orders history by.</summary>
+    public DateTime StartedAt { get; init; }
+
+    public DateTime FinishedAt { get; init; }
+
+    /// <summary>
+    /// A copy-only full does not reset the differential base, so it can never be the base for a
+    /// differential restore - the same rule the blob path already applies (#49).
+    /// </summary>
+    public bool IsCopyOnly { get; init; }
+
+    // ── the LSNs, which are the whole point ─────────────────────────────────────
+
+    /// <summary>The first LSN in this backup.</summary>
+    public decimal? FirstLsn { get; init; }
+
+    /// <summary>The last LSN in this backup.</summary>
+    public decimal? LastLsn { get; init; }
+
+    /// <summary>The checkpoint a full was taken at. A differential's DatabaseBackupLsn matches it.</summary>
+    public decimal? CheckpointLsn { get; init; }
+
+    /// <summary>
+    /// Which full this backup belongs to. Matching it against a full's <see cref="CheckpointLsn"/>
+    /// is the definitive test of whether a differential belongs to that full - timestamps only
+    /// suggest it.
+    /// </summary>
+    public decimal? DatabaseBackupLsn { get; init; }
+
+    /// <summary>
+    /// Every file this backup was written to, in stripe order.
+    ///
+    /// More than one means a striped set, and all of them are needed: a restore given three of four
+    /// stripes fails, and #62 was written because a missing stripe used to be discovered at restore
+    /// time rather than before it.
+    /// </summary>
+    public IReadOnlyList<string> Files { get; init; } = [];
+
+    public long? BackupSizeBytes { get; init; }
+
+    /// <summary>The server that took it, as msdb recorded it.</summary>
+    public string? ServerName { get; init; }
+
+    /// <summary>
+    /// A record with no files cannot be restored from, whatever else it says.
+    ///
+    /// msdb keeps history for backups whose files have since been deleted, archived or pruned by a
+    /// retention job, so "it is in the history" and "it is on disk" are different questions - which
+    /// is exactly why #149 verifies the files separately, on the target, before offering them.
+    /// </summary>
+    public bool HasFiles => Files.Count > 0;
+
+    public override string ToString() =>
+        $"{Type} of {DatabaseName} at {StartedAt:yyyy-MM-dd HH:mm:ss} ({Files.Count} file(s))";
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -232,6 +232,138 @@ public class SqlServerService : ISqlServerService
         return databases;
     }
 
+    /// <summary>
+    /// What this instance recorded backing up, read from msdb (#149).
+    ///
+    /// The first half of restoring from a shared backup location: there is no container to list,
+    /// but the instance that took the backups knows exactly what it took, when, to which files and
+    /// at which LSNs.
+    ///
+    /// Ordered newest first, and capped, because msdb on a busy instance holds years of history and
+    /// a restore is almost always from the recent end of it. A cap is honest about what it returns -
+    /// see BackupHistoryLimit.
+    ///
+    /// It reports what msdb SAYS. Whether those files still exist is a different question, asked
+    /// separately and on the target, because msdb keeps history for backups whose files were
+    /// deleted, archived or pruned by a retention job long ago.
+    /// </summary>
+    public async Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
+        ServerConnection server, string? databaseName = null, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+
+        await using var cmd = conn.CreateCommand();
+
+        // backupset holds one row per backup; backupmediafamily one per FILE it was written to, so
+        // a striped backup is several rows and family_sequence_number is the stripe order. Grouping
+        // in the app rather than with STRING_AGG keeps this readable on every supported version.
+        cmd.CommandText = $@"
+            SELECT TOP ({BackupHistoryLimit})
+                   bs.backup_set_id,
+                   bs.database_name,
+                   bs.type,
+                   bs.backup_start_date,
+                   bs.backup_finish_date,
+                   bs.is_copy_only,
+                   bs.first_lsn,
+                   bs.last_lsn,
+                   bs.checkpoint_lsn,
+                   bs.database_backup_lsn,
+                   bs.backup_size,
+                   bs.server_name,
+                   bmf.physical_device_name,
+                   bmf.family_sequence_number
+            FROM msdb.dbo.backupset AS bs
+            JOIN msdb.dbo.backupmediafamily AS bmf
+              ON bmf.media_set_id = bs.media_set_id
+            WHERE (@database IS NULL OR bs.database_name = @database)
+              AND bmf.device_type IN (2, 102)   -- disk, including logical disk devices
+            ORDER BY bs.backup_start_date DESC, bs.backup_set_id DESC, bmf.family_sequence_number";
+
+        cmd.Parameters.AddWithValue("@database", (object?)databaseName ?? DBNull.Value);
+
+        // One row per FILE, gathered back into one entry per backup set.
+        var files = new Dictionary<int, List<(int Sequence, string Path)>>();
+        var sets = new Dictionary<int, BackupHistoryEntry>();
+        var order = new List<int>();
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var id = reader.GetInt32(0);
+
+            if (!sets.ContainsKey(id))
+            {
+                order.Add(id);
+                sets[id] = new BackupHistoryEntry
+                {
+                    DatabaseName = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+                    Type = TypeFromMsdb(reader.IsDBNull(2) ? null : reader.GetString(2)),
+                    StartedAt = reader.GetDateTime(3),
+                    FinishedAt = reader.IsDBNull(4) ? reader.GetDateTime(3) : reader.GetDateTime(4),
+                    IsCopyOnly = !reader.IsDBNull(5) && reader.GetBoolean(5),
+                    FirstLsn = reader.IsDBNull(6) ? null : reader.GetDecimal(6),
+                    LastLsn = reader.IsDBNull(7) ? null : reader.GetDecimal(7),
+                    CheckpointLsn = reader.IsDBNull(8) ? null : reader.GetDecimal(8),
+                    DatabaseBackupLsn = reader.IsDBNull(9) ? null : reader.GetDecimal(9),
+                    BackupSizeBytes = reader.IsDBNull(10) ? null : (long)reader.GetDecimal(10),
+                    ServerName = reader.IsDBNull(11) ? null : reader.GetString(11)
+                };
+                files[id] = [];
+            }
+
+            // family_sequence_number is tinyint, not int - GetInt32 throws an InvalidCastException
+            // on it. Found by running this against a real instance rather than by reading the docs.
+            if (!reader.IsDBNull(12))
+                files[id].Add((
+                    reader.IsDBNull(13) ? 1 : Convert.ToInt32(reader.GetValue(13)),
+                    reader.GetString(12)));
+        }
+
+        return order
+            .Select(id => CloneWithFiles(sets[id],
+                files[id].OrderBy(f => f.Sequence).Select(f => f.Path).ToList()))
+            .ToList();
+    }
+
+    /// <summary>
+    /// How far back to read. msdb on a busy instance holds years of history, and a restore is
+    /// almost always from the recent end of it - but the number is stated here rather than left
+    /// implicit, because silently returning "the newest 500" while looking like "everything" is
+    /// how somebody concludes a backup is missing when it is simply older than the cap.
+    /// </summary>
+    public const int BackupHistoryLimit = 500;
+
+    private static BackupHistoryEntry CloneWithFiles(BackupHistoryEntry entry, List<string> files) => new()
+    {
+        DatabaseName = entry.DatabaseName,
+        Type = entry.Type,
+        StartedAt = entry.StartedAt,
+        FinishedAt = entry.FinishedAt,
+        IsCopyOnly = entry.IsCopyOnly,
+        FirstLsn = entry.FirstLsn,
+        LastLsn = entry.LastLsn,
+        CheckpointLsn = entry.CheckpointLsn,
+        DatabaseBackupLsn = entry.DatabaseBackupLsn,
+        BackupSizeBytes = entry.BackupSizeBytes,
+        ServerName = entry.ServerName,
+        Files = files
+    };
+
+    /// <summary>
+    /// msdb's one-letter backup type. D is a full, I a differential, L a log; the rest - file and
+    /// filegroup backups, partial backups - are not chain members this app restores, and are
+    /// reported as Unknown rather than guessed at.
+    /// </summary>
+    internal static BackupType TypeFromMsdb(string? type) => type switch
+    {
+        "D" => BackupType.Full,
+        "I" => BackupType.Differential,
+        "L" => BackupType.TransactionLog,
+        _ => BackupType.Unknown
+    };
+
     // These two read backup metadata off blob URLs, and neither takes a credential name any more.
     //
     // They used to, and passing one could never work. SQL Server rejects WITH CREDENTIAL against a

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -654,6 +654,28 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// What one header read cost, in the terms #130 needs to settle its design.
+    ///
+    /// Kept as a property as well as a log line so it can be read off the screen without going to
+    /// the file - the point of measuring is that somebody looks at the number.
+    /// </summary>
+    [ObservableProperty]
+    private string _headerReadTiming = string.Empty;
+
+    /// <summary>
+    /// Per FILE rather than per set: a striped set is several reads, and the question #130 asks is
+    /// what it would cost to read every file in a container.
+    /// </summary>
+    internal static string DescribeHeaderTiming(int setCount, int fileCount, TimeSpan elapsed)
+    {
+        if (fileCount == 0) return string.Empty;
+
+        var perFile = elapsed.TotalMilliseconds / fileCount;
+        return $"{fileCount} file(s) in {setCount} set(s) took {elapsed.TotalMilliseconds:N0} ms " +
+               $"({perFile:N0} ms per file).";
+    }
+
+    /// <summary>
     /// Works out which points this database can be restored to, and hands them to the timeline.
     /// </summary>
     private void ComputeAndDisplayRestorePoints()
@@ -896,6 +918,15 @@ public partial class RestoreViewModel : ViewModelBase
         try
         {
             var headers = new List<ChainHeader>();
+
+            // Timed, because #130 turns on a number nobody has: how long ONE header read actually
+            // costs against a real container. Building chains from headers rather than filenames is
+            // only sensible if that number is small, and the whole design in that issue is written
+            // around an assumption that it is not. This is the cheapest place to find out - the
+            // work is already being done, one read per chain member, against real backups.
+            var headerTimer = System.Diagnostics.Stopwatch.StartNew();
+            var filesRead = 0;
+
             foreach (var set in RestoreChain.AllSets)
             {
                 ct.ThrowIfCancellationRequested();
@@ -905,6 +936,7 @@ public partial class RestoreViewModel : ViewModelBase
                 {
                     var header = await _sqlService.RestoreHeaderOnlyMultiAsync(ConnectedServer, urls, ct);
                     headers.Add(new ChainHeader(set, header));
+                    filesRead += urls.Count;
                 }
                 catch (OperationCanceledException)
                 {
@@ -920,12 +952,17 @@ public partial class RestoreViewModel : ViewModelBase
                 }
             }
 
+            headerTimer.Stop();
+            HeaderReadTiming = DescribeHeaderTiming(headers.Count, filesRead, headerTimer.Elapsed);
+            _log.Info($"[headeronly] {HeaderReadTiming}");
+
             UpdateChainIssues(RestoreChain, headers);
             ChainLsnVerified = true;
 
             SetStatus(HasChainIssues
                 ? $"Chain check found problems - see the panel above."
-                : $"Chain checked: {headers.Count} header(s) read, the LSN chain is unbroken.");
+                : $"Chain checked: {headers.Count} header(s) read, the LSN chain is unbroken. " +
+                  HeaderReadTiming);
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
@
Two foundations, one for each issue, chosen because both turn on the same question: **where the authoritative answer about a backup comes from**. **1,006 passing** (1,031 total).

## #130: the measurement it asks for, before anything is designed

That issue opens with *"Measure first"* and ends *"worth doing before building anything"* — because every part of its suggested shape rests on one HEADERONLY read being slow, and it says so outright: *"if it turns out to be ~20ms, option 2 could run automatically... and the whole question changes shape."*

**Check chain already does exactly one read per chain member, against real backups**, so the number costs nothing to collect there. It is now reported **per file** — a striped set is several reads, and the question is what reading a whole container would cost — on screen next to the result and in the log.

**Nothing is designed around it yet. That is deliberate**: the number needs to come off a real container, which needs your storage account and your SQL Server. Run Check chain once and the answer will be in the status line and the log, and #130 can then be decided on evidence rather than on the assumption in its own text.

## #149: the first half — what the source instance already knows

For a shared backup location there is no container to list. But the instance that took the backups knows exactly what it took, when, to which files, and **at which LSNs** — `msdb.dbo.backupset` joined to `backupmediafamily`.

That also answers #130 *for this source* without any of its cost: no filename convention to parse and no header to read, because the authoritative values are already in a table. A differentials `DatabaseBackupLSN` against a fulls `CheckpointLSN` is the definitive test of whether they belong together, and it arrives free.

Deliberate in the design:

- **One row per file, gathered into one entry per set, in stripe order.** A restore given three of four stripes fails, and #62 exists because a missing stripe used to surface at restore time.
- **The history cap is a named constant, not a silent `TOP`.** Returning "the newest 500" while looking like "everything" is how somebody concludes a backup is missing when it is only older than the limit.
- **File, filegroup and partial backups report as `Unknown`** rather than being mapped onto the nearest chain type — putting one in a chain that cannot restore it would be worse than admitting it is not a chain member.
- **It reports what msdb SAYS.** Whether the files still exist is a different question, asked separately and on the target, because msdb keeps history for backups deleted, archived or pruned long ago.

## The live test earned its place immediately

`family_sequence_number` is **tinyint**, so `GetInt32` threw an `InvalidCastException` on the first real row. Found by running it against SQL Express rather than by reading documentation. The test is read-only — it creates nothing and takes no backups — and skipped unless `NINELIVES_TEST_SQL` is set.

## Not in this PR

The rest of #149: the source→target workflow, declaring the shared path, verifying the files **on the target** with `RESTORE HEADERONLY FROM DISK` as the SQL service account, and `FROM DISK` script generation. Those need a two-host share to test properly, which is not something I can stand up here.
@