### PR TITLE
Add the Restore from Share screen (#149)

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -244,6 +244,46 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// </summary>
     public Func<string, CancellationToken, Task<BlobCredentialStatus>>? OnCredentialCheck { get; set; }
 
+    // ── shared backup location (#149) ───────────────────────────────────────────
+
+    /// <summary>What the fake source instance says it backed up.</summary>
+    public List<BackupHistoryEntry> BackupHistory { get; set; } = [];
+
+    /// <summary>Every path the target was asked about, so a test can prove WHICH names were checked.</summary>
+    public List<string> CheckedPaths { get; } = [];
+
+    /// <summary>Paths the fake target refuses, and why. Anything not listed is readable.</summary>
+    public Dictionary<string, BackupFileProblem> UnreadablePaths { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
+        ServerConnection server, string? databaseName = null, CancellationToken ct = default)
+        => Task.FromResult(databaseName == null
+            ? BackupHistory
+            : BackupHistory.Where(h => h.DatabaseName == databaseName).ToList());
+
+    public Task<BackupFileCheck> CheckBackupFileAsync(
+        ServerConnection server, string path, CancellationToken ct = default)
+    {
+        CheckedPaths.Add(path);
+
+        return Task.FromResult(UnreadablePaths.TryGetValue(path, out var problem)
+            ? new BackupFileCheck(path, problem, $"fake failure: {problem}")
+            : BackupFileCheck.Ok(path));
+    }
+
+    public async Task<List<BackupFileCheck>> CheckBackupFilesAsync(
+        ServerConnection server, IEnumerable<string> paths, CancellationToken ct = default)
+    {
+        var results = new List<BackupFileCheck>();
+        foreach (var path in paths)
+        {
+            var check = await CheckBackupFileAsync(server, path, ct);
+            results.Add(check);
+            if (!check.CanBeRestored) break;
+        }
+        return results;
+    }
+
     public Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default)
         => OnCredentialCheck?.Invoke(credentialName, ct) ?? Task.FromResult(Credential);

--- a/src/NineLives.Tests/SharedLocationRestoreTests.cs
+++ b/src/NineLives.Tests/SharedLocationRestoreTests.cs
@@ -1,0 +1,267 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Restoring from a location both hosts can see (#149).
+///
+/// The ordering in that issue is not presentation: each step's output is the next one's input, so a
+/// script cannot be generated from files the target has not confirmed it can read. These are the
+/// tests for that, plus the path substitution - which is the part of this workflow that catches
+/// people out, because msdb records paths as the SOURCE saw them.
+/// </summary>
+public class SharedLocationRestoreTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static ServerConnection Server(string name) => new()
+    {
+        Id = ServerConnection.NewId(),
+        Name = name,
+        ServerName = name
+    };
+
+    private static BackupHistoryEntry Full(params string[] files) => new()
+    {
+        DatabaseName = "MyDb",
+        ServerName = "SRV01",
+        Type = BackupType.Full,
+        StartedAt = T0,
+        FinishedAt = T0.AddMinutes(5),
+        CheckpointLsn = 100,
+        LastLsn = 200,
+        Files = files
+    };
+
+    private static (SharedLocationRestoreViewModel vm, FakeSqlServerService sql) New(
+        params BackupHistoryEntry[] history)
+    {
+        var store = new FakeCredentialStore();
+        var source = Server("SRV01");
+        var target = Server("SRV02");
+        store.Config.Servers.Add(source);
+        store.Config.Servers.Add(target);
+
+        var sql = new FakeSqlServerService { BackupHistory = history.ToList() };
+        var vm = new SharedLocationRestoreViewModel(store, sql)
+        {
+            SourceServer = source,
+            TargetServer = target,
+            TargetDatabaseName = "MyDb_Restored"
+        };
+        return (vm, sql);
+    }
+
+    // ── the ordering ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The source knowing about a backup says nothing about whether the target can reach it. A
+    /// script generated before that is answered is one that fails part-way through - after WITH
+    /// REPLACE has already dropped the database being restored over.
+    /// </summary>
+    [Fact]
+    public async Task NoScriptIsOfferedBeforeTheTargetHasConfirmedItCanReadTheFiles()
+    {
+        var (vm, _) = New(Full(@"\\nas01\sql\full.bak"));
+        await vm.ReadHistoryCommand.ExecuteAsync(null);
+        vm.SelectedChain = vm.AvailableChains.Single();
+
+        Assert.False(vm.CanGenerate);
+
+        vm.GenerateScriptCommand.Execute(null);
+        Assert.Equal(string.Empty, vm.GeneratedScript);
+    }
+
+    [Fact]
+    public async Task OnceTheTargetHasConfirmedThemAScriptIsGenerated()
+    {
+        var (vm, _) = New(Full(@"\\nas01\sql\full.bak"));
+        await vm.ReadHistoryCommand.ExecuteAsync(null);
+        vm.SelectedChain = vm.AvailableChains.Single();
+
+        await vm.VerifyFilesCommand.ExecuteAsync(null);
+
+        Assert.True(vm.FilesVerified);
+        Assert.True(vm.CanGenerate);
+
+        vm.GenerateScriptCommand.Execute(null);
+        Assert.Contains(@"DISK = N'\\nas01\sql\full.bak'", vm.GeneratedScript);
+    }
+
+    /// <summary>
+    /// Choosing a different chain means different files, so anything proved about the last one no
+    /// longer applies. Leaving the ticks up would let a script be generated from a verification
+    /// that was never run against these backups.
+    /// </summary>
+    [Fact]
+    public async Task ChangingWhatIsBeingRestoredWithdrawsTheVerification()
+    {
+        var older = Full(@"\\nas01\sql\older.bak");
+        var newer = new BackupHistoryEntry
+        {
+            DatabaseName = "MyDb", ServerName = "SRV01", Type = BackupType.Full,
+            StartedAt = T0.AddDays(1), FinishedAt = T0.AddDays(1).AddMinutes(5),
+            CheckpointLsn = 300, LastLsn = 400, Files = [@"\\nas01\sql\newer.bak"]
+        };
+
+        var (vm, _) = New(older, newer);
+        await vm.ReadHistoryCommand.ExecuteAsync(null);
+
+        vm.SelectedChain = vm.AvailableChains.First();
+        await vm.VerifyFilesCommand.ExecuteAsync(null);
+        Assert.True(vm.FilesVerified);
+
+        vm.SelectedChain = vm.AvailableChains.Last();
+
+        Assert.False(vm.FilesVerified);
+        Assert.False(vm.CanGenerate);
+        Assert.Equal(string.Empty, vm.GeneratedScript);
+    }
+
+    /// <summary>Nothing is chosen for the user - the same rule the Restore screen learned.</summary>
+    [Fact]
+    public async Task ReadingTheHistoryChoosesNothing()
+    {
+        var (vm, _) = New(Full(@"\\nas01\sql\full.bak"));
+
+        await vm.ReadHistoryCommand.ExecuteAsync(null);
+
+        Assert.NotEmpty(vm.AvailableChains);
+        Assert.Null(vm.SelectedChain);
+        Assert.False(vm.CanGenerate);
+    }
+
+    // ── the target's answer ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An unreadable file is explained in the target's terms, and the workflow stops there. Access
+    /// denied is the case this whole check exists for.
+    /// </summary>
+    [Fact]
+    public async Task AFileTheTargetCannotReadStopsTheWorkflowAndSaysWhy()
+    {
+        var (vm, sql) = New(Full(@"\\nas01\sql\full.bak"));
+        sql.UnreadablePaths[@"\\nas01\sql\full.bak"] = BackupFileProblem.AccessDenied;
+
+        await vm.ReadHistoryCommand.ExecuteAsync(null);
+        vm.SelectedChain = vm.AvailableChains.Single();
+        await vm.VerifyFilesCommand.ExecuteAsync(null);
+
+        Assert.False(vm.FilesVerified);
+        Assert.False(vm.CanGenerate);
+        Assert.Contains("service account", vm.VerificationSummary);
+        Assert.Contains("SRV02", vm.VerificationSummary);
+    }
+
+    // ── the path substitution ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// msdb records the path the SOURCE wrote. When the target reaches the same place by another
+    /// name, the target must be asked about ITS name - asking about the source's would check a
+    /// path that means something different on that machine, or nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task TheTargetIsAskedAboutThePathItReachesTheFilesBy()
+    {
+        var (vm, sql) = New(Full(@"E:\SQLBackups\MyDb\full.bak"));
+        vm.SourcePathPrefix = @"E:\SQLBackups";
+        vm.TargetPathPrefix = @"\\SRV01\SQLBackups";
+
+        await vm.ReadHistoryCommand.ExecuteAsync(null);
+        vm.SelectedChain = vm.AvailableChains.Single();
+        await vm.VerifyFilesCommand.ExecuteAsync(null);
+
+        Assert.Equal(@"\\SRV01\SQLBackups\MyDb\full.bak", Assert.Single(sql.CheckedPaths));
+    }
+
+    [Fact]
+    public async Task TheScriptNamesTheFilesTheWayTheTargetReachesThem()
+    {
+        var (vm, _) = New(Full(@"E:\SQLBackups\MyDb\full.bak"));
+        vm.SourcePathPrefix = @"E:\SQLBackups";
+        vm.TargetPathPrefix = @"\\SRV01\SQLBackups";
+
+        await vm.ReadHistoryCommand.ExecuteAsync(null);
+        vm.SelectedChain = vm.AvailableChains.Single();
+        await vm.VerifyFilesCommand.ExecuteAsync(null);
+        vm.GenerateScriptCommand.Execute(null);
+
+        Assert.Contains(@"\\SRV01\SQLBackups\MyDb\full.bak", vm.GeneratedScript);
+        Assert.DoesNotContain(@"E:\SQLBackups", vm.GeneratedScript);
+    }
+
+    /// <summary>
+    /// The one failure here that can end in a SUCCESSFUL restore of the wrong backup: a local path
+    /// on the source may resolve on the target to the target's own drive of that letter. Said
+    /// before the check runs, not after it.
+    /// </summary>
+    [Fact]
+    public async Task ALocalSourcePathIsWarnedAboutBeforeAnythingIsChecked()
+    {
+        var (vm, _) = New(Full(@"E:\SQLBackups\MyDb\full.bak"));
+        await vm.ReadHistoryCommand.ExecuteAsync(null);
+
+        vm.SelectedChain = vm.AvailableChains.Single();
+
+        Assert.Contains("local path", vm.PathAdvice);
+        Assert.Contains("target's own drive", vm.PathAdvice);
+    }
+
+    [Fact]
+    public async Task NoWarningWhenTheBackupsWereAlreadyOnAShare()
+    {
+        var (vm, _) = New(Full(@"\\nas01\sql\full.bak"));
+        await vm.ReadHistoryCommand.ExecuteAsync(null);
+
+        vm.SelectedChain = vm.AvailableChains.Single();
+
+        Assert.Equal(string.Empty, vm.PathAdvice);
+    }
+
+    // ── the mapping itself ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void AMappingRewritesOnlyWhatItMatches()
+    {
+        var mapping = new BackupPathMapping(@"E:\SQLBackups", @"\\SRV01\SQLBackups");
+
+        Assert.Equal(@"\\SRV01\SQLBackups\MyDb\full.bak", mapping.Apply(@"E:\SQLBackups\MyDb\full.bak"));
+
+        // A chain can hold files from more than one place; rewriting one that was already
+        // reachable would break a restore that would otherwise have worked.
+        Assert.Equal(@"\\nas02\other\full.bak", mapping.Apply(@"\\nas02\other\full.bak"));
+    }
+
+    [Fact]
+    public void AMappingIsCaseInsensitiveBecauseWindowsPathsAre()
+    {
+        var mapping = new BackupPathMapping(@"e:\sqlbackups", @"\\SRV01\SQLBackups");
+
+        Assert.Equal(@"\\SRV01\SQLBackups\MyDb\full.bak", mapping.Apply(@"E:\SQLBackups\MyDb\full.bak"));
+    }
+
+    [Theory]
+    [InlineData(@"E:\SQLBackups\", @"\\SRV01\SQLBackups\")]
+    [InlineData(@"E:\SQLBackups", @"\\SRV01\SQLBackups")]
+    public void TrailingSeparatorsOnEitherSideDoNotDoubleUp(string source, string target)
+    {
+        var mapping = new BackupPathMapping(source, target);
+
+        Assert.Equal(@"\\SRV01\SQLBackups\MyDb\full.bak", mapping.Apply(@"E:\SQLBackups\MyDb\full.bak"));
+    }
+
+    [Fact]
+    public void WithNoMappingPathsAreLeftExactlyAsTheyWere()
+    {
+        Assert.Equal(@"\\nas01\sql\full.bak", BackupPathMapping.None.Apply(@"\\nas01\sql\full.bak"));
+    }
+
+    [Theory]
+    [InlineData(@"E:\SQLBackups\full.bak", true)]
+    [InlineData(@"C:\backups\full.bak", true)]
+    [InlineData(@"\\nas01\sql\full.bak", false)]
+    public void ALocalPathIsToldApartFromAShare(string path, bool expected)
+        => Assert.Equal(expected, BackupPathMapping.LooksLocalToTheSource(path));
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -832,7 +832,151 @@ public class XamlLoadTests(WpfFixture wpf)
         => Check("HistoryView (empty)", () =>
             new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) });
 
+    // ── restoring from a shared location (#149) ─────────────────────────────────
+
+    [Fact]
+    public void SharedLocationRestoreViewLoads()
+        => Check("SharedLocationRestoreView", () =>
+            new SharedLocationRestoreView { DataContext = NewSharedLocationViewModel() });
+
+    /// <summary>
+    /// The failure this screen exists to catch, on screen in the target's words.
+    ///
+    /// A collapsed row is not a message: the per-file explanation is bound behind a visibility
+    /// trigger, so its binding is never evaluated in the default state the plain load test
+    /// exercises - and a broken one there would be silent.
+    /// </summary>
+    [Fact]
+    public void AFileTheTargetCannotReadIsExplainedOnScreen()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewSharedLocationViewModel();
+            vm.FileChecks =
+            [
+                new FileCheckRow(@"\nas01\sqlull.bak", false,
+                    "SRV02 can see it but is not allowed to read it. The RESTORE runs as the SQL Server service account.")
+            ];
+
+            var listener = BindingErrorListener.Attach();
+            try
+            {
+                var view = new SharedLocationRestoreView { DataContext = vm };
+                Realise(view);
+
+                var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+                Assert.Contains(shown, t => t.Contains(@"\nas01\sqlull.bak", StringComparison.Ordinal));
+                Assert.Contains(shown, t => t.Contains("service account", StringComparison.Ordinal));
+
+                listener.AssertNone("SharedLocationRestoreView file checks");
+            }
+            finally
+            {
+                listener.Detach();
+            }
+        });
+    }
+
+    /// <summary>
+    /// The gate, as the screen actually renders it. CanGenerate is tested directly elsewhere; what
+    /// this asks is whether the button is really bound to it - an IsEnabled binding that silently
+    /// fails leaves a live button offering a script for files nobody has checked.
+    /// </summary>
+    [Fact]
+    public void TheGenerateButtonIsDeadUntilTheTargetHasAnswered()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewSharedLocationViewModel();
+            vm.TargetDatabaseName = "MyDb_Restored";
+
+            var view = new SharedLocationRestoreView { DataContext = vm };
+            Realise(view);
+
+            var generate = VisibleButtons(view)
+                .Single(b => b.Content as string == "Generate script");
+
+            Assert.False(generate.IsEnabled);
+        });
+    }
+
+    /// <summary>
+    /// The two dropdowns show the servers' names.
+    ///
+    /// Found by rendering the screen: under this app's ComboBox template a DisplayMemberPath left
+    /// the selection box showing "Blackcat.NineLives.Models.ServerConnection". Nothing throws and
+    /// no binding error is traced - it is only wrong to look at, which is why it needs an assertion
+    /// on what is drawn rather than on what is bound.
+    /// </summary>
+    [Fact]
+    public void TheServerDropdownsShowServerNames()
+    {
+        wpf.Invoke(() =>
+        {
+            var store = new FakeCredentialStore();
+            var source = new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+            var target = new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" };
+            store.Config.Servers.Add(source);
+            store.Config.Servers.Add(target);
+
+            var vm = new SharedLocationRestoreViewModel(store, new SqlServerService(store))
+            {
+                SourceServer = source,
+                TargetServer = target
+            };
+
+            var view = new SharedLocationRestoreView { DataContext = vm };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.Contains("SRV01", shown);
+            Assert.Contains("SRV02", shown);
+            Assert.DoesNotContain(shown, t => t.Contains("ServerConnection", StringComparison.Ordinal));
+        });
+    }
+
+    /// <summary>
+    /// A file the target could not read is marked with a cross, not a tick.
+    ///
+    /// Also found by rendering it. The glyph was one Run with a trigger swapping its Text, and a
+    /// style setter cannot override a locally set value - so the failing row kept its tick and only
+    /// changed colour. On a screen whose entire job is saying which files the target cannot read,
+    /// a tick on the one that failed is the worst thing it could draw.
+    /// </summary>
+    [Fact]
+    public void TheRowForAnUnreadableFileIsMarkedWithACross()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewSharedLocationViewModel();
+            vm.FileChecks =
+            [
+                new FileCheckRow(@"\nas01\sqlull.bak", true, "Readable"),
+                new FileCheckRow(@"\nas01\sql\log1.trn", false, "SRV02 is not allowed to read it.")
+            ];
+
+            var view = new SharedLocationRestoreView { DataContext = vm };
+            Realise(view);
+
+            var glyphs = FindAll<TextBlock>(view)
+                .Where(IsShown)
+                .Select(t => t.Text)
+                .Where(t => t is "✓" or "✗")
+                .ToList();
+
+            Assert.Equal(["✓", "✗"], glyphs);
+        });
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static SharedLocationRestoreViewModel NewSharedLocationViewModel()
+    {
+        var store = Store();
+        return new SharedLocationRestoreViewModel(store, new SqlServerService(store));
+    }
 
     private RestoreViewModel NewRestoreViewModel()
     {

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -26,9 +26,10 @@
         <KeyBinding Modifiers="Ctrl" Key="D2" Command="{Binding NavigateToCommand}" CommandParameter="SQL Servers" />
         <KeyBinding Modifiers="Ctrl" Key="D3" Command="{Binding NavigateToCommand}" CommandParameter="Browse Backups" />
         <KeyBinding Modifiers="Ctrl" Key="D4" Command="{Binding NavigateToCommand}" CommandParameter="Restore" />
-        <KeyBinding Modifiers="Ctrl" Key="D5" Command="{Binding NavigateToCommand}" CommandParameter="History" />
-        <KeyBinding Modifiers="Ctrl" Key="D6" Command="{Binding NavigateToCommand}" CommandParameter="Settings" />
-        <KeyBinding Modifiers="Ctrl" Key="D7" Command="{Binding NavigateToCommand}" CommandParameter="About" />
+        <KeyBinding Modifiers="Ctrl" Key="D5" Command="{Binding NavigateToCommand}" CommandParameter="Restore from Share" />
+        <KeyBinding Modifiers="Ctrl" Key="D6" Command="{Binding NavigateToCommand}" CommandParameter="History" />
+        <KeyBinding Modifiers="Ctrl" Key="D7" Command="{Binding NavigateToCommand}" CommandParameter="Settings" />
+        <KeyBinding Modifiers="Ctrl" Key="D8" Command="{Binding NavigateToCommand}" CommandParameter="About" />
         <KeyBinding Key="F5" Command="{Binding ReloadCommand}" />
         <KeyBinding Modifiers="Ctrl" Key="G" Command="{Binding GenerateScriptCommand}" />
         <KeyBinding Key="Escape" Command="{Binding CancelCurrentCommand}" />
@@ -53,6 +54,9 @@
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:RestoreViewModel}">
             <views:RestoreView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:SharedLocationRestoreViewModel}">
+            <views:SharedLocationRestoreView />
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:HistoryViewModel}">
             <views:HistoryView />
@@ -269,6 +273,16 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#x267B;" FontSize="15" VerticalAlignment="Center" Width="24" />
                                 <TextBlock Text="Restore" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <RadioButton Style="{StaticResource SidebarButton}"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Restore from Share'}"
+                                     Command="{Binding NavigateToCommand}"
+                                     CommandParameter="Restore from Share">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#x1F5C2;" FontSize="15" VerticalAlignment="Center" Width="24" />
+                                <TextBlock Text="Restore from Share" VerticalAlignment="Center" />
                             </StackPanel>
                         </RadioButton>
 

--- a/src/NineLives/Models/BackupPathMapping.cs
+++ b/src/NineLives/Models/BackupPathMapping.cs
@@ -1,0 +1,67 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// How the target reaches the files the source wrote (#149).
+///
+/// msdb records paths as the SOURCE saw them, which is the one thing about this workflow that
+/// catches people out. A job that backed up to <c>E:\SQLBackups\MyDb.bak</c> recorded a path that
+/// means something entirely different on the target machine - if it resolves there at all, it
+/// resolves to the target's own E: drive, which is worse than failing.
+///
+/// So the shared location this issue is about is often not the path in msdb: the source wrote to a
+/// local path that happens to be a share, and the target reaches it by its UNC name. Stating that
+/// substitution explicitly is what makes "both hosts can see it" a checkable claim rather than an
+/// assumption.
+///
+/// When the source backed up to a UNC path already - the usual arrangement with a central backup
+/// share - no mapping is needed and this does nothing.
+/// </summary>
+/// <param name="SourcePrefix">The path as the source wrote it, e.g. <c>E:\SQLBackups</c>.</param>
+/// <param name="TargetPrefix">How the target reaches the same place, e.g. <c>\\SRV01\SQLBackups</c>.</param>
+public sealed record BackupPathMapping(string SourcePrefix, string TargetPrefix)
+{
+    /// <summary>No substitution: the paths mean the same thing on both machines.</summary>
+    public static readonly BackupPathMapping None = new(string.Empty, string.Empty);
+
+    public bool IsInUse => !string.IsNullOrWhiteSpace(SourcePrefix) && !string.IsNullOrWhiteSpace(TargetPrefix);
+
+    /// <summary>
+    /// The path as the target should be asked about it.
+    ///
+    /// Case-insensitive, because Windows paths are - a mapping typed as <c>e:\backups</c> must
+    /// still match a path msdb recorded as <c>E:\SQLBackups</c>'s drive. Anything that does not
+    /// start with the source prefix is returned untouched rather than mangled: a chain can hold
+    /// files from more than one location, and rewriting one that was already reachable would break
+    /// a restore that would otherwise have worked.
+    /// </summary>
+    public string Apply(string path)
+    {
+        if (!IsInUse || string.IsNullOrWhiteSpace(path)) return path;
+
+        if (!path.StartsWith(SourcePrefix, StringComparison.OrdinalIgnoreCase)) return path;
+
+        var remainder = path[SourcePrefix.Length..];
+
+        // Neither side is trusted to have a trailing separator, or to lack one.
+        return $"{TargetPrefix.TrimEnd('\\', '/')}\\{remainder.TrimStart('\\', '/')}";
+    }
+
+    /// <summary>
+    /// True when this mapping would change the path - so the screen can say whether the check it is
+    /// about to run is asking about the same file the source wrote or a different name for it.
+    /// </summary>
+    public bool Changes(string path) => !string.Equals(path, Apply(path), StringComparison.Ordinal);
+
+    /// <summary>
+    /// Whether a path is one the target could plausibly reach at all.
+    ///
+    /// A local path on the source is the case worth catching early: it is not that the target
+    /// cannot find it, but that it may find its OWN drive of that letter and read something else
+    /// entirely. That is the only failure here that can produce a successful restore of the wrong
+    /// backup, so it is worth saying before the check rather than after it.
+    /// </summary>
+    public static bool LooksLocalToTheSource(string path) =>
+        !string.IsNullOrWhiteSpace(path) &&
+        !path.StartsWith(@"\\", StringComparison.Ordinal) &&
+        path.Length > 1 && path[1] == ':';
+}

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -49,6 +49,18 @@ public interface ISqlServerService
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default);
 
+    /// <summary>What this instance recorded backing up, from msdb (#149).</summary>
+    Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
+        ServerConnection server, string? databaseName = null, CancellationToken ct = default);
+
+    /// <summary>Whether THIS instance can read a backup file, and why not (#149).</summary>
+    Task<BackupFileCheck> CheckBackupFileAsync(
+        ServerConnection server, string path, CancellationToken ct = default);
+
+    /// <summary>Checks every file a chain needs, stopping at the first that cannot be read.</summary>
+    Task<List<BackupFileCheck>> CheckBackupFilesAsync(
+        ServerConnection server, IEnumerable<string> paths, CancellationToken ct = default);
+
     Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default);
 

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -51,6 +51,7 @@ public partial class MainViewModel : ViewModelBase
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }
     public RestoreViewModel Restore { get; }
+    public SharedLocationRestoreViewModel SharedLocationRestore { get; }
     public HistoryViewModel History { get; }
     public SettingsViewModel Settings { get; }
     public AboutViewModel About { get; }
@@ -96,6 +97,7 @@ public partial class MainViewModel : ViewModelBase
         Restore = new RestoreViewModel(
             _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
             log: null, history: _historyStore);
+        SharedLocationRestore = new SharedLocationRestoreViewModel(_credentialStore, _sqlService);
         History = new HistoryViewModel(_historyStore);
         Settings = new SettingsViewModel(_credentialStore);
         About = new AboutViewModel();
@@ -111,7 +113,7 @@ public partial class MainViewModel : ViewModelBase
         // One place that answers "is it doing something?". Every screen already tracks its own
         // work; without this the answer depended on which part of a long page was scrolled into
         // view, and the Restore screen's own status line is below the fold most of the time (#128).
-        WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Restore);
+        WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Restore, SharedLocationRestore);
 
         CurrentView = BlobConfig;
 
@@ -294,6 +296,10 @@ public partial class MainViewModel : ViewModelBase
             case Nav.BrowseBackups:
                 BlobBrowser.RefreshContainers();
                 break;
+            case Nav.SharedLocation:
+                if (SharedLocationRestore.ReadHistoryCommand.CanExecute(null))
+                    SharedLocationRestore.ReadHistoryCommand.Execute(null);
+                break;
             case Nav.History:
                 History.Refresh();
                 break;
@@ -338,12 +344,13 @@ public partial class MainViewModel : ViewModelBase
         public const string SqlServers = "SQL Servers";
         public const string BrowseBackups = "Browse Backups";
         public const string Restore = "Restore";
+        public const string SharedLocation = "Restore from Share";
         public const string History = "History";
         public const string Settings = "Settings";
         public const string About = "About";
 
         public static IReadOnlyList<string> Views =>
-            [BlobStorage, SqlServers, BrowseBackups, Restore, History, Settings, About];
+            [BlobStorage, SqlServers, BrowseBackups, Restore, SharedLocation, History, Settings, About];
     }
 
     [RelayCommand]
@@ -356,6 +363,7 @@ public partial class MainViewModel : ViewModelBase
             Nav.SqlServers => ServerManager,
             Nav.BrowseBackups => BlobBrowser,
             Nav.Restore => Restore,
+            Nav.SharedLocation => SharedLocationRestore,
             Nav.History => History,
             Nav.Settings => Settings,
             Nav.About => About,
@@ -367,6 +375,10 @@ public partial class MainViewModel : ViewModelBase
             BlobBrowser.RefreshContainers();
         else if (viewName is Nav.Restore)
             Restore.RefreshContainers();
+        else if (viewName is Nav.SharedLocation)
+            // A server added on the SQL Servers screen since the last visit has to be selectable
+            // here, and this screen's two lists are the only place both ends are chosen.
+            SharedLocationRestore.RefreshServers();
         else if (viewName is Nav.History)
             // Re-read on every visit: a restore run since the last look must be here, and the
             // history is written by the Restore screen rather than by this one.

--- a/src/NineLives/ViewModels/SharedLocationRestoreViewModel.cs
+++ b/src/NineLives/ViewModels/SharedLocationRestoreViewModel.cs
@@ -1,0 +1,364 @@
+using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// Restoring from a backup location both hosts can see (#149).
+///
+/// The workflow in that issue, in order: pick the source and the target, read what the source
+/// recorded backing up, choose what to restore, prove the TARGET can read those files, and only
+/// then generate a script.
+///
+/// The order is not presentation. Each step's output is the next step's input - the chain comes
+/// from the source's msdb, and the script is generated from the files the target confirmed it can
+/// read - so a screen cannot offer to run a restore it has not checked, because it would have
+/// nothing to generate from.
+/// </summary>
+public partial class SharedLocationRestoreViewModel : ViewModelBase
+{
+    private readonly ICredentialStore _store;
+    private readonly ISqlServerService _sql;
+    private readonly BackupHistoryChainBuilder _chains = new();
+    private readonly RestoreScriptGenerator _generator = new();
+    private readonly OperationCancellation _cancellation = new();
+
+    public SharedLocationRestoreViewModel(ICredentialStore store, ISqlServerService sql)
+    {
+        _store = store;
+        _sql = sql;
+        RefreshServers();
+    }
+
+    // ── 1. source and target ────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private ObservableCollection<ServerConnection> _servers = [];
+
+    /// <summary>The instance that TOOK the backups - the one whose msdb is read.</summary>
+    [ObservableProperty]
+    private ServerConnection? _sourceServer;
+
+    /// <summary>
+    /// The instance the RESTORE runs on. Not necessarily the one the backups came from - that
+    /// distinction is the whole reason this screen exists, and the one people get wrong.
+    /// </summary>
+    [ObservableProperty]
+    private ServerConnection? _targetServer;
+
+    public void RefreshServers()
+    {
+        try
+        {
+            Servers = new ObservableCollection<ServerConnection>(_store.LoadConfig().Servers);
+        }
+        catch
+        {
+            // A config that will not load is reported where it is loaded for real; here it just
+            // means an empty list rather than a screen that cannot open.
+            Servers = [];
+        }
+    }
+
+    // ── 2. the shared location ──────────────────────────────────────────────────
+
+    /// <summary>The path as the source wrote it, when the target reaches it by another name.</summary>
+    [ObservableProperty]
+    private string _sourcePathPrefix = string.Empty;
+
+    /// <summary>How the target reaches the same place.</summary>
+    [ObservableProperty]
+    private string _targetPathPrefix = string.Empty;
+
+    public BackupPathMapping Mapping => new(SourcePathPrefix, TargetPathPrefix);
+
+    /// <summary>
+    /// Said before anything is checked, because it is the one failure here that can end in a
+    /// SUCCESSFUL restore of the wrong backup: a local path on the source may resolve on the target
+    /// to the target's own drive of that letter.
+    /// </summary>
+    public string PathAdvice
+    {
+        get
+        {
+            if (SelectedChain == null) return string.Empty;
+
+            var local = SelectedChain.Files.Where(BackupPathMapping.LooksLocalToTheSource).ToList();
+            if (local.Count == 0 || Mapping.IsInUse) return string.Empty;
+
+            return $"{local.Count} of these backups were written to a local path on the source " +
+                   $"(for example {local[0]}). That path means something different on the target - " +
+                   "at best it will not be found, at worst it resolves to the target's own drive. " +
+                   "Give the path as the target reaches it below.";
+        }
+    }
+
+    // ── 3. what the source recorded ─────────────────────────────────────────────
+
+    [ObservableProperty]
+    private ObservableCollection<string> _databases = [];
+
+    [ObservableProperty]
+    private string? _selectedDatabase;
+
+    private List<BackupHistoryEntry> _history = [];
+
+    [ObservableProperty]
+    private ObservableCollection<BackupHistoryChain> _availableChains = [];
+
+    [ObservableProperty]
+    private BackupHistoryChain? _selectedChain;
+
+    [RelayCommand]
+    private async Task ReadHistoryAsync()
+    {
+        if (SourceServer == null)
+        {
+            SetError("Choose the server the backups were taken on.");
+            return;
+        }
+
+        var ct = _cancellation.Begin();
+        IsBusy = true;
+        ClearStatus();
+
+        try
+        {
+            _history = await _sql.ReadBackupHistoryAsync(SourceServer, SelectedDatabase, ct);
+
+            Databases = new ObservableCollection<string>(
+                _history.Select(h => h.DatabaseName)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase));
+
+            RebuildChains();
+
+            SetStatus(_history.Count == 0
+                ? $"{SourceServer.ServerName} has no backup history for that database."
+                : $"Read {_history.Count} backup(s) from {SourceServer.ServerName}.");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Stopped.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not read the backup history: {ex.Message}");
+        }
+        finally
+        {
+            _cancellation.End();
+            IsBusy = false;
+        }
+    }
+
+    partial void OnSelectedDatabaseChanged(string? value) => RebuildChains();
+
+    private void RebuildChains()
+    {
+        var forDatabase = string.IsNullOrEmpty(SelectedDatabase)
+            ? _history
+            : _history.Where(h => string.Equals(h.DatabaseName, SelectedDatabase, StringComparison.OrdinalIgnoreCase));
+
+        AvailableChains = new ObservableCollection<BackupHistoryChain>(_chains.Build(forDatabase));
+
+        // Nothing is chosen for the user - the same rule the Restore screen learned. Picking a
+        // chain is choosing what to restore, and this screen's last button overwrites a database.
+        SelectedChain = null;
+        ClearVerification();
+    }
+
+    partial void OnSelectedChainChanged(BackupHistoryChain? value)
+    {
+        // A different chain has different files, so anything proved about the last one no longer
+        // applies. Leaving the ticks up would let a script be generated from a verification that
+        // was never run against these backups.
+        ClearVerification();
+        OnPropertyChanged(nameof(PathAdvice));
+    }
+
+    // ── 4. can the target actually read them ────────────────────────────────────
+
+    [ObservableProperty]
+    private ObservableCollection<FileCheckRow> _fileChecks = [];
+
+    [ObservableProperty]
+    private bool _filesVerified;
+
+    [ObservableProperty]
+    private string _verificationSummary = string.Empty;
+
+    private void ClearVerification()
+    {
+        FileChecks = [];
+        FilesVerified = false;
+        VerificationSummary = string.Empty;
+        GeneratedScript = string.Empty;
+        OnPropertyChanged(nameof(CanGenerate));
+    }
+
+    /// <summary>
+    /// Asks the TARGET whether it can read every file in the chain.
+    ///
+    /// On the target and not here, because this app's process can see a share the SQL Server
+    /// service account cannot, and the restore runs as that account on that host. A check from here
+    /// would pass and the restore would then fail with "Operating system error 5".
+    /// </summary>
+    [RelayCommand]
+    private async Task VerifyFilesAsync()
+    {
+        if (TargetServer == null)
+        {
+            SetError("Choose the server the restore will run on.");
+            return;
+        }
+
+        if (SelectedChain == null)
+        {
+            SetError("Choose what to restore first.");
+            return;
+        }
+
+        var ct = _cancellation.Begin();
+        IsBusy = true;
+        ClearStatus();
+        ClearVerification();
+
+        try
+        {
+            var paths = SelectedChain.Files.Select(Mapping.Apply).ToList();
+            var checks = await _sql.CheckBackupFilesAsync(TargetServer, paths, ct);
+
+            FileChecks = new ObservableCollection<FileCheckRow>(
+                checks.Select(c => new FileCheckRow(
+                    c.Path,
+                    c.CanBeRestored,
+                    c.CanBeRestored ? "Readable" : c.Explain(TargetServer.ServerName))));
+
+            var failed = checks.FirstOrDefault(c => !c.CanBeRestored);
+            FilesVerified = failed == null && checks.Count == paths.Count;
+
+            VerificationSummary = FilesVerified
+                ? $"{TargetServer.ServerName} can read all {checks.Count} file(s)."
+                : failed?.Explain(TargetServer.ServerName)
+                  ?? $"{TargetServer.ServerName} could not read every file.";
+
+            if (!FilesVerified) SetError(VerificationSummary);
+            else SetStatus(VerificationSummary);
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Stopped.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not check the files: {ex.Message}");
+        }
+        finally
+        {
+            _cancellation.End();
+            IsBusy = false;
+            OnPropertyChanged(nameof(CanGenerate));
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        if (_cancellation.CanCancel) _cancellation.Cancel();
+    }
+
+    // ── 5. the script ───────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private string _targetDatabaseName = string.Empty;
+
+    [ObservableProperty]
+    private bool _withReplace;
+
+    [ObservableProperty]
+    private string _generatedScript = string.Empty;
+
+    /// <summary>
+    /// A script is only offered once the target has said it can read the files.
+    ///
+    /// Not caution for its own sake: the point of this screen is that the source knowing about a
+    /// backup says nothing about whether the target can reach it, and a script generated before
+    /// that is answered is a script that fails part-way through - after WITH REPLACE has already
+    /// dropped the database being restored over.
+    /// </summary>
+    public bool CanGenerate =>
+        FilesVerified && SelectedChain != null && !string.IsNullOrWhiteSpace(TargetDatabaseName);
+
+    partial void OnTargetDatabaseNameChanged(string value) => OnPropertyChanged(nameof(CanGenerate));
+
+    [RelayCommand]
+    private void GenerateScript()
+    {
+        if (!CanGenerate || SelectedChain == null) return;
+
+        // The paths the TARGET confirmed, not the ones msdb recorded - if a mapping is in use, the
+        // script has to name the files the way the machine running it reaches them.
+        var mapped = MapChain(SelectedChain);
+
+        GeneratedScript = _generator.Generate(
+            BackupHistoryChainAdapter.ToRestorableChain(mapped),
+            new RestoreOptions
+            {
+                TargetDatabaseName = TargetDatabaseName,
+                WithReplace = WithReplace,
+                RecoveryMode = RecoveryMode.Recovery
+            });
+
+        SetStatus("Script generated.");
+    }
+
+    /// <summary>The chain with every path as the target reaches it.</summary>
+    internal BackupHistoryChain MapChain(BackupHistoryChain chain)
+    {
+        if (!Mapping.IsInUse) return chain;
+
+        return new BackupHistoryChain(
+            MapEntry(chain.Full),
+            chain.Differential == null ? null : MapEntry(chain.Differential),
+            chain.Logs.Select(MapEntry).ToList());
+    }
+
+    private BackupHistoryEntry MapEntry(BackupHistoryEntry entry) => new()
+    {
+        DatabaseName = entry.DatabaseName,
+        Type = entry.Type,
+        StartedAt = entry.StartedAt,
+        FinishedAt = entry.FinishedAt,
+        IsCopyOnly = entry.IsCopyOnly,
+        FirstLsn = entry.FirstLsn,
+        LastLsn = entry.LastLsn,
+        CheckpointLsn = entry.CheckpointLsn,
+        DatabaseBackupLsn = entry.DatabaseBackupLsn,
+        BackupSizeBytes = entry.BackupSizeBytes,
+        ServerName = entry.ServerName,
+        Files = entry.Files.Select(Mapping.Apply).ToList()
+    };
+
+    public bool HasScript => !string.IsNullOrWhiteSpace(GeneratedScript);
+
+    partial void OnGeneratedScriptChanged(string value) => OnPropertyChanged(nameof(HasScript));
+
+    [RelayCommand]
+    private void CopyScript() => TryCopyToClipboard(GeneratedScript, "Script copied to clipboard.");
+}
+
+/// <summary>
+/// One line of the target's answer, for the list on screen.
+///
+/// The explanation is worked out once, when the check comes back, rather than by the view: it
+/// needs the target's name to say anything useful, and a row that outlives the server selection
+/// would otherwise start naming the wrong machine.
+/// </summary>
+/// <param name="Path">The file as the target was asked about it.</param>
+/// <param name="CanBeRestored">Whether the target could read it.</param>
+/// <param name="Message">What to do about it, in the target's terms.</param>
+public sealed record FileCheckRow(string Path, bool CanBeRestored, string Message);

--- a/src/NineLives/Views/SharedLocationRestoreView.xaml
+++ b/src/NineLives/Views/SharedLocationRestoreView.xaml
@@ -1,0 +1,309 @@
+<UserControl x:Class="Blackcat.NineLives.Views.SharedLocationRestoreView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
+             xmlns:views="clr-namespace:Blackcat.NineLives.Views">
+
+    <UserControl.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+        <converters:NullToVisibilityConverter x:Key="NullToVis" />
+    </UserControl.Resources>
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <!-- Header -->
+            <StackPanel Margin="0,0,0,20">
+                <TextBlock Text="Restore From a Shared Location"
+                           Style="{StaticResource HeaderText}" />
+                <TextBlock Text="Restore a database from backups on a file share, using the source instance's own backup history rather than a container listing."
+                           Style="{StaticResource SecondaryText}"
+                           TextWrapping="Wrap"
+                           Margin="0,4,0,0" />
+            </StackPanel>
+
+            <!-- Step 1: which instance took the backups, and which one restores them -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="1. Source and target" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock TextWrapping="Wrap"
+                               Style="{StaticResource SecondaryText}"
+                               Margin="0,4,0,12"
+                               Text="The source is the instance that took the backups - its msdb is what gets read. The target is the instance the restore runs on. They are usually not the same, and that difference is the whole point of this screen." />
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="SOURCE - WHERE THE BACKUPS CAME FROM" Style="{StaticResource LabelText}" />
+                            <ComboBox ItemsSource="{Binding Servers}"
+                                      SelectedItem="{Binding SourceServer}"
+                                      Style="{StaticResource DarkComboBox}"
+                                      Margin="0,4,0,0">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="2">
+                            <TextBlock Text="TARGET - WHERE THE RESTORE RUNS" Style="{StaticResource LabelText}" />
+                            <ComboBox ItemsSource="{Binding Servers}"
+                                      SelectedItem="{Binding TargetServer}"
+                                      Style="{StaticResource DarkComboBox}"
+                                      Margin="0,4,0,0">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <!-- Step 2: what the source recorded -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="2. What the source recorded" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock TextWrapping="Wrap"
+                               Style="{StaticResource SecondaryText}"
+                               Margin="0,4,0,12"
+                               Text="Chains are assembled from msdb by LSN, so a differential is matched to the full it was actually taken against rather than to the nearest one by time." />
+
+                    <!-- Wrapped rather than laid out in a row: the button and the label sat over
+                         each other at narrow widths, because a Grid does not clip its children. -->
+                    <WrapPanel Margin="0,0,0,8">
+                        <Button Content="Read backup history"
+                                Command="{Binding ReadHistoryCommand}"
+                                Style="{StaticResource PrimaryButton}"
+                                Padding="16,8"
+                                Margin="0,0,8,8" />
+                        <Button Content="Stop"
+                                Command="{Binding CancelCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}"
+                                Padding="16,8"
+                                Margin="0,0,8,8" />
+                    </WrapPanel>
+
+                    <Grid Margin="0,4,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="2*" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="DATABASE" Style="{StaticResource LabelText}" />
+                            <ComboBox ItemsSource="{Binding Databases}"
+                                      SelectedItem="{Binding SelectedDatabase}"
+                                      Style="{StaticResource DarkComboBox}"
+                                      Margin="0,4,0,0" />
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="2">
+                            <TextBlock Text="RESTORE CHAIN" Style="{StaticResource LabelText}" />
+                            <ComboBox ItemsSource="{Binding AvailableChains}"
+                                      SelectedItem="{Binding SelectedChain}"
+                                      Style="{StaticResource DarkComboBox}"
+                                      Margin="0,4,0,0">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock TextWrapping="Wrap">
+                                            <Run Text="{Binding RestoresTo, Mode=OneWay, StringFormat='{}{0:yyyy-MM-dd HH:mm}'}" />
+                                            <Run Text=" - " Foreground="{DynamicResource SecondaryTextBrush}" />
+                                            <Run Text="{Binding Summary, Mode=OneWay}"
+                                                 Foreground="{DynamicResource SecondaryTextBrush}" />
+                                        </TextBlock>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <!-- Step 3: how the target reaches the same files -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="3. How the target reaches the files" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock TextWrapping="Wrap"
+                               Style="{StaticResource SecondaryText}"
+                               Margin="0,4,0,12"
+                               Text="msdb records the path the source wrote. Leave these empty when both hosts reach the backups by the same path - which is the usual arrangement with a central backup share." />
+
+                    <!-- The one failure here that can end in a SUCCESSFUL restore of the wrong
+                         backup, so it is said before the check runs rather than after it. -->
+                    <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                            BorderThickness="1" CornerRadius="4" Padding="10,8"
+                            Margin="0,0,0,12"
+                            Visibility="{Binding PathAdvice, Converter={StaticResource NullToVis}}">
+                        <TextBlock Text="{Binding PathAdvice}"
+                                   Foreground="{DynamicResource WarningBrush}"
+                                   TextWrapping="Wrap" />
+                    </Border>
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="AS THE SOURCE WROTE IT" Style="{StaticResource LabelText}" />
+                            <TextBox Text="{Binding SourcePathPrefix, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource DarkTextBox}"
+                                     Margin="0,4,0,0"
+                                     ToolTip="For example E:\SQLBackups" />
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="2">
+                            <TextBlock Text="AS THE TARGET REACHES IT" Style="{StaticResource LabelText}" />
+                            <TextBox Text="{Binding TargetPathPrefix, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource DarkTextBox}"
+                                     Margin="0,4,0,0"
+                                     ToolTip="For example \\SRV01\SQLBackups" />
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <!-- Step 4: ask the target -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="4. Can the target read them" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock TextWrapping="Wrap"
+                               Style="{StaticResource SecondaryText}"
+                               Margin="0,4,0,12"
+                               Text="Asked on the target, not from here. This app's process can see a share the SQL Server service account cannot, and the restore runs as that account on that host - so a check from here would pass and the restore would fail with operating system error 5." />
+
+                    <WrapPanel Margin="0,0,0,8">
+                        <Button Content="Check the files on the target"
+                                Command="{Binding VerifyFilesCommand}"
+                                Style="{StaticResource PrimaryButton}"
+                                Padding="16,8"
+                                Margin="0,0,8,8" />
+                    </WrapPanel>
+
+                    <ItemsControl ItemsSource="{Binding FileChecks}" Margin="0,4,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Margin="0,0,0,6">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <Grid Grid.Column="0" Width="20" VerticalAlignment="Top">
+                                        <TextBlock Text="&#x2713;"
+                                                   Foreground="{DynamicResource SuccessBrush}"
+                                                   Visibility="{Binding CanBeRestored, Converter={StaticResource BoolToVis}}" />
+                                        <TextBlock Text="&#x2717;"
+                                                   Foreground="{DynamicResource ErrorBrush}"
+                                                   Visibility="{Binding CanBeRestored, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+                                    </Grid>
+
+                                    <StackPanel Grid.Column="1">
+                                        <TextBlock Text="{Binding Path}"
+                                                   TextWrapping="Wrap"
+                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                   FontSize="12" />
+                                        <TextBlock Text="{Binding Message}"
+                                                   TextWrapping="Wrap"
+                                                   Style="{StaticResource SecondaryText}"
+                                                   FontSize="11"
+                                                   Visibility="{Binding CanBeRestored, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+                                    </StackPanel>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
+            <!-- Step 5: the script -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="5. The script" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock TextWrapping="Wrap"
+                               Style="{StaticResource SecondaryText}"
+                               Margin="0,4,0,12"
+                               Text="Only offered once the target has confirmed it can read every file. A script generated before that is one that fails part-way through - after WITH REPLACE has already dropped the database being restored over." />
+
+                    <Grid Margin="0,0,0,12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="RESTORE AS" Style="{StaticResource LabelText}" />
+                            <TextBox Text="{Binding TargetDatabaseName, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource DarkTextBox}"
+                                     Margin="0,4,0,0" />
+                        </StackPanel>
+
+                        <CheckBox Grid.Column="2"
+                                  Content="Overwrite if it already exists (WITH REPLACE)"
+                                  IsChecked="{Binding WithReplace}"
+                                  Style="{StaticResource DarkCheckBox}"
+                                  VerticalAlignment="Bottom"
+                                  Margin="0,0,0,8" />
+                    </Grid>
+
+                    <WrapPanel>
+                        <Button Content="Generate script"
+                                Command="{Binding GenerateScriptCommand}"
+                                IsEnabled="{Binding CanGenerate}"
+                                Style="{StaticResource PrimaryButton}"
+                                Padding="16,8"
+                                Margin="0,0,8,8" />
+                        <Button Content="Copy to clipboard"
+                                Command="{Binding CopyScriptCommand}"
+                                IsEnabled="{Binding HasScript}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="16,8"
+                                Margin="0,0,8,8" />
+                    </WrapPanel>
+
+                    <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                            BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Margin="0,4,0,0"
+                            Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
+                        <ScrollViewer MaxHeight="320"
+                                      VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      Padding="12,10,12,10">
+                            <views:SqlTextBlock Sql="{Binding GeneratedScript}"
+                                                FontFamily="{StaticResource ConsoleFont}"
+                                                FontSize="12"
+                                                TextWrapping="NoWrap"
+                                                Foreground="{DynamicResource ConsoleTextBrush}" />
+                        </ScrollViewer>
+                    </Border>
+                </StackPanel>
+            </Border>
+
+            <!-- Status -->
+            <!-- Binds itself to the ViewModelBase members on the inherited DataContext. -->
+            <ContentControl Style="{StaticResource ErrorBanner}" />
+
+            <TextBlock Text="{Binding StatusMessage}"
+                       Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,16" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/NineLives/Views/SharedLocationRestoreView.xaml.cs
+++ b/src/NineLives/Views/SharedLocationRestoreView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class SharedLocationRestoreView : UserControl
+{
+    public SharedLocationRestoreView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Closes #149.

The engine landed over #161-#163; this is the screen that drives it.

## The workflow

Five steps in the order the issue sets out, which is not presentation - each step's output is the next one's input:

1. **Source and target.** The source is the instance that took the backups; the target is the one the restore runs on. They are usually not the same, and that difference is the whole point of the screen.
2. **What the source recorded.** Chains from msdb, assembled by LSN.
3. **How the target reaches the files.** The path substitution, when the two hosts reach the same place by different names.
4. **Can the target read them.** Asked on the target, by the account that will do the work.
5. **The script.**

The chain comes from the source's msdb and the script is generated from the files the target confirmed it can read, so the screen cannot offer to run a restore it has not checked - it would have nothing to generate from. Choosing a different chain withdraws the verification: different files, so nothing proved about the last one still applies.

## Step 3 is the one that catches people out

msdb records paths as the SOURCE wrote them. A job that backed up to `E:\SQLBackups\MyDb.bak` recorded a path that means something entirely different on the target - and if it resolves there at all, it resolves to the target's own E: drive, which is worse than failing. So the target is asked about ITS name for the file, and the script names the files the same way.

A local source path is warned about **before** the check runs rather than after it, because it is the one failure here that can end in a *successful* restore of the wrong backup.

## What rendering the screen caught

Two bugs nothing else would have:

- Under this app's ComboBox template a `DisplayMemberPath` left the selection box showing `Blackcat.NineLives.Models.ServerConnection`. No exception, no traced binding error - only wrong to look at.
- The tick was one `Run` with a trigger swapping its `Text`, and a style setter cannot override a locally set value. The row that FAILED kept its tick and only changed colour. On a screen whose entire job is saying which files the target cannot read, that is the worst thing it could draw.

Both are pinned by tests that assert on what is drawn.

## Also

- Nothing is preselected, the same rule the Restore screen learned.
- Sidebar entry and Ctrl+5; History, Settings and About shift down one.

1,060 tests pass.