### PR TITLE
Take a backup, to either medium (#165)

### DIFF
--- a/src/NineLives.Tests/BackupDestinationBuilderTests.cs
+++ b/src/NineLives.Tests/BackupDestinationBuilderTests.cs
@@ -1,0 +1,240 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A backup this app writes has to be one this app can then FIND (#165).
+///
+/// The blob path infers a backup's type, server and database from where it sits in the container,
+/// using the container's own configured pattern. A backup written to a layout of its own would land
+/// in the container and be invisible to the screen that would restore it - which is the worst shape
+/// a backup can take, because it looks like it worked.
+///
+/// So the tests that matter here are round trips: write a destination, list it back through the
+/// real parser, and check the app recognises what it wrote.
+/// </summary>
+public class BackupDestinationBuilderTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 30, 15);
+
+    private static BlobContainerConfig Container(string? pattern = null) => new()
+    {
+        Id = "c1",
+        Name = "backups",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups",
+        PathPattern = pattern ?? "{BackupType}/{ServerName}/{DatabaseName}/{FileName}"
+    };
+
+    // ── the round trip ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The one that matters. Everything else here is a detail of this.
+    /// </summary>
+    [Theory]
+    [InlineData(BackupType.Full)]
+    [InlineData(BackupType.Differential)]
+    [InlineData(BackupType.TransactionLog)]
+    public void ABackupWrittenByThisAppIsFoundByThisApp(BackupType type)
+    {
+        var container = Container();
+        var url = BackupDestinationBuilder
+            .ForContainer(container, "SRV01", "MyDb", type, T0, copyOnly: false)
+            .Single();
+
+        var found = ListBack(container, url);
+
+        Assert.Equal(type, found.Type);
+        Assert.Equal("SRV01", found.InferredServerName);
+        Assert.Equal("MyDb", found.InferredDatabaseName);
+    }
+
+    [Fact]
+    public void ACopyOnlyBackupIsRecognisedAsCopyOnlyWhenItIsListedBack()
+    {
+        var container = Container();
+        var url = BackupDestinationBuilder
+            .ForContainer(container, "SRV01", "MyDb", BackupType.Full, T0, copyOnly: true)
+            .Single();
+
+        Assert.True(ListBack(container, url).IsCopyOnly);
+    }
+
+    /// <summary>
+    /// The timestamp is what groups stripes into one set and orders sets on the timeline, and the
+    /// parser looks for exactly yyyyMMdd_HHmmss - so the format is a requirement, not a preference.
+    /// </summary>
+    [Fact]
+    public void TheTimestampInTheNameIsTheOneTheParserReads()
+    {
+        var name = BackupDestinationBuilder.FileName("MyDb", BackupType.Full, T0);
+
+        Assert.Equal(T0, BackupSet.ParseTimestamp(name));
+    }
+
+    [Fact]
+    public void AStripedBackupIsWrittenAsOneFilePerStripe()
+    {
+        var urls = BackupDestinationBuilder
+            .ForContainer(Container(), "SRV01", "MyDb", BackupType.Full, T0, stripes: 3);
+
+        Assert.Equal(3, urls.Count);
+        Assert.EndsWith("_1.bak", urls[0]);
+        Assert.EndsWith("_2.bak", urls[1]);
+        Assert.EndsWith("_3.bak", urls[2]);
+    }
+
+    /// <summary>A single-file backup carries no stripe number, because it is not one of several.</summary>
+    [Fact]
+    public void AnUnstripedBackupHasNoStripeNumber()
+    {
+        var url = BackupDestinationBuilder
+            .ForContainer(Container(), "SRV01", "MyDb", BackupType.Full, T0)
+            .Single();
+
+        Assert.EndsWith("_20260801_223015.bak", url);
+    }
+
+    // ── the container's own pattern, not one of ours ────────────────────────────
+
+    [Fact]
+    public void ThePatternTheContainerIsConfiguredWithIsTheOneUsed()
+    {
+        var container = Container("{ServerName}/{DatabaseName}/{BackupType}/{FileName}");
+
+        var url = BackupDestinationBuilder
+            .ForContainer(container, "SRV01", "MyDb", BackupType.Full, T0)
+            .Single();
+
+        Assert.Contains("/SRV01/MyDb/FULL/", url);
+        Assert.Equal(BackupType.Full, ListBack(container, url).Type);
+    }
+
+    [Fact]
+    public void ANamedInstanceIsSplitTheWayThePathParserExpects()
+    {
+        var container = Container("{BackupType}/{ServerName}/{InstanceName}/{DatabaseName}/{FileName}");
+
+        var url = BackupDestinationBuilder
+            .ForContainer(container, @"SRV01\PROD", "MyDb", BackupType.Full, T0)
+            .Single();
+
+        Assert.Contains("/FULL/SRV01/PROD/MyDb/", url);
+    }
+
+    /// <summary>
+    /// A pattern with a token this app cannot fill would otherwise leave an empty segment, putting
+    /// the backup one folder shallower than the listing expects to find it.
+    /// </summary>
+    [Fact]
+    public void AnUnfillableTokenDoesNotLeaveAHoleInThePath()
+    {
+        var container = Container("{BackupType}/{ServerName}/{InstanceName}/{DatabaseName}/{FileName}");
+
+        var url = BackupDestinationBuilder
+            .ForContainer(container, "SRV01", "MyDb", BackupType.Full, T0)
+            .Single();
+
+        Assert.DoesNotContain("//backups//", url);
+        Assert.Contains("/FULL/SRV01/MyDb/", url);
+    }
+
+    [Fact]
+    public void ATrailingSlashOnTheContainerUrlDoesNotDoubleUp()
+    {
+        var container = Container();
+        container.ContainerUrl = "https://acct.blob.core.windows.net/backups/";
+
+        var url = BackupDestinationBuilder
+            .ForContainer(container, "SRV01", "MyDb", BackupType.Full, T0)
+            .Single();
+
+        Assert.DoesNotContain("backups//FULL", url);
+    }
+
+    // ── names that are legal on SQL Server and not in a path ────────────────────
+
+    /// <summary>
+    /// A database name is far freer than a filename. <c>My/Db</c> is legal on SQL Server and would
+    /// silently become a FOLDER in a blob path, putting the backup somewhere the listing reads as a
+    /// different database entirely.
+    /// </summary>
+    [Fact]
+    public void ASlashInADatabaseNameDoesNotBecomeAFolder()
+    {
+        var container = Container();
+
+        var url = BackupDestinationBuilder
+            .ForContainer(container, "SRV01", "My/Db", BackupType.Full, T0)
+            .Single();
+
+        Assert.Contains("/My_Db/", url);
+        Assert.Equal("My_Db", ListBack(container, url).InferredDatabaseName);
+    }
+
+    [Theory]
+    [InlineData("My:Db")]
+    [InlineData("My*Db")]
+    [InlineData(@"My\Db")]
+    public void CharactersAFileNameCannotHoldAreReplaced(string databaseName)
+    {
+        var name = BackupDestinationBuilder.FileName(databaseName, BackupType.Full, T0);
+
+        Assert.DoesNotContain(":", name);
+        Assert.DoesNotContain("*", name);
+        Assert.DoesNotContain(@"\", name);
+    }
+
+    // ── a share ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A share needs no pattern - backups there are found through the source instance's msdb, which
+    /// records the path. So the layout only has to be sane for a person looking at the folder.
+    /// </summary>
+    [Fact]
+    public void ABackupToAShareGoesInADirectoryPerDatabase()
+    {
+        var path = BackupDestinationBuilder
+            .ForSharedPath(@"\\nas01\sql", "MyDb", BackupType.Full, T0)
+            .Single();
+
+        Assert.Equal(@"\\nas01\sql\MyDb\MyDb_FULL_COPY_ONLY_20260801_223015.bak", path);
+    }
+
+    [Fact]
+    public void ATrailingSeparatorOnTheShareRootDoesNotDoubleUp()
+    {
+        var path = BackupDestinationBuilder
+            .ForSharedPath(@"\\nas01\sql\", "MyDb", BackupType.Full, T0)
+            .Single();
+
+        Assert.DoesNotContain(@"sql\\MyDb", path);
+    }
+
+    [Fact]
+    public void ALogBackupToAShareIsWrittenAsTrn()
+    {
+        var path = BackupDestinationBuilder
+            .ForSharedPath(@"\\nas01\sql", "MyDb", BackupType.TransactionLog, T0)
+            .Single();
+
+        Assert.EndsWith(".trn", path);
+    }
+
+    // ── helper ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Runs a written destination back through the REAL listing parser, so these tests break if
+    /// either side of the round trip changes without the other.
+    /// </summary>
+    private static BackupFileInfo ListBack(BlobContainerConfig container, string url)
+    {
+        var blobName = url[(container.ContainerUrl.TrimEnd('/').Length + 1)..];
+
+        var files = new BlobStorageService(new FakeCredentialStore())
+            .ParseListedBlobsForTests(container, [(blobName, 5_000_000L, new DateTimeOffset(T0, TimeSpan.Zero))]);
+
+        return Assert.Single(files);
+    }
+}

--- a/src/NineLives.Tests/BackupScriptGeneratorTests.cs
+++ b/src/NineLives.Tests/BackupScriptGeneratorTests.cs
@@ -1,0 +1,211 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Taking a backup, to either medium (#165).
+///
+/// The app has only ever restored backups other things took. This is the half that touches a
+/// PRODUCTION server, so the defaults matter more than the restore ones do - and most of these
+/// tests are about a default rather than about syntax.
+/// </summary>
+public class BackupScriptGeneratorTests
+{
+    private static string Generate(Action<BackupOptions>? configure = null)
+    {
+        var options = new BackupOptions
+        {
+            DatabaseName = "MyDb",
+            Medium = BackupMedium.SharedPath,
+            Destinations = [@"\\nas01\sql\MyDb_full.bak"]
+        };
+
+        configure?.Invoke(options);
+        return new BackupScriptGenerator().Generate(options);
+    }
+
+    // ── the medium ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ABackupToAShareIsWrittenToDisk()
+    {
+        var script = Generate();
+
+        Assert.Contains(@"TO DISK = N'\\nas01\sql\MyDb_full.bak'", script);
+        Assert.DoesNotContain("URL =", script);
+    }
+
+    [Fact]
+    public void ABackupToBlobIsWrittenToUrl()
+    {
+        var script = Generate(o =>
+        {
+            o.Medium = BackupMedium.AzureBlob;
+            o.Destinations = ["https://acct.blob.core.windows.net/backups/MyDb_full.bak"];
+        });
+
+        Assert.Contains("TO URL = N'https://acct.blob.core.windows.net/backups/MyDb_full.bak'", script);
+        Assert.DoesNotContain("DISK =", script);
+    }
+
+    /// <summary>
+    /// A blob URL is percent-encoded and a path is not. A UNC path is not a URI, and encoding one
+    /// produces a path SQL Server cannot open.
+    /// </summary>
+    [Fact]
+    public void APathWithSpacesIsNotUrlEncoded()
+    {
+        var script = Generate(o => o.Destinations = [@"\\nas01\SQL Backups\My Db\full backup.bak"]);
+
+        Assert.Contains(@"DISK = N'\\nas01\SQL Backups\My Db\full backup.bak'", script);
+        Assert.DoesNotContain("%20", script);
+    }
+
+    [Fact]
+    public void ABlobUrlWithSpacesIsEncoded()
+    {
+        var script = Generate(o =>
+        {
+            o.Medium = BackupMedium.AzureBlob;
+            o.Destinations = ["https://acct.blob.core.windows.net/backups/My Db.bak"];
+        });
+
+        Assert.Contains("My%20Db.bak", script);
+    }
+
+    [Fact]
+    public void EveryStripeIsNamedInOrder()
+    {
+        var script = Generate(o => o.Destinations =
+            [@"\\nas01\sql\p1.bak", @"\\nas01\sql\p2.bak", @"\\nas01\sql\p3.bak"]);
+
+        var one = script.IndexOf("p1.bak", StringComparison.Ordinal);
+        var two = script.IndexOf("p2.bak", StringComparison.Ordinal);
+        var three = script.IndexOf("p3.bak", StringComparison.Ordinal);
+
+        Assert.True(one > 0 && two > one && three > two, "stripes must be named in order");
+    }
+
+    // ── the defaults that protect the source ────────────────────────────────────
+
+    /// <summary>
+    /// The most important default in this file.
+    ///
+    /// A plain full backup resets the differential base on the source, so every differential the
+    /// production schedule takes afterwards is based on a backup living in this app's container
+    /// that whoever runs the restore has never heard of.
+    /// </summary>
+    [Fact]
+    public void ABackupIsCopyOnlyUnlessSomebodySaysOtherwise()
+    {
+        Assert.Contains("COPY_ONLY", Generate());
+    }
+
+    /// <summary>
+    /// And turning it off says what that costs, in the script itself - the script gets copied into
+    /// SSMS and run by somebody who never saw the checkbox.
+    /// </summary>
+    [Fact]
+    public void TurningCopyOnlyOffWarnsAboutTheDifferentialBaseInTheScript()
+    {
+        var script = Generate(o => o.CopyOnly = false);
+
+        Assert.DoesNotContain("COPY_ONLY", script);
+        Assert.Contains("RESETS THE DIFFERENTIAL", script);
+    }
+
+    [Fact]
+    public void CompressionAndChecksumAreOnByDefault()
+    {
+        var script = Generate();
+
+        Assert.Contains("COMPRESSION", script);
+        Assert.Contains("CHECKSUM", script);
+    }
+
+    /// <summary>
+    /// CHECKSUM is what makes a later RESTORE VERIFYONLY mean anything - against a backup taken
+    /// without it, verifying can only confirm the file is readable.
+    /// </summary>
+    [Fact]
+    public void ChecksumCanBeTurnedOff()
+    {
+        Assert.DoesNotContain("CHECKSUM", Generate(o => o.Checksum = false));
+    }
+
+    /// <summary>
+    /// FORMAT discards whatever the media set already holds, so it is never inferred - only ever
+    /// asked for.
+    /// </summary>
+    [Fact]
+    public void FormatIsNotWrittenUnlessItWasAskedFor()
+    {
+        var script = Generate();
+
+        Assert.DoesNotContain("FORMAT", script);
+        Assert.Contains("INIT", script);
+    }
+
+    /// <summary>FORMAT implies INIT, so naming both is noise at best.</summary>
+    [Fact]
+    public void FormatReplacesInitRatherThanJoiningIt()
+    {
+        var script = Generate(o => o.Format = true);
+
+        Assert.Contains("FORMAT", script);
+        Assert.DoesNotContain("INIT", script);
+    }
+
+    // ── the ordinary care ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ADatabaseNameIsQuotedRatherThanConcatenated()
+    {
+        var script = Generate(o => o.DatabaseName = "My Db");
+
+        Assert.Contains("BACKUP DATABASE [My Db]", script);
+    }
+
+    [Fact]
+    public void ADatabaseNameWithABracketCannotBreakOutOfTheIdentifier()
+    {
+        var script = Generate(o => o.DatabaseName = "My]Db");
+
+        Assert.Contains("BACKUP DATABASE [My]]Db]", script);
+    }
+
+    [Fact]
+    public void AQuoteInADescriptionCannotBreakOutOfTheLiteral()
+    {
+        var script = Generate(o => o.Description = "Jake's refresh");
+
+        Assert.Contains("N'Jake''s refresh'", script);
+    }
+
+    [Fact]
+    public void NothingIsGeneratedWithoutADatabase()
+    {
+        Assert.Equal(string.Empty, Generate(o => o.DatabaseName = string.Empty));
+    }
+
+    /// <summary>
+    /// A BACKUP with nowhere to write is not a partial script to be fixed up by hand - it is a
+    /// statement that would fail, and offering it invites somebody to fill in a device themselves.
+    /// </summary>
+    [Fact]
+    public void NothingIsGeneratedWithoutSomewhereToWriteTo()
+    {
+        Assert.Equal(string.Empty, Generate(o => o.Destinations = []));
+    }
+
+    [Fact]
+    public void TheDatabaseAndFileCountAreStatedInTheHeader()
+    {
+        var script = Generate(o => o.Destinations = [@"\\nas01\sql\p1.bak", @"\\nas01\sql\p2.bak"]);
+
+        Assert.Contains("Database:  MyDb", script);
+        Assert.Contains("2 file(s)", script);
+    }
+}

--- a/src/NineLives.Tests/BackupViewModelTests.cs
+++ b/src/NineLives.Tests/BackupViewModelTests.cs
@@ -1,0 +1,286 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Taking a backup (#165).
+///
+/// The asymmetry these are mostly about: a restore destroys the TARGET and everybody expects that,
+/// so the app guards it loudly. A backup looks harmless and can quietly damage the SOURCE - a plain
+/// full moves a production database's differential base, and nothing about pressing the button says
+/// so. Most of what follows is that guard.
+/// </summary>
+public class BackupViewModelTests
+{
+    /// <summary>A log in a temp directory: constructing this must not append to the user's own.</summary>
+    private static OperationLog TestLog() =>
+        new(Path.Combine(Path.GetTempPath(), "ninelives-backup-tests", Guid.NewGuid().ToString("n")));
+
+    private static (BackupViewModel vm, FakeSqlServerService sql) New()
+    {
+        var store = new FakeCredentialStore();
+
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb", "OtherDb"] };
+        var vm = new BackupViewModel(store, sql, TestLog());
+
+        vm.Server = vm.Servers.Single();
+        vm.Container = vm.Containers.Single();
+
+        return (vm, sql);
+    }
+
+    private static async Task<(BackupViewModel vm, FakeSqlServerService sql)> ReadyAsync()
+    {
+        var (vm, sql) = New();
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.SelectedDatabase = "MyDb";
+        vm.GenerateCommand.Execute(null);
+        return (vm, sql);
+    }
+
+    // ── nothing runs that was not on screen first ───────────────────────────────
+
+    [Fact]
+    public async Task NothingCanRunUntilThereIsAScriptToRead()
+    {
+        var (vm, sql) = New();
+
+        Assert.False(vm.CanExecute);
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    /// <summary>
+    /// Armed on the first press, run on the second - the same rule the restore has, for a different
+    /// reason. A backup reads a production server flat out and can move its differential base.
+    /// </summary>
+    [Fact]
+    public async Task TheFirstPressArmsAndTheSecondRuns()
+    {
+        var (vm, sql) = await ReadyAsync();
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        Assert.True(vm.IsArmed);
+        Assert.Empty(sql.ExecutedScripts);
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        Assert.False(vm.IsArmed);
+        Assert.Single(sql.ExecutedScripts);
+    }
+
+    /// <summary>
+    /// An armed button that survives an option change is armed for something else. Changing what
+    /// the backup would do has to take the safety catch back off.
+    /// </summary>
+    [Fact]
+    public async Task ChangingAnOptionDisarmsTheButton()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+        Assert.True(vm.IsArmed);
+
+        vm.CopyOnly = false;
+
+        Assert.False(vm.IsArmed);
+    }
+
+    /// <summary>
+    /// The script on screen is what runs. A stale one is a script that does something different
+    /// from what it shows, and here what it shows is the only warning anybody gets.
+    /// </summary>
+    [Fact]
+    public async Task ChangingAnOptionRewritesTheScript()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        Assert.Contains("COPY_ONLY", vm.GeneratedScript);
+
+        vm.CopyOnly = false;
+
+        Assert.DoesNotContain("COPY_ONLY", vm.GeneratedScript);
+        Assert.Contains("RESETS THE DIFFERENTIAL", vm.GeneratedScript);
+    }
+
+    // ── the source-side guard ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ABackupIsCopyOnlyUntilSomebodyChangesIt()
+    {
+        var (vm, _) = New();
+
+        Assert.True(vm.CopyOnly);
+        Assert.False(vm.WillResetTheDifferentialBase);
+    }
+
+    [Fact]
+    public void TurningCopyOnlyOffIsSurfacedAsSomethingThatHappensToTheSource()
+    {
+        var (vm, _) = New();
+
+        vm.CopyOnly = false;
+
+        Assert.True(vm.WillResetTheDifferentialBase);
+    }
+
+    /// <summary>
+    /// It is also said in the console, because by then the script has scrolled out of view and this
+    /// is the last chance to say it before a production database's schedule changes.
+    /// </summary>
+    [Fact]
+    public async Task RunningANonCopyOnlyBackupSaysSoAsItStarts()
+    {
+        var (vm, _) = await ReadyAsync();
+        vm.CopyOnly = false;
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        Assert.Contains(vm.Console, l => l.Contains("differential base", StringComparison.Ordinal));
+    }
+
+    // ── nothing is chosen for the user ──────────────────────────────────────────
+
+    /// <summary>
+    /// The same rule the Restore screen learned, and it matters more here: the wrong choice is a
+    /// production database read at full speed for several minutes.
+    /// </summary>
+    [Fact]
+    public async Task ListingTheDatabasesChoosesNoneOfThem()
+    {
+        var (vm, _) = New();
+
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, vm.Databases.Count);
+        Assert.Null(vm.SelectedDatabase);
+        Assert.False(vm.CanGenerate);
+    }
+
+    /// <summary>
+    /// A database list left over from another instance invites somebody to back up a name that
+    /// exists on both and mean the other one.
+    /// </summary>
+    [Fact]
+    public async Task ChangingTheServerDropsTheDatabaseList()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        vm.Server = null;
+
+        Assert.Empty(vm.Databases);
+        Assert.Null(vm.SelectedDatabase);
+        Assert.False(vm.CanGenerate);
+    }
+
+    // ── where it goes ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ABackupToBlobIsWrittenIntoTheChosenContainer()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        Assert.Contains("TO URL", vm.GeneratedScript);
+        Assert.Contains("https://acct.blob.core.windows.net/backups/", Assert.Single(vm.Destinations));
+    }
+
+    [Fact]
+    public async Task ABackupToAShareIsWrittenToTheFolderGiven()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        vm.Medium = BackupMedium.SharedPath;
+        vm.SharedPathRoot = @"\\nas01\sql";
+        vm.GenerateCommand.Execute(null);
+
+        Assert.Contains("TO DISK", vm.GeneratedScript);
+        Assert.StartsWith(@"\\nas01\sql\MyDb\", Assert.Single(vm.Destinations));
+    }
+
+    /// <summary>
+    /// Switching medium leaves the destination unanswered, so nothing can be generated against the
+    /// other medium's answer.
+    /// </summary>
+    [Fact]
+    public async Task SwitchingToASharedPathNeedsAFolderBeforeAnythingCanBeGenerated()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        vm.Medium = BackupMedium.SharedPath;
+
+        Assert.False(vm.CanGenerate);
+    }
+
+    [Fact]
+    public async Task AStripedBackupNamesOneFilePerStripe()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        vm.Stripes = 4;
+
+        Assert.Equal(4, vm.Destinations.Count);
+    }
+
+    // ── what happens when it goes wrong ─────────────────────────────────────────
+
+    /// <summary>
+    /// A cancelled BACKUP leaves a partial file behind. It is not a backup, and it will sit in the
+    /// container looking exactly like one - so the app says so rather than reporting "cancelled"
+    /// and leaving somebody to find out at restore time.
+    /// </summary>
+    [Fact]
+    public async Task ACancelledBackupSaysThePartialFileIsNotUsable()
+    {
+        var (vm, sql) = await ReadyAsync();
+        sql.ExecuteThrows = new OperationCanceledException();
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        Assert.Contains(vm.Console, l => l.Contains("incomplete", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AFailedBackupReportsWhatTheServerSaid()
+    {
+        var (vm, sql) = await ReadyAsync();
+        sql.ExecuteThrows = new InvalidOperationException("Cannot open backup device");
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        Assert.True(vm.HasError);
+        Assert.Contains("Cannot open backup device", vm.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task AFailureLeavesTheButtonUsableAgain()
+    {
+        var (vm, sql) = await ReadyAsync();
+        sql.ExecuteThrows = new InvalidOperationException("nope");
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        Assert.False(vm.IsRunning);
+        Assert.True(vm.CanExecute);
+    }
+}

--- a/src/NineLives.Tests/CancellationTests.cs
+++ b/src/NineLives.Tests/CancellationTests.cs
@@ -144,7 +144,7 @@ public class SqlCancellationTests
         var messages = new List<string>();
 
         var started = Stopwatch.StartNew();
-        var run = Service().ExecuteRestoreWithProgressAsync(
+        var run = Service().ExecuteWithProgressAsync(
             TestServer(),
             "WAITFOR DELAY '00:00:30'",
             messages.Add,
@@ -176,7 +176,7 @@ public class SqlCancellationTests
         var messages = new List<string>();
 
         await Assert.ThrowsAsync<Microsoft.Data.SqlClient.SqlException>(() =>
-            Service().ExecuteRestoreWithProgressAsync(
+            Service().ExecuteWithProgressAsync(
                 TestServer(),
                 "RESTORE DATABASE [NineLives_NoSuchDb] FROM DISK = 'Z:\\nope.bak'",
                 messages.Add,
@@ -192,7 +192,7 @@ public class SqlCancellationTests
         await cts.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-            Service().ExecuteRestoreWithProgressAsync(
+            Service().ExecuteWithProgressAsync(
                 TestServer(), "SELECT 1", null, cts.Token));
     }
 
@@ -203,7 +203,7 @@ public class SqlCancellationTests
         using var cts = new CancellationTokenSource();
         var messages = new List<string>();
 
-        await Service().ExecuteRestoreWithProgressAsync(
+        await Service().ExecuteWithProgressAsync(
             TestServer(), "SELECT 1", messages.Add, cts.Token);
 
         Assert.NotEmpty(messages);

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -174,8 +174,11 @@ public sealed class FakeSqlServerService : ISqlServerService
     public Task<string> GetServerVersionAsync(ServerConnection server, CancellationToken ct = default)
         => Task.FromResult("Microsoft SQL Server 2022");
 
+    /// <summary>What the fake instance says it holds.</summary>
+    public List<string> DatabaseList { get; set; } = [];
+
     public Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
-        => Task.FromResult(new List<string>());
+        => Task.FromResult(DatabaseList);
 
     public Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(ServerConnection server, CancellationToken ct = default)
         => Task.FromResult((@"D:\Data", @"D:\Logs"));
@@ -228,7 +231,7 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.CompletedTask;
     }
 
-    public Task ExecuteRestoreWithProgressAsync(
+    public Task ExecuteWithProgressAsync(
         ServerConnection server, string sql, Action<string>? messageCallback = null, CancellationToken ct = default)
     {
         ExecutedAgainst.Add(server);

--- a/src/NineLives.Tests/SqlExecutionFailureTests.cs
+++ b/src/NineLives.Tests/SqlExecutionFailureTests.cs
@@ -65,7 +65,7 @@ public class SqlExecutionFailureTests
         var messages = new List<string>();
 
         await Assert.ThrowsAsync<SqlException>(() =>
-            Service().ExecuteRestoreWithProgressAsync(
+            Service().ExecuteWithProgressAsync(
                 TestServer(), FailingBatch, messages.Add));
     }
 
@@ -75,7 +75,7 @@ public class SqlExecutionFailureTests
         var messages = new List<string>();
 
         var ex = await Assert.ThrowsAsync<SqlException>(() =>
-            Service().ExecuteRestoreWithProgressAsync(
+            Service().ExecuteWithProgressAsync(
                 TestServer(), FailingRestore, messages.Add));
 
         // 3201 = cannot open backup device. This is the error an expired SAS produces.
@@ -99,7 +99,7 @@ public class SqlExecutionFailureTests
         ]);
 
         await Assert.ThrowsAsync<SqlException>(() =>
-            Service().ExecuteRestoreWithProgressAsync(TestServer(), script, messages.Add));
+            Service().ExecuteWithProgressAsync(TestServer(), script, messages.Add));
 
         Assert.Contains(messages, m => m.Contains("nine-lives-statement-1"));
         Assert.DoesNotContain(messages, m => m.Contains("should-not-run"));
@@ -112,7 +112,7 @@ public class SqlExecutionFailureTests
         // is what RESTORE's "X percent processed" and PRINT are - must still arrive after the fix.
         var messages = new List<string>();
 
-        await Service().ExecuteRestoreWithProgressAsync(
+        await Service().ExecuteWithProgressAsync(
             TestServer(), "PRINT 'nine-lives-progress-message';", messages.Add);
 
         Assert.Contains(messages, m => m.Contains("nine-lives-progress-message"));
@@ -125,7 +125,7 @@ public class SqlExecutionFailureTests
         // otherwise ordinary restore chatter would abort a healthy restore.
         var messages = new List<string>();
 
-        await Service().ExecuteRestoreWithProgressAsync(
+        await Service().ExecuteWithProgressAsync(
             TestServer(), "RAISERROR('nine-lives-informational', 10, 1);", messages.Add);
 
         Assert.Contains(messages, m => m.Contains("nine-lives-informational"));

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -832,6 +832,69 @@ public class XamlLoadTests(WpfFixture wpf)
         => Check("HistoryView (empty)", () =>
             new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) });
 
+    // ── the Backup screen (#165) ────────────────────────────────────────────────
+
+    [Fact]
+    public void BackupViewLoads()
+        => Check("BackupView", () => new BackupView { DataContext = NewBackupViewModel() });
+
+    [Fact]
+    public void TheBackupViewLoadsWithASharedPathChosen()
+        => Check("BackupView (shared path)", () =>
+        {
+            var vm = NewBackupViewModel();
+            vm.Medium = BackupMedium.SharedPath;
+            return new BackupView { DataContext = vm };
+        });
+
+    /// <summary>
+    /// Turning COPY_ONLY off puts what it costs on screen, in the terms it costs it in.
+    ///
+    /// This is the one thing on the screen that changes the SOURCE, and it is the one thing nothing
+    /// about pressing the button would otherwise say. A collapsed banner is not a warning, so this
+    /// asserts on what is drawn.
+    /// </summary>
+    [Fact]
+    public void TurningCopyOnlyOffWarnsAboutTheSourceOnScreen()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewBackupViewModel();
+            vm.CopyOnly = false;
+
+            var view = new BackupView { DataContext = vm };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.Contains("THIS WILL CHANGE THE SOURCE DATABASE", shown);
+            Assert.Contains(shown, t => t.Contains("differential base", StringComparison.Ordinal));
+        });
+    }
+
+    [Fact]
+    public void ACopyOnlyBackupSaysNothingAboutChangingTheSource()
+    {
+        wpf.Invoke(() =>
+        {
+            var view = new BackupView { DataContext = NewBackupViewModel() };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.DoesNotContain("THIS WILL CHANGE THE SOURCE DATABASE", shown);
+        });
+    }
+
+    private static BackupViewModel NewBackupViewModel()
+    {
+        var store = Store();
+        return new BackupViewModel(
+            store,
+            new SqlServerService(store),
+            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))));
+    }
+
     // ── the Restore screen under a shared path (#149, #165) ─────────────────
 
     /// <summary>

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -25,10 +25,11 @@
         <KeyBinding Modifiers="Ctrl" Key="D1" Command="{Binding NavigateToCommand}" CommandParameter="Blob Storage" />
         <KeyBinding Modifiers="Ctrl" Key="D2" Command="{Binding NavigateToCommand}" CommandParameter="SQL Servers" />
         <KeyBinding Modifiers="Ctrl" Key="D3" Command="{Binding NavigateToCommand}" CommandParameter="Browse Backups" />
-        <KeyBinding Modifiers="Ctrl" Key="D4" Command="{Binding NavigateToCommand}" CommandParameter="Restore" />
-        <KeyBinding Modifiers="Ctrl" Key="D5" Command="{Binding NavigateToCommand}" CommandParameter="History" />
-        <KeyBinding Modifiers="Ctrl" Key="D6" Command="{Binding NavigateToCommand}" CommandParameter="Settings" />
-        <KeyBinding Modifiers="Ctrl" Key="D7" Command="{Binding NavigateToCommand}" CommandParameter="About" />
+        <KeyBinding Modifiers="Ctrl" Key="D4" Command="{Binding NavigateToCommand}" CommandParameter="Back Up" />
+        <KeyBinding Modifiers="Ctrl" Key="D5" Command="{Binding NavigateToCommand}" CommandParameter="Restore" />
+        <KeyBinding Modifiers="Ctrl" Key="D6" Command="{Binding NavigateToCommand}" CommandParameter="History" />
+        <KeyBinding Modifiers="Ctrl" Key="D7" Command="{Binding NavigateToCommand}" CommandParameter="Settings" />
+        <KeyBinding Modifiers="Ctrl" Key="D8" Command="{Binding NavigateToCommand}" CommandParameter="About" />
         <KeyBinding Key="F5" Command="{Binding ReloadCommand}" />
         <KeyBinding Modifiers="Ctrl" Key="G" Command="{Binding GenerateScriptCommand}" />
         <KeyBinding Key="Escape" Command="{Binding CancelCurrentCommand}" />
@@ -50,6 +51,9 @@
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:BlobBrowserViewModel}">
             <views:BlobBrowserView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:BackupViewModel}">
+            <views:BackupView />
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:RestoreViewModel}">
             <views:RestoreView />
@@ -259,6 +263,16 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#x1F4C2;" FontSize="15" VerticalAlignment="Center" Width="24" />
                                 <TextBlock Text="Browse Backups" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <RadioButton Style="{StaticResource SidebarButton}"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Back Up'}"
+                                     Command="{Binding NavigateToCommand}"
+                                     CommandParameter="Back Up">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#x1F4BE;" FontSize="15" VerticalAlignment="Center" Width="24" />
+                                <TextBlock Text="Back Up" VerticalAlignment="Center" />
                             </StackPanel>
                         </RadioButton>
 

--- a/src/NineLives/Models/BackupOptions.cs
+++ b/src/NineLives/Models/BackupOptions.cs
@@ -1,0 +1,75 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// What a BACKUP should do (#165).
+///
+/// The app has only ever restored backups other things took. Taking one is the other half of an
+/// orchestrator, and it is the half that touches a production server - so the defaults here matter
+/// more than the restore ones do. Every default below is the safe reading of a choice that has a
+/// dangerous one.
+/// </summary>
+public class BackupOptions
+{
+    /// <summary>The database to back up, as it is named on the source instance.</summary>
+    public string DatabaseName { get; set; } = string.Empty;
+
+    /// <summary>Where it is written. The medium decides TO URL or TO DISK.</summary>
+    public BackupMedium Medium { get; set; } = BackupMedium.AzureBlob;
+
+    /// <summary>
+    /// The files or blobs to write, in stripe order.
+    ///
+    /// More than one is a striped backup, which is faster on a large database and is also the only
+    /// way past the 195 GB per-blob limit in Azure - a single-blob backup of anything larger simply
+    /// fails partway, which is a bad way to find out.
+    /// </summary>
+    public List<string> Destinations { get; set; } = [];
+
+    /// <summary>
+    /// COPY_ONLY, and on by default.
+    ///
+    /// A plain full backup resets the differential base on the source. Doing that to a production
+    /// server that runs a differential schedule silently breaks every differential taken afterwards
+    /// - they will be based on a backup that lives in this app's container and that whoever runs
+    /// the restore has never heard of.
+    ///
+    /// The app already understands copy-only fulls (#49), so it knows what it is writing. Turning
+    /// this off is a real choice with a real consequence and should look like one.
+    /// </summary>
+    public bool CopyOnly { get; set; } = true;
+
+    /// <summary>
+    /// COMPRESSION. On by default: it is faster on nearly everything, and on a backup that is about
+    /// to cross a network or go into a container the size matters twice over.
+    /// </summary>
+    public bool Compression { get; set; } = true;
+
+    /// <summary>
+    /// CHECKSUM. On by default, because it is what makes a later RESTORE VERIFYONLY mean anything -
+    /// verifying a backup taken without it can only confirm the file is readable, not that its
+    /// contents are intact.
+    /// </summary>
+    public bool Checksum { get; set; } = true;
+
+    /// <summary>
+    /// FORMAT, which overwrites whatever the media set already holds.
+    ///
+    /// Off, and it stays off unless somebody asks for it: on a path that already holds a backup,
+    /// this discards it. INIT and NOINIT below decide the ordinary append-or-overwrite question.
+    /// </summary>
+    public bool Format { get; set; }
+
+    /// <summary>
+    /// INIT: overwrite the backup set on this device rather than appending to it.
+    ///
+    /// On by default, because the app writes one backup per file with a timestamped name, so there
+    /// is nothing to append to and appending to a file that unexpectedly exists produces a media
+    /// set with two backups in it that nothing here would then read correctly.
+    /// </summary>
+    public bool Init { get; set; } = true;
+
+    public int StatsPercent { get; set; } = 10;
+
+    /// <summary>A description written into the backup header, for whoever finds it later.</summary>
+    public string? Description { get; set; }
+}

--- a/src/NineLives/Services/BackupDestinationBuilder.cs
+++ b/src/NineLives/Services/BackupDestinationBuilder.cs
@@ -1,0 +1,133 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Where a backup this app takes should be written (#165).
+///
+/// The property that matters is a round trip: a backup this app writes must be one this app can
+/// then FIND. The blob path already infers a backup's type, server and database from where it sits
+/// in the container, using the container's own configured pattern - so a backup written anywhere
+/// else lands in the container and is invisible to the screen that would restore it.
+///
+/// That is why this builds the destination from the SAME pattern the listing parses rather than
+/// picking a layout of its own. A second convention here would be a backup that exists and cannot
+/// be found, which is the worst shape a backup can take.
+/// </summary>
+public static class BackupDestinationBuilder
+{
+    /// <summary>
+    /// The folder names the listing maps back to a type. These are what it parses, so these are
+    /// what gets written.
+    /// </summary>
+    public static string FolderFor(BackupType type) => type switch
+    {
+        BackupType.Full => "FULL",
+        BackupType.Differential => "DIFF",
+        BackupType.TransactionLog => "LOG",
+        _ => "FULL"
+    };
+
+    public static string ExtensionFor(BackupType type) =>
+        type == BackupType.TransactionLog ? ".trn" : ".bak";
+
+    /// <summary>
+    /// The file name, in the shape the timestamp parser reads: <c>Db_TYPE_yyyyMMdd_HHmmss.bak</c>.
+    ///
+    /// The timestamp is not decoration. It is what groups stripes into one set and orders sets on
+    /// the timeline, and the parser looks for exactly <c>yyyyMMdd_HHmmss</c> - so this format is a
+    /// requirement rather than a preference.
+    /// </summary>
+    /// <param name="stripe">1-based stripe number, or null when the backup is not striped.</param>
+    public static string FileName(
+        string databaseName, BackupType type, DateTime takenAt, int? stripe = null, bool copyOnly = false)
+    {
+        var suffix = stripe.HasValue ? $"_{stripe.Value}" : string.Empty;
+
+        // COPY_ONLY in the name as well as in the header. The listing reads it from the name (#49),
+        // and a copy-only full that is not recognised as one becomes a differential's base - which
+        // SQL Server then rejects with 3136.
+        var copy = copyOnly ? "_COPY_ONLY" : string.Empty;
+
+        return $"{Sanitise(databaseName)}_{FolderFor(type)}{copy}_{takenAt:yyyyMMdd_HHmmss}{suffix}" +
+               ExtensionFor(type);
+    }
+
+    /// <summary>
+    /// The blob URLs to write, in stripe order, laid out by the container's own pattern.
+    /// </summary>
+    public static List<string> ForContainer(
+        BlobContainerConfig container,
+        string serverName,
+        string databaseName,
+        BackupType type,
+        DateTime takenAt,
+        int stripes = 1,
+        bool copyOnly = true)
+    {
+        var (host, instance) = ServerIdentity.Split(serverName);
+        var root = container.ContainerUrl.TrimEnd('/');
+
+        return Enumerable.Range(1, Math.Max(1, stripes))
+            .Select(i =>
+            {
+                var name = FileName(databaseName, type, takenAt, stripes > 1 ? i : null, copyOnly);
+
+                var path = container.PathPattern
+                    .Replace("{BackupType}", FolderFor(type), StringComparison.OrdinalIgnoreCase)
+                    .Replace("{ServerName}", Sanitise(host), StringComparison.OrdinalIgnoreCase)
+                    .Replace("{InstanceName}", Sanitise(instance), StringComparison.OrdinalIgnoreCase)
+                    .Replace("{DatabaseName}", Sanitise(databaseName), StringComparison.OrdinalIgnoreCase)
+                    .Replace("{FileName}", name, StringComparison.OrdinalIgnoreCase);
+
+                // A pattern with a token this app cannot fill leaves an empty segment behind, which
+                // would put the backup one folder shallower than the listing expects to find it.
+                path = string.Join("/", path.Split('/', StringSplitOptions.RemoveEmptyEntries));
+
+                return $"{root}/{path}";
+            })
+            .ToList();
+    }
+
+    /// <summary>
+    /// The file paths to write on a share.
+    ///
+    /// A share has no configured pattern to follow, and it does not need one: backups written here
+    /// are discovered through the source instance's msdb, which records the path it wrote and
+    /// everything else besides. So the layout only has to be sane for a person looking at the
+    /// folder - one directory per database, which is what backup jobs do anyway.
+    /// </summary>
+    public static List<string> ForSharedPath(
+        string root,
+        string databaseName,
+        BackupType type,
+        DateTime takenAt,
+        int stripes = 1,
+        bool copyOnly = true)
+    {
+        var trimmed = root.TrimEnd('\\', '/');
+
+        return Enumerable.Range(1, Math.Max(1, stripes))
+            .Select(i => $@"{trimmed}\{Sanitise(databaseName)}\" +
+                         FileName(databaseName, type, takenAt, stripes > 1 ? i : null, copyOnly))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Strips what cannot appear in a file or blob name.
+    ///
+    /// A database name is far freer than a filename: <c>My/Db</c> is legal on SQL Server and would
+    /// silently become a FOLDER in a blob path, putting the backup somewhere the listing would read
+    /// as a different database entirely.
+    /// </summary>
+    private static string Sanitise(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+
+        var cleaned = value;
+        foreach (var c in System.IO.Path.GetInvalidFileNameChars().Concat(['/', '\\']).Distinct())
+            cleaned = cleaned.Replace(c, '_');
+
+        return cleaned;
+    }
+}

--- a/src/NineLives/Services/BackupScriptGenerator.cs
+++ b/src/NineLives/Services/BackupScriptGenerator.cs
@@ -1,0 +1,105 @@
+using System.Text;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Writes the BACKUP statement (#165).
+///
+/// Deliberately the same shape as <see cref="RestoreScriptGenerator"/>, and for the same reason:
+/// nothing runs that was not on screen first. A BACKUP touches a production server, so what it is
+/// about to do has to be readable before it does it - including the parts somebody would not think
+/// to ask about, which is why COPY_ONLY gets a comment rather than just a keyword.
+///
+/// The medium decides TO URL or TO DISK and nothing else. That is the same one-line difference the
+/// restore path has, kept in one place here too.
+/// </summary>
+public class BackupScriptGenerator
+{
+    public string Generate(BackupOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.DatabaseName) || options.Destinations.Count == 0)
+            return string.Empty;
+
+        var sb = new StringBuilder();
+
+        AppendHeader(sb, options);
+        AppendBackup(sb, options);
+
+        return sb.ToString();
+    }
+
+    private static void AppendHeader(StringBuilder sb, BackupOptions options)
+    {
+        sb.AppendLine("-- ============================================================");
+        sb.AppendLine("-- Nine Lives - Generated Backup Script (Blackcat Data Solutions)");
+        sb.AppendLine($"-- Generated: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine($"-- Database:  {options.DatabaseName}");
+        sb.AppendLine($"-- Writing:   {options.Destinations.Count} file(s)");
+        sb.AppendLine("-- ============================================================");
+
+        // Said in the script rather than only in a tooltip: the script gets copied into SSMS and
+        // run by somebody who never saw the checkbox.
+        if (!options.CopyOnly)
+        {
+            sb.AppendLine();
+            sb.AppendLine("-- WARNING: this is NOT a copy-only backup, so it RESETS THE DIFFERENTIAL");
+            sb.AppendLine("-- BASE on this database. Every differential taken afterwards will be based");
+            sb.AppendLine("-- on this backup rather than on the last scheduled full - so restoring from");
+            sb.AppendLine("-- the scheduled fulls will need this file too. If this database has a");
+            sb.AppendLine("-- differential schedule, that schedule is now depending on this backup.");
+        }
+
+        sb.AppendLine();
+    }
+
+    private static void AppendBackup(StringBuilder sb, BackupOptions options)
+    {
+        sb.AppendLine($"BACKUP DATABASE {TSql.QuoteName(options.DatabaseName)}");
+        sb.AppendLine($"    TO {DeviceClause(options)}");
+        sb.AppendLine($"    WITH {string.Join(", ", WithOptions(options))};");
+        sb.AppendLine("GO");
+    }
+
+    /// <summary>
+    /// The devices, in stripe order, one per line so a striped backup is readable.
+    ///
+    /// A blob URL is percent-encoded and a path is not: a UNC path is not a URI, and encoding one
+    /// produces a path SQL Server cannot open.
+    /// </summary>
+    private static string DeviceClause(BackupOptions options)
+    {
+        var keyword = options.Medium == BackupMedium.AzureBlob ? "URL" : "DISK";
+
+        var devices = options.Destinations.Select(d =>
+        {
+            var value = options.Medium == BackupMedium.AzureBlob ? BlobUrlEncoder.Encode(d) : d;
+            return $"{keyword} = N'{TSql.EscapeLiteral(value)}'";
+        });
+
+        return string.Join($",{Environment.NewLine}       ", devices);
+    }
+
+    private static List<string> WithOptions(BackupOptions options)
+    {
+        var with = new List<string>();
+
+        // First, because it is the one that changes what happens to the SOURCE.
+        if (options.CopyOnly) with.Add("COPY_ONLY");
+
+        if (options.Compression) with.Add("COMPRESSION");
+        if (options.Checksum) with.Add("CHECKSUM");
+
+        // FORMAT implies INIT, and naming both is noise at best. FORMAT also discards whatever the
+        // media set already held, so it is never inferred - only ever asked for.
+        if (options.Format) with.Add("FORMAT");
+        else if (options.Init) with.Add("INIT");
+
+        if (!string.IsNullOrWhiteSpace(options.Description))
+            with.Add($"DESCRIPTION = N'{TSql.EscapeLiteral(options.Description)}'");
+
+        with.Add($"STATS = {options.StatsPercent}");
+
+        return with;
+    }
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -247,18 +247,48 @@ public class BlobStorageService : IBlobStorageService
         return prefixes is { Count: > 0 } ? [.. prefixes] : [null];
     }
 
+    /// <summary>Runs the real listing inference over blobs a test names, without Azure.</summary>
+    internal List<BackupFileInfo> ParseListedBlobsForTests(
+        BlobContainerConfig config, IEnumerable<(string Name, long Size, DateTimeOffset Modified)> blobs)
+    {
+        var files = new List<BackupFileInfo>();
+        foreach (var (name, size, modified) in blobs) ReadBlob(config, name, size, modified, files);
+        return files;
+    }
+
     private void ReadBlob(BlobContainerConfig config, BlobItem blob, List<BackupFileInfo> files)
+        => ReadBlob(
+            config,
+            blob.Name,
+            blob.Properties.ContentLength ?? 0,
+            blob.Properties.LastModified ?? DateTimeOffset.MinValue,
+            files);
+
+    /// <summary>
+    /// Everything this app infers about a backup from where it sits in the container and what it is
+    /// called - separated from the Azure types so it can be exercised without them.
+    ///
+    /// Worth the seam: this is the inference #44, #45 and #130 are all about, and it is also the
+    /// other half of a round trip now that the app WRITES backups too (#165). A backup written to a
+    /// layout this cannot read back is a backup that exists and cannot be found.
+    /// </summary>
+    internal void ReadBlob(
+        BlobContainerConfig config,
+        string blobName,
+        long sizeBytes,
+        DateTimeOffset lastModified,
+        List<BackupFileInfo> files)
     {
         {
-            var blobUrl = $"{config.ContainerUrl.TrimEnd('/')}/{blob.Name}";
+            var blobUrl = $"{config.ContainerUrl.TrimEnd('/')}/{blobName}";
 
             var file = new BackupFileInfo
             {
-                BlobName = blob.Name,
+                BlobName = blobName,
                 BlobUrl = blobUrl,
                 Type = BackupType.Unknown,
-                SizeBytes = blob.Properties.ContentLength ?? 0,
-                LastModified = blob.Properties.LastModified ?? DateTimeOffset.MinValue
+                SizeBytes = sizeBytes,
+                LastModified = lastModified
             };
 
             var pathParts = file.BlobName.Split('/', StringSplitOptions.RemoveEmptyEntries);
@@ -268,7 +298,7 @@ public class BlobStorageService : IBlobStorageService
 
             if (tryAgParsing)
             {
-                var agParsed = OlaAgFileNameParser.TryParse(blob.Name);
+                var agParsed = OlaAgFileNameParser.TryParse(blobName);
                 if (agParsed != null)
                 {
                     file.InferredServerName = agParsed.ServerDisplay;
@@ -305,7 +335,7 @@ public class BlobStorageService : IBlobStorageService
             }
 
             if (file.Type == BackupType.Unknown)
-                file.Type = InferBackupTypeFromExtension(blob.Name);
+                file.Type = InferBackupTypeFromExtension(blobName);
 
             if (!file.IsCopyOnly)
                 file.IsCopyOnly = IsCopyOnlyFileName(file.FileName);

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -45,7 +45,13 @@ public interface ISqlServerService
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default);
 
-    Task ExecuteRestoreWithProgressAsync(
+    /// <summary>
+    /// Runs a script statement by statement, reporting SQL Server's own progress as it goes.
+    ///
+    /// Not restore-specific despite where it started: a BACKUP reports STATS through exactly the
+    /// same InfoMessage channel, so both halves of the orchestrator share one execution path (#165).
+    /// </summary>
+    Task ExecuteWithProgressAsync(
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default);
 

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -755,7 +755,7 @@ public class SqlServerService : ISqlServerService
         await cmd.ExecuteNonQueryAsync(ct);
     }
 
-    public async Task ExecuteRestoreWithProgressAsync(
+    public async Task ExecuteWithProgressAsync(
         ServerConnection server, string sql,
         Action<string>? messageCallback = null, CancellationToken ct = default)
     {
@@ -797,7 +797,7 @@ public class SqlServerService : ISqlServerService
                 // propagates as the failure it is.
                 messageCallback?.Invoke(
                     $"Cancelled during statement {i + 1} of {executable.Count}: {Summarize(statement)}");
-                throw new OperationCanceledException("The restore was cancelled.", ct);
+                throw new OperationCanceledException("Cancelled.", ct);
             }
             catch (SqlException)
             {

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -1,0 +1,376 @@
+using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// Taking a backup (#165).
+///
+/// The half of an orchestrator this app has never had. It restores backups other things took; this
+/// takes one, to either medium, with the same rules the restore screen earned: nothing runs that
+/// was not on screen first, and the button that touches a server has to be pressed twice.
+///
+/// The asymmetry worth knowing about: a restore destroys the TARGET, and everybody expects that. A
+/// backup looks harmless and can quietly damage the SOURCE - a plain full resets the differential
+/// base, so a production server's whole differential schedule starts depending on a file in this
+/// app's container. That is why COPY_ONLY is on by default and why turning it off is loud.
+/// </summary>
+public partial class BackupViewModel : ViewModelBase
+{
+    private readonly ICredentialStore _store;
+    private readonly ISqlServerService _sql;
+    private readonly BackupScriptGenerator _generator = new();
+    private readonly OperationCancellation _cancellation = new();
+    private readonly OperationLog _log;
+
+    public BackupViewModel(ICredentialStore store, ISqlServerService sql, OperationLog? log = null)
+    {
+        _store = store;
+        _sql = sql;
+        _log = log ?? App.Log;
+
+        Refresh();
+    }
+
+    // ── what is being backed up ─────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private ObservableCollection<ServerConnection> _servers = [];
+
+    [ObservableProperty]
+    private ServerConnection? _server;
+
+    [ObservableProperty]
+    private ObservableCollection<string> _databases = [];
+
+    [ObservableProperty]
+    private string? _selectedDatabase;
+
+    public void Refresh()
+    {
+        try
+        {
+            var config = _store.LoadConfig();
+
+            var previousServer = Server?.Id;
+            Servers = new ObservableCollection<ServerConnection>(config.Servers);
+            if (previousServer != null)
+                Server = Servers.FirstOrDefault(s => s.Id == previousServer);
+
+            var previousContainer = Container?.Id;
+            Containers = new ObservableCollection<BlobContainerConfig>(config.BlobContainers);
+            if (previousContainer != null)
+                Container = Containers.FirstOrDefault(c => c.Id == previousContainer);
+        }
+        catch
+        {
+            // A config that will not load is reported where it is loaded for real. Here it only
+            // means empty lists rather than a screen that cannot open.
+            Servers = [];
+            Containers = [];
+        }
+    }
+
+    /// <summary>Asks the chosen instance what it has, rather than making somebody type a name.</summary>
+    [RelayCommand]
+    private async Task LoadDatabasesAsync()
+    {
+        if (Server == null)
+        {
+            SetError("Choose the server to back up from.");
+            return;
+        }
+
+        var ct = _cancellation.Begin();
+        IsBusy = true;
+        ClearStatus();
+
+        try
+        {
+            var names = await _sql.GetDatabaseListAsync(Server, ct);
+
+            Databases = new ObservableCollection<string>(names);
+
+            // Nothing is chosen for the user, the same rule the Restore screen learned - and here
+            // the wrong choice means a production database read at full speed for several minutes.
+            SelectedDatabase = null;
+
+            SetStatus($"{Server.ServerName} has {names.Count} database(s).");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Stopped.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not list the databases: {ex.Message}");
+        }
+        finally
+        {
+            _cancellation.End();
+            IsBusy = false;
+        }
+    }
+
+    partial void OnServerChanged(ServerConnection? value)
+    {
+        // The database list belonged to the previous instance. Leaving it up invites somebody to
+        // back up a name that exists on both and mean the other one.
+        Databases = [];
+        SelectedDatabase = null;
+        Invalidate();
+    }
+
+    partial void OnSelectedDatabaseChanged(string? value) => Invalidate();
+
+    // ── where it is written ─────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private BackupMedium _medium = BackupMedium.AzureBlob;
+
+    public bool MediumIsBlob => Medium == BackupMedium.AzureBlob;
+    public bool MediumIsSharedPath => Medium == BackupMedium.SharedPath;
+
+    partial void OnMediumChanged(BackupMedium value)
+    {
+        OnPropertyChanged(nameof(MediumIsBlob));
+        OnPropertyChanged(nameof(MediumIsSharedPath));
+        Invalidate();
+    }
+
+    [ObservableProperty]
+    private ObservableCollection<BlobContainerConfig> _containers = [];
+
+    [ObservableProperty]
+    private BlobContainerConfig? _container;
+
+    /// <summary>
+    /// The folder the backup is written to on a share.
+    ///
+    /// The instance writes it as its own service account, so this has to be somewhere THAT account
+    /// can write - which is not the same as somewhere this app can see.
+    /// </summary>
+    [ObservableProperty]
+    private string _sharedPathRoot = string.Empty;
+
+    partial void OnContainerChanged(BlobContainerConfig? value) => Invalidate();
+    partial void OnSharedPathRootChanged(string value) => Invalidate();
+
+    // ── how ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// COPY_ONLY, on by default and deliberately awkward to turn off.
+    ///
+    /// A plain full backup resets the differential base on the source. On a production server with
+    /// a differential schedule that silently makes every subsequent differential depend on this
+    /// file - which lives wherever this app put it, under a name nobody else knows.
+    /// </summary>
+    [ObservableProperty]
+    private bool _copyOnly = true;
+
+    [ObservableProperty]
+    private bool _compression = true;
+
+    [ObservableProperty]
+    private bool _checksum = true;
+
+    /// <summary>
+    /// How many files to write.
+    ///
+    /// More than one is faster on a large database, and for blob it is the only way past the 195 GB
+    /// per-blob limit - a single-blob backup of anything larger fails partway through, which is a
+    /// bad way to find out how big the database was.
+    /// </summary>
+    [ObservableProperty]
+    private int _stripes = 1;
+
+    [ObservableProperty]
+    private string _description = string.Empty;
+
+    partial void OnCopyOnlyChanged(bool value) => Invalidate();
+    partial void OnCompressionChanged(bool value) => Invalidate();
+    partial void OnChecksumChanged(bool value) => Invalidate();
+    partial void OnStripesChanged(int value) => Invalidate();
+    partial void OnDescriptionChanged(string value) => Invalidate();
+
+    /// <summary>True when the differential base on a production database is about to move.</summary>
+    public bool WillResetTheDifferentialBase => !CopyOnly;
+
+    // ── the script ──────────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private string _generatedScript = string.Empty;
+
+    public bool HasScript => !string.IsNullOrWhiteSpace(GeneratedScript);
+
+    partial void OnGeneratedScriptChanged(string value)
+    {
+        OnPropertyChanged(nameof(HasScript));
+        ExecuteCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// Everything needed to write a statement at all. Not a judgement about whether it is a good
+    /// idea - that is what the confirmation is for.
+    /// </summary>
+    public bool CanGenerate =>
+        Server != null &&
+        !string.IsNullOrWhiteSpace(SelectedDatabase) &&
+        (MediumIsBlob ? Container != null : !string.IsNullOrWhiteSpace(SharedPathRoot));
+
+    /// <summary>
+    /// Rebuilds the script from the current options, or clears it.
+    ///
+    /// Called by every option, so what is on screen is always what would run. The restore screen
+    /// learned this the hard way: a stale script is one that does something different from what it
+    /// shows, and here what it shows is the only warning anybody gets.
+    /// </summary>
+    private void Invalidate()
+    {
+        OnPropertyChanged(nameof(CanGenerate));
+        OnPropertyChanged(nameof(WillResetTheDifferentialBase));
+        GenerateCommand.NotifyCanExecuteChanged();
+
+        // Disarm: an armed button that survives an option change is armed for something else.
+        IsArmed = false;
+
+        if (HasScript) Generate();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanGenerate))]
+    private void Generate()
+    {
+        if (!CanGenerate) return;
+
+        var takenAt = DateTime.Now;
+
+        var destinations = MediumIsBlob
+            ? BackupDestinationBuilder.ForContainer(
+                Container!, Server!.ServerName, SelectedDatabase!, BackupType.Full,
+                takenAt, Math.Max(1, Stripes), CopyOnly)
+            : BackupDestinationBuilder.ForSharedPath(
+                SharedPathRoot, SelectedDatabase!, BackupType.Full,
+                takenAt, Math.Max(1, Stripes), CopyOnly);
+
+        GeneratedScript = _generator.Generate(new BackupOptions
+        {
+            DatabaseName = SelectedDatabase!,
+            Medium = Medium,
+            Destinations = destinations,
+            CopyOnly = CopyOnly,
+            Compression = Compression,
+            Checksum = Checksum,
+            Description = string.IsNullOrWhiteSpace(Description) ? null : Description
+        });
+
+        Destinations = new ObservableCollection<string>(destinations);
+        SetStatus("Script generated.");
+    }
+
+    /// <summary>Where the files will land, so it can be read before anything is written.</summary>
+    [ObservableProperty]
+    private ObservableCollection<string> _destinations = [];
+
+    [RelayCommand]
+    private void CopyScript() => TryCopyToClipboard(GeneratedScript, "Script copied to clipboard.");
+
+    // ── running it ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Armed on the first press, run on the second.
+    ///
+    /// The same rule the restore has, for a different reason. A restore destroys the target and
+    /// everybody knows it; a backup looks harmless right up until it moves a production database's
+    /// differential base, or reads a busy server flat out for twenty minutes in the middle of the
+    /// working day.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isArmed;
+
+    [ObservableProperty]
+    private bool _isRunning;
+
+    public string ButtonText => IsRunning ? "Backing up..." : IsArmed ? "Confirm - run the backup" : "Run backup";
+
+    partial void OnIsArmedChanged(bool value) => OnPropertyChanged(nameof(ButtonText));
+    partial void OnIsRunningChanged(bool value)
+    {
+        OnPropertyChanged(nameof(ButtonText));
+        ExecuteCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>SQL Server's own words as it goes, in the order it said them.</summary>
+    public ObservableCollection<string> Console { get; } = [];
+
+    public bool CanExecute => HasScript && !IsRunning;
+
+    [RelayCommand(CanExecute = nameof(CanExecute))]
+    private async Task ExecuteAsync()
+    {
+        if (!HasScript || Server == null) return;
+
+        if (!IsArmed)
+        {
+            IsArmed = true;
+            return;
+        }
+
+        IsArmed = false;
+        IsRunning = true;
+        ClearStatus();
+        Console.Clear();
+
+        var ct = _cancellation.Begin();
+        var started = DateTime.Now;
+
+        try
+        {
+            Append($"Backing up {SelectedDatabase} on {Server.ServerName}...");
+            if (!CopyOnly)
+                Append("This is NOT a copy-only backup - the differential base on this database is moving.");
+
+            _log.Info($"Backup started: {SelectedDatabase} on {Server.ServerName}, " +
+                      $"copyOnly={CopyOnly}, files={Destinations.Count}");
+
+            await _sql.ExecuteWithProgressAsync(Server, GeneratedScript, Append, ct);
+
+            var elapsed = DateTime.Now - started;
+            Append($"Finished in {elapsed.TotalSeconds:N0}s.");
+            SetStatus($"Backed up {SelectedDatabase} in {elapsed.TotalSeconds:N0}s.");
+            _log.Info($"Backup finished: {SelectedDatabase} in {elapsed.TotalSeconds:N0}s");
+        }
+        catch (OperationCanceledException)
+        {
+            // A cancelled BACKUP leaves a partial file behind, which is worth saying plainly - it
+            // is not a backup, and it will sit there looking like one.
+            Append("Cancelled. Any file already written is incomplete and cannot be restored from.");
+            SetStatus("Backup cancelled.");
+            _log.Info($"Backup cancelled: {SelectedDatabase}");
+        }
+        catch (Exception ex)
+        {
+            Append(ex.Message);
+            SetError($"The backup did not complete: {ex.Message}");
+            _log.Error($"Backup failed: {SelectedDatabase}: {ex.Message}");
+        }
+        finally
+        {
+            _cancellation.End();
+            IsRunning = false;
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        if (!_cancellation.CanCancel) return;
+
+        _cancellation.Cancel();
+        SetStatus("Stopping...");
+    }
+
+    private void Append(string line) => Console.Add(line);
+}

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -50,6 +50,7 @@ public partial class MainViewModel : ViewModelBase
     public BlobConfigViewModel BlobConfig { get; }
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }
+    public BackupViewModel Backup { get; }
     public RestoreViewModel Restore { get; }
     public HistoryViewModel History { get; }
     public SettingsViewModel Settings { get; }
@@ -96,6 +97,7 @@ public partial class MainViewModel : ViewModelBase
         Restore = new RestoreViewModel(
             _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
             log: null, history: _historyStore);
+        Backup = new BackupViewModel(_credentialStore, _sqlService);
         History = new HistoryViewModel(_historyStore);
         Settings = new SettingsViewModel(_credentialStore);
         About = new AboutViewModel();
@@ -111,7 +113,7 @@ public partial class MainViewModel : ViewModelBase
         // One place that answers "is it doing something?". Every screen already tracks its own
         // work; without this the answer depended on which part of a long page was scrolled into
         // view, and the Restore screen's own status line is below the fold most of the time (#128).
-        WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Restore);
+        WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Backup, Restore);
 
         CurrentView = BlobConfig;
 
@@ -337,13 +339,14 @@ public partial class MainViewModel : ViewModelBase
         public const string BlobStorage = "Blob Storage";
         public const string SqlServers = "SQL Servers";
         public const string BrowseBackups = "Browse Backups";
+        public const string Backup = "Back Up";
         public const string Restore = "Restore";
         public const string History = "History";
         public const string Settings = "Settings";
         public const string About = "About";
 
         public static IReadOnlyList<string> Views =>
-            [BlobStorage, SqlServers, BrowseBackups, Restore, History, Settings, About];
+            [BlobStorage, SqlServers, BrowseBackups, Backup, Restore, History, Settings, About];
     }
 
     [RelayCommand]
@@ -355,6 +358,7 @@ public partial class MainViewModel : ViewModelBase
             Nav.BlobStorage => BlobConfig,
             Nav.SqlServers => ServerManager,
             Nav.BrowseBackups => BlobBrowser,
+            Nav.Backup => Backup,
             Nav.Restore => Restore,
             Nav.History => History,
             Nav.Settings => Settings,
@@ -365,6 +369,10 @@ public partial class MainViewModel : ViewModelBase
         // Refresh container lists when navigating to views that depend on them
         if (viewName is Nav.BrowseBackups)
             BlobBrowser.RefreshContainers();
+        else if (viewName is Nav.Backup)
+            // Servers AND containers: a backup needs one of each, and either can have been added
+            // on another screen since the last visit.
+            Backup.Refresh();
         else if (viewName is Nav.Restore)
             // Containers AND servers: either can be the backup source now, and one added on
             // another screen since the last visit has to be selectable here (#165).

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -215,7 +215,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             AppendLog("Beginning restore execution...\n");
 
-            await _sql.ExecuteRestoreWithProgressAsync(
+            await _sql.ExecuteWithProgressAsync(
                 run.Server,
                 run.Script,
                 // InvokeAsync, not Invoke. This callback runs on the connection's thread when SQL

--- a/src/NineLives/Views/BackupView.xaml
+++ b/src/NineLives/Views/BackupView.xaml
@@ -1,0 +1,278 @@
+<UserControl x:Class="Blackcat.NineLives.Views.BackupView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
+             xmlns:views="clr-namespace:Blackcat.NineLives.Views">
+
+    <UserControl.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+        <converters:EnumToBoolConverter x:Key="EnumToBool" />
+    </UserControl.Resources>
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <!-- Header -->
+            <StackPanel Margin="0,0,0,20">
+                <TextBlock Text="Back Up a Database" Style="{StaticResource HeaderText}" />
+                <TextBlock Text="Take a backup to Azure Blob Storage or to a path the server can write to. Copy-only by default, so a production differential schedule is left alone."
+                           Style="{StaticResource SecondaryText}"
+                           TextWrapping="Wrap"
+                           Margin="0,4,0,0" />
+            </StackPanel>
+
+            <!-- What is about to happen to the SOURCE.
+                 At the top rather than beside the checkbox: a restore destroys the target and
+                 everybody expects it, but a backup looks harmless right up until it moves a
+                 production database's differential base. -->
+            <Border CornerRadius="6" Padding="14,12" Margin="0,0,0,16"
+                    Background="{DynamicResource WarningPanelBackgroundBrush}"
+                    BorderBrush="{DynamicResource WarningBrush}"
+                    BorderThickness="1"
+                    Visibility="{Binding WillResetTheDifferentialBase, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Text="THIS WILL CHANGE THE SOURCE DATABASE"
+                               Style="{StaticResource LabelText}"
+                               Margin="0,0,0,6" />
+                    <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap" LineHeight="22"
+                               Text="This is not a copy-only backup, so it resets the differential base. Every differential this database's schedule takes afterwards will be based on THIS file rather than on the last scheduled full - so restoring from the scheduled fulls will need this file too." />
+                </StackPanel>
+            </Border>
+
+            <!-- 1. What to back up -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="1. What to back up" Style="{StaticResource SubHeaderText}" />
+
+                    <Grid Margin="0,10,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                            <TextBlock Text="SERVER" Style="{StaticResource LabelText}" />
+                            <ComboBox ItemsSource="{Binding Servers}"
+                                      SelectedItem="{Binding Server}"
+                                      Style="{StaticResource DarkComboBox}"
+                                      Margin="0,4,0,0">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+
+                        <Button Grid.Column="1"
+                                Content="List databases"
+                                Command="{Binding LoadDatabasesCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="16,8"
+                                VerticalAlignment="Bottom" />
+                    </Grid>
+
+                    <StackPanel Margin="0,12,0,0">
+                        <TextBlock Text="DATABASE" Style="{StaticResource LabelText}" />
+                        <ComboBox ItemsSource="{Binding Databases}"
+                                  SelectedItem="{Binding SelectedDatabase}"
+                                  Style="{StaticResource DarkComboBox}"
+                                  Margin="0,4,0,0" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- 2. Where it goes -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="2. Where it goes" Style="{StaticResource SubHeaderText}" />
+
+                    <TextBlock Text="WRITE IT TO" Style="{StaticResource LabelText}" Margin="0,10,0,0" />
+                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                        <RadioButton Content="Azure Blob Storage"
+                                     GroupName="BackupMedium"
+                                     Style="{StaticResource DarkRadioButton}"
+                                     IsChecked="{Binding Medium, Converter={StaticResource EnumToBool}, ConverterParameter=AzureBlob}"
+                                     Margin="0,0,20,0"
+                                     ToolTip="BACKUP TO URL. Needs a credential on the server, and needs no network path between hosts." />
+                        <RadioButton Content="A path the server can write to"
+                                     GroupName="BackupMedium"
+                                     Style="{StaticResource DarkRadioButton}"
+                                     IsChecked="{Binding Medium, Converter={StaticResource EnumToBool}, ConverterParameter=SharedPath}"
+                                     ToolTip="BACKUP TO DISK. Faster, no egress - but the SQL Server service account has to be able to write there." />
+                    </StackPanel>
+
+                    <StackPanel Margin="0,12,0,0"
+                                Visibility="{Binding MediumIsBlob, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="CONTAINER" Style="{StaticResource LabelText}" />
+                        <ComboBox ItemsSource="{Binding Containers}"
+                                  SelectedItem="{Binding Container}"
+                                  Style="{StaticResource DarkComboBox}"
+                                  Margin="0,4,0,0">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Name}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </StackPanel>
+
+                    <StackPanel Margin="0,12,0,0"
+                                Visibility="{Binding MediumIsSharedPath, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="FOLDER" Style="{StaticResource LabelText}" />
+                        <TextBox Text="{Binding SharedPathRoot, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource DarkTextBox}"
+                                 Margin="0,4,0,0"
+                                 ToolTip="For example \\nas01\sql" />
+                        <TextBlock Style="{StaticResource SecondaryText}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,6,0,0"
+                                   Text="The server writes this as its own SQL Server service account, so it has to be somewhere THAT account can write - which is not the same as somewhere you can see from here." />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- 3. How -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="3. How" Style="{StaticResource SubHeaderText}" />
+
+                    <Grid Margin="0,10,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0">
+                            <CheckBox Content="COPY_ONLY (leave the differential schedule alone)"
+                                      IsChecked="{Binding CopyOnly}"
+                                      Style="{StaticResource DarkCheckBox}"
+                                      Margin="0,0,0,8"
+                                      ToolTip="On by default. Turning this off resets the differential base on the source database." />
+                            <CheckBox Content="COMPRESSION"
+                                      IsChecked="{Binding Compression}"
+                                      Style="{StaticResource DarkCheckBox}"
+                                      Margin="0,0,0,8" />
+                            <CheckBox Content="CHECKSUM"
+                                      IsChecked="{Binding Checksum}"
+                                      Style="{StaticResource DarkCheckBox}"
+                                      ToolTip="What makes a later RESTORE VERIFYONLY mean anything. Without it, verifying can only confirm the file is readable." />
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="2">
+                            <TextBlock Text="FILES TO WRITE" Style="{StaticResource LabelText}" />
+                            <TextBox Text="{Binding Stripes, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource DarkTextBox}"
+                                     Width="80" HorizontalAlignment="Left"
+                                     Margin="0,4,0,8"
+                                     ToolTip="More than one stripes the backup. Faster on a large database, and for blob it is the only way past the 195 GB per-blob limit." />
+
+                            <TextBlock Text="DESCRIPTION" Style="{StaticResource LabelText}" />
+                            <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource DarkTextBox}"
+                                     Margin="0,4,0,0"
+                                     ToolTip="Written into the backup header, for whoever finds this file later." />
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <!-- 4. The script, and running it -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="4. Run it" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,12"
+                               Text="Nothing runs that was not on screen first. Generate the script, read what it says, then run it - the button arms on the first press and runs on the second." />
+
+                    <WrapPanel>
+                        <Button Content="Generate script"
+                                Command="{Binding GenerateCommand}"
+                                Style="{StaticResource PrimaryButton}"
+                                Padding="16,8" Margin="0,0,8,8" />
+                        <Button Content="Copy to clipboard"
+                                Command="{Binding CopyScriptCommand}"
+                                IsEnabled="{Binding HasScript}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="16,8" Margin="0,0,8,8" />
+                        <Button Content="{Binding ButtonText}"
+                                Command="{Binding ExecuteCommand}"
+                                Style="{StaticResource DangerButton}"
+                                Padding="16,8" Margin="0,0,8,8"
+                                MinWidth="180" />
+                        <Button Content="Stop"
+                                Command="{Binding CancelCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}"
+                                Padding="16,8" Margin="0,0,8,8" />
+                    </WrapPanel>
+
+                    <!-- Where the files will land, readable before anything is written. -->
+                    <StackPanel Margin="0,8,0,0"
+                                Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="WRITING TO" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
+                        <ItemsControl ItemsSource="{Binding Destinations}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding}"
+                                               TextWrapping="Wrap"
+                                               FontFamily="{StaticResource ConsoleFont}"
+                                               FontSize="12"
+                                               Margin="0,0,0,2" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+
+                    <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                            BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                            BorderThickness="1" CornerRadius="4"
+                            Margin="0,12,0,0"
+                            Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
+                        <ScrollViewer MaxHeight="260"
+                                      VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      Padding="12,10,12,10">
+                            <views:SqlTextBlock Sql="{Binding GeneratedScript}"
+                                                FontFamily="{StaticResource ConsoleFont}"
+                                                FontSize="12"
+                                                TextWrapping="NoWrap"
+                                                Foreground="{DynamicResource ConsoleTextBrush}" />
+                        </ScrollViewer>
+                    </Border>
+
+                    <!-- What the server said, as it said it. -->
+                    <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                            BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                            BorderThickness="1" CornerRadius="4"
+                            Margin="0,12,0,0"
+                            Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}">
+                        <ScrollViewer MaxHeight="220"
+                                      VerticalScrollBarVisibility="Auto"
+                                      Padding="12,10,12,10">
+                            <ItemsControl ItemsSource="{Binding Console}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding}"
+                                                   TextWrapping="Wrap"
+                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                   FontSize="12"
+                                                   Foreground="{DynamicResource ConsoleTextBrush}" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </Border>
+                </StackPanel>
+            </Border>
+
+            <ContentControl Style="{StaticResource ErrorBanner}" />
+
+            <TextBlock Text="{Binding StatusMessage}"
+                       Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,16" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/NineLives/Views/BackupView.xaml.cs
+++ b/src/NineLives/Views/BackupView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class BackupView : UserControl
+{
+    public BackupView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Second step of #165. The app can now **take** a backup - the half of an orchestrator it has never had.

## The asymmetry this is built around

A restore destroys the TARGET, and everybody expects that, so the app guards it loudly. A backup looks harmless and can quietly damage the SOURCE: a plain full moves a production database's differential base, and every differential that database's schedule takes afterwards then depends on a file living in this app's container, under a name nobody else knows.

So:

- **COPY_ONLY is on by default.**
- Turning it off raises a banner at the top of the screen saying what it costs, in the terms it costs it in.
- The same warning is written into the **script itself** - the script gets copied into SSMS and run by somebody who never saw the checkbox.
- And said again in the console as the backup starts, because by then the script has scrolled out of view.

COMPRESSION and CHECKSUM default on; CHECKSUM is what makes a later `RESTORE VERIFYONLY` mean anything. FORMAT is never inferred, only ever asked for - it discards whatever the media set already holds.

## Where it goes, and finding it again

The property that matters is a **round trip**: a backup this app writes must be one this app can then FIND.

The blob path infers a backup's type, server and database from where it sits in the container, using the container's own configured pattern - so the destination is built from that same pattern rather than a layout of its own. A backup written elsewhere lands in the container and is invisible to the screen that would restore it, which is the worst shape a backup can take because it looks like it worked. The tests prove the round trip through the real listing parser, for all three backup types.

A share needs no pattern - backups there are found through the source instance's msdb, which records the path. So that layout only has to be sane for a person looking at the folder: one directory per database.

Also handled: a database name is far freer than a filename. `My/Db` is legal on SQL Server and would silently become a **folder** in a blob path, putting the backup where the listing reads it as a different database.

## The rules the restore screen earned, applied here

- nothing runs that was not on screen first
- the button arms on the first press and runs on the second
- changing any option rewrites the script and disarms the button
- nothing is chosen for you - and here the wrong choice is a production database read flat out for several minutes

Where the files will land is shown before anything is written. A cancelled backup says plainly that the partial file left behind is **not** a backup - it will sit in the container looking exactly like one otherwise.

## Smaller things

- `ExecuteRestoreWithProgressAsync` becomes `ExecuteWithProgressAsync`. It was never restore-specific - a BACKUP reports STATS through the same InfoMessage channel - and now it has a second caller.
- The blob-listing inference is extracted from the Azure types so it can be exercised without them.
- Sidebar entry between Browse Backups and Restore; Ctrl+4 onwards shift by one.

1,122 tests pass.

Still to come for #165: the one-button copy between servers (#105), which is this plus the restore half.