### PR TITLE
Choose a chain's logs by LSN where the sets carry them (#130)

### DIFF
--- a/src/NineLives.Tests/BackupMediumTests.cs
+++ b/src/NineLives.Tests/BackupMediumTests.cs
@@ -26,7 +26,10 @@ public class BackupMediumTests
         FinishedAt = at.AddMinutes(2),
         CheckpointLsn = type == BackupType.Full ? 100 : null,
         DatabaseBackupLsn = type == BackupType.Differential ? 100 : null,
-        LastLsn = 200,
+
+        // Advances with the clock: an LSN is a position in the log, so two backups cannot end at
+        // the same one and hold different transactions.
+        LastLsn = 100 + (decimal)(at - T0).TotalMinutes,
         Files = files.Length == 0 ? [@"\\nas01\sql\full.bak"] : files
     };
 

--- a/src/NineLives.Tests/FromDiskRestoreScriptTests.cs
+++ b/src/NineLives.Tests/FromDiskRestoreScriptTests.cs
@@ -29,7 +29,11 @@ public class FromDiskRestoreScriptTests
         FinishedAt = at.AddMinutes(2),
         CheckpointLsn = type == BackupType.Full ? 100 : null,
         DatabaseBackupLsn = type == BackupType.Differential ? 100 : null,
-        LastLsn = 200,
+
+        // An LSN is a position in the log, so it has to advance with time - two backups cannot end
+        // at the same one and hold different transactions. Derived from the clock so the fixture
+        // stays honest as cases are added.
+        LastLsn = 100 + (decimal)(at - T0).TotalMinutes,
         BackupSizeBytes = 5_000_000,
         Files = files
     };

--- a/src/NineLives.Tests/LogChainFromLsnsTests.cs
+++ b/src/NineLives.Tests/LogChainFromLsnsTests.cs
@@ -1,0 +1,191 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Choosing which logs a chain needs by LSN, where the sets carry them (#130).
+///
+/// A timestamp says WHEN a backup was taken; an LSN says what is IN it. They answer the same
+/// question with different accuracy, and they differ exactly when a log backup overlaps the backup
+/// it follows — which on a busy instance is routine, not exotic.
+///
+/// Both cases are exercised, because sets from a container listing have no LSNs and must go on
+/// behaving precisely as they did.
+/// </summary>
+public class LogChainFromLsnsTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupSet Full(DateTime at, decimal? checkpoint = null, decimal? lastLsn = null) => new()
+    {
+        SetId = $"full_{at:HHmmss}",
+        DatabaseName = "MyDb",
+        Type = BackupType.Full,
+        Timestamp = at,
+        CheckpointLsn = checkpoint,
+        LastLsn = lastLsn,
+        Files = [new BackupFileInfo { LocalPath = $@"\\nas01\sql\full_{at:HHmmss}.bak" }]
+    };
+
+    private static BackupSet Log(DateTime at, decimal? lastLsn = null) => new()
+    {
+        SetId = $"log_{at:HHmmss}",
+        DatabaseName = "MyDb",
+        Type = BackupType.TransactionLog,
+        Timestamp = at,
+        LastLsn = lastLsn,
+        Files = [new BackupFileInfo { LocalPath = $@"\\nas01\sql\log_{at:HHmmss}.trn" }]
+    };
+
+    private static BackupSet Diff(DateTime at, decimal? basedOn = null, decimal? lastLsn = null) => new()
+    {
+        SetId = $"diff_{at:HHmmss}",
+        DatabaseName = "MyDb",
+        Type = BackupType.Differential,
+        Timestamp = at,
+        DatabaseBackupLsn = basedOn,
+        LastLsn = lastLsn,
+        Files = [new BackupFileInfo { LocalPath = $@"\\nas01\sql\diff_{at:HHmmss}.bak" }]
+    };
+
+    private static List<RestorePoint> Points(params BackupSet[] sets)
+        => new BackupChainBuilder().ComputeRestorePoints(sets.ToList());
+
+    // ── the case timestamps get wrong ───────────────────────────────────────────
+
+    /// <summary>
+    /// The one the LSN rule exists for.
+    ///
+    /// A log backup that STARTED before the full but finished after it. By time it looks like it
+    /// belongs before the full and gets dropped; by LSN it holds transactions past the end of the
+    /// full and the chain needs it. Dropping it breaks point-in-time recovery at exactly that spot.
+    /// </summary>
+    [Fact]
+    public void ALogThatOverlapsTheFullIsStillOfferedWhenItsLsnSaysItIsNeeded()
+    {
+        // Timestamped a minute BEFORE the full, but ends past it.
+        var overlapping = Log(T0.AddMinutes(-1), lastLsn: 250);
+        var full = Full(T0, checkpoint: 100, lastLsn: 200);
+
+        var points = Points(full, overlapping);
+
+        var log = points.Single(p => p.Type == BackupType.TransactionLog);
+        Assert.Same(overlapping, log.PrimarySet);
+        Assert.Same(full, log.RequiredFullSet);
+    }
+
+    /// <summary>
+    /// And the mirror image: a log timestamped after the full whose LSNs show it contains nothing
+    /// past it. Restoring it would be rejected as already applied.
+    /// </summary>
+    [Fact]
+    public void ALogThatAddsNothingPastTheFullIsNotOffered()
+    {
+        var full = Full(T0, checkpoint: 100, lastLsn: 500);
+        var spent = Log(T0.AddMinutes(5), lastLsn: 400);
+
+        Assert.DoesNotContain(Points(full, spent), p => p.Type == BackupType.TransactionLog);
+    }
+
+    /// <summary>
+    /// Once a differential is in the chain, the logs still needed are the ones past the
+    /// DIFFERENTIAL - not past the full. Including the earlier ones adds restores SQL Server
+    /// rejects.
+    /// </summary>
+    [Fact]
+    public void OnlyTheLogsPastTheDifferentialJoinAChainThatUsesIt()
+    {
+        var full = Full(T0, checkpoint: 100, lastLsn: 200);
+        var beforeDiff = Log(T0.AddHours(1), lastLsn: 300);
+        var diff = Diff(T0.AddHours(2), basedOn: 100, lastLsn: 400);
+        var afterDiff = Log(T0.AddHours(3), lastLsn: 500);
+
+        var points = Points(full, beforeDiff, diff, afterDiff);
+        var last = points.Last(p => p.Type == BackupType.TransactionLog);
+
+        Assert.Same(afterDiff, last.PrimarySet);
+        Assert.Same(diff, Assert.Single(last.RequiredDiffSets));
+        Assert.Same(afterDiff, Assert.Single(last.RequiredLogSets));
+    }
+
+    /// <summary>
+    /// And before the differential exists, the chain is full + logs - which SQL Server restores
+    /// happily, and which the per-log choice was introduced to stop hiding.
+    /// </summary>
+    [Fact]
+    public void ALogBeforeTheDifferentialStillGetsAChainOfFullPlusLogs()
+    {
+        var full = Full(T0, checkpoint: 100, lastLsn: 200);
+        var beforeDiff = Log(T0.AddHours(1), lastLsn: 300);
+        var diff = Diff(T0.AddHours(2), basedOn: 100, lastLsn: 400);
+
+        var points = Points(full, beforeDiff, diff);
+        var log = points.Single(p => p.Type == BackupType.TransactionLog);
+
+        Assert.Same(beforeDiff, log.PrimarySet);
+        Assert.Empty(log.RequiredDiffSets);
+        Assert.Same(beforeDiff, Assert.Single(log.RequiredLogSets));
+    }
+
+    [Fact]
+    public void EveryLogNeededToReachAPointIsInItsChain()
+    {
+        var full = Full(T0, checkpoint: 100, lastLsn: 200);
+        var one = Log(T0.AddHours(1), lastLsn: 300);
+        var two = Log(T0.AddHours(2), lastLsn: 400);
+        var three = Log(T0.AddHours(3), lastLsn: 500);
+
+        var points = Points(full, one, two, three);
+        var last = points.Last(p => p.Type == BackupType.TransactionLog);
+
+        Assert.Equal([one, two, three], last.RequiredLogSets);
+    }
+
+    // ── sets from a container behave exactly as before ──────────────────────────
+
+    /// <summary>
+    /// A blob listing gives a type and a time and nothing else, so the timestamp rule is all there
+    /// is - and it has to stay precisely as it was, including its known-awkward edges.
+    /// </summary>
+    [Fact]
+    public void WithoutLsnsLogsAreStillChosenByTime()
+    {
+        var full = Full(T0);
+        var one = Log(T0.AddHours(1));
+        var two = Log(T0.AddHours(2));
+
+        var points = Points(full, one, two);
+        var last = points.Last(p => p.Type == BackupType.TransactionLog);
+
+        Assert.Equal([one, two], last.RequiredLogSets);
+    }
+
+    /// <summary>
+    /// The collision #46 is about: a log sharing a full's exact timestamp. Nothing says which came
+    /// first, so it cannot be trusted to follow the full - and treating it as though it did
+    /// produced restore points that could not be restored.
+    ///
+    /// This is why the two callers of the rule differ on what a tie means, and it only arises
+    /// without LSNs: two backups cannot both end at the same LSN and differ in what they hold.
+    /// </summary>
+    [Fact]
+    public void WithoutLsnsALogAtTheFullsExactTimestampIsStillNotTrustedToFollowIt()
+    {
+        var full = Full(T0);
+        var colliding = Log(T0);
+
+        Assert.DoesNotContain(Points(full, colliding), p => p.Type == BackupType.TransactionLog);
+    }
+
+    /// <summary>A mixed set falls back rather than refusing - there is nothing to be definitive with.</summary>
+    [Fact]
+    public void ALogWithAnLsnAgainstAFullWithoutOneFallsBackToTime()
+    {
+        var full = Full(T0);
+        var log = Log(T0.AddHours(1), lastLsn: 300);
+
+        Assert.Single(Points(full, log), p => p.Type == BackupType.TransactionLog);
+    }
+}

--- a/src/NineLives/Services/BackupChainBuilder.cs
+++ b/src/NineLives/Services/BackupChainBuilder.cs
@@ -88,8 +88,17 @@ public class BackupChainBuilder
             var nextFull = fulls.FirstOrDefault(f => f.Timestamp > full.Timestamp);
             var upperBound = nextFull?.Timestamp ?? DateTime.MaxValue;
 
+            // Which logs carry this chain forward.
+            //
+            // By time, that means a log taken after the full - which is a good approximation and
+            // is wrong in one real case: on a busy instance a log backup that STARTED before the
+            // full can finish after it. By time it is excluded; by LSN it may hold transactions the
+            // restore still needs, and dropping it breaks the chain at that point.
+            //
+            // So where the sets carry LSNs, ask them. LastLSN past the full's LastLSN is the same
+            // test SQL Server applies when it decides whether a log is applicable at all (#130).
             var applicableLogs = logs
-                .Where(l => l.Timestamp > full.Timestamp && l.Timestamp < upperBound)
+                .Where(l => CarriesTheChainPast(l, full, sameInstantCounts: false) && l.Timestamp < upperBound)
                 .OrderBy(l => l.Timestamp)
                 .ToList();
 
@@ -119,10 +128,13 @@ public class BackupChainBuilder
             foreach (var log in applicableLogs)
             {
                 var diff = applicableDiffs.LastOrDefault(d => d.Timestamp <= log.Timestamp);
-                var baseTimestamp = diff?.Timestamp ?? full.Timestamp;
+
+                // Where the restore has already reached once the full, and any differential, are
+                // applied - and therefore which logs are still needed to get from there to here.
+                var reached = diff ?? full;
 
                 var chainLogs = applicableLogs
-                    .Where(l => l.Timestamp >= baseTimestamp && l.Timestamp <= log.Timestamp)
+                    .Where(l => CarriesTheChainPast(l, reached, sameInstantCounts: true) && l.Timestamp <= log.Timestamp)
                     .ToList();
 
                 points.Add(new RestorePoint
@@ -138,6 +150,42 @@ public class BackupChainBuilder
         }
 
         return points.OrderBy(p => p.Timestamp).ToList();
+    }
+
+    /// <summary>
+    /// Whether a log carries the chain PAST the point a backup restores to - so whether it still
+    /// has anything the restore needs (#130).
+    ///
+    /// LSNs when both sets have them, timestamps otherwise. The two answer the same question with
+    /// different accuracy: a timestamp says when a backup was taken, an LSN says what is IN it.
+    /// They differ exactly when a log backup overlaps the backup it follows, which on a busy
+    /// instance is routine - and getting it wrong there either drops a log the chain needs, or
+    /// includes one SQL Server will reject as already applied.
+    ///
+    /// A set from a container listing has no LSNs, so this is the same timestamp rule it has always
+    /// used.
+    /// </summary>
+    /// <param name="sameInstantCounts">
+    /// What to do when the two readings are identical, which only arises without LSNs.
+    ///
+    /// The two callers genuinely differ here and it is not an oversight. A log sharing a FULL's
+    /// exact timestamp is a collision - nothing says which came first, so it cannot be trusted to
+    /// follow the full, and #46 exists because treating it as though it did produced restore points
+    /// that could not be restored. A log sharing the DIFFERENTIAL's timestamp is a different case:
+    /// the differential was picked as the latest one at or before this log, so equality there means
+    /// the log is the one being restored to.
+    ///
+    /// With LSNs the question does not arise: two backups cannot both end at the same LSN and
+    /// differ in what they contain.
+    /// </param>
+    private static bool CarriesTheChainPast(BackupSet log, BackupSet reached, bool sameInstantCounts)
+    {
+        if (log.LastLsn is { } logEnd && reached.LastLsn is { } reachedEnd)
+            return logEnd > reachedEnd;
+
+        return sameInstantCounts
+            ? log.Timestamp >= reached.Timestamp
+            : log.Timestamp > reached.Timestamp;
     }
 
     /// <summary>


### PR DESCRIPTION
The pairing half of #130 landed in #166. This is the log half.

A timestamp says **when** a backup was taken; an LSN says what is **in** it. They answer the same question with different accuracy, and they differ exactly when a log backup overlaps the backup it follows — which on a busy instance is routine, not exotic.

## Two cases the timestamp rule gets wrong

- **A log that started before the full and finished after it.** By time it looks like it belongs before the full and is dropped; by LSN it holds transactions past the end of the full and the chain needs it. Dropping it breaks point-in-time recovery at exactly that spot.
- **A log taken after the full that contains nothing past it.** Restoring it would be rejected as already applied.

The same rule decides which logs a chain still needs once a differential is in it: those past the **differential**, not past the full.

## What does not change

Sets from a container listing carry no LSNs and behave precisely as before — including the awkward edge #46 is about. A log sharing a full's exact timestamp cannot be trusted to follow it, because nothing says which came first, and treating it as though it did produced restore points that could not be restored.

That tie is the one place the two callers of the rule genuinely differ, and it only arises without LSNs: two backups cannot both end at the same LSN and hold different transactions. It is a named parameter with the reason written next to it rather than an unexplained `>` against a `>=`.

## Also

Corrects two test fixtures I wrote in #166 and #167 that gave every backup the same `LastLsn`. An LSN is a position in the log, so that is not a thing that can happen — and the new rule reads it, so the fixtures had to become honest. They now derive from the clock.

1,154 tests pass.

**Still open on #130**, and genuinely blocked: the timing measurement. How long `RESTORE HEADERONLY` actually takes per file against a real container decides whether the audit action is a background sweep or an explicit button — and it needs someone to press **Check chain** against a real container. The app reports it per file already.