### PR TITLE
Identify the files a filename could not place, from their headers (#130)

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -194,9 +194,44 @@ public sealed class FakeSqlServerService : ISqlServerService
         ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
         => Task.FromResult(new List<FileMoveOption>());
 
+    /// <summary>What the fake instance reads out of a backup header, or null for nothing.</summary>
+    public BackupFileInfo? Header { get; set; }
+
+    /// <summary>Every set of URLs a header read was asked about, in order.</summary>
+    public List<IReadOnlyList<string>> HeaderReads { get; } = [];
+
+    /// <summary>
+    /// Makes one file unreadable - a container legitimately holds things that are not backups, and
+    /// one of those must not stop the rest (#130).
+    /// </summary>
+    public string? HeaderThrowsForUrlContaining { get; set; }
+
     public Task<BackupFileInfo?> RestoreHeaderOnlyMultiAsync(
         ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
-        => Task.FromResult<BackupFileInfo?>(null);
+    {
+        HeaderReads.Add(blobUrls);
+
+        if (HeaderThrowsForUrlContaining != null &&
+            blobUrls.Any(u => u.Contains(HeaderThrowsForUrlContaining, StringComparison.Ordinal)))
+            throw new InvalidOperationException("fake: not a valid backup");
+
+        // A fresh copy each time: the identifier writes onto the FILE from what it reads, and a
+        // shared instance would let one file's result be mutated by the next.
+        return Task.FromResult(Header == null ? null : Clone(Header));
+    }
+
+    private static BackupFileInfo Clone(BackupFileInfo source) => new()
+    {
+        DatabaseName = source.DatabaseName,
+        Type = source.Type,
+        BackupTypeCode = source.BackupTypeCode,
+        BackupStartDate = source.BackupStartDate,
+        BackupFinishDate = source.BackupFinishDate,
+        FirstLsn = source.FirstLsn,
+        LastLsn = source.LastLsn,
+        CheckpointLsn = source.CheckpointLsn,
+        DatabaseBackupLsn = source.DatabaseBackupLsn
+    };
 
     /// <summary>Called with the token the viewmodel supplied, so a test can see it was cancellable.</summary>
     public Action<CancellationToken>? OnVerify { get; set; }

--- a/src/NineLives.Tests/IdentifyThroughTheInventoryTests.cs
+++ b/src/NineLives.Tests/IdentifyThroughTheInventoryTests.cs
@@ -1,0 +1,238 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A file the filename could not place going from invisible to restorable (#130).
+///
+/// The end-to-end claim. Reading a header is only worth anything if what it settles reaches the
+/// working set - the sets are keyed on the database and type the header has just corrected, so
+/// nothing improves unless the inventory regroups afterwards.
+/// </summary>
+public class IdentifyThroughTheInventoryTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupLocation Container() => BackupLocation.Blob(new BlobContainerConfig
+    {
+        Id = "c1",
+        Name = "backups",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups"
+    });
+
+    /// <summary>A file whose name says nothing: no type, no database, no timestamp.</summary>
+    private static BackupFileInfo Unplaceable(string name) => new()
+    {
+        BlobName = name,
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/{name}",
+        Type = BackupType.Unknown,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    private static (BackupInventoryViewModel vm, FakeSqlServerService sql) New(params BackupFileInfo[] files)
+    {
+        var blob = new FakeBlobStorageService { Files = files.ToList() };
+        var sql = new FakeSqlServerService();
+        return (new BackupInventoryViewModel(blob, sql), sql);
+    }
+
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    // ── it is counted, and it is offered ────────────────────────────────────────
+
+    [Fact]
+    public async Task FilesTheFilenameCouldNotPlaceAreCounted()
+    {
+        var (vm, _) = New(Unplaceable("mystery1.bak"), Unplaceable("mystery2.bak"));
+
+        await vm.LoadAsync(Container());
+
+        Assert.Equal(2, vm.UnclassifiedCount);
+        Assert.True(vm.HasUnclassified);
+    }
+
+    /// <summary>
+    /// Until the header is read they are not merely unlabelled - they are absent. An unknown type
+    /// never enters the fulls collection, so there is no restore point to select.
+    /// </summary>
+    [Fact]
+    public async Task BeforeTheHeaderIsReadTheyAreInvisible()
+    {
+        var (vm, _) = New(Unplaceable("mystery.bak"));
+
+        await vm.LoadAsync(Container());
+        vm.SelectedDatabaseName = "MyDb";
+
+        Assert.Empty(vm.WorkingSet);
+    }
+
+    /// <summary>The whole point: after the header, the file is a restorable set.</summary>
+    [Fact]
+    public async Task AfterTheHeaderIsReadTheyReachTheWorkingSet()
+    {
+        var (vm, sql) = New(Unplaceable("mystery.bak"));
+        sql.Header = new BackupFileInfo
+        {
+            DatabaseName = "MyDb",
+            Type = BackupType.Full,
+            BackupTypeCode = 1,
+            BackupStartDate = T0.AddHours(-3),
+            CheckpointLsn = 100,
+            LastLsn = 200
+        };
+
+        await vm.LoadAsync(Container());
+        await vm.IdentifyUnclassifiedAsync(Server());
+
+        vm.SelectedDatabaseName = "MyDb";
+
+        var set = Assert.Single(vm.WorkingSet);
+        Assert.Equal(BackupType.Full, set.Type);
+        Assert.Equal("MyDb", set.DatabaseName);
+        Assert.Equal(0, vm.UnclassifiedCount);
+    }
+
+    /// <summary>
+    /// And it arrives carrying its LSNs, so the chain builder can pair it definitively rather than
+    /// by proximity in time - the second reason the round trip is worth making.
+    /// </summary>
+    [Fact]
+    public async Task TheIdentifiedSetCarriesItsLsns()
+    {
+        var (vm, sql) = New(Unplaceable("mystery.bak"));
+        sql.Header = new BackupFileInfo
+        {
+            DatabaseName = "MyDb",
+            Type = BackupType.Full,
+            BackupTypeCode = 1,
+            BackupStartDate = T0.AddHours(-3),
+            CheckpointLsn = 100,
+            LastLsn = 200
+        };
+
+        await vm.LoadAsync(Container());
+        await vm.IdentifyUnclassifiedAsync(Server());
+        vm.SelectedDatabaseName = "MyDb";
+
+        var set = Assert.Single(vm.WorkingSet);
+
+        Assert.True(set.HasLsns);
+        Assert.Equal(100, set.CheckpointLsn);
+    }
+
+    /// <summary>
+    /// The header's own record of when the backup ran replaces the fallback, which for a file whose
+    /// name says nothing is the blob's LastModified - the moment the UPLOAD finished, in UTC.
+    /// </summary>
+    [Fact]
+    public async Task TheIdentifiedSetIsTimedFromTheHeaderRatherThanTheUpload()
+    {
+        var (vm, sql) = New(Unplaceable("mystery.bak"));
+        sql.Header = new BackupFileInfo
+        {
+            DatabaseName = "MyDb",
+            Type = BackupType.Full,
+            BackupTypeCode = 1,
+            BackupStartDate = T0.AddHours(-3)
+        };
+
+        await vm.LoadAsync(Container());
+        await vm.IdentifyUnclassifiedAsync(Server());
+        vm.SelectedDatabaseName = "MyDb";
+
+        var set = Assert.Single(vm.WorkingSet);
+
+        Assert.Equal(T0.AddHours(-3), set.Timestamp);
+        Assert.Equal(BackupTimestampSource.BackupHeader, set.TimestampSource);
+        Assert.False(set.IsTimestampApproximate);
+    }
+
+    // ── what it does not do ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Only the unplaceable ones. That scoping is the whole design - one HEADERONLY per file is a
+    /// network read, and across a real container that is thousands of round trips.
+    /// </summary>
+    [Fact]
+    public async Task FilesTheFilenameAlreadyPlacedAreNotAskedAbout()
+    {
+        var placed = new BackupFileInfo
+        {
+            BlobName = "FULL/SRV01/MyDb/MyDb_20260801_220000.bak",
+            BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/MyDb_20260801_220000.bak",
+            Type = BackupType.Full,
+            InferredDatabaseName = "MyDb",
+            InferredServerName = "SRV01",
+            LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+        };
+
+        var (vm, sql) = New(placed, Unplaceable("mystery.bak"));
+        sql.Header = new BackupFileInfo { DatabaseName = "MyDb", Type = BackupType.Full, BackupTypeCode = 1 };
+
+        await vm.LoadAsync(Container());
+        await vm.IdentifyUnclassifiedAsync(Server());
+
+        Assert.Single(sql.HeaderReads);
+    }
+
+    [Fact]
+    public async Task WithNothingUnplaceableNoHeaderIsRead()
+    {
+        var (vm, sql) = New();
+
+        await vm.LoadAsync(Container());
+        await vm.IdentifyUnclassifiedAsync(Server());
+
+        Assert.Empty(sql.HeaderReads);
+        Assert.False(vm.HasUnclassified);
+    }
+
+    /// <summary>
+    /// A container that answers nothing useful is reported honestly rather than as a success. The
+    /// files are still unplaceable, and saying otherwise would send somebody looking for them on a
+    /// timeline they are not on.
+    /// </summary>
+    [Fact]
+    public async Task HeadersThatSettleNothingSaySo()
+    {
+        var (vm, sql) = New(Unplaceable("mystery.bak"));
+        sql.Header = null;
+
+        await vm.LoadAsync(Container());
+        await vm.IdentifyUnclassifiedAsync(Server());
+
+        Assert.Equal(1, vm.UnclassifiedCount);
+        Assert.Contains("none of them", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Nothing read from an instance's msdb ever arrives unplaced - msdb recorded the database, the
+    /// type and the LSNs - so the offer never appears on that medium.
+    /// </summary>
+    [Fact]
+    public async Task BackupsReadFromMsdbAreNeverUnplaceable()
+    {
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "MyDb", ServerName = "SRV01", Type = BackupType.Full,
+                    StartedAt = T0, FinishedAt = T0.AddMinutes(2),
+                    Files = [@"\\nas01\sql\full.bak"]
+                }
+            ]
+        };
+
+        var vm = new BackupInventoryViewModel(new FakeBlobStorageService(), sql);
+
+        await vm.LoadAsync(BackupLocation.Shared(Server()));
+
+        Assert.False(vm.HasUnclassified);
+    }
+}

--- a/src/NineLives.Tests/IdentifyUnclassifiedTests.cs
+++ b/src/NineLives.Tests/IdentifyUnclassifiedTests.cs
@@ -1,0 +1,215 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Asking SQL Server what a file is, for the files whose NAME did not say (#130).
+///
+/// The header is what the RESTORE itself reads, so it is immune to every way the filename inference
+/// has been wrong - a database whose name contains "diff" (#44), a full misread as a differential
+/// leaving a container with no restore points at all (#45), a wrong path pattern, a file dropped in
+/// the wrong folder.
+///
+/// It is scoped to the unplaceable files rather than run over everything because of cost: one
+/// HEADERONLY per file is a network read, and across a container that is thousands. Across the
+/// handful the pattern could not place it is seconds - and those are exactly the files worth
+/// paying for, because they are the ones the app cannot offer at all.
+/// </summary>
+public class IdentifyUnclassifiedTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupFileInfo Unplaceable(string name = "mystery.bak") => new()
+    {
+        BlobName = name,
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/{name}",
+        Type = BackupType.Unknown,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    private static BackupFileInfo Header(
+        BackupType type = BackupType.Full,
+        string database = "MyDb",
+        decimal? checkpoint = 100,
+        decimal? lastLsn = 200) => new()
+    {
+        DatabaseName = database,
+        Type = type,
+        BackupTypeCode = type == BackupType.Full ? 1 : type == BackupType.Differential ? 5 : 2,
+        BackupStartDate = T0.AddHours(-3),
+        BackupFinishDate = T0.AddHours(-3).AddMinutes(4),
+        CheckpointLsn = checkpoint,
+        LastLsn = lastLsn
+    };
+
+    // ── which files get asked about ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Both of these mean a file cannot reach a chain at all: an unknown type never enters the
+    /// fulls, diffs or logs collections, and one with no database is filtered out of every working
+    /// set. They are invisible, not merely unlabelled.
+    /// </summary>
+    [Fact]
+    public void AFileWithNoTypeNeedsIdentifying()
+        => Assert.True(BackupHeaderIdentifier.NeedsIdentifying(Unplaceable()));
+
+    [Fact]
+    public void AFileWithNoDatabaseNeedsIdentifying()
+    {
+        var file = Unplaceable();
+        file.Type = BackupType.Full;
+
+        Assert.True(BackupHeaderIdentifier.NeedsIdentifying(file));
+    }
+
+    [Fact]
+    public void AFileTheFilenamePlacedIsLeftAlone()
+    {
+        var file = Unplaceable();
+        file.Type = BackupType.Full;
+        file.InferredDatabaseName = "MyDb";
+
+        Assert.False(BackupHeaderIdentifier.NeedsIdentifying(file));
+    }
+
+    // ── what the header settles ─────────────────────────────────────────────────
+
+    [Fact]
+    public void TheHeaderSaysWhatTheFileIsAndWhichDatabaseItBelongsTo()
+    {
+        var file = Unplaceable();
+
+        Assert.True(BackupHeaderIdentifier.Apply(file, Header(BackupType.Differential)));
+
+        Assert.Equal(BackupType.Differential, file.Type);
+        Assert.Equal("MyDb", file.InferredDatabaseName);
+    }
+
+    /// <summary>
+    /// The header wins wherever the two disagree, because it is what the restore reads. #44 and #45
+    /// are both cases where the filename was confidently wrong.
+    /// </summary>
+    [Fact]
+    public void TheHeaderBeatsTheFilenameWhereTheyDisagree()
+    {
+        var file = Unplaceable("DiffusionDb_full.bak");
+        file.Type = BackupType.Differential;
+        file.InferredDatabaseName = "Diffusion";
+
+        Assert.True(BackupHeaderIdentifier.Apply(file, Header(BackupType.Full, "DiffusionDb")));
+
+        Assert.Equal(BackupType.Full, file.Type);
+        Assert.Equal("DiffusionDb", file.InferredDatabaseName);
+    }
+
+    /// <summary>
+    /// The LSNs are the second reason a header read earns its round trip: a set that knows them can
+    /// be paired definitively rather than by proximity in time.
+    /// </summary>
+    [Fact]
+    public void TheLsnsComeAcrossWhetherOrNotAnythingWasReclassified()
+    {
+        var file = Unplaceable();
+        file.Type = BackupType.Full;
+        file.InferredDatabaseName = "MyDb";
+
+        // Nothing to settle - the header agrees with what was already known.
+        Assert.False(BackupHeaderIdentifier.Apply(file, Header()));
+
+        Assert.Equal(100, file.CheckpointLsn);
+        Assert.Equal(200, file.LastLsn);
+    }
+
+    /// <summary>
+    /// The instance's own record of when the backup ran. Stronger than a filename, and far stronger
+    /// than the blob's LastModified - which is when the UPLOAD finished, in UTC, and is exactly what
+    /// a file with an unreadable name falls back to.
+    /// </summary>
+    [Fact]
+    public void TheHeaderSuppliesTheTimeTheBackupActuallyRan()
+    {
+        var file = Unplaceable();
+
+        BackupHeaderIdentifier.Apply(file, Header());
+
+        Assert.Equal(T0.AddHours(-3), file.BackupStartDate);
+    }
+
+    // ── through the whole thing ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EveryUnplaceableFileIsAskedAbout()
+    {
+        var sql = new FakeSqlServerService { Header = Header() };
+        var files = new List<BackupFileInfo> { Unplaceable("a.bak"), Unplaceable("b.bak") };
+
+        var settled = await new BackupHeaderIdentifier(sql).IdentifyAsync(Server(), files);
+
+        Assert.Equal(2, settled);
+        Assert.Equal(2, sql.HeaderReads.Count);
+    }
+
+    /// <summary>
+    /// A container legitimately holds things that are not backups. One that cannot be read leaves
+    /// the app exactly where it started for that file, which is not a worse position - and must not
+    /// stop the rest.
+    /// </summary>
+    [Fact]
+    public async Task AFileTheServerCannotReadDoesNotStopTheOthers()
+    {
+        var sql = new FakeSqlServerService
+        {
+            Header = Header(),
+            HeaderThrowsForUrlContaining = "notabackup"
+        };
+
+        var files = new List<BackupFileInfo>
+        {
+            Unplaceable("notabackup.txt"), Unplaceable("real.bak")
+        };
+
+        var settled = await new BackupHeaderIdentifier(sql).IdentifyAsync(Server(), files);
+
+        Assert.Equal(1, settled);
+        Assert.Equal(BackupType.Unknown, files[0].Type);
+        Assert.Equal(BackupType.Full, files[1].Type);
+    }
+
+    /// <summary>
+    /// A file discovered through an instance's msdb was never unplaceable - msdb recorded its
+    /// database, its type and its LSNs - so this path is only ever reached by a container listing,
+    /// and a HEADERONLY built out of URL clauses would be wrong for it anyway.
+    /// </summary>
+    [Fact]
+    public async Task AFileOnDiskIsNotAskedAbout()
+    {
+        var sql = new FakeSqlServerService { Header = Header() };
+        var onDisk = new BackupFileInfo { LocalPath = @"\\nas01\sql\full.bak", Type = BackupType.Unknown };
+
+        await new BackupHeaderIdentifier(sql).IdentifyAsync(Server(), [onDisk]);
+
+        Assert.Empty(sql.HeaderReads);
+    }
+
+    [Fact]
+    public async Task ProgressIsReportedPerFile()
+    {
+        var sql = new FakeSqlServerService { Header = Header() };
+        var seen = new List<int>();
+
+        await new BackupHeaderIdentifier(sql).IdentifyAsync(
+            Server(),
+            [Unplaceable("a.bak"), Unplaceable("b.bak"), Unplaceable("c.bak")],
+            new Progress<int>(seen.Add));
+
+        // Progress<T> marshals through the synchronisation context, so what matters is that it
+        // reaches the last count rather than exactly how the intermediate ones interleave.
+        await Task.Delay(50);
+        Assert.Contains(3, seen);
+    }
+
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -832,6 +832,75 @@ public class XamlLoadTests(WpfFixture wpf)
         => Check("HistoryView (empty)", () =>
             new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) });
 
+    // ── files the filename could not place (#130) ───────────────────────────────
+
+    /// <summary>
+    /// The offer, and why it cannot be taken up yet, both on screen.
+    ///
+    /// A disabled button with no stated reason is one somebody works around, and the reason here is
+    /// not obvious: the header is read by the SERVER, so browsing a container is not enough.
+    /// </summary>
+    [Fact]
+    public void UnplaceableFilesAreExplainedAndTheReasonTheOfferIsDeadIsGiven()
+    {
+        wpf.Invoke(() =>
+        {
+            var store = new FakeCredentialStore();
+            store.Config.BlobContainers.Add(new BlobContainerConfig
+            { Id = "c1", Name = "backups", ContainerUrl = "https://acct.blob.core.windows.net/backups" });
+
+            var blob = new FakeBlobStorageService
+            {
+                Files =
+                [
+                    new BackupFileInfo
+                    {
+                        BlobName = "mystery.bak",
+                        BlobUrl = "https://acct.blob.core.windows.net/backups/mystery.bak",
+                        Type = BackupType.Unknown
+                    }
+                ]
+            };
+
+            var vm = new RestoreViewModel(
+                blob, new FakeSqlServerService(), new BackupChainBuilder(),
+                new RestoreScriptGenerator(), store,
+                new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))),
+                new FakeRestoreHistoryStore());
+
+            vm.RefreshContainers();
+            vm.LoadBackupsCommand.Execute(null);
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.Contains(shown, t => t.Contains("not on the timeline", StringComparison.Ordinal));
+            Assert.Contains(shown, t => t.Contains("it is the server that reads them", StringComparison.Ordinal));
+
+            var identify = VisibleButtons(view)
+                .Single(b => b.Content as string == "Identify them from their headers");
+
+            Assert.False(identify.IsEnabled);
+        });
+    }
+
+    /// <summary>Nothing unplaceable, nothing said - the panel is not a permanent fixture.</summary>
+    [Fact]
+    public void WithNothingUnplaceableTheOfferIsNotOnScreen()
+    {
+        wpf.Invoke(() =>
+        {
+            var view = new RestoreView { DataContext = NewRestoreViewModel() };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.DoesNotContain(shown, t => t.Contains("not on the timeline", StringComparison.Ordinal));
+        });
+    }
+
     // ── the Copy Database screen (#105) ─────────────────────────────────────────
 
     [Fact]

--- a/src/NineLives/Services/BackupHeaderIdentifier.cs
+++ b/src/NineLives/Services/BackupHeaderIdentifier.cs
@@ -1,0 +1,133 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Asks SQL Server what a backup file actually is, for the files whose NAME did not say (#130).
+///
+/// Chains are built from path structure and filenames: the pattern gives server, database and type,
+/// the filename gives the time. That is cheap, works with no connection at all, and is right the
+/// large majority of the time - which is why it stays the primary mechanism.
+///
+/// But it fails, and this repo's history is largely a list of the ways: a database whose name
+/// contains "diff" (#44), a full misread as a differential leaving a container with no restore
+/// points at all (#45), a wrong path pattern, a file copied into the wrong folder. The header is
+/// what the RESTORE itself reads, so it is immune to every one of them.
+///
+/// The reason this is scoped to the UNCLASSIFIED files rather than run over everything is cost: one
+/// HEADERONLY per file, each a network read. Across a 4,400-blob container that is thousands of
+/// round trips. Across the handful the pattern could not place, it is seconds - and those are
+/// precisely the files where the answer is worth paying for, because they are the ones the app
+/// currently cannot offer at all.
+/// </summary>
+public class BackupHeaderIdentifier(ISqlServerService sql)
+{
+    /// <summary>
+    /// Whether a file is one the filename could not place.
+    ///
+    /// Either of these means it cannot reach a restore chain: an unknown type never enters the
+    /// fulls, diffs or logs collections, and a file with no database is filtered out of every
+    /// working set. So they are not merely untidy - they are invisible.
+    /// </summary>
+    public static bool NeedsIdentifying(BackupFileInfo file) =>
+        file.Type == BackupType.Unknown || string.IsNullOrWhiteSpace(file.InferredDatabaseName);
+
+    /// <summary>
+    /// Reads the header of each unidentified file and writes back what SQL Server says.
+    ///
+    /// Files are asked about ONE AT A TIME rather than as a striped set, because a set is exactly
+    /// what is not known yet: grouping happens on the inferred database and type, which are the
+    /// things being established. A stripe of a striped backup answers with its own header anyway.
+    /// </summary>
+    /// <returns>How many files the header settled.</returns>
+    public async Task<int> IdentifyAsync(
+        ServerConnection server,
+        IReadOnlyList<BackupFileInfo> files,
+        IProgress<int>? progress = null,
+        CancellationToken ct = default)
+    {
+        var identified = 0;
+        var done = 0;
+
+        foreach (var file in files)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // Blob only. A file discovered through an instance's msdb was never unidentified -
+            // msdb recorded its database, its type and its LSNs - so this path is only ever reached
+            // by a container listing.
+            if (file.IsOnDisk || string.IsNullOrWhiteSpace(file.BlobUrl))
+            {
+                progress?.Report(++done);
+                continue;
+            }
+
+            try
+            {
+                var header = await sql.RestoreHeaderOnlyMultiAsync(
+                    server, [BlobUrlEncoder.Encode(file.BlobUrl)], ct);
+
+                if (header != null && Apply(file, header)) identified++;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                // One unreadable file does not stop the rest. A container legitimately holds things
+                // that are not backups at all, and a file this cannot read is simply one the app
+                // still cannot place - which is where it started, not a worse position.
+            }
+
+            progress?.Report(++done);
+        }
+
+        return identified;
+    }
+
+    /// <summary>
+    /// Writes the header's answer onto the file, and says whether it settled anything.
+    ///
+    /// The header wins over the filename wherever the two disagree, because it is what the restore
+    /// reads. Nothing here is merged or averaged: a value the header gives replaces the guess.
+    /// </summary>
+    internal static bool Apply(BackupFileInfo file, BackupFileInfo header)
+    {
+        var settled = false;
+
+        if (header.Type != BackupType.Unknown && header.Type != file.Type)
+        {
+            file.Type = header.Type;
+            file.BackupTypeCode = header.BackupTypeCode;
+            settled = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(header.DatabaseName) &&
+            !string.Equals(header.DatabaseName, file.InferredDatabaseName, StringComparison.Ordinal))
+        {
+            file.DatabaseName = header.DatabaseName;
+            file.InferredDatabaseName = header.DatabaseName;
+            settled = true;
+        }
+
+        // Carried across whether or not anything was settled. These are the whole reason a header
+        // read is worth its round trip beyond the classification: a set that knows its LSNs is one
+        // the chain builder can pair definitively rather than by proximity in time.
+        file.FirstLsn ??= header.FirstLsn;
+        file.LastLsn ??= header.LastLsn;
+        file.CheckpointLsn ??= header.CheckpointLsn;
+        file.DatabaseBackupLsn ??= header.DatabaseBackupLsn;
+
+        // The instance's own record of when the backup ran, on its own clock. Stronger than a
+        // filename and far stronger than the blob's LastModified - which is when the UPLOAD
+        // finished, in UTC, and is what a file with an unreadable name falls back to today.
+        if (header.BackupStartDate.HasValue)
+        {
+            file.BackupStartDate = header.BackupStartDate;
+            file.BackupFinishDate = header.BackupFinishDate;
+        }
+
+        return settled;
+    }
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -465,20 +465,37 @@ public class BlobStorageService : IBlobStorageService
                 ? BackupTime.ToBackupServerTime(first.LastModified, backupServerTimeZoneId)
                 : null;
 
+            // A header read beats all of the above, where one has happened (#130).
+            //
+            // It is the instance's own record of when the backup ran, on its own clock - not parsed
+            // out of a name, and not the moment an upload finished. The files that reach here with
+            // a header are the ones the filename could not place, which are exactly the ones whose
+            // fallback reading was the weakest available.
+            var fromHeader = first.BackupStartDate;
+
             sets.Add(new BackupSet
             {
                 SetId = setId,
                 Type = first.Type,
                 Files = groupFiles.OrderBy(f => f.FileName).ToList(),
-                Timestamp = parsed ?? converted ?? BackupTime.WallClock(first.LastModified),
+                Timestamp = fromHeader ?? parsed ?? converted ?? BackupTime.WallClock(first.LastModified),
                 TimestampSource =
-                    parsed != null ? BackupTimestampSource.FileName
+                    fromHeader != null ? BackupTimestampSource.BackupHeader
+                    : parsed != null ? BackupTimestampSource.FileName
                     : converted != null ? BackupTimestampSource.BlobLastModifiedConverted
                     : BackupTimestampSource.BlobLastModified,
                 DatabaseName = first.InferredDatabaseName,
                 ServerName = first.InferredServerName,
                 InstanceName = first.InferredInstanceName,
-                IsCopyOnly = first.IsCopyOnly
+                IsCopyOnly = first.IsCopyOnly,
+
+                // Carried up from the file so the chain builder can pair definitively rather than by
+                // proximity in time. Null for everything a listing alone produced, which is the
+                // state it has always been in.
+                CheckpointLsn = first.CheckpointLsn,
+                DatabaseBackupLsn = first.DatabaseBackupLsn,
+                FirstLsn = first.FirstLsn,
+                LastLsn = first.LastLsn
             });
         }
 

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -105,6 +105,91 @@ public partial class BackupInventoryViewModel : ViewModelBase
     [ObservableProperty]
     private int _setCount;
 
+    // ── files the filename could not place (#130) ───────────────────────────────
+
+    /// <summary>
+    /// How many loaded files the path and filename could not classify.
+    ///
+    /// Not a tidiness count. A file with an unknown type never enters the fulls, diffs or logs
+    /// collections, and one with no database is filtered out of every working set - so these are
+    /// not merely unlabelled, they are invisible to the restore screen entirely. That is worth
+    /// saying out loud rather than leaving somebody to wonder why a backup they can see in the
+    /// container is not on the timeline.
+    /// </summary>
+    [ObservableProperty]
+    private int _unclassifiedCount;
+
+    public bool HasUnclassified => UnclassifiedCount > 0;
+
+    partial void OnUnclassifiedCountChanged(int value) => OnPropertyChanged(nameof(HasUnclassified));
+
+    [ObservableProperty]
+    private string _identifyProgressText = string.Empty;
+
+    private void RefreshUnclassifiedCount()
+        => UnclassifiedCount = _allBackups.Count(BackupHeaderIdentifier.NeedsIdentifying);
+
+    /// <summary>
+    /// Asks SQL Server what those files actually are, and regroups.
+    ///
+    /// Scoped to the unclassified ones rather than run over everything, which is the whole design:
+    /// one HEADERONLY per file is a network read, and across a container that is thousands of round
+    /// trips - but across the handful the pattern could not place it is seconds, and those are
+    /// exactly the files where the answer is worth paying for.
+    ///
+    /// The header also carries LSNs, so a file identified this way reaches the chain builder able to
+    /// be paired definitively rather than by proximity in time.
+    /// </summary>
+    public async Task IdentifyUnclassifiedAsync(ServerConnection server)
+    {
+        var unidentified = _allBackups.Where(BackupHeaderIdentifier.NeedsIdentifying).ToList();
+        if (unidentified.Count == 0) return;
+
+        var ct = _loadCancellation.Begin();
+        IsBusy = true;
+        ClearStatus();
+        RaiseCancelStateChanged();
+
+        try
+        {
+            var identifier = new BackupHeaderIdentifier(_sql);
+            var progress = new Progress<int>(
+                n => IdentifyProgressText = $"Read {n:N0} of {unidentified.Count:N0} header(s)...");
+
+            var settled = await identifier.IdentifyAsync(server, unidentified, progress, ct);
+
+            // Regroup: what the headers said changes which set a file belongs to, and a set is
+            // keyed on the database and type that have just been corrected.
+            _allSets = _blob.GroupIntoBackupSets(
+                _allBackups, LoadedFrom?.Container?.BackupServerTimeZoneId);
+
+            DiscoveredServers = new ObservableCollection<string>(_blob.GetDiscoveredServers(_allBackups));
+            DiscoveredDatabases = new ObservableCollection<string>(_blob.GetDiscoveredDatabases(_allBackups));
+
+            RefreshUnclassifiedCount();
+            RebuildWorkingSet();
+
+            SetStatus(settled == 0
+                ? $"Read {unidentified.Count} header(s); none of them said anything the filename did not."
+                : $"Identified {settled} of {unidentified.Count} file(s) from their backup headers.");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Stopped.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not read the backup headers: {ex.Message}");
+        }
+        finally
+        {
+            _loadCancellation.End();
+            IsBusy = false;
+            IdentifyProgressText = string.Empty;
+            RaiseCancelStateChanged();
+        }
+    }
+
     partial void OnSelectedServerNameChanged(string? value)
     {
         if (_allSets.Count == 0) return;
@@ -221,6 +306,8 @@ public partial class BackupInventoryViewModel : ViewModelBase
             DiscoveredDatabases = new ObservableCollection<string>(_blob.GetDiscoveredDatabases(files));
             BackupsLoaded = files.Count > 0;
 
+            RefreshUnclassifiedCount();
+
             // The lists are offered, not answered - and until one IS answered there is nothing to
             // show.
             RebuildWorkingSet();
@@ -288,6 +375,10 @@ public partial class BackupInventoryViewModel : ViewModelBase
 
         BackupsLoaded = sets.Count > 0;
 
+        // Never any: msdb recorded each backup's database, type and LSNs, so nothing read from it
+        // arrives unplaced.
+        UnclassifiedCount = 0;
+
         // Offered, not answered - the same rule the container path follows.
         RebuildWorkingSet();
 
@@ -349,6 +440,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
         SelectedServerName = null;
         SelectedDatabaseName = null;
         FullCount = DiffCount = LogCount = SetCount = 0;
+        UnclassifiedCount = 0;
 
         WorkingSetChanged?.Invoke();
     }

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -752,6 +752,9 @@ public partial class RestoreViewModel : ViewModelBase
         // actually loaded, not from the paths typed above.
         OnPropertyChanged(nameof(PathAdvice));
         OnPropertyChanged(nameof(HasPathAdvice));
+
+        // How many files the filenames could not place is only known once they have been read.
+        RefreshIdentifyState();
     }
 
 
@@ -772,6 +775,43 @@ public partial class RestoreViewModel : ViewModelBase
     /// <summary>Stops an in-progress backup listing.</summary>
     [RelayCommand]
     private void CancelLoad() => Inventory.CancelLoadCommand.Execute(null);
+
+    /// <summary>
+    /// Asks the connected instance what the unplaceable files actually are (#130).
+    ///
+    /// Needs a server because the header can only be read by one - which is also why this is an
+    /// action rather than something the load does on its own. Browsing a container works with no
+    /// connection at all today, and working out WHICH server is needed is sometimes the reason for
+    /// browsing in the first place.
+    /// </summary>
+    public bool CanIdentifyUnclassified =>
+        Inventory.HasUnclassified && IsConnectedToServer && !Inventory.IsBusy;
+
+    /// <summary>Why the button cannot be pressed, or empty when it can.</summary>
+    public string IdentifyBlockedReason =>
+        !Inventory.HasUnclassified ? string.Empty
+        : IsConnectedToServer ? string.Empty
+        : "Connect to a SQL Server instance to read the backup headers - it is the server that reads them, not this app.";
+
+    [RelayCommand(CanExecute = nameof(CanIdentifyUnclassified))]
+    private async Task IdentifyUnclassifiedAsync()
+    {
+        var server = ConnectedServer;
+        if (server == null) return;
+
+        await Inventory.IdentifyUnclassifiedAsync(server);
+
+        // What the headers settled changes the working set, so whatever was on the timeline was
+        // computed from the state before them.
+        RefreshIdentifyState();
+    }
+
+    private void RefreshIdentifyState()
+    {
+        OnPropertyChanged(nameof(CanIdentifyUnclassified));
+        OnPropertyChanged(nameof(IdentifyBlockedReason));
+        IdentifyUnclassifiedCommand.NotifyCanExecuteChanged();
+    }
 
     [RelayCommand]
     private void ToggleChainDetails()
@@ -1325,6 +1365,11 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnIsConnectedToServerChanged(bool value)
     {
         RefreshExecuteBlockedReason();
+
+        // Reading a backup header needs a server, so connecting is what makes that offer live -
+        // and disconnecting is what has to withdraw it (#130).
+        RefreshIdentifyState();
+
         var chips = value && ConnectedServer != null
             ? ConnectedServer.TagChips
             : [];

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -287,6 +287,41 @@
                 </StackPanel>
             </Border>
 
+            <!-- Files the filename could not place (#130).
+
+                 Not tidiness: a file with an unknown type never enters the fulls, diffs or logs
+                 collections and one with no database is filtered out of every working set - so
+                 these are invisible to this screen rather than merely unlabelled. Somebody who can
+                 see the backup in the container and not on the timeline deserves to be told why. -->
+            <Border CornerRadius="4" Padding="12" Margin="0,0,0,16"
+                    Background="{DynamicResource WarningPanelBackgroundBrush}"
+                    BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                    BorderThickness="1"
+                    Visibility="{Binding Inventory.HasUnclassified, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap">
+                        <Run Text="{Binding Inventory.UnclassifiedCount, Mode=OneWay}" FontWeight="SemiBold" />
+                        <Run Text="file(s) could not be identified from their path or filename, so they are not on the timeline. SQL Server can read what they actually are from the backup header itself." />
+                    </TextBlock>
+
+                    <TextBlock Text="{Binding IdentifyBlockedReason}"
+                               Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,8,0,0"
+                               Visibility="{Binding IdentifyBlockedReason, Converter={StaticResource NullToVis}}" />
+
+                    <WrapPanel Margin="0,10,0,0">
+                        <Button Content="Identify them from their headers"
+                                Command="{Binding IdentifyUnclassifiedCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="14,7" Margin="0,0,8,0" />
+                        <TextBlock Text="{Binding Inventory.IdentifyProgressText}"
+                                   Style="{StaticResource SecondaryText}"
+                                   VerticalAlignment="Center" />
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+
             <!-- Findings about the discovered backups rather than the selected chain: things that
                  exist in the container but can never be offered as a restore point (#46).
 


### PR DESCRIPTION
The third piece of #130, and the one that does not need the timing measurement first.

Chains are built from path structure and filenames. That is cheap, works with no connection, and is right the large majority of the time — which is why it stays the primary mechanism. But it fails, and this repo's history is largely a list of the ways: a database whose name contains "diff" (#44), a full misread as a differential leaving a container with **no restore points at all** (#45), a wrong path pattern, a file dropped in the wrong folder.

The header is what the `RESTORE` itself reads, so it is immune to all of them.

## Scoped to the files that could not be placed

That scoping is the whole design. One `HEADERONLY` per file is a network read, and across a 4,400-blob container that is thousands of round trips. Across the handful that landed as `Unknown` or with no database it is seconds — and those are exactly the files worth paying for, because **they are the ones the app cannot offer at all**.

A file with an unknown type never enters the fulls, diffs or logs collections; one with no database is filtered out of every working set. So they are invisible, not merely unlabelled. The screen now says so, with a count, rather than leaving somebody to wonder why a backup they can see in the container is not on the timeline.

## What the header brings besides the classification

- **LSNs.** Carried up to the set, so a file identified this way reaches the chain builder able to be paired definitively rather than by proximity in time — which is what #166 and #170 built.
- **The time the backup actually ran**, on the instance's own clock. For a file whose name says nothing, the fallback is the blob's `LastModified` — the moment the *upload* finished, in UTC. The header replaces the weakest reading the app has with the strongest.

## It needs a server, and says so

The header is read by the **server**, not by this app. That is not obvious, so the reason is on screen rather than the button just being dead — a disabled control with no stated reason is one somebody works around. Browsing a container still needs no connection at all.

One file that cannot be read does not stop the rest: a container legitimately holds things that are not backups, and a file this cannot read is one the app still cannot place, which is where it started.

Nothing read from an instance's `msdb` ever arrives unplaced, so the offer never appears on that medium.

1,176 tests pass.

**Still open on #130:** the timing measurement, which decides whether the broader audit action is a background sweep or an explicit button. Press **Check chain** against a real container and the app reports it per file.