### PR TITLE
Write to the log a viewmodel was given, not the user's own (#130)

### DIFF
--- a/src/NineLives.Tests/BackupInventorySeamTests.cs
+++ b/src/NineLives.Tests/BackupInventorySeamTests.cs
@@ -46,7 +46,7 @@ public class BackupInventorySeamTests
                 File("OtherDb", "SRV01", BackupType.Full, T0)
             ]
         };
-        return (new BackupInventoryViewModel(blob, new FakeSqlServerService()), blob);
+        return (new BackupInventoryViewModel(blob, new FakeSqlServerService(), TestLogs.Temp()), blob);
     }
 
     [Fact]

--- a/src/NineLives.Tests/BackupViewModelTests.cs
+++ b/src/NineLives.Tests/BackupViewModelTests.cs
@@ -16,10 +16,6 @@ namespace Blackcat.NineLives.Tests;
 /// </summary>
 public class BackupViewModelTests
 {
-    /// <summary>A log in a temp directory: constructing this must not append to the user's own.</summary>
-    private static OperationLog TestLog() =>
-        new(Path.Combine(Path.GetTempPath(), "ninelives-backup-tests", Guid.NewGuid().ToString("n")));
-
     private static (BackupViewModel vm, FakeSqlServerService sql) New()
     {
         var store = new FakeCredentialStore();
@@ -35,7 +31,7 @@ public class BackupViewModelTests
         });
 
         var sql = new FakeSqlServerService { DatabaseList = ["MyDb", "OtherDb"] };
-        var vm = new BackupViewModel(store, sql, TestLog());
+        var vm = new BackupViewModel(store, sql, TestLogs.Temp());
 
         vm.Server = vm.Servers.Single();
         vm.Container = vm.Containers.Single();

--- a/src/NineLives.Tests/CopyDatabaseTests.cs
+++ b/src/NineLives.Tests/CopyDatabaseTests.cs
@@ -19,9 +19,6 @@ namespace Blackcat.NineLives.Tests;
 /// </summary>
 public class CopyDatabaseTests
 {
-    private static OperationLog TestLog() =>
-        new(Path.Combine(Path.GetTempPath(), "ninelives-copy-tests", Guid.NewGuid().ToString("n")));
-
     private static (CopyDatabaseViewModel vm, FakeSqlServerService sql) New()
     {
         var store = new FakeCredentialStore();
@@ -39,7 +36,7 @@ public class CopyDatabaseTests
         });
 
         var sql = new FakeSqlServerService { DatabaseList = ["MyDb", "OtherDb"] };
-        var vm = new CopyDatabaseViewModel(store, sql, TestLog());
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp());
 
         vm.SourceServer = vm.Servers.First();
         vm.TargetServer = vm.Servers.Last();

--- a/src/NineLives.Tests/IdentifyThroughTheInventoryTests.cs
+++ b/src/NineLives.Tests/IdentifyThroughTheInventoryTests.cs
@@ -36,7 +36,7 @@ public class IdentifyThroughTheInventoryTests
     {
         var blob = new FakeBlobStorageService { Files = files.ToList() };
         var sql = new FakeSqlServerService();
-        return (new BackupInventoryViewModel(blob, sql), sql);
+        return (new BackupInventoryViewModel(blob, sql, TestLogs.Temp()), sql);
     }
 
     private static ServerConnection Server() =>
@@ -229,7 +229,7 @@ public class IdentifyThroughTheInventoryTests
             ]
         };
 
-        var vm = new BackupInventoryViewModel(new FakeBlobStorageService(), sql);
+        var vm = new BackupInventoryViewModel(new FakeBlobStorageService(), sql, TestLogs.Temp());
 
         await vm.LoadAsync(BackupLocation.Shared(Server()));
 

--- a/src/NineLives.Tests/LogGoesWhereItIsToldTests.cs
+++ b/src/NineLives.Tests/LogGoesWhereItIsToldTests.cs
@@ -1,0 +1,112 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A viewmodel writes to the log it was GIVEN.
+///
+/// Found in a real log file:
+///
+///     2026-08-07 19:23:19 INFO  [headeronly] fake: 1 statement(s)
+///
+/// That line came from <see cref="FakeSqlServerService"/> - a test run, appending to the log in the
+/// profile of whoever ran it, because the inventory reached for App.Log directly instead of taking
+/// one. Harmless here, and the same class of side effect #41 was about: a test that touches the
+/// user's real machine can also delete from it.
+///
+/// So this asserts the wiring rather than the absence, which is the part that can be checked: give
+/// a viewmodel a log and its output lands in that file and no other.
+/// </summary>
+public class LogGoesWhereItIsToldTests
+{
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    private static BackupLocation Container() => BackupLocation.Blob(new BlobContainerConfig
+    {
+        Id = "c1",
+        Name = "backups",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups"
+    });
+
+    /// <summary>
+    /// The header timing is the line that escaped, so it is the one worth pinning: it has to reach
+    /// the log the inventory was constructed with.
+    /// </summary>
+    [Fact]
+    public async Task TheHeaderTimingIsWrittenToTheLogTheInventoryWasGiven()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "ninelives-tests", Guid.NewGuid().ToString("n"));
+        var log = new OperationLog(directory);
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = "mystery.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/mystery.bak",
+                    Type = BackupType.Unknown
+                }
+            ]
+        };
+
+        var vm = new BackupInventoryViewModel(blob, new FakeSqlServerService(), log);
+
+        await vm.LoadAsync(Container());
+        await vm.IdentifyUnclassifiedAsync(Server());
+
+        var written = Directory.Exists(directory)
+            ? string.Join("\n", Directory.GetFiles(directory).Select(File.ReadAllText))
+            : string.Empty;
+
+        Assert.Contains("[headeronly]", written);
+    }
+
+    /// <summary>
+    /// And the Restore screen hands its own log down rather than letting the inventory find one -
+    /// otherwise the injection point exists and is simply not used, which is where this started.
+    /// </summary>
+    [Fact]
+    public async Task TheRestoreScreenGivesItsOwnLogToTheInventory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "ninelives-tests", Guid.NewGuid().ToString("n"));
+        var log = new OperationLog(directory);
+
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        { Id = "c1", Name = "backups", ContainerUrl = "https://acct.blob.core.windows.net/backups" });
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = "mystery.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/mystery.bak",
+                    Type = BackupType.Unknown
+                }
+            ]
+        };
+
+        var vm = new RestoreViewModel(
+            blob, new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, log, new FakeRestoreHistoryStore());
+
+        vm.RefreshContainers();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        await vm.Inventory.IdentifyUnclassifiedAsync(Server());
+
+        var written = Directory.Exists(directory)
+            ? string.Join("\n", Directory.GetFiles(directory).Select(File.ReadAllText))
+            : string.Empty;
+
+        Assert.Contains("[headeronly]", written);
+    }
+}

--- a/src/NineLives.Tests/TestLogs.cs
+++ b/src/NineLives.Tests/TestLogs.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A log that writes somewhere disposable.
+///
+/// Exists because reaching for <c>App.Log</c> from a viewmodel means a TEST run appends to the log
+/// file in the profile of whoever ran it. That is not hypothetical: "[headeronly] fake: 1
+/// statement(s)" turned up in a real user's log, written by a test - which is the same class of
+/// side effect #41 was about, and the reason every viewmodel that logs takes one.
+///
+/// One obvious helper, so nobody has to invent a temp path at each call site and nobody is tempted
+/// to leave the parameter off.
+/// </summary>
+public static class TestLogs
+{
+    public static OperationLog Temp() =>
+        new(Path.Combine(Path.GetTempPath(), "ninelives-tests", Guid.NewGuid().ToString("n")));
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -865,7 +865,7 @@ public class XamlLoadTests(WpfFixture wpf)
             var vm = new RestoreViewModel(
                 blob, new FakeSqlServerService(), new BackupChainBuilder(),
                 new RestoreScriptGenerator(), store,
-                new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))),
+                TestLogs.Temp(),
                 new FakeRestoreHistoryStore());
 
             vm.RefreshContainers();
@@ -936,7 +936,7 @@ public class XamlLoadTests(WpfFixture wpf)
             store.Config.BlobContainers.Add(new BlobContainerConfig
             { Id = "c1", Name = "backups", ContainerUrl = "https://acct.blob.core.windows.net/backups" });
 
-            var vm = new CopyDatabaseViewModel(store, new FakeSqlServerService(), TestOperationLog());
+            var vm = new CopyDatabaseViewModel(store, new FakeSqlServerService(), TestLogs.Temp());
             vm.SourceServer = vm.Servers.First();
             vm.TargetServer = vm.Servers.Last();
             vm.Container = vm.Containers.Single();
@@ -969,7 +969,7 @@ public class XamlLoadTests(WpfFixture wpf)
             var server = new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
             store.Config.Servers.Add(server);
 
-            var vm = new CopyDatabaseViewModel(store, new FakeSqlServerService(), TestOperationLog());
+            var vm = new CopyDatabaseViewModel(store, new FakeSqlServerService(), TestLogs.Temp());
             vm.SourceServer = vm.Servers.Single();
             vm.TargetServer = vm.Servers.Single();
             vm.SourceDatabase = "MyDb";
@@ -985,10 +985,7 @@ public class XamlLoadTests(WpfFixture wpf)
     }
 
     private static CopyDatabaseViewModel NewCopyViewModel()
-        => new(Store(), new SqlServerService(Store()), TestOperationLog());
-
-    private static OperationLog TestOperationLog()
-        => new(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n")));
+        => new(Store(), new SqlServerService(Store()), TestLogs.Temp());
 
     // ── the Backup screen (#165) ────────────────────────────────────────────────
 
@@ -1050,7 +1047,7 @@ public class XamlLoadTests(WpfFixture wpf)
         return new BackupViewModel(
             store,
             new SqlServerService(store),
-            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))));
+            TestLogs.Temp());
     }
 
     // ── the Restore screen under a shared path (#149, #165) ─────────────────
@@ -1213,7 +1210,7 @@ public class XamlLoadTests(WpfFixture wpf)
             new BackupChainBuilder(),
             new RestoreScriptGenerator(),
             store,
-            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-xaml-tests", Guid.NewGuid().ToString("n"))),
+            TestLogs.Temp(),
             new FakeRestoreHistoryStore());
     }
 

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -29,12 +29,19 @@ public partial class BackupInventoryViewModel : ViewModelBase
 {
     private readonly IBlobStorageService _blob;
     private readonly ISqlServerService _sql;
+    private readonly OperationLog _log;
     private readonly OperationCancellation _loadCancellation = new();
 
-    public BackupInventoryViewModel(IBlobStorageService blob, ISqlServerService sql)
+    /// <param name="log">
+    /// Optional so a test can point it at a temp directory. Reaching for App.Log directly is what
+    /// put "[headeronly] fake: 1 statement(s)" into a real user's log file - a test run writing
+    /// into the profile of whoever ran it, which is the same class of side effect #41 was about.
+    /// </param>
+    public BackupInventoryViewModel(IBlobStorageService blob, ISqlServerService sql, OperationLog? log = null)
     {
         _blob = blob;
         _sql = sql;
+        _log = log ?? App.Log;
     }
 
     /// <summary>Raised when the working set changes, so the chain and timeline can be rebuilt.</summary>
@@ -160,7 +167,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
             // settle what a container-wide audit would cost, and it is worth having from every run
             // rather than only from a deliberate measurement.
             var settled = await identifier.IdentifyAsync(
-                server, unidentified, progress, t => App.Log.Info($"[headeronly] {t}"), ct);
+                server, unidentified, progress, t => _log.Info($"[headeronly] {t}"), ct);
 
             // Regroup: what the headers said changes which set a file belongs to, and a set is
             // keyed on the database and type that have just been corrected.

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -526,7 +526,7 @@ public partial class RestoreViewModel : ViewModelBase
         // actual log file, which is the same class of side effect this whole change is about.
         _log = log ?? App.Log;
 
-        Inventory = new BackupInventoryViewModel(blobService, sqlService);
+        Inventory = new BackupInventoryViewModel(blobService, sqlService, _log);
 
         // The chain and the timeline are built from whatever the inventory currently holds, so a
         // change there is the one signal that rebuilds them.


### PR DESCRIPTION
Found in a real log file:

```
2026-08-07 19:23:19.051 INFO  [headeronly] fake: 1 statement(s)
```

That line came from `FakeSqlServerService`. A **test run** appended to the log in the profile of whoever ran it, because `BackupInventoryViewModel` reached for `App.Log` directly instead of taking one — the only viewmodel that logs which did not have the injection point every other one has. I added it in #171.

Harmless in itself, and the same class of side effect #41 was about: a test that can write to the user's real machine can also delete from it.

## The fix

- The inventory takes an optional `OperationLog`, like `RestoreViewModel`, `BackupViewModel` and `CopyDatabaseViewModel` already do.
- `RestoreViewModel` hands its own down rather than letting the inventory find one — otherwise the injection point exists and simply is not used, which is where this started.
- A test pins that the header timing lands in the file it was given, through both the inventory directly and the Restore screen.
- `TestLogs.Temp` replaces four hand-rolled copies of the same temp path, so nobody has to invent one at a call site and nobody is tempted to leave the parameter off.

1,183 tests pass.