### PR TITLE
Generate FROM DISK restores for a shared backup location (#149)

### DIFF
--- a/src/NineLives.Tests/FromDiskRestoreScriptTests.cs
+++ b/src/NineLives.Tests/FromDiskRestoreScriptTests.cs
@@ -1,0 +1,188 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Restoring from a shared backup location produces a FROM DISK script (#149).
+///
+/// The interesting property is not that DISK appears - it is that everything else is identical.
+/// WITH REPLACE, NORECOVERY on every step but the last, STOPAT on every log rather than only the
+/// final one, the MOVE clauses, disconnecting sessions: all of it is the same logic that has been
+/// through #110, #45 and #44, reached through an adapter rather than reimplemented.
+/// </summary>
+public class FromDiskRestoreScriptTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupHistoryEntry Entry(BackupType type, DateTime at, params string[] files) => new()
+    {
+        DatabaseName = "MyDb",
+        ServerName = "SRV01",
+        Type = type,
+        StartedAt = at,
+        FinishedAt = at.AddMinutes(2),
+        CheckpointLsn = 100,
+        LastLsn = 200,
+        BackupSizeBytes = 5_000_000,
+        Files = files
+    };
+
+    private static string Generate(BackupHistoryChain chain, RestoreOptions? options = null)
+        => new RestoreScriptGenerator().Generate(
+            BackupHistoryChainAdapter.ToRestorableChain(chain, options?.StopAt),
+            options ?? new RestoreOptions { TargetDatabaseName = "MyDb_Restored" });
+
+    [Fact]
+    public void AFullFromAShareIsRestoredFromDisk()
+    {
+        var chain = new BackupHistoryChain(
+            Entry(BackupType.Full, T0, @"\\nas01\sql\MyDb_full.bak"), null, []);
+
+        var script = Generate(chain);
+
+        Assert.Contains(@"DISK = N'\\nas01\sql\MyDb_full.bak'", script);
+        Assert.DoesNotContain("URL =", script);
+    }
+
+    /// <summary>
+    /// A UNC path is not a URI. Percent-encoding one - which is right for a blob URL - would
+    /// produce a path SQL Server cannot open.
+    /// </summary>
+    [Fact]
+    public void APathWithSpacesIsNotUrlEncoded()
+    {
+        var chain = new BackupHistoryChain(
+            Entry(BackupType.Full, T0, @"\\nas01\SQL Backups\My Db\full backup.bak"), null, []);
+
+        var script = Generate(chain);
+
+        Assert.Contains(@"DISK = N'\\nas01\SQL Backups\My Db\full backup.bak'", script);
+        Assert.DoesNotContain("%20", script);
+    }
+
+    [Fact]
+    public void EveryStripeIsNamedInOrder()
+    {
+        var chain = new BackupHistoryChain(
+            Entry(BackupType.Full, T0, @"\\nas01\sql\p1.bak", @"\\nas01\sql\p2.bak", @"\\nas01\sql\p3.bak"),
+            null, []);
+
+        var script = Generate(chain);
+
+        var one = script.IndexOf(@"p1.bak", StringComparison.Ordinal);
+        var two = script.IndexOf(@"p2.bak", StringComparison.Ordinal);
+        var three = script.IndexOf(@"p3.bak", StringComparison.Ordinal);
+
+        Assert.True(one > 0 && two > one && three > two, "stripes must be named in order");
+    }
+
+    /// <summary>
+    /// The whole point of the adapter: a chain from a share gets the restore semantics the blob
+    /// path already has, rather than a second implementation of them.
+    /// </summary>
+    [Fact]
+    public void EveryStepButTheLastLeavesTheDatabaseRestoring()
+    {
+        var chain = new BackupHistoryChain(
+            Entry(BackupType.Full, T0, @"\\nas01\sql\full.bak"),
+            Entry(BackupType.Differential, T0.AddHours(1), @"\\nas01\sql\diff.bak"),
+            [Entry(BackupType.TransactionLog, T0.AddHours(2), @"\\nas01\sql\log1.trn"),
+             Entry(BackupType.TransactionLog, T0.AddHours(3), @"\\nas01\sql\log2.trn")]);
+
+        var script = Generate(chain);
+
+        // Three NORECOVERY steps - full, differential, first log - then RECOVERY on the last.
+        Assert.Equal(3, System.Text.RegularExpressions.Regex.Matches(script, "NORECOVERY").Count);
+        Assert.Contains("RECOVERY,", script);
+        Assert.Contains("RESTORE LOG", script);
+    }
+
+    [Fact]
+    public void PointInTimePutsStopAtOnEveryLog()
+    {
+        var chain = new BackupHistoryChain(
+            Entry(BackupType.Full, T0, @"\\nas01\sql\full.bak"),
+            null,
+            [Entry(BackupType.TransactionLog, T0.AddHours(1), @"\\nas01\sql\log1.trn"),
+             Entry(BackupType.TransactionLog, T0.AddHours(2), @"\\nas01\sql\log2.trn")]);
+
+        var script = Generate(chain, new RestoreOptions
+        {
+            TargetDatabaseName = "MyDb_Restored",
+            StopAt = T0.AddHours(1).AddMinutes(30)
+        });
+
+        // On EVERY log, not just the last: a log restored without it rolls past the target and the
+        // ones after it then have nothing to apply.
+        Assert.Equal(2, System.Text.RegularExpressions.Regex.Matches(script, "STOPAT").Count);
+    }
+
+    [Fact]
+    public void ReplaceIsCarriedThroughFromTheOptions()
+    {
+        var chain = new BackupHistoryChain(
+            Entry(BackupType.Full, T0, @"\\nas01\sql\full.bak"), null, []);
+
+        var script = Generate(chain, new RestoreOptions
+        {
+            TargetDatabaseName = "MyDb_Restored",
+            WithReplace = true
+        });
+
+        Assert.Contains("REPLACE", script);
+    }
+
+    // ── what the adapter carries across ─────────────────────────────────────────
+
+    [Fact]
+    public void TheFilesKnowTheyAreOnDiskRatherThanInAContainer()
+    {
+        var chain = new BackupHistoryChain(
+            Entry(BackupType.Full, T0, @"\\nas01\sql\full.bak"), null, []);
+
+        var restorable = BackupHistoryChainAdapter.ToRestorableChain(chain);
+        var file = Assert.Single(restorable.FullSet.Files);
+
+        Assert.True(file.IsOnDisk);
+        Assert.Equal(@"\\nas01\sql\full.bak", file.RestoreDevice);
+
+        // No URL is invented. A path in that field would be the kind of quiet lie that ends in a
+        // restore aimed at the wrong device.
+        Assert.Equal(string.Empty, file.BlobUrl);
+    }
+
+    /// <summary>
+    /// msdb records size per SET, not per stripe. Repeating it on every file would report a striped
+    /// backup as several times its real size.
+    /// </summary>
+    [Fact]
+    public void AStripedBackupIsNotCountedOncePerStripe()
+    {
+        var chain = new BackupHistoryChain(
+            Entry(BackupType.Full, T0, @"\\nas01\sql\p1.bak", @"\\nas01\sql\p2.bak"), null, []);
+
+        var restorable = BackupHistoryChainAdapter.ToRestorableChain(chain);
+
+        Assert.Equal(5_000_000, restorable.TotalSizeBytes);
+    }
+
+    [Fact]
+    public void ACopyOnlyFullStaysCopyOnlyThroughTheAdapter()
+    {
+        var full = new BackupHistoryEntry
+        {
+            DatabaseName = "MyDb",
+            Type = BackupType.Full,
+            StartedAt = T0,
+            FinishedAt = T0.AddMinutes(2),
+            IsCopyOnly = true,
+            Files = [@"\\nas01\sql\copyonly.bak"]
+        };
+
+        var restorable = BackupHistoryChainAdapter.ToRestorableChain(new BackupHistoryChain(full, null, []));
+
+        Assert.True(restorable.FullSet.IsCopyOnly);
+    }
+}

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -121,6 +121,22 @@ public class BackupFileInfo
 {
     public string BlobName { get; set; } = string.Empty;
     public string BlobUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Where this backup lives on disk, when it was never in blob storage at all (#149).
+    ///
+    /// Set for backups discovered through a source instance's msdb rather than by listing a
+    /// container. It is what decides how the restore addresses the file - a file with a local path
+    /// is restored FROM DISK, everything else FROM URL - so the data says where it lives rather
+    /// than a flag somewhere else having to agree with it.
+    /// </summary>
+    public string? LocalPath { get; set; }
+
+    /// <summary>The device clause a RESTORE should name this file by.</summary>
+    public string RestoreDevice => string.IsNullOrWhiteSpace(LocalPath) ? BlobUrl : LocalPath!;
+
+    /// <summary>True when this is a file on a path rather than a blob.</summary>
+    public bool IsOnDisk => !string.IsNullOrWhiteSpace(LocalPath);
     public BackupType Type { get; set; } = BackupType.Unknown;
     public long SizeBytes { get; set; }
     public DateTimeOffset LastModified { get; set; }

--- a/src/NineLives/Services/BackupHistoryChainAdapter.cs
+++ b/src/NineLives/Services/BackupHistoryChainAdapter.cs
@@ -1,0 +1,66 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Turns a chain discovered through a source instance's msdb into the shape the restore script
+/// generator already understands (#149).
+///
+/// Deliberately an adapter rather than a second generator. Everything a restore script has to get
+/// right - WITH REPLACE dropping the target, NORECOVERY on every step but the last, STOPAT on every
+/// log rather than only the final one, the MOVE clauses, disconnecting and reconnecting sessions -
+/// is the same whether the backups came from a container or a file share. That logic has been
+/// through #110, #45 and #44 and has the tests to show for it; the only thing that differs is how a
+/// file is named, and the file itself now says which it is.
+///
+/// So a shared backup location gets the whole of that behaviour for free, and a fix to any of it
+/// applies to both sources at once.
+/// </summary>
+public static class BackupHistoryChainAdapter
+{
+    /// <summary>
+    /// The chain as a <see cref="BackupChain"/>, with every file carrying its path so the script
+    /// addresses them as DISK.
+    /// </summary>
+    public static BackupChain ToRestorableChain(BackupHistoryChain chain, DateTime? stopAt = null)
+    {
+        return new BackupChain
+        {
+            FullSet = ToSet(chain.Full),
+            DiffSets = chain.Differential == null ? [] : [ToSet(chain.Differential)],
+            LogSets = chain.Logs.Select(ToSet).ToList(),
+            StopAt = stopAt
+        };
+    }
+
+    private static BackupSet ToSet(BackupHistoryEntry entry) => new()
+    {
+        // msdb has no notion of the set ids this app derives from blob names, so the identity is
+        // what a person would recognise it by: what it is and when it ran.
+        SetId = $"{entry.DatabaseName}_{entry.StartedAt:yyyyMMdd_HHmmss}",
+        DatabaseName = entry.DatabaseName,
+        ServerName = entry.ServerName,
+        Type = entry.Type,
+        Timestamp = entry.StartedAt,
+        IsCopyOnly = entry.IsCopyOnly,
+        Files = entry.Files.Select((path, index) => ToFile(entry, path, index)).ToList()
+    };
+
+    private static BackupFileInfo ToFile(BackupHistoryEntry entry, string path, int index) => new()
+    {
+        // The path is what the restore names. BlobName is kept human-readable for the panels that
+        // show a file, and BlobUrl is deliberately left empty - there is no URL, and filling one in
+        // with a path would be the kind of quiet lie that produces a restore from the wrong device.
+        LocalPath = path,
+        BlobName = System.IO.Path.GetFileName(path),
+        Type = entry.Type,
+        InferredDatabaseName = entry.DatabaseName,
+        InferredServerName = entry.ServerName,
+        IsCopyOnly = entry.IsCopyOnly,
+        LastModified = new DateTimeOffset(entry.FinishedAt, TimeSpan.Zero),
+
+        // Size is per SET in msdb, not per stripe, so it is recorded once rather than repeated on
+        // every file - a striped backup would otherwise report several times its real size.
+        SizeBytes = index == 0 ? entry.BackupSizeBytes ?? 0 : 0
+    };
+}

--- a/src/NineLives/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives/Services/RestoreScriptGenerator.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
@@ -144,15 +144,29 @@ public class RestoreScriptGenerator
         sb.AppendLine();
     }
 
+    /// <summary>
+    /// Names the devices to restore from - URL for a blob, DISK for a file on a path (#149).
+    ///
+    /// Which one comes from the FILE rather than from an option, so a chain cannot be told to
+    /// restore from the wrong kind of device: a backup discovered through a source instance's msdb
+    /// has a local path and nothing else, and one listed from a container has a URL.
+    ///
+    /// Only URLs are encoded. A UNC path is not a URI and percent-encoding one would produce a
+    /// path SQL Server cannot open.
+    /// </summary>
     private static void AppendFromUrls(StringBuilder sb, BackupSet set, RestoreOptions options)
     {
         for (int i = 0; i < set.Files.Count; i++)
         {
             var file = set.Files[i];
-            var url = BlobUrlEncoder.Encode(file.BlobUrl);
+
+            var device = file.IsOnDisk
+                ? $"DISK = N'{TSql.EscapeLiteral(file.RestoreDevice)}'"
+                : $"URL = N'{TSql.EscapeLiteral(BlobUrlEncoder.Encode(file.BlobUrl))}'";
+
             var prefix = i == 0 ? "    FROM" : "        ";
             var suffix = i < set.Files.Count - 1 ? "," : "";
-            sb.AppendLine($"{prefix} URL = N'{TSql.EscapeLiteral(url)}'{suffix}");
+            sb.AppendLine($"{prefix} {device}{suffix}");
         }
 
         sb.AppendLine("    WITH");


### PR DESCRIPTION
@
**1,038 passing** (1,064 total).

## The device comes from the file, not from a setting

A backup discovered through a source instances `msdb` carries its path and is restored `FROM DISK`; one listed from a container carries a URL and is restored `FROM URL`. A chain therefore **cannot** be told to restore from the wrong kind of device, because there is no separate flag that has to agree with the data.

## An adapter, deliberately, rather than a second generator

Everything a restore script has to get right is identical whichever source the backups came from: `WITH REPLACE` dropping the target, `NORECOVERY` on every step but the last, `STOPAT` on **every** log rather than only the final one, the `MOVE` clauses, disconnecting and reconnecting sessions.

That logic has been through #110, #45 and #44 and has the tests to show for it. A shared location gets all of it for free — and a fix to any of it applies to both sources at once, which a second generator would quietly not do.

## Two things the adapter has to be careful about

- **Paths are not URL-encoded.** A UNC path is not a URI, and percent-encoding one produces a path SQL Server cannot open. Encoding stays on the blob branch only; there is a test with spaces in the path.
- **Size is recorded once per set, not once per stripe.** msdb reports it per backup set, so repeating it across files would report a striped backup as several times its real size.

`BlobUrl` is left **empty** for a backup on disk rather than filled with the path. A path in a field called `BlobUrl` is the kind of quiet lie that ends in a restore aimed at the wrong device — the same shape as the stale-property bug seam 4 turned up.

## Where #149 stands

Done: msdb discovery (#161), LSN chain building and on-target file checks (#162), and `FROM DISK` script generation here. That is the whole engine.

Remaining is the screen: choosing source and target instances, declaring the shared path, and running the checks in order. Nothing in it is blocked.
@