### PR TITLE
Describe what the app actually is (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Every database deserves nine lives.**
 
-Nine Lives is a modern desktop application for restoring SQL Server databases from Azure Blob Storage backups — point-in-time recovery with a visual timeline, intelligent backup chain detection, striped backup support, and secure credential management. Built with WPF on .NET 10, featuring a dark-mode UI.
+Nine Lives is a modern desktop application for **backing up and restoring SQL Server databases**, to and from either Azure Blob Storage or a file share both servers can see — point-in-time recovery with a visual timeline, intelligent backup chain detection, striped backup support, and secure credential management. Built with WPF on .NET 10, featuring a dark-mode UI.
 
 *A free tool from [Blackcat Data Solutions](https://blackcat.wales).*
 
@@ -18,14 +18,50 @@ The application is distributed as a single self-contained executable (`NineLives
 
 ## Why Nine Lives?
 
-Restoring a native SQL Server backup from a blob container is painful with existing tooling when the destination server has no msdb backup history (the normal case for DR, environment refreshes, and migrations):
+Restoring a native SQL Server backup is painful with existing tooling when the destination server has no msdb backup history — the normal case for DR, environment refreshes, and migrations:
 
 - **SSMS** makes you pick blobs from a container one file at a time, with no chain calculation and no timeline.
 - **dbatools** (`Restore-DbaDatabase`) is excellent if you live in PowerShell — Nine Lives is the GUI complement, not a replacement. If your team prefers clicking a restore point on a timeline over composing cmdlet parameters mid-incident, this is for you.
 
-Nine Lives points at a container, discovers every backup, groups striped sets, computes the full restore chain (full → differential → log tail), and gives you a clickable point-in-time timeline. Generate the T-SQL, or execute it directly with live progress.
+Nine Lives discovers every backup, groups striped sets, computes the full restore chain (full → differential → log tail), and gives you a clickable point-in-time timeline. Generate the T-SQL, or execute it directly with live progress.
+
+### Two media, both directions
+
+Where a backup lives is a choice per operation, not a property of the tool:
+
+|             | Azure Blob Storage      | A path both servers can see |
+|-------------|-------------------------|-----------------------------|
+| **Back up** | `BACKUP ... TO URL`     | `BACKUP ... TO DISK`        |
+| **Restore** | `RESTORE ... FROM URL`  | `RESTORE ... FROM DISK`     |
+
+Neither is right in every estate. **Blob** needs no network path between the two hosts, which is often the real blocker when source and target sit in different environments. **A shared path** is faster, costs no egress, needs no SAS with write, and does not make the restore wait on an upload — where both instances can reach it.
+
+The whole workflow is the same either way: the same timeline, the same chain, the same options, the same script, the same execute path. Only two things ever differ — where the list of backups comes from, and how a `RESTORE` addresses a file.
+
+### Restoring from a shared path
+
+A file share cannot be listed the way a container can: a directory of `.bak` files says nothing about which database each belongs to, what type it is, or which full a differential was taken against. So Nine Lives reads the **source instance's own `msdb`** instead, which recorded all of it — including the LSNs, so a differential is paired with the full it was genuinely taken against rather than the nearest one by time.
+
+Two things it checks that are easy to get wrong by hand:
+
+- **`msdb` records the path the source wrote.** A job that backed up to `E:\SQLBackups\MyDb.bak` recorded a path that means something entirely different on the target — and if it resolves there at all, it resolves to the target's *own* `E:` drive, which is worse than failing. Nine Lives warns about that before it checks anything, and lets you say how the target reaches the same place.
+- **Before the restore runs, it asks the target whether it can actually read every file** — with `RESTORE HEADERONLY`, on that instance, as the account that will do the work. This app's process can see a share the SQL Server service account cannot, and the usual cause of failure is an instance running as a local account or `NT SERVICE\MSSQLSERVER`, which has no identity on the network and so cannot read *any* share. Finding that out afterwards means finding it out after `WITH REPLACE` has already dropped the database being restored over.
+
+### Taking a backup
+
+`COPY_ONLY` is on by default, and turning it off is loud. A plain full backup resets the differential base on the source, so every differential that database's schedule takes afterwards depends on the file Nine Lives just wrote — which the person running the restore has never heard of. That warning appears on the screen, in the generated script, and in the console as the backup starts.
+
+Backups are written to the layout the container is configured with, so what Nine Lives writes is what Nine Lives can then find.
 
 ## Features
+
+### Backing Up
+- Back up a database to Azure Blob Storage or to a path the SQL Server service account can write to
+- `COPY_ONLY` by default, so a production differential schedule is left alone — and a clear warning when it is turned off
+- `COMPRESSION` and `CHECKSUM` on by default
+- Striped backups, which for blob are the only way past the 195 GB per-blob limit
+- Written to the container's own configured layout, so the backup is discoverable by the restore screen
+- The script is shown before anything runs, and the button arms on the first press
 
 ### Azure Blob Storage Integration
 - Connect to Azure Blob Storage containers using SAS tokens, or Entra ID for organisations that prohibit long-lived SAS ([see the caveat](#entra-id-for-blob-storage))
@@ -259,10 +295,20 @@ credential on the *instance* for the blob container, which is separate and confi
 4. Use filters to narrow down by server, database, or backup type
 5. Review the summary showing backup set counts
 
-### 4. Restore a Database
+### 4. Back Up a Database
+
+1. Navigate to **Back Up** in the sidebar
+2. Choose the server and click **List databases**, then pick the database
+3. Choose where it goes — a blob container, or a folder the SQL Server service account can write to
+4. Leave **COPY_ONLY** ticked unless you specifically mean to move the differential base
+5. Click **Generate script**, read what it says, then press **Run backup** twice — it arms on the first press
+
+### 5. Restore a Database
 
 1. Navigate to **Restore** in the sidebar
-2. Select your container and click **Load Backups**
+2. Choose where the backups live:
+   - **Azure Blob Storage** — select your container and click **Load Backups**
+   - **A path both servers can see** — select the instance that TOOK the backups and click **Load Backups**. Its `msdb` is read rather than a folder being listed. If the target reaches the files by a different path, give both forms in the two boxes below.
 3. Filter by server/database if needed
 4. Click a restore point on the timeline (or in the list)
 5. Review the restore chain in the details panel
@@ -280,7 +326,7 @@ credential on the *instance* for the blob container, which is separate and confi
    - **Copy to Clipboard** or **Save to File** to run manually in SSMS
    - **Execute on Server** to run directly (requires connected SQL Server)
 
-### 5. Execute Restore
+### 6. Execute Restore
 
 When clicking **Execute on Server**:
 1. The button changes to "Confirm Execute (5)" with a countdown


### PR DESCRIPTION
Docs only.

The README still opened by calling Nine Lives a tool for restoring from Azure Blob Storage. It backs up and restores, to and from blob or a shared path, and has since #166 and #167 - the words were the last thing describing the old shape.

Adds:

- The two-media table, and what each medium is actually for. Neither is right in every estate: blob needs no network path between the hosts; a shared path is faster and costs no egress where both instances reach it.
- How a shared-path restore finds its backups - through the source instance's own `msdb`, because a folder of `.bak` files says nothing about which database each belongs to.
- The two things that path checks which are easy to get wrong by hand: `msdb` recording the path the SOURCE wrote (which on the target may resolve to the target's own drive of that letter - worse than failing), and whether the target's service account can read the files at all.
- The `COPY_ONLY` default and why it exists.
- A Backing Up feature section, and a usage step for taking a backup.

No code changes.