### PR TITLE
Copy a database to another server in one action (#105)

### DIFF
--- a/src/NineLives.Tests/CopyDatabaseTests.cs
+++ b/src/NineLives.Tests/CopyDatabaseTests.cs
@@ -1,0 +1,363 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Copying a database from one server onto another in one action (#105).
+///
+/// Two things make this more dangerous than either half alone, and most of these are about one or
+/// the other.
+///
+/// TWO servers are involved and only one is being protected: the source is read at full speed, the
+/// target is overwritten. And a PARTIAL run is not a failure - a backup that succeeded with a
+/// restore that did not has left a perfectly good backup behind, and reporting that as "failed" is
+/// how a second backup of a production database gets taken for no reason.
+/// </summary>
+public class CopyDatabaseTests
+{
+    private static OperationLog TestLog() =>
+        new(Path.Combine(Path.GetTempPath(), "ninelives-copy-tests", Guid.NewGuid().ToString("n")));
+
+    private static (CopyDatabaseViewModel vm, FakeSqlServerService sql) New()
+    {
+        var store = new FakeCredentialStore();
+
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb", "OtherDb"] };
+        var vm = new CopyDatabaseViewModel(store, sql, TestLog());
+
+        vm.SourceServer = vm.Servers.First();
+        vm.TargetServer = vm.Servers.Last();
+        vm.Container = vm.Containers.Single();
+
+        return (vm, sql);
+    }
+
+    private static async Task<(CopyDatabaseViewModel vm, FakeSqlServerService sql)> ReadyAsync(
+        BackupMedium medium = BackupMedium.AzureBlob)
+    {
+        var (vm, sql) = New();
+
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetDatabaseName = "MyDb_Test";
+
+        vm.Medium = medium;
+        if (medium == BackupMedium.SharedPath) vm.SharedPathRoot = @"\\nas01\sql";
+
+        vm.GenerateCommand.Execute(null);
+        return (vm, sql);
+    }
+
+    private static async Task RunAsync(CopyDatabaseViewModel vm)
+    {
+        await vm.RunCommand.ExecuteAsync(null);
+        await vm.RunCommand.ExecuteAsync(null);
+    }
+
+    // ── both halves, in order, on the right servers ─────────────────────────────
+
+    /// <summary>
+    /// The backup runs on the SOURCE and the restore on the TARGET. Getting that the wrong way
+    /// round would restore a production database over a test one's contents, or worse.
+    /// </summary>
+    [Fact]
+    public async Task TheBackupRunsOnTheSourceAndTheRestoreOnTheTarget()
+    {
+        var (vm, sql) = await ReadyAsync();
+
+        await RunAsync(vm);
+
+        Assert.Equal(2, sql.ExecutedScripts.Count);
+        Assert.Contains("BACKUP DATABASE", sql.ExecutedScripts[0]);
+        Assert.Contains("RESTORE DATABASE", sql.ExecutedScripts[1]);
+
+        Assert.Equal("SRV01", sql.ExecutedAgainst[0].ServerName);
+        Assert.Equal("SRV02", sql.ExecutedAgainst[1].ServerName);
+    }
+
+    [Fact]
+    public async Task ASuccessfulCopyReportsItselfAsCopied()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        await RunAsync(vm);
+
+        Assert.Equal(CopyOutcome.Copied, vm.Outcome);
+        Assert.False(vm.HasError);
+    }
+
+    /// <summary>The restore names the target database, not the source one.</summary>
+    [Fact]
+    public async Task TheCopyIsRestoredUnderTheNameItWasGiven()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        Assert.Contains("BACKUP DATABASE [MyDb]", vm.BackupScript);
+        Assert.Contains("[MyDb_Test]", vm.RestoreScript);
+    }
+
+    /// <summary>
+    /// The restore reads back exactly what the backup wrote. If these two ever disagree the copy
+    /// restores something else, or nothing.
+    /// </summary>
+    [Fact]
+    public async Task TheRestoreReadsTheFileTheBackupWrote()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        var destination = Assert.Single(vm.Destinations);
+
+        Assert.Contains(destination, vm.BackupScript);
+        Assert.Contains(destination, vm.RestoreScript);
+    }
+
+    [Fact]
+    public async Task ACopyThroughAShareUsesDiskAtBothEnds()
+    {
+        var (vm, _) = await ReadyAsync(BackupMedium.SharedPath);
+
+        Assert.Contains("TO DISK", vm.BackupScript);
+        Assert.Contains("FROM DISK", vm.RestoreScript);
+    }
+
+    // ── a partial run is not a failure ──────────────────────────────────────────
+
+    /// <summary>
+    /// The distinction this whole outcome type exists for. A backup that succeeded and a restore
+    /// that did not has left a real, usable backup behind - and the right next step is to restore
+    /// from it, not to run this again and read the production database a second time.
+    /// </summary>
+    [Fact]
+    public async Task ABackupThatSucceededWithAFailedRestoreSaysTheBackupIsStillGood()
+    {
+        var (vm, sql) = await ReadyAsync();
+        sql.FailOnExecuteNumber = 2;
+
+        await RunAsync(vm);
+
+        Assert.Equal(CopyOutcome.BackupTakenRestoreFailed, vm.Outcome);
+        Assert.Contains("backup is real and usable", vm.OutcomeText);
+        Assert.Contains("rather than running this again", vm.OutcomeText);
+    }
+
+    /// <summary>
+    /// A failed backup means nothing was restored, and any file written is not a backup - which is
+    /// worth saying, because it will sit in the container looking exactly like one.
+    /// </summary>
+    [Fact]
+    public async Task AFailedBackupStopsBeforeTheTargetIsTouched()
+    {
+        var (vm, sql) = await ReadyAsync();
+        sql.FailOnExecuteNumber = 1;
+
+        await RunAsync(vm);
+
+        Assert.Equal(CopyOutcome.BackupFailed, vm.Outcome);
+        Assert.Single(sql.ExecutedScripts);
+        Assert.Contains("incomplete", vm.OutcomeText);
+    }
+
+    [Fact]
+    public async Task AFailedBackupNeverNamesTheTargetServerAsHavingBeenChanged()
+    {
+        var (vm, sql) = await ReadyAsync();
+        sql.FailOnExecuteNumber = 1;
+
+        await RunAsync(vm);
+
+        Assert.DoesNotContain(sql.ExecutedAgainst, s => s.ServerName == "SRV02");
+    }
+
+    // ── the check between the halves ────────────────────────────────────────────
+
+    /// <summary>
+    /// The question a shared path turns on, and it can only be asked once the backup exists.
+    ///
+    /// The SOURCE writes the file as its service account and the TARGET reads it as a different
+    /// one. Those are routinely not the same account, and nothing before this point would notice.
+    /// </summary>
+    [Fact]
+    public async Task TheTargetIsAskedWhetherItCanReadWhatTheSourceWrote()
+    {
+        var (vm, sql) = await ReadyAsync(BackupMedium.SharedPath);
+
+        await RunAsync(vm);
+
+        Assert.Equal(Assert.Single(vm.Destinations), Assert.Single(sql.CheckedPaths));
+    }
+
+    /// <summary>
+    /// And when it cannot, the restore does not run - which leaves the backup intact and the target
+    /// untouched, the most recoverable state this screen can produce.
+    /// </summary>
+    [Fact]
+    public async Task ATargetThatCannotReadTheBackupStopsBeforeTheRestore()
+    {
+        var (vm, sql) = await ReadyAsync(BackupMedium.SharedPath);
+        sql.UnreadablePaths[vm.Destinations.Single()] = BackupFileProblem.AccessDenied;
+
+        await RunAsync(vm);
+
+        Assert.Equal(CopyOutcome.BackupTakenRestoreFailed, vm.Outcome);
+        Assert.Single(sql.ExecutedScripts);
+        Assert.Contains(vm.Console, l => l.Contains("service account", StringComparison.Ordinal));
+    }
+
+    /// <summary>Blob has no share permission to check, so nothing is asked and the copy proceeds.</summary>
+    [Fact]
+    public async Task ACopyThroughBlobAsksNoQuestionAboutFilePermissions()
+    {
+        var (vm, sql) = await ReadyAsync();
+
+        await RunAsync(vm);
+
+        Assert.Empty(sql.CheckedPaths);
+        Assert.Equal(CopyOutcome.Copied, vm.Outcome);
+    }
+
+    // ── the guard rails ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Onto itself under its own name is not a copy - it is a backup restored over the database it
+    /// was taken from, which at best is an expensive no-op and at worst destroys it when the
+    /// restore fails halfway.
+    /// </summary>
+    [Fact]
+    public async Task RestoringADatabaseOverItselfIsRefused()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        vm.TargetServer = vm.SourceServer;
+        vm.TargetDatabaseName = "MyDb";
+
+        Assert.True(vm.IsRefused);
+        Assert.False(vm.CanGenerate);
+        Assert.False(vm.CanRun);
+        Assert.Contains("over itself", vm.Refusal);
+    }
+
+    /// <summary>The same instance under a DIFFERENT name is an ordinary copy, and is allowed.</summary>
+    [Fact]
+    public async Task CopyingOntoTheSameInstanceUnderAnotherNameIsFine()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        vm.TargetServer = vm.SourceServer;
+        vm.TargetDatabaseName = "MyDb_Copy";
+
+        Assert.False(vm.IsRefused);
+        Assert.True(vm.CanGenerate);
+    }
+
+    /// <summary>
+    /// The confirmation names BOTH servers. The whole point of this screen is that two are
+    /// involved, so a prompt naming one is a prompt somebody can read as being about the other.
+    /// </summary>
+    [Fact]
+    public async Task TheConfirmationNamesBothServers()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.True(vm.IsArmed);
+        Assert.Contains("SRV01", vm.ConfirmationText);
+        Assert.Contains("SRV02", vm.ConfirmationText);
+        Assert.Contains("MyDb_Test", vm.ConfirmationText);
+    }
+
+    [Fact]
+    public async Task ChangingAnythingDisarmsTheRun()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        await vm.RunCommand.ExecuteAsync(null);
+        Assert.True(vm.IsArmed);
+
+        vm.TargetDatabaseName = "MyDb_Other";
+
+        Assert.False(vm.IsArmed);
+    }
+
+    // ── the source is somebody else's production server ─────────────────────────
+
+    [Fact]
+    public async Task ACopyIsCopyOnlyUntilSomebodyChangesIt()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        Assert.True(vm.CopyOnly);
+        Assert.Contains("COPY_ONLY", vm.BackupScript);
+        Assert.False(vm.WillResetTheDifferentialBase);
+    }
+
+    [Fact]
+    public async Task TurningCopyOnlyOffIsSurfacedAndSaidAgainAsItRuns()
+    {
+        var (vm, _) = await ReadyAsync();
+        vm.CopyOnly = false;
+
+        Assert.True(vm.WillResetTheDifferentialBase);
+
+        await RunAsync(vm);
+
+        Assert.Contains(vm.Console, l => l.Contains("differential base", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Overwriting the target is usually the whole point - a test environment being refreshed - but
+    /// it is the part that destroys something, so it is stated rather than left in a checkbox.
+    /// </summary>
+    [Fact]
+    public async Task OverwritingTheTargetIsStatedRatherThanImplied()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        Assert.True(vm.WillOverwriteTheTarget);
+        Assert.Contains("overwriting it if it already exists", vm.ConfirmationText);
+
+        vm.WithReplace = false;
+
+        Assert.False(vm.WillOverwriteTheTarget);
+        Assert.DoesNotContain("overwriting", vm.ConfirmationText);
+    }
+
+    // ── nothing runs that was not on screen first ───────────────────────────────
+
+    [Fact]
+    public void NothingCanRunBeforeBothScriptsExist()
+    {
+        var (vm, _) = New();
+
+        Assert.False(vm.HasScripts);
+        Assert.False(vm.CanRun);
+    }
+
+    [Fact]
+    public async Task ListingTheSourceDatabasesChoosesNoneOfThem()
+    {
+        var (vm, _) = New();
+
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, vm.SourceDatabases.Count);
+        Assert.Null(vm.SourceDatabase);
+        Assert.False(vm.CanGenerate);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -231,12 +231,24 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Which execute call fails, 1-based, or null for none.
+    ///
+    /// A copy between servers runs two of them, and the interesting cases are the ones where the
+    /// FIRST succeeds and the second does not - so a test has to be able to say which (#105).
+    /// </summary>
+    public int? FailOnExecuteNumber { get; set; }
+
     public Task ExecuteWithProgressAsync(
         ServerConnection server, string sql, Action<string>? messageCallback = null, CancellationToken ct = default)
     {
         ExecutedAgainst.Add(server);
         ExecutedScripts.Add(sql);
         messageCallback?.Invoke("100 percent processed.");
+
+        if (FailOnExecuteNumber == ExecutedScripts.Count)
+            throw new InvalidOperationException($"fake failure on execute {ExecutedScripts.Count}");
+
         if (ExecuteThrows != null) throw ExecuteThrows;
         return Task.CompletedTask;
     }

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -832,6 +832,95 @@ public class XamlLoadTests(WpfFixture wpf)
         => Check("HistoryView (empty)", () =>
             new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) });
 
+    // ── the Copy Database screen (#105) ─────────────────────────────────────────
+
+    [Fact]
+    public void CopyDatabaseViewLoads()
+        => Check("CopyDatabaseView", () => new CopyDatabaseView { DataContext = NewCopyViewModel() });
+
+    [Fact]
+    public void TheCopyViewLoadsWithASharedPathChosen()
+        => Check("CopyDatabaseView (shared path)", () =>
+        {
+            var vm = NewCopyViewModel();
+            vm.Medium = BackupMedium.SharedPath;
+            return new CopyDatabaseView { DataContext = vm };
+        });
+
+    /// <summary>
+    /// The armed confirmation names BOTH servers, on screen.
+    ///
+    /// The whole point of this screen is that two are involved, so a prompt naming one is a prompt
+    /// somebody can read as being about the other. A collapsed panel is not a confirmation, so this
+    /// asserts on what is drawn.
+    /// </summary>
+    [Fact]
+    public void TheArmedConfirmationNamesBothServersOnScreen()
+    {
+        wpf.Invoke(() =>
+        {
+            var store = new FakeCredentialStore();
+            var source = new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+            var target = new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" };
+            store.Config.Servers.Add(source);
+            store.Config.Servers.Add(target);
+            store.Config.BlobContainers.Add(new BlobContainerConfig
+            { Id = "c1", Name = "backups", ContainerUrl = "https://acct.blob.core.windows.net/backups" });
+
+            var vm = new CopyDatabaseViewModel(store, new FakeSqlServerService(), TestOperationLog());
+            vm.SourceServer = vm.Servers.First();
+            vm.TargetServer = vm.Servers.Last();
+            vm.Container = vm.Containers.Single();
+            vm.SourceDatabase = "MyDb";
+            vm.TargetDatabaseName = "MyDb_Test";
+            vm.GenerateCommand.Execute(null);
+            vm.RunCommand.Execute(null);
+
+            var view = new CopyDatabaseView { DataContext = vm };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.True(vm.IsArmed);
+            Assert.Contains(shown, t => t.Contains("SRV01", StringComparison.Ordinal)
+                                     && t.Contains("SRV02", StringComparison.Ordinal));
+        });
+    }
+
+    /// <summary>
+    /// A refusal is shown rather than silently disabling the button - a button dead for no stated
+    /// reason is one somebody works around.
+    /// </summary>
+    [Fact]
+    public void ARefusedCopySaysWhyOnScreen()
+    {
+        wpf.Invoke(() =>
+        {
+            var store = new FakeCredentialStore();
+            var server = new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+            store.Config.Servers.Add(server);
+
+            var vm = new CopyDatabaseViewModel(store, new FakeSqlServerService(), TestOperationLog());
+            vm.SourceServer = vm.Servers.Single();
+            vm.TargetServer = vm.Servers.Single();
+            vm.SourceDatabase = "MyDb";
+            vm.TargetDatabaseName = "MyDb";
+
+            var view = new CopyDatabaseView { DataContext = vm };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.Contains(shown, t => t.Contains("over itself", StringComparison.Ordinal));
+        });
+    }
+
+    private static CopyDatabaseViewModel NewCopyViewModel()
+        => new(Store(), new SqlServerService(Store()), TestOperationLog());
+
+    private static OperationLog TestOperationLog()
+        => new(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n")));
+
     // ── the Backup screen (#165) ────────────────────────────────────────────────
 
     [Fact]

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -27,9 +27,10 @@
         <KeyBinding Modifiers="Ctrl" Key="D3" Command="{Binding NavigateToCommand}" CommandParameter="Browse Backups" />
         <KeyBinding Modifiers="Ctrl" Key="D4" Command="{Binding NavigateToCommand}" CommandParameter="Back Up" />
         <KeyBinding Modifiers="Ctrl" Key="D5" Command="{Binding NavigateToCommand}" CommandParameter="Restore" />
-        <KeyBinding Modifiers="Ctrl" Key="D6" Command="{Binding NavigateToCommand}" CommandParameter="History" />
-        <KeyBinding Modifiers="Ctrl" Key="D7" Command="{Binding NavigateToCommand}" CommandParameter="Settings" />
-        <KeyBinding Modifiers="Ctrl" Key="D8" Command="{Binding NavigateToCommand}" CommandParameter="About" />
+        <KeyBinding Modifiers="Ctrl" Key="D6" Command="{Binding NavigateToCommand}" CommandParameter="Copy Database" />
+        <KeyBinding Modifiers="Ctrl" Key="D7" Command="{Binding NavigateToCommand}" CommandParameter="History" />
+        <KeyBinding Modifiers="Ctrl" Key="D8" Command="{Binding NavigateToCommand}" CommandParameter="Settings" />
+        <KeyBinding Modifiers="Ctrl" Key="D9" Command="{Binding NavigateToCommand}" CommandParameter="About" />
         <KeyBinding Key="F5" Command="{Binding ReloadCommand}" />
         <KeyBinding Modifiers="Ctrl" Key="G" Command="{Binding GenerateScriptCommand}" />
         <KeyBinding Key="Escape" Command="{Binding CancelCurrentCommand}" />
@@ -57,6 +58,9 @@
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:RestoreViewModel}">
             <views:RestoreView />
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:CopyDatabaseViewModel}">
+            <views:CopyDatabaseView />
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:HistoryViewModel}">
             <views:HistoryView />
@@ -283,6 +287,16 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#x267B;" FontSize="15" VerticalAlignment="Center" Width="24" />
                                 <TextBlock Text="Restore" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <RadioButton Style="{StaticResource SidebarButton}"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Copy Database'}"
+                                     Command="{Binding NavigateToCommand}"
+                                     CommandParameter="Copy Database">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#x21C4;" FontSize="15" VerticalAlignment="Center" Width="24" />
+                                <TextBlock Text="Copy Database" VerticalAlignment="Center" />
                             </StackPanel>
                         </RadioButton>
 

--- a/src/NineLives/Models/CopyOutcome.cs
+++ b/src/NineLives/Models/CopyOutcome.cs
@@ -1,0 +1,69 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// How far a copy between servers got (#105).
+///
+/// The distinction that matters is not success versus failure - it is WHERE it stopped, because the
+/// two halves leave completely different states behind and want completely different next steps.
+///
+/// A backup that succeeded and a restore that failed is not "failed". It left a perfectly good
+/// backup sitting in the container, and the right next step is to restore from it - not to run the
+/// whole thing again and take a second backup of a production database for no reason. Reporting
+/// that as a bare failure is how that second backup gets taken.
+/// </summary>
+public enum CopyOutcome
+{
+    /// <summary>Nothing has run yet.</summary>
+    NotStarted,
+
+    /// <summary>
+    /// Stopped before the source was touched - a guard rail, or a preflight that refused.
+    /// Nothing exists anywhere; nothing to clean up.
+    /// </summary>
+    StoppedBeforeAnythingHappened,
+
+    /// <summary>
+    /// The BACKUP did not complete. Any file written is partial, is not a backup, and cannot be
+    /// restored from - which is worth saying, because it will sit there looking like one.
+    /// </summary>
+    BackupFailed,
+
+    /// <summary>
+    /// The backup succeeded and the restore did not.
+    ///
+    /// The one worth telling apart. The backup is real and usable; the target is whatever the
+    /// failed restore left it as, which after WITH REPLACE may be nothing.
+    /// </summary>
+    BackupTakenRestoreFailed,
+
+    /// <summary>Both halves finished.</summary>
+    Copied
+}
+
+public static class CopyOutcomeText
+{
+    public static string Describe(CopyOutcome outcome, string? backupLocation = null) => outcome switch
+    {
+        CopyOutcome.NotStarted => string.Empty,
+
+        CopyOutcome.StoppedBeforeAnythingHappened =>
+            "Stopped before anything ran. Nothing was written and neither server was changed.",
+
+        CopyOutcome.BackupFailed =>
+            "The backup did not complete, so nothing was restored. Any file already written is " +
+            "incomplete and cannot be restored from - delete it rather than keeping it.",
+
+        CopyOutcome.BackupTakenRestoreFailed =>
+            $"The backup succeeded and the restore did not. The backup is real and usable{Where(backupLocation)} - " +
+            "restore from it rather than running this again, which would take a second backup of " +
+            "the source for no reason. The target database is whatever the failed restore left it " +
+            "as, which after WITH REPLACE may be nothing.",
+
+        CopyOutcome.Copied => "Copied.",
+
+        _ => string.Empty
+    };
+
+    private static string Where(string? location) =>
+        string.IsNullOrWhiteSpace(location) ? string.Empty : $" and is at {location}";
+}

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -1,0 +1,577 @@
+using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// Put a copy of this database from one server onto another, in one action (#105).
+///
+/// The job the app could not do until both halves existed. It is deliberately not a third
+/// implementation of anything: the backup is the backup screen's generator and destinations, the
+/// restore is the restore screen's generator, and both run through the same execution path. What is
+/// new is only the orchestration between them, and what has to be true for it to be safe.
+///
+/// Two things make this more dangerous than either half alone.
+///
+/// First, TWO servers are involved and only one of them is the one being protected. The source is
+/// read - which is why COPY_ONLY matters here even more than it does on the backup screen. The
+/// target is overwritten. A confirmation that names only one of them is a confirmation somebody can
+/// misread, so this one names both.
+///
+/// Second, a partial run is not a failure. A backup that succeeded and a restore that did not has
+/// left a perfectly good backup behind, and the right next step is to restore from it - not to run
+/// the whole thing again and read a production database at full speed for a second time.
+/// </summary>
+public partial class CopyDatabaseViewModel : ViewModelBase
+{
+    private readonly ICredentialStore _store;
+    private readonly ISqlServerService _sql;
+    private readonly BackupScriptGenerator _backupGenerator = new();
+    private readonly RestoreScriptGenerator _restoreGenerator = new();
+    private readonly OperationCancellation _cancellation = new();
+    private readonly OperationLog _log;
+
+    public CopyDatabaseViewModel(ICredentialStore store, ISqlServerService sql, OperationLog? log = null)
+    {
+        _store = store;
+        _sql = sql;
+        _log = log ?? App.Log;
+
+        Refresh();
+    }
+
+    // ── the two ends ────────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private ObservableCollection<ServerConnection> _servers = [];
+
+    /// <summary>The instance the database is copied FROM. It is read, and it is backed up.</summary>
+    [ObservableProperty]
+    private ServerConnection? _sourceServer;
+
+    /// <summary>The instance the copy lands on. It is overwritten.</summary>
+    [ObservableProperty]
+    private ServerConnection? _targetServer;
+
+    [ObservableProperty]
+    private ObservableCollection<string> _sourceDatabases = [];
+
+    [ObservableProperty]
+    private string? _sourceDatabase;
+
+    [ObservableProperty]
+    private string _targetDatabaseName = string.Empty;
+
+    [ObservableProperty]
+    private ObservableCollection<BlobContainerConfig> _containers = [];
+
+    [ObservableProperty]
+    private BlobContainerConfig? _container;
+
+    [ObservableProperty]
+    private BackupMedium _medium = BackupMedium.AzureBlob;
+
+    public bool MediumIsBlob => Medium == BackupMedium.AzureBlob;
+    public bool MediumIsSharedPath => Medium == BackupMedium.SharedPath;
+
+    /// <summary>
+    /// The folder the backup is written to and read back from.
+    ///
+    /// Both instances have to reach it, and each reaches it as its OWN service account - the source
+    /// has to write there and the target has to read there. Neither is the same as this app being
+    /// able to see it.
+    /// </summary>
+    [ObservableProperty]
+    private string _sharedPathRoot = string.Empty;
+
+    /// <summary>
+    /// COPY_ONLY, on by default. The source here is somebody else's production server, so moving
+    /// its differential base as a side effect of refreshing a test environment is the exact thing
+    /// this default exists to stop.
+    /// </summary>
+    [ObservableProperty]
+    private bool _copyOnly = true;
+
+    [ObservableProperty]
+    private bool _compression = true;
+
+    [ObservableProperty]
+    private bool _withReplace = true;
+
+    public void Refresh()
+    {
+        try
+        {
+            var config = _store.LoadConfig();
+
+            var previousSource = SourceServer?.Id;
+            var previousTarget = TargetServer?.Id;
+            var previousContainer = Container?.Id;
+
+            Servers = new ObservableCollection<ServerConnection>(config.Servers);
+            Containers = new ObservableCollection<BlobContainerConfig>(config.BlobContainers);
+
+            if (previousSource != null) SourceServer = Servers.FirstOrDefault(s => s.Id == previousSource);
+            if (previousTarget != null) TargetServer = Servers.FirstOrDefault(s => s.Id == previousTarget);
+            if (previousContainer != null) Container = Containers.FirstOrDefault(c => c.Id == previousContainer);
+        }
+        catch
+        {
+            Servers = [];
+            Containers = [];
+        }
+    }
+
+    [RelayCommand]
+    private async Task LoadSourceDatabasesAsync()
+    {
+        if (SourceServer == null)
+        {
+            SetError("Choose the server to copy from.");
+            return;
+        }
+
+        var ct = _cancellation.Begin();
+        IsBusy = true;
+        ClearStatus();
+
+        try
+        {
+            var names = await _sql.GetDatabaseListAsync(SourceServer, ct);
+            SourceDatabases = new ObservableCollection<string>(names);
+
+            // Nothing is chosen for the user. Here the wrong choice reads a production database at
+            // full speed AND overwrites a database on another server.
+            SourceDatabase = null;
+
+            SetStatus($"{SourceServer.ServerName} has {names.Count} database(s).");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Stopped.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not list the databases: {ex.Message}");
+        }
+        finally
+        {
+            _cancellation.End();
+            IsBusy = false;
+        }
+    }
+
+    partial void OnSourceServerChanged(ServerConnection? value)
+    {
+        SourceDatabases = [];
+        SourceDatabase = null;
+        Invalidate();
+    }
+
+    partial void OnTargetServerChanged(ServerConnection? value) => Invalidate();
+    partial void OnSourceDatabaseChanged(string? value) => Invalidate();
+    partial void OnTargetDatabaseNameChanged(string value) => Invalidate();
+    partial void OnContainerChanged(BlobContainerConfig? value) => Invalidate();
+    partial void OnSharedPathRootChanged(string value) => Invalidate();
+    partial void OnCopyOnlyChanged(bool value) => Invalidate();
+    partial void OnCompressionChanged(bool value) => Invalidate();
+    partial void OnWithReplaceChanged(bool value) => Invalidate();
+
+    partial void OnMediumChanged(BackupMedium value)
+    {
+        OnPropertyChanged(nameof(MediumIsBlob));
+        OnPropertyChanged(nameof(MediumIsSharedPath));
+        Invalidate();
+    }
+
+    // ── the guard rails ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Why this copy is refused, or empty when it is not.
+    ///
+    /// Separate from CanGenerate, which only asks whether the inputs are filled in. This asks
+    /// whether the thing being described should happen at all, and it is shown rather than merely
+    /// disabling a button - a button that is dead for no stated reason is one somebody works around.
+    /// </summary>
+    public string Refusal
+    {
+        get
+        {
+            if (SourceServer == null || TargetServer == null) return string.Empty;
+            if (string.IsNullOrWhiteSpace(SourceDatabase)) return string.Empty;
+            if (string.IsNullOrWhiteSpace(TargetDatabaseName)) return string.Empty;
+
+            // Onto itself, under its own name. That is not a copy - it is a backup of a database
+            // immediately restored over the top of the database it was taken from, which at best
+            // is an expensive no-op and at worst destroys it when the restore fails halfway.
+            var sameInstance = string.Equals(
+                SourceServer.ServerName, TargetServer.ServerName, StringComparison.OrdinalIgnoreCase);
+
+            var sameName = string.Equals(
+                SourceDatabase, TargetDatabaseName, StringComparison.OrdinalIgnoreCase);
+
+            if (sameInstance && sameName)
+                return $"That would restore {SourceDatabase} over itself on {SourceServer.ServerName}. " +
+                       "Give the copy a different name, or choose a different server to restore onto.";
+
+            return string.Empty;
+        }
+    }
+
+    public bool IsRefused => Refusal.Length > 0;
+
+    /// <summary>
+    /// True when the copy overwrites a database that is already there.
+    ///
+    /// Not a refusal - it is usually the whole point, a test environment being refreshed. But it is
+    /// the part of this that destroys something, so it is stated rather than buried in a checkbox.
+    /// </summary>
+    public bool WillOverwriteTheTarget => WithReplace && !string.IsNullOrWhiteSpace(TargetDatabaseName);
+
+    /// <summary>True when the source's own differential schedule is about to be disturbed.</summary>
+    public bool WillResetTheDifferentialBase => !CopyOnly;
+
+    // ── the two scripts, together ───────────────────────────────────────────────
+
+    /// <summary>What the source will be asked to do.</summary>
+    [ObservableProperty]
+    private string _backupScript = string.Empty;
+
+    /// <summary>What the target will be asked to do.</summary>
+    [ObservableProperty]
+    private string _restoreScript = string.Empty;
+
+    /// <summary>Where the backup goes, and is read back from.</summary>
+    [ObservableProperty]
+    private ObservableCollection<string> _destinations = [];
+
+    public bool HasScripts => BackupScript.Length > 0 && RestoreScript.Length > 0;
+
+    partial void OnBackupScriptChanged(string value) => OnPropertyChanged(nameof(HasScripts));
+
+    partial void OnRestoreScriptChanged(string value)
+    {
+        OnPropertyChanged(nameof(HasScripts));
+        RunCommand.NotifyCanExecuteChanged();
+    }
+
+    public bool CanGenerate =>
+        SourceServer != null &&
+        TargetServer != null &&
+        !string.IsNullOrWhiteSpace(SourceDatabase) &&
+        !string.IsNullOrWhiteSpace(TargetDatabaseName) &&
+        (MediumIsBlob ? Container != null : !string.IsNullOrWhiteSpace(SharedPathRoot)) &&
+        !IsRefused;
+
+    private void Invalidate()
+    {
+        OnPropertyChanged(nameof(Refusal));
+        OnPropertyChanged(nameof(IsRefused));
+        OnPropertyChanged(nameof(CanGenerate));
+        OnPropertyChanged(nameof(WillOverwriteTheTarget));
+        OnPropertyChanged(nameof(WillResetTheDifferentialBase));
+        GenerateCommand.NotifyCanExecuteChanged();
+
+        // An armed run that survives a change is armed for something else.
+        IsArmed = false;
+
+        if (HasScripts) Generate();
+    }
+
+    /// <summary>
+    /// Both statements, shown together.
+    ///
+    /// Together deliberately: what is about to happen to a production server and what is about to
+    /// happen to another one are one decision, and reading them one at a time is how somebody
+    /// approves the half they were looking at.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanGenerate))]
+    private void Generate()
+    {
+        if (!CanGenerate) return;
+
+        var takenAt = DateTime.Now;
+
+        var destinations = MediumIsBlob
+            ? BackupDestinationBuilder.ForContainer(
+                Container!, SourceServer!.ServerName, SourceDatabase!, BackupType.Full, takenAt, 1, CopyOnly)
+            : BackupDestinationBuilder.ForSharedPath(
+                SharedPathRoot, SourceDatabase!, BackupType.Full, takenAt, 1, CopyOnly);
+
+        Destinations = new ObservableCollection<string>(destinations);
+
+        BackupScript = _backupGenerator.Generate(new BackupOptions
+        {
+            DatabaseName = SourceDatabase!,
+            Medium = Medium,
+            Destinations = destinations,
+            CopyOnly = CopyOnly,
+            Compression = Compression,
+            Description = $"Copy of {SourceDatabase} from {SourceServer!.ServerName} " +
+                          $"to {TargetServer!.ServerName} as {TargetDatabaseName}"
+        });
+
+        RestoreScript = _restoreGenerator.Generate(ChainForWhatWasWritten(destinations, takenAt),
+            new RestoreOptions
+            {
+                TargetDatabaseName = TargetDatabaseName,
+                WithReplace = WithReplace,
+                RecoveryMode = RecoveryMode.Recovery
+            });
+
+        SetStatus("Scripts generated.");
+    }
+
+    /// <summary>
+    /// The chain to restore: the one full backup that is about to be written.
+    ///
+    /// Built from what is being WRITTEN rather than discovered by listing afterwards, because there
+    /// is nothing to discover - this app chose the paths, the database and the moment, so re-reading
+    /// them back out of a container listing or an msdb query would only be asking a second source to
+    /// confirm what is already known, and would introduce a way for the two to disagree.
+    ///
+    /// Whether the file is actually THERE and readable is a different question, and it is asked
+    /// separately, on the target, after the backup has run.
+    /// </summary>
+    private BackupChain ChainForWhatWasWritten(List<string> destinations, DateTime takenAt) => new()
+    {
+        FullSet = new BackupSet
+        {
+            SetId = $"{SourceDatabase}_{takenAt:yyyyMMdd_HHmmss}",
+            DatabaseName = SourceDatabase,
+            ServerName = SourceServer?.ServerName,
+            Type = BackupType.Full,
+            Timestamp = takenAt,
+            IsCopyOnly = CopyOnly,
+            Files = destinations.Select(d => new BackupFileInfo
+            {
+                // The medium decides how the RESTORE addresses it, exactly as it does everywhere
+                // else: a file with a local path is restored FROM DISK, everything else FROM URL.
+                LocalPath = MediumIsSharedPath ? d : null,
+                BlobUrl = MediumIsBlob ? d : string.Empty,
+                BlobName = System.IO.Path.GetFileName(d),
+                Type = BackupType.Full,
+                InferredDatabaseName = SourceDatabase,
+                InferredServerName = SourceServer?.ServerName,
+                IsCopyOnly = CopyOnly,
+
+                // Kind is stripped first. takenAt is a local DateTime.Now, and pairing a local
+                // reading with a zero offset throws - which is the constructor telling the truth:
+                // every time value this app sorts on is a bare wall clock whose zone is recorded
+                // separately, so the Kind has to come off rather than be reinterpreted.
+                LastModified = new DateTimeOffset(
+                    DateTime.SpecifyKind(takenAt, DateTimeKind.Unspecified), TimeSpan.Zero)
+            }).ToList()
+        }
+    };
+
+    [RelayCommand]
+    private void CopyScripts() =>
+        TryCopyToClipboard(
+            $"{BackupScript}{Environment.NewLine}{Environment.NewLine}{RestoreScript}",
+            "Both scripts copied to clipboard.");
+
+    // ── running it ──────────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private bool _isArmed;
+
+    [ObservableProperty]
+    private bool _isRunning;
+
+    [ObservableProperty]
+    private CopyOutcome _outcome = CopyOutcome.NotStarted;
+
+    /// <summary>What state the two servers were left in, in terms of what to do next.</summary>
+    [ObservableProperty]
+    private string _outcomeText = string.Empty;
+
+    public bool HasOutcome => OutcomeText.Length > 0;
+
+    partial void OnOutcomeTextChanged(string value) => OnPropertyChanged(nameof(HasOutcome));
+
+    public ObservableCollection<string> Console { get; } = [];
+
+    /// <summary>
+    /// The confirmation, naming BOTH servers.
+    ///
+    /// The whole point of this screen is that two are involved, so a prompt that names one of them
+    /// is a prompt somebody can read as being about the other.
+    /// </summary>
+    public string ConfirmationText =>
+        SourceServer == null || TargetServer == null
+            ? string.Empty
+            : $"Back up {SourceDatabase} on {SourceServer.ServerName}, then restore it onto " +
+              $"{TargetServer.ServerName} as {TargetDatabaseName}" +
+              (WithReplace ? ", overwriting it if it already exists." : ".");
+
+    public string ButtonText => IsRunning ? "Copying..." : IsArmed ? "Confirm - copy it" : "Copy database";
+
+    partial void OnIsArmedChanged(bool value)
+    {
+        OnPropertyChanged(nameof(ButtonText));
+        OnPropertyChanged(nameof(ConfirmationText));
+    }
+
+    partial void OnIsRunningChanged(bool value)
+    {
+        OnPropertyChanged(nameof(ButtonText));
+        RunCommand.NotifyCanExecuteChanged();
+    }
+
+    public bool CanRun => HasScripts && !IsRunning && !IsRefused;
+
+    [RelayCommand(CanExecute = nameof(CanRun))]
+    private async Task RunAsync()
+    {
+        if (!CanRun || SourceServer == null || TargetServer == null) return;
+
+        if (!IsArmed)
+        {
+            IsArmed = true;
+            return;
+        }
+
+        IsArmed = false;
+        IsRunning = true;
+        ClearStatus();
+        Console.Clear();
+        Outcome = CopyOutcome.NotStarted;
+        OutcomeText = string.Empty;
+
+        var ct = _cancellation.Begin();
+
+        try
+        {
+            await RunBothHalvesAsync(ct);
+        }
+        finally
+        {
+            _cancellation.End();
+            IsRunning = false;
+            OutcomeText = CopyOutcomeText.Describe(Outcome, Destinations.FirstOrDefault());
+
+            if (Outcome == CopyOutcome.Copied)
+                SetStatus($"Copied {SourceDatabase} to {TargetServer.ServerName} as {TargetDatabaseName}.");
+            else if (Outcome != CopyOutcome.NotStarted)
+                SetError(OutcomeText);
+        }
+    }
+
+    private async Task RunBothHalvesAsync(CancellationToken ct)
+    {
+        // ── the source half ─────────────────────────────────────────────────────
+        Append($"Backing up {SourceDatabase} on {SourceServer!.ServerName}...");
+        if (!CopyOnly)
+            Append("This is NOT a copy-only backup - the differential base on the source is moving.");
+
+        _log.Info($"Copy started: {SourceDatabase} from {SourceServer.ServerName} " +
+                  $"to {TargetServer!.ServerName} as {TargetDatabaseName}");
+
+        try
+        {
+            await _sql.ExecuteWithProgressAsync(SourceServer, BackupScript, Append, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            Append("Cancelled during the backup.");
+            Outcome = CopyOutcome.BackupFailed;
+            return;
+        }
+        catch (Exception ex)
+        {
+            Append(ex.Message);
+            Outcome = CopyOutcome.BackupFailed;
+            _log.Error($"Copy failed during backup: {ex.Message}");
+            return;
+        }
+
+        Append("Backup complete.");
+
+        // ── can the target reach what was just written ──────────────────────────
+        //
+        // Between the halves rather than before either, because until the backup has run there is
+        // nothing to check. On a shared path this is the question the whole medium turns on: the
+        // SOURCE wrote the file as its service account, and the TARGET has to read it as a
+        // different one. The two are routinely not the same account, and nothing before this point
+        // would have noticed.
+        if (MediumIsSharedPath && !await TargetCanReadAsync(ct))
+        {
+            Outcome = CopyOutcome.BackupTakenRestoreFailed;
+            return;
+        }
+
+        // ── the target half ─────────────────────────────────────────────────────
+        Append($"Restoring onto {TargetServer.ServerName} as {TargetDatabaseName}...");
+
+        try
+        {
+            await _sql.ExecuteWithProgressAsync(TargetServer, RestoreScript, Append, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            Append("Cancelled during the restore.");
+            Outcome = CopyOutcome.BackupTakenRestoreFailed;
+            return;
+        }
+        catch (Exception ex)
+        {
+            Append(ex.Message);
+            Outcome = CopyOutcome.BackupTakenRestoreFailed;
+            _log.Error($"Copy failed during restore: {ex.Message}");
+            return;
+        }
+
+        Append("Restore complete.");
+        Outcome = CopyOutcome.Copied;
+        _log.Info($"Copy finished: {TargetDatabaseName} on {TargetServer.ServerName}");
+    }
+
+    /// <summary>
+    /// Asks the target instance whether it can read the file the source just wrote.
+    ///
+    /// A failure here is the most recoverable state this screen produces and the most confusing to
+    /// read: the backup is real and fine, and the only thing wrong is a permission on a share. So
+    /// it is reported in those terms rather than as a restore that failed.
+    /// </summary>
+    private async Task<bool> TargetCanReadAsync(CancellationToken ct)
+    {
+        Append($"Checking {TargetServer!.ServerName} can read the backup...");
+
+        try
+        {
+            var checks = await _sql.CheckBackupFilesAsync(TargetServer, Destinations, ct);
+            var failed = checks.FirstOrDefault(c => !c.CanBeRestored);
+
+            if (failed == null)
+            {
+                Append($"{TargetServer.ServerName} can read it.");
+                return true;
+            }
+
+            Append(failed.Explain(TargetServer.ServerName));
+            return false;
+        }
+        catch (Exception ex)
+        {
+            // A check that could not be completed is not a check that passed. Going ahead would put
+            // the failure back where it was: after WITH REPLACE has dropped the target.
+            Append($"Could not confirm {TargetServer.ServerName} can read the backup: {ex.Message}");
+            return false;
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        if (!_cancellation.CanCancel) return;
+
+        _cancellation.Cancel();
+        SetStatus("Stopping...");
+    }
+
+    private void Append(string line) => Console.Add(line);
+}

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -51,6 +51,7 @@ public partial class MainViewModel : ViewModelBase
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }
     public BackupViewModel Backup { get; }
+    public CopyDatabaseViewModel CopyDatabase { get; }
     public RestoreViewModel Restore { get; }
     public HistoryViewModel History { get; }
     public SettingsViewModel Settings { get; }
@@ -98,6 +99,7 @@ public partial class MainViewModel : ViewModelBase
             _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
             log: null, history: _historyStore);
         Backup = new BackupViewModel(_credentialStore, _sqlService);
+        CopyDatabase = new CopyDatabaseViewModel(_credentialStore, _sqlService);
         History = new HistoryViewModel(_historyStore);
         Settings = new SettingsViewModel(_credentialStore);
         About = new AboutViewModel();
@@ -113,7 +115,7 @@ public partial class MainViewModel : ViewModelBase
         // One place that answers "is it doing something?". Every screen already tracks its own
         // work; without this the answer depended on which part of a long page was scrolled into
         // view, and the Restore screen's own status line is below the fold most of the time (#128).
-        WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Backup, Restore);
+        WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Backup, Restore, CopyDatabase);
 
         CurrentView = BlobConfig;
 
@@ -341,12 +343,13 @@ public partial class MainViewModel : ViewModelBase
         public const string BrowseBackups = "Browse Backups";
         public const string Backup = "Back Up";
         public const string Restore = "Restore";
+        public const string CopyDatabase = "Copy Database";
         public const string History = "History";
         public const string Settings = "Settings";
         public const string About = "About";
 
         public static IReadOnlyList<string> Views =>
-            [BlobStorage, SqlServers, BrowseBackups, Backup, Restore, History, Settings, About];
+            [BlobStorage, SqlServers, BrowseBackups, Backup, Restore, CopyDatabase, History, Settings, About];
     }
 
     [RelayCommand]
@@ -360,6 +363,7 @@ public partial class MainViewModel : ViewModelBase
             Nav.BrowseBackups => BlobBrowser,
             Nav.Backup => Backup,
             Nav.Restore => Restore,
+            Nav.CopyDatabase => CopyDatabase,
             Nav.History => History,
             Nav.Settings => Settings,
             Nav.About => About,
@@ -373,6 +377,9 @@ public partial class MainViewModel : ViewModelBase
             // Servers AND containers: a backup needs one of each, and either can have been added
             // on another screen since the last visit.
             Backup.Refresh();
+        else if (viewName is Nav.CopyDatabase)
+            // Two servers and a container here, for the same reason.
+            CopyDatabase.Refresh();
         else if (viewName is Nav.Restore)
             // Containers AND servers: either can be the backup source now, and one added on
             // another screen since the last visit has to be selectable here (#165).

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -1,0 +1,318 @@
+<UserControl x:Class="Blackcat.NineLives.Views.CopyDatabaseView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
+             xmlns:views="clr-namespace:Blackcat.NineLives.Views">
+
+    <UserControl.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+        <converters:NullToVisibilityConverter x:Key="NullToVis" />
+        <converters:EnumToBoolConverter x:Key="EnumToBool" />
+    </UserControl.Resources>
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <StackPanel Margin="0,0,0,20">
+                <TextBlock Text="Copy a Database to Another Server" Style="{StaticResource HeaderText}" />
+                <TextBlock Text="Back up the source and restore it onto the target in one action. Copy-only by default, so the source's differential schedule is left alone."
+                           Style="{StaticResource SecondaryText}"
+                           TextWrapping="Wrap"
+                           Margin="0,4,0,0" />
+            </StackPanel>
+
+            <!-- Refused outright. Shown rather than silently disabling the button - a button that
+                 is dead for no stated reason is one somebody works around. -->
+            <Border CornerRadius="6" Padding="14,12" Margin="0,0,0,16"
+                    Background="{DynamicResource DangerPanelBackgroundBrush}"
+                    BorderBrush="{DynamicResource ErrorBrush}"
+                    BorderThickness="1"
+                    Visibility="{Binding IsRefused, Converter={StaticResource BoolToVis}}">
+                <TextBlock Text="{Binding Refusal}"
+                           Foreground="{DynamicResource ErrorBrush}"
+                           TextWrapping="Wrap" />
+            </Border>
+
+            <!-- What this does to the SOURCE - the server nobody came here to change. -->
+            <Border CornerRadius="6" Padding="14,12" Margin="0,0,0,16"
+                    Background="{DynamicResource WarningPanelBackgroundBrush}"
+                    BorderBrush="{DynamicResource WarningBrush}"
+                    BorderThickness="1"
+                    Visibility="{Binding WillResetTheDifferentialBase, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Text="THIS WILL CHANGE THE SOURCE DATABASE"
+                               Style="{StaticResource LabelText}"
+                               Margin="0,0,0,6" />
+                    <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap" LineHeight="22"
+                               Text="This is not a copy-only backup, so it resets the differential base on the server being copied FROM. Every differential that database's schedule takes afterwards will depend on the file this writes." />
+                </StackPanel>
+            </Border>
+
+            <!-- 1. From -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="1. Copy from" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,4,0,10"
+                               Text="This server is read, and backed up. It is usually the one nobody wants disturbed." />
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                            <TextBlock Text="SOURCE SERVER" Style="{StaticResource LabelText}" />
+                            <ComboBox ItemsSource="{Binding Servers}"
+                                      SelectedItem="{Binding SourceServer}"
+                                      Style="{StaticResource DarkComboBox}"
+                                      Margin="0,4,0,0">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+
+                        <Button Grid.Column="1"
+                                Content="List databases"
+                                Command="{Binding LoadSourceDatabasesCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="16,8"
+                                VerticalAlignment="Bottom" />
+                    </Grid>
+
+                    <StackPanel Margin="0,12,0,0">
+                        <TextBlock Text="DATABASE" Style="{StaticResource LabelText}" />
+                        <ComboBox ItemsSource="{Binding SourceDatabases}"
+                                  SelectedItem="{Binding SourceDatabase}"
+                                  Style="{StaticResource DarkComboBox}"
+                                  Margin="0,4,0,0" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- 2. Via -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="2. Via" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,4,0,10"
+                               Text="Where the backup is written and then read back from. Blob needs no network path between the two servers; a shared path is faster and costs no egress, where both can reach it." />
+
+                    <StackPanel Orientation="Horizontal">
+                        <RadioButton Content="Azure Blob Storage"
+                                     GroupName="CopyMedium"
+                                     Style="{StaticResource DarkRadioButton}"
+                                     IsChecked="{Binding Medium, Converter={StaticResource EnumToBool}, ConverterParameter=AzureBlob}"
+                                     Margin="0,0,20,0" />
+                        <RadioButton Content="A path both servers can reach"
+                                     GroupName="CopyMedium"
+                                     Style="{StaticResource DarkRadioButton}"
+                                     IsChecked="{Binding Medium, Converter={StaticResource EnumToBool}, ConverterParameter=SharedPath}" />
+                    </StackPanel>
+
+                    <StackPanel Margin="0,12,0,0"
+                                Visibility="{Binding MediumIsBlob, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="CONTAINER" Style="{StaticResource LabelText}" />
+                        <ComboBox ItemsSource="{Binding Containers}"
+                                  SelectedItem="{Binding Container}"
+                                  Style="{StaticResource DarkComboBox}"
+                                  Margin="0,4,0,0">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Name}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                    </StackPanel>
+
+                    <StackPanel Margin="0,12,0,0"
+                                Visibility="{Binding MediumIsSharedPath, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="FOLDER" Style="{StaticResource LabelText}" />
+                        <TextBox Text="{Binding SharedPathRoot, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource DarkTextBox}"
+                                 Margin="0,4,0,0"
+                                 ToolTip="For example \\nas01\sql" />
+                        <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                   Text="The source has to WRITE here as its own service account, and the target has to READ here as its own - two different accounts, and routinely not the same one. Whether the target can read it is checked after the backup, before the restore." />
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,14,0,0">
+                        <CheckBox Content="COPY_ONLY"
+                                  IsChecked="{Binding CopyOnly}"
+                                  Style="{StaticResource DarkCheckBox}"
+                                  Margin="0,0,20,0"
+                                  ToolTip="On by default. Turning it off resets the differential base on the SOURCE database." />
+                        <CheckBox Content="COMPRESSION"
+                                  IsChecked="{Binding Compression}"
+                                  Style="{StaticResource DarkCheckBox}" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- 3. To -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="3. Copy to" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,4,0,10"
+                               Text="This server is written to. If a database of this name is already there and WITH REPLACE is on, it is overwritten." />
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="16" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackPanel Grid.Column="0">
+                            <TextBlock Text="TARGET SERVER" Style="{StaticResource LabelText}" />
+                            <ComboBox ItemsSource="{Binding Servers}"
+                                      SelectedItem="{Binding TargetServer}"
+                                      Style="{StaticResource DarkComboBox}"
+                                      Margin="0,4,0,0">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="2">
+                            <TextBlock Text="RESTORE AS" Style="{StaticResource LabelText}" />
+                            <TextBox Text="{Binding TargetDatabaseName, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource DarkTextBox}"
+                                     Margin="0,4,0,0" />
+                        </StackPanel>
+                    </Grid>
+
+                    <CheckBox Content="Overwrite it if it already exists (WITH REPLACE)"
+                              IsChecked="{Binding WithReplace}"
+                              Style="{StaticResource DarkCheckBox}"
+                              Margin="0,14,0,0" />
+                </StackPanel>
+            </Border>
+
+            <!-- 4. Both scripts, then run -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
+                <StackPanel>
+                    <TextBlock Text="4. Run it" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,4,0,12"
+                               Text="Both statements are shown together, because what happens to each server is one decision - reading them one at a time is how somebody approves the half they were looking at." />
+
+                    <WrapPanel>
+                        <Button Content="Generate scripts"
+                                Command="{Binding GenerateCommand}"
+                                Style="{StaticResource PrimaryButton}"
+                                Padding="16,8" Margin="0,0,8,8" />
+                        <Button Content="Copy both to clipboard"
+                                Command="{Binding CopyScriptsCommand}"
+                                IsEnabled="{Binding HasScripts}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="16,8" Margin="0,0,8,8" />
+                        <Button Content="{Binding ButtonText}"
+                                Command="{Binding RunCommand}"
+                                Style="{StaticResource DangerButton}"
+                                Padding="16,8" Margin="0,0,8,8"
+                                MinWidth="180" />
+                        <Button Content="Stop"
+                                Command="{Binding CancelCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}"
+                                Padding="16,8" Margin="0,0,8,8" />
+                    </WrapPanel>
+
+                    <!-- Armed. Names BOTH servers, because that is the whole point of this screen. -->
+                    <Border CornerRadius="4" Padding="12,10" Margin="0,4,0,0"
+                            Background="{DynamicResource DangerPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource ErrorBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding IsArmed, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding ConfirmationText}"
+                                   TextWrapping="Wrap"
+                                   Style="{StaticResource BodyText}" />
+                    </Border>
+
+                    <StackPanel Margin="0,12,0,0"
+                                Visibility="{Binding HasScripts, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="THROUGH" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
+                        <ItemsControl ItemsSource="{Binding Destinations}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding}"
+                                               TextWrapping="Wrap"
+                                               FontFamily="{StaticResource ConsoleFont}"
+                                               FontSize="12" />
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+
+                    <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                            BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                            BorderThickness="1" CornerRadius="4"
+                            Margin="0,12,0,0"
+                            Visibility="{Binding HasScripts, Converter={StaticResource BoolToVis}}">
+                        <ScrollViewer MaxHeight="340"
+                                      VerticalScrollBarVisibility="Auto"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      Padding="12,10,12,10">
+                            <StackPanel>
+                                <TextBlock Text="ON THE SOURCE" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
+                                <views:SqlTextBlock Sql="{Binding BackupScript}"
+                                                    FontFamily="{StaticResource ConsoleFont}"
+                                                    FontSize="12"
+                                                    TextWrapping="NoWrap"
+                                                    Foreground="{DynamicResource ConsoleTextBrush}" />
+                                <TextBlock Text="ON THE TARGET" Style="{StaticResource LabelText}" Margin="0,14,0,4" />
+                                <views:SqlTextBlock Sql="{Binding RestoreScript}"
+                                                    FontFamily="{StaticResource ConsoleFont}"
+                                                    FontSize="12"
+                                                    TextWrapping="NoWrap"
+                                                    Foreground="{DynamicResource ConsoleTextBrush}" />
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Border>
+
+                    <!-- What state the two servers were left in, in terms of what to do next. -->
+                    <Border CornerRadius="4" Padding="12,10" Margin="0,12,0,0"
+                            Background="{DynamicResource WarningPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding HasOutcome, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding OutcomeText}" TextWrapping="Wrap" Style="{StaticResource BodyText}" />
+                    </Border>
+
+                    <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                            BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                            BorderThickness="1" CornerRadius="4"
+                            Margin="0,12,0,0"
+                            Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}">
+                        <ScrollViewer MaxHeight="220"
+                                      VerticalScrollBarVisibility="Auto"
+                                      Padding="12,10,12,10">
+                            <ItemsControl ItemsSource="{Binding Console}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding}"
+                                                   TextWrapping="Wrap"
+                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                   FontSize="12"
+                                                   Foreground="{DynamicResource ConsoleTextBrush}" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </Border>
+                </StackPanel>
+            </Border>
+
+            <ContentControl Style="{StaticResource ErrorBanner}" />
+
+            <TextBlock Text="{Binding StatusMessage}"
+                       Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,16" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/NineLives/Views/CopyDatabaseView.xaml.cs
+++ b/src/NineLives/Views/CopyDatabaseView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class CopyDatabaseView : UserControl
+{
+    public CopyDatabaseView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Closes #105. Completes #165.

Pick a source server and database, pick a target server and name, press one button. Deliberately **not** a third implementation of anything: the backup is the backup screen's generator and destinations, the restore is the restore screen's generator, both run through the same execution path. What is new is the orchestration between them and what has to be true for it to be safe.

## Two things make this more dangerous than either half alone

**Two servers, and only one is being protected.** The source is read at full speed and can have its differential base moved; the target is overwritten. So `COPY_ONLY` is on by default, and the confirmation names **both** servers - a prompt naming one is a prompt somebody can read as being about the other.

**A partial run is not a failure.** A backup that succeeded with a restore that did not has left a perfectly good backup behind, and the right next step is to restore from it - *not* to run the whole thing again and read a production database at full speed a second time. `CopyOutcome` tells those apart and says what to do about each:

| Outcome | What it says |
|---|---|
| Backup failed | Nothing was restored. Any file written is incomplete and is not a backup - delete it rather than keeping it, because it will sit there looking like one. |
| Backup taken, restore failed | The backup is real and usable, and where it is. Restore from it rather than running this again. The target is whatever the failed restore left it as, which after `WITH REPLACE` may be nothing. |
| Copied | Both halves finished. |

## The chain is built from what is written, not discovered afterwards

There is nothing to discover: this app chose the paths, the database and the moment. Re-reading them back out of a container listing or an msdb query would only ask a second source to confirm what is already known, and would introduce a way for the two to disagree.

Whether the file is actually **there and readable** is a different question, and it is asked separately - **between** the halves, on a shared path, because it can only be asked then. The source writes the file as its own service account and the target reads it as a different one. Those are routinely not the same account, and nothing before the backup has run would notice. When the target cannot read it, the restore does not run - which leaves the backup intact and the target untouched, the most recoverable state this screen can produce.

## Guard rails

- Restoring a database over **itself** on the same instance is refused outright. That is not a copy - it is a backup restored over the database it was taken from, which at best is an expensive no-op and at worst destroys it when the restore fails halfway. The same instance under a *different* name is fine.
- The refusal is **shown**, not silently applied to a disabled button. A button dead for no stated reason is one somebody works around.
- Overwriting the target is stated in the confirmation rather than left in a checkbox.
- Turning `COPY_ONLY` off raises a banner and is said again in the console as it runs.
- Changing anything disarms the run.

## Also

Sidebar entry after Restore; Ctrl+6 onwards shift by one.

1,146 tests pass.