### PR TITLE
Audit a database against its own backup headers (#130)

### DIFF
--- a/src/NineLives.Tests/BackupAuditTests.cs
+++ b/src/NineLives.Tests/BackupAuditTests.cs
@@ -1,0 +1,309 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Checking a database's backups against their own headers (#130).
+///
+/// Belt and braces. Path-and-filename inference is right most of the time and wrong in ways that
+/// stay invisible until a restore is needed - a log filed as a full becomes a chain root and drops
+/// every earlier log (#44); a full filed as a differential never enters the fulls collection at all
+/// (#45). The header is what a RESTORE reads, so it settles both.
+///
+/// The cache is not an optimisation here. A header read is about 1.7 seconds, measured, so a
+/// hundred sets is a few minutes - and nobody runs a few minutes twice. Cached, the second run is
+/// instant, which is the difference between a diagnostic and a habit.
+/// </summary>
+public class BackupAuditTests : IDisposable
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private readonly string _directory =
+        Path.Combine(Path.GetTempPath(), "ninelives-tests", Guid.NewGuid().ToString("n"));
+
+    private BackupAuditStore Store() => new(_directory);
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true); }
+        catch { /* a temp directory that will not delete is not a test failure */ }
+    }
+
+    private static BackupSet Set(
+        BackupType type = BackupType.Full,
+        string database = "MyDb",
+        string name = "MyDb_FULL_20260801_220000.bak",
+        string etag = "\"aaa\"") => new()
+    {
+        SetId = "MyDb_20260801_220000",
+        DatabaseName = database,
+        Type = type,
+        Timestamp = T0,
+        Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = name,
+                BlobUrl = $"https://acct.blob.core.windows.net/backups/{name}",
+                ETag = etag,
+                Type = type,
+                InferredDatabaseName = database
+            }
+        ]
+    };
+
+    private static BackupFileInfo Header(BackupType type = BackupType.Full, string database = "MyDb") => new()
+    {
+        DatabaseName = database,
+        Type = type,
+        BackupTypeCode = type == BackupType.Full ? 1 : type == BackupType.Differential ? 5 : 2
+    };
+
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    // ── what it finds ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WhenTheHeaderAgreesNothingIsReported()
+    {
+        var sql = new FakeSqlServerService { Header = Header() };
+
+        var findings = await new BackupAuditor(sql, Store()).AuditAsync(Server(), [Set()]);
+
+        Assert.Empty(findings);
+    }
+
+    /// <summary>
+    /// The disagreement that breaks a chain outright rather than misfiling it - #44 and #45 are
+    /// both this.
+    /// </summary>
+    [Fact]
+    public async Task ABackupFiledAsTheWrongTypeIsReported()
+    {
+        var sql = new FakeSqlServerService { Header = Header(BackupType.TransactionLog) };
+
+        var finding = Assert.Single(
+            await new BackupAuditor(sql, Store()).AuditAsync(Server(), [Set(BackupType.Full)]));
+
+        Assert.Equal(BackupAuditVerdict.WrongType, finding.Verdict);
+        Assert.Contains("Full", finding.PathSaid);
+        Assert.Contains("TransactionLog", finding.HeaderSaid);
+    }
+
+    /// <summary>
+    /// Quieter and arguably worse: the backup is offered on a timeline it does not belong to, and
+    /// missing from the one it does.
+    /// </summary>
+    [Fact]
+    public async Task ABackupFiledUnderTheWrongDatabaseIsReported()
+    {
+        var sql = new FakeSqlServerService { Header = Header(database: "SomethingElse") };
+
+        var finding = Assert.Single(
+            await new BackupAuditor(sql, Store()).AuditAsync(Server(), [Set(database: "MyDb")]));
+
+        Assert.Equal(BackupAuditVerdict.WrongDatabase, finding.Verdict);
+        Assert.Contains("SomethingElse", finding.Description);
+    }
+
+    [Fact]
+    public async Task ABackupThatCannotBeReadIsReported()
+    {
+        var sql = new FakeSqlServerService { Header = null };
+
+        var finding = Assert.Single(
+            await new BackupAuditor(sql, Store()).AuditAsync(Server(), [Set()]));
+
+        Assert.Equal(BackupAuditVerdict.Unreadable, finding.Verdict);
+    }
+
+    /// <summary>
+    /// Findings are REPORTED, not applied. A database full of them almost always means the path
+    /// pattern is wrong, and correcting each symptom quietly would hide the one thing worth knowing.
+    /// </summary>
+    [Fact]
+    public async Task AMismatchIsNotSilentlyCorrected()
+    {
+        var sql = new FakeSqlServerService { Header = Header(BackupType.TransactionLog) };
+        var set = Set(BackupType.Full);
+
+        await new BackupAuditor(sql, Store()).AuditAsync(Server(), [set]);
+
+        Assert.Equal(BackupType.Full, set.Type);
+    }
+
+    // ── the pill ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AFileThatPassedIsMarkedAsAudited()
+    {
+        var sql = new FakeSqlServerService { Header = Header() };
+        var set = Set();
+
+        await new BackupAuditor(sql, Store()).AuditAsync(Server(), [set]);
+
+        Assert.True(set.Files[0].AuditPassed);
+    }
+
+    [Fact]
+    public async Task AFileThatFailedIsMarkedAsMismatched()
+    {
+        var sql = new FakeSqlServerService { Header = Header(BackupType.TransactionLog) };
+        var set = Set(BackupType.Full);
+
+        await new BackupAuditor(sql, Store()).AuditAsync(Server(), [set]);
+
+        Assert.True(set.Files[0].AuditFailed);
+    }
+
+    // ── the cache, which is what makes it usable twice ──────────────────────────
+
+    [Fact]
+    public async Task ASecondAuditOfTheSameBackupsReadsNothing()
+    {
+        var sql = new FakeSqlServerService { Header = Header() };
+        var store = Store();
+
+        await new BackupAuditor(sql, store).AuditAsync(Server(), [Set()]);
+        Assert.Single(sql.HeaderBatches);
+
+        await new BackupAuditor(sql, store).AuditAsync(Server(), [Set()]);
+
+        Assert.Single(sql.HeaderBatches);
+    }
+
+    /// <summary>The pill survives the cache, or a re-audit would be needed just to see it again.</summary>
+    [Fact]
+    public async Task TheCachedAnswerStillMarksTheFile()
+    {
+        var sql = new FakeSqlServerService { Header = Header() };
+        var store = Store();
+
+        await new BackupAuditor(sql, store).AuditAsync(Server(), [Set()]);
+
+        var second = Set();
+        await new BackupAuditor(sql, store).AuditAsync(Server(), [second]);
+
+        Assert.True(second.Files[0].AuditPassed);
+    }
+
+    /// <summary>
+    /// The reason the key is the ETag. A backup header never changes, so the only reason to read one
+    /// twice is that the blob is a different blob - which is exactly when Azure changes the ETag.
+    /// </summary>
+    [Fact]
+    public async Task AFileReplacedUnderTheSameNameIsReadAgain()
+    {
+        var sql = new FakeSqlServerService { Header = Header() };
+        var store = Store();
+
+        await new BackupAuditor(sql, store).AuditAsync(Server(), [Set(etag: "\"aaa\"")]);
+        await new BackupAuditor(sql, store).AuditAsync(Server(), [Set(etag: "\"bbb\"")]);
+
+        Assert.Equal(2, sql.HeaderBatches.Count);
+    }
+
+    /// <summary>
+    /// A failure is cached too. The answer will not have changed, and finding that out costs the
+    /// same round trip as the first time.
+    /// </summary>
+    [Fact]
+    public async Task AMismatchIsNotReReadEitherAndIsStillReported()
+    {
+        var sql = new FakeSqlServerService { Header = Header(BackupType.TransactionLog) };
+        var store = Store();
+
+        await new BackupAuditor(sql, store).AuditAsync(Server(), [Set(BackupType.Full)]);
+
+        var findings = await new BackupAuditor(sql, store).AuditAsync(Server(), [Set(BackupType.Full)]);
+
+        Assert.Single(sql.HeaderBatches);
+        Assert.Single(findings);
+    }
+
+    [Fact]
+    public void WithoutAnETagTheKeyStillDistinguishesADifferentFile()
+    {
+        var one = new BackupFileInfo { BlobName = "a.bak", SizeBytes = 100, LastModified = new DateTimeOffset(T0, TimeSpan.Zero) };
+        var two = new BackupFileInfo { BlobName = "a.bak", SizeBytes = 200, LastModified = new DateTimeOffset(T0, TimeSpan.Zero) };
+
+        Assert.NotEqual(BackupAuditStore.KeyFor(one), BackupAuditStore.KeyFor(two));
+    }
+
+    /// <summary>An unreadable cache is a slow audit, not an error - and must not be overwritten blindly (#7).</summary>
+    [Fact]
+    public void AnUnreadableCacheComesBackEmpty()
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(Path.Combine(_directory, "audit-cache.json"), "{ this is not json");
+
+        Assert.Empty(Store().Load());
+    }
+
+    // ── the estimate ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Said BEFORE it starts: a three-minute operation nobody expected reads as a hang.
+    /// </summary>
+    [Fact]
+    public void TheEstimateIsGivenInSecondsForASmallDatabase()
+    {
+        var text = BackupAuditor.DescribeEstimate(10);
+
+        Assert.Contains("10 backup header(s)", text);
+        Assert.Contains("seconds", text);
+    }
+
+    [Fact]
+    public void TheEstimateIsGivenInMinutesForALargeOne()
+    {
+        var text = BackupAuditor.DescribeEstimate(200);
+
+        Assert.Contains("minute(s)", text);
+    }
+
+    /// <summary>Re-running after a fix quotes what is left, not the full price again.</summary>
+    [Fact]
+    public void WithEverythingCachedTheEstimateSaysItWillBeInstant()
+        => Assert.Contains("instant", BackupAuditor.DescribeEstimate(0));
+
+    [Fact]
+    public void OnlyTheSetsNotAlreadyKnownAreCounted()
+    {
+        var known = Set(name: "known.bak", etag: "\"aaa\"");
+        var unknown = Set(name: "unknown.bak", etag: "\"bbb\"");
+
+        var cached = new Dictionary<string, AuditRecord>
+        {
+            [BackupAuditStore.KeyFor(known.Files[0])] = new("k", true, "MyDb", 1, T0)
+        };
+
+        Assert.Same(unknown, Assert.Single(BackupAuditor.NotYetAudited([known, unknown], cached)));
+    }
+
+    // ── progress ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ProgressReachesTheTotalSoTheBarFills()
+    {
+        var sql = new FakeSqlServerService { Header = Header() };
+        var seen = new List<int>();
+
+        var sets = new[]
+        {
+            Set(name: "a.bak", etag: "\"a\""),
+            Set(name: "b.bak", etag: "\"b\""),
+            Set(name: "c.bak", etag: "\"c\"")
+        };
+
+        await new BackupAuditor(sql, Store()).AuditAsync(
+            Server(), sets, new Progress<int>(seen.Add));
+
+        await Task.Delay(50);
+        Assert.Contains(3, seen);
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -832,6 +832,112 @@ public class XamlLoadTests(WpfFixture wpf)
         => Check("HistoryView (empty)", () =>
             new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) });
 
+    // ── auditing against headers (#130) ─────────────────────────────────────────
+
+    /// <summary>
+    /// A finding says what it found, on screen.
+    ///
+    /// Found by rendering it: the text was bound to a METHOD, and a binding cannot call one. WPF
+    /// rendered an empty amber box, threw nothing, and traced nothing - a finding that reported
+    /// nothing at all, on the panel whose entire job is reporting.
+    /// </summary>
+    [Fact]
+    public void AnAuditFindingSaysWhatItFound()
+    {
+        wpf.Invoke(() =>
+        {
+            // The audit panel only exists once something has been loaded to audit.
+            var vm = LoadedRestoreViewModel();
+            vm.Inventory.AuditSummary = "1 of 3 backup set(s) do not match their headers.";
+            vm.Inventory.AuditFindings =
+            [
+                new BackupAuditFinding("s1", "MyDb_LOG_20260802.trn",
+                    BackupAuditVerdict.WrongType, "Log", "Differential")
+            ];
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.Contains(shown, t => t.Contains("MyDb_LOG_20260802.trn", StringComparison.Ordinal)
+                                     && t.Contains("Differential", StringComparison.Ordinal));
+        });
+    }
+
+    /// <summary>
+    /// A backup checked against its own header is marked as such, and one that disagreed is marked
+    /// differently.
+    ///
+    /// The point of the pill: a chain built from inference and one confirmed by the backups
+    /// themselves look identical otherwise, and that difference is what somebody wants to know
+    /// before restoring from it.
+    /// </summary>
+    [Fact]
+    public void AnAuditedFileCarriesAPillAndAMismatchedOneCarriesADifferentPill()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+
+            // The chain list lives inside step 2, which is collapsed by default - and a collapsed
+            // pane is not on screen, so nothing inside it would be found.
+            vm.Steps.Point.IsVisible = true;
+            vm.Steps.Point.IsExpanded = true;
+            vm.ShowChainDetails = true;
+            vm.ChainFiles =
+            [
+                new BackupFileInfo { BlobName = "passed.bak", Type = BackupType.Full, AuditState = BackupAuditState.Passed },
+                new BackupFileInfo { BlobName = "failed.trn", Type = BackupType.TransactionLog, AuditState = BackupAuditState.Failed },
+                new BackupFileInfo { BlobName = "unchecked.trn", Type = BackupType.TransactionLog }
+            ];
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.Contains("✓ audited", shown);
+            Assert.Contains("✗ mismatch", shown);
+
+            // Exactly one of each: an unaudited file carries neither, because "not checked" is not
+            // a claim about the backup.
+            Assert.Single(shown, t => t == "✓ audited");
+            Assert.Single(shown, t => t == "✗ mismatch");
+        });
+    }
+
+    /// <summary>A Restore screen with one backup loaded, so the panels that need one are on screen.</summary>
+    private RestoreViewModel LoadedRestoreViewModel()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        { Id = "c1", Name = "backups", ContainerUrl = "https://acct.blob.core.windows.net/backups" });
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = "FULL/SRV01/MyDb/MyDb_FULL_20260801_220000.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/MyDb_FULL_20260801_220000.bak",
+                    Type = BackupType.Full,
+                    InferredDatabaseName = "MyDb",
+                    InferredServerName = "SRV01"
+                }
+            ]
+        };
+
+        var vm = new RestoreViewModel(
+            blob, new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeRestoreHistoryStore());
+
+        vm.RefreshContainers();
+        vm.LoadBackupsCommand.Execute(null);
+        return vm;
+    }
+
     // ── files the filename could not place (#130) ───────────────────────────────
 
     /// <summary>

--- a/src/NineLives/Models/BackupAuditFinding.cs
+++ b/src/NineLives/Models/BackupAuditFinding.cs
@@ -1,0 +1,72 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>What an audit found when it compared a backup's header with what its path claimed.</summary>
+public enum BackupAuditVerdict
+{
+    /// <summary>The header agreed with the path. Most rows, and the point of the exercise.</summary>
+    Agrees,
+
+    /// <summary>
+    /// The header says this is a different KIND of backup.
+    ///
+    /// The one that breaks chains outright. A log misread as a full becomes a chain root and every
+    /// earlier log is dropped (#44); a full misread as a differential never enters the fulls
+    /// collection at all, and if it is the only full the database gets no restore points
+    /// whatsoever (#45).
+    /// </summary>
+    WrongType,
+
+    /// <summary>
+    /// The header says this belongs to a different database.
+    ///
+    /// Quieter and arguably worse: the backup is filed under the wrong database, so it is offered
+    /// on a timeline it does not belong to and missing from the one it does.
+    /// </summary>
+    WrongDatabase,
+
+    /// <summary>The header could not be read - which is itself worth knowing about a backup.</summary>
+    Unreadable
+}
+
+/// <summary>
+/// One backup set, as the path described it and as its header actually reads (#130).
+///
+/// The audit exists because path-and-filename inference is right most of the time and wrong in ways
+/// that are invisible until a restore is needed. A finding is a disagreement worth showing to a
+/// person - not something to fix silently, because a container full of them usually means the path
+/// pattern is wrong, and correcting the symptoms one at a time hides that.
+/// </summary>
+/// <param name="SetId">The set as the app knows it.</param>
+/// <param name="FileName">A file from the set, so the row can be recognised.</param>
+/// <param name="Verdict">What the comparison found.</param>
+/// <param name="PathSaid">What the path and filename claimed.</param>
+/// <param name="HeaderSaid">What SQL Server read out of the backup itself.</param>
+public sealed record BackupAuditFinding(
+    string SetId,
+    string FileName,
+    BackupAuditVerdict Verdict,
+    string PathSaid,
+    string HeaderSaid)
+{
+    public bool IsDisagreement => Verdict != BackupAuditVerdict.Agrees;
+
+    /// <summary>
+    /// A property rather than a method, because a binding cannot call one - WPF renders nothing and
+    /// says nothing, which is how this shipped as an empty amber box in the first render.
+    /// </summary>
+    public string Description => Verdict switch
+    {
+        BackupAuditVerdict.Agrees => $"{FileName}: the header agrees.",
+
+        BackupAuditVerdict.WrongType =>
+            $"{FileName} was read as {PathSaid} from its path, but its header says {HeaderSaid}.",
+
+        BackupAuditVerdict.WrongDatabase =>
+            $"{FileName} was filed under {PathSaid}, but its header says it belongs to {HeaderSaid}.",
+
+        BackupAuditVerdict.Unreadable =>
+            $"{FileName} could not be read: {HeaderSaid}",
+
+        _ => FileName
+    };
+}

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -117,10 +117,44 @@ public static class BackupTime
             : value.ToString("yyyy-MM-dd HH:mm:ss");
 }
 
+/// <summary>Whether a backup has been checked against its own header (#130).</summary>
+public enum BackupAuditState
+{
+    /// <summary>Nobody has read this backup's header, so what it is remains an inference.</summary>
+    Unaudited,
+
+    /// <summary>The header agreed with what the path and filename claimed.</summary>
+    Passed,
+
+    /// <summary>The header disagreed, or could not be read at all.</summary>
+    Failed
+}
+
 public class BackupFileInfo
 {
     public string BlobName { get; set; } = string.Empty;
     public string BlobUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Azure's identity for this blob's CONTENT, when it gave one.
+    ///
+    /// The key an audit result is cached against. A backup header never changes, so the only reason
+    /// to read one twice is that the blob is a different blob - and the ETag is exactly what Azure
+    /// changes when that happens (#130).
+    /// </summary>
+    public string? ETag { get; set; }
+
+    /// <summary>
+    /// Whether this backup has been checked against its own header.
+    ///
+    /// Worth showing on the file rather than only in a findings list: a chain built from inference
+    /// and a chain confirmed by the backups themselves look identical otherwise, and the difference
+    /// is exactly what somebody wants to know before restoring from it.
+    /// </summary>
+    public BackupAuditState AuditState { get; set; } = BackupAuditState.Unaudited;
+
+    public bool AuditPassed => AuditState == BackupAuditState.Passed;
+    public bool AuditFailed => AuditState == BackupAuditState.Failed;
 
     /// <summary>
     /// Where this backup lives on disk, when it was never in blob storage at all (#149).

--- a/src/NineLives/Services/BackupAuditStore.cs
+++ b/src/NineLives/Services/BackupAuditStore.cs
@@ -1,0 +1,135 @@
+using System.IO;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>What an audit established about one backup file, kept so it need not be established again.</summary>
+/// <param name="Key">Blob name and ETag - see <see cref="BackupAuditStore.KeyFor"/>.</param>
+/// <param name="Passed">Whether the header agreed with what the path claimed.</param>
+/// <param name="DatabaseName">What the header said the database was.</param>
+/// <param name="BackupTypeCode">What the header said the type was.</param>
+/// <param name="AuditedAt">When, so a person can see how stale the answer is.</param>
+public sealed record AuditRecord(
+    string Key,
+    bool Passed,
+    string? DatabaseName,
+    int? BackupTypeCode,
+    DateTime AuditedAt);
+
+public interface IBackupAuditStore
+{
+    /// <summary>What is already known. Never throws - an unreadable cache is a slow audit, not an error.</summary>
+    Dictionary<string, AuditRecord> Load();
+
+    void Save(IEnumerable<AuditRecord> records);
+
+    string FilePath { get; }
+}
+
+/// <summary>
+/// What previous audits established, kept between runs (#130).
+///
+/// The point is cost. A header read is about 1.7 seconds - measured, not guessed - so auditing a
+/// database of a hundred backup sets is a few minutes. Nobody does that twice. Cached, the second
+/// run is instant, which turns the audit from a thing you do once into a thing you can use.
+///
+/// The key is the blob name and its ETag. A backup header never changes, so the only reason to
+/// re-read one is that the blob itself is a different blob - and the ETag is precisely the thing
+/// Azure changes when that happens. A file replaced under the same name gets re-audited; one that
+/// has merely been listed again does not.
+///
+/// Same two rules as the restore history, both learned from the config-loss defect (#7): a cache
+/// that cannot be read comes back empty rather than being overwritten blindly, and writes go
+/// through a temp file and an atomic swap so a crash mid-write cannot truncate it.
+/// </summary>
+public sealed class BackupAuditStore : IBackupAuditStore
+{
+    /// <summary>
+    /// Older records fall off the end. Each is small, but a cache that grows for every blob ever
+    /// listed across every container is one nobody ever prunes.
+    /// </summary>
+    private const int MaxRecords = 20_000;
+
+    private readonly string _path;
+    private readonly object _gate = new();
+
+    public BackupAuditStore() : this(Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "NineLives"))
+    { }
+
+    /// <summary>Lets the tests write somewhere disposable instead of the real profile.</summary>
+    internal BackupAuditStore(string directory)
+        => _path = Path.Combine(directory, "audit-cache.json");
+
+    public string FilePath => _path;
+
+    /// <summary>
+    /// The identity of a blob's CONTENT, not its name.
+    ///
+    /// ETag when Azure gave one, which is the whole point - it changes when the blob does and not
+    /// otherwise. Size and last-modified as a fallback, which is weaker but still catches a file
+    /// replaced with a different one; without either, the name alone, which would treat a
+    /// replacement as the same file and is therefore only used when nothing better exists.
+    /// </summary>
+    public static string KeyFor(BackupFileInfo file)
+    {
+        if (!string.IsNullOrWhiteSpace(file.ETag))
+            return $"{file.BlobName}|{file.ETag}";
+
+        return $"{file.BlobName}|{file.SizeBytes}|{file.LastModified.UtcTicks}";
+    }
+
+    public Dictionary<string, AuditRecord> Load()
+    {
+        lock (_gate)
+        {
+            try
+            {
+                if (!File.Exists(_path)) return [];
+
+                var records = JsonSerializer.Deserialize<List<AuditRecord>>(File.ReadAllText(_path));
+                if (records == null) return [];
+
+                // Last one wins on a duplicate key rather than throwing: a cache is not worth an
+                // exception, and a duplicate only means an older record for the same content.
+                var map = new Dictionary<string, AuditRecord>(StringComparer.Ordinal);
+                foreach (var record in records) map[record.Key] = record;
+                return map;
+            }
+            catch
+            {
+                // Unreadable, half-written, or from a future version. An audit that runs again is a
+                // few minutes; a cache file overwritten on a bad read is the defect #7 was.
+                return [];
+            }
+        }
+    }
+
+    public void Save(IEnumerable<AuditRecord> records)
+    {
+        lock (_gate)
+        {
+            try
+            {
+                var kept = records
+                    .OrderByDescending(r => r.AuditedAt)
+                    .Take(MaxRecords)
+                    .ToList();
+
+                Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+
+                var temp = _path + ".tmp";
+                File.WriteAllText(temp, JsonSerializer.Serialize(kept, JsonOptions));
+                File.Move(temp, _path, overwrite: true);
+            }
+            catch
+            {
+                // Caching must never be able to fail the thing it was speeding up.
+            }
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+}

--- a/src/NineLives/Services/BackupAuditor.cs
+++ b/src/NineLives/Services/BackupAuditor.cs
@@ -1,0 +1,186 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Checks a database's backups against their own headers (#130).
+///
+/// Path-and-filename inference is right most of the time and wrong in ways that stay invisible
+/// until a restore is needed - a log read as a full becomes a chain root and drops every earlier
+/// log (#44); a full read as a differential never enters the fulls collection at all (#45). The
+/// header is what the RESTORE itself reads, so it settles every one of those.
+///
+/// Scoped to ONE database because of what it costs. A header read is about 1.7 seconds, measured
+/// against a real container, so a hundred sets is a few minutes and a whole 4,400-blob container is
+/// most of an hour. One database is a coffee; the container is an afternoon, and nobody would run
+/// it. That is why this is an explicit action with an estimate in front of it and a Stop behind it,
+/// rather than something that happens on load.
+/// </summary>
+public class BackupAuditor(ISqlServerService sql, IBackupAuditStore store)
+{
+    /// <summary>
+    /// What one header read costs, measured rather than guessed.
+    ///
+    /// Two runs against a real container: 5.8s per statement with a fresh connection each time, and
+    /// 1.7s per statement once they shared one and connecting fell to nothing. The second is the
+    /// figure to plan with; it is a blob round trip plus SQL Server reading a header, and it is not
+    /// going to get much better.
+    ///
+    /// Deliberately a stated constant rather than a running average. An estimate that changes
+    /// between one glance and the next is one nobody trusts, and being roughly right in front of a
+    /// three-minute operation is the whole job.
+    /// </summary>
+    public static readonly TimeSpan MeasuredCostPerSet = TimeSpan.FromMilliseconds(1_700);
+
+    /// <summary>How long auditing this many sets should take, given what is already cached.</summary>
+    public static TimeSpan Estimate(int setsToRead) =>
+        setsToRead <= 0 ? TimeSpan.Zero : MeasuredCostPerSet * setsToRead;
+
+    /// <summary>
+    /// The estimate as something to put in front of somebody about to wait for it.
+    ///
+    /// Rounded hard and upward. A number to the second implies a precision that is not there, and
+    /// an estimate that runs over reads as a fault where one that comes in early does not.
+    /// </summary>
+    public static string DescribeEstimate(int setsToRead)
+    {
+        if (setsToRead <= 0) return "Everything here has been audited already - this will be instant.";
+
+        var estimate = Estimate(setsToRead);
+
+        var howLong = estimate.TotalSeconds < 90
+            ? $"about {Math.Max(5, Math.Ceiling(estimate.TotalSeconds / 5) * 5):N0} seconds"
+            : $"about {Math.Ceiling(estimate.TotalMinutes):N0} minute(s)";
+
+        return $"Reading {setsToRead:N0} backup header(s) - {howLong}. " +
+               "SQL Server reads each backup to answer, so this is a network round trip per set. " +
+               "It can be stopped at any point, and what it has already checked is kept.";
+    }
+
+    /// <summary>Sets whose files are not already in the cache, and therefore have to be read.</summary>
+    public static List<BackupSet> NotYetAudited(
+        IEnumerable<BackupSet> sets, IReadOnlyDictionary<string, AuditRecord> cached) =>
+        sets.Where(s => s.Files.Any(f => !cached.ContainsKey(BackupAuditStore.KeyFor(f)))).ToList();
+
+    /// <summary>
+    /// Reads the header of every set not already known, and reports where they disagree.
+    ///
+    /// Findings are reported rather than applied. A container full of them almost always means the
+    /// PATH PATTERN is wrong, and quietly correcting each symptom hides the one thing worth
+    /// knowing - so this says what it found and leaves the decision where it belongs.
+    /// </summary>
+    public async Task<List<BackupAuditFinding>> AuditAsync(
+        ServerConnection server,
+        IReadOnlyList<BackupSet> sets,
+        IProgress<int>? progress = null,
+        Action<string>? timing = null,
+        CancellationToken ct = default)
+    {
+        var cached = store.Load();
+        var findings = new List<BackupAuditFinding>();
+
+        // Everything the cache already answers, without a round trip. This is what makes a second
+        // audit worth running at all.
+        var toRead = new List<BackupSet>();
+        foreach (var set in sets)
+        {
+            var record = set.Files
+                .Select(f => cached.GetValueOrDefault(BackupAuditStore.KeyFor(f)))
+                .FirstOrDefault(r => r != null);
+
+            if (record == null)
+            {
+                toRead.Add(set);
+                continue;
+            }
+
+            MarkFiles(set, record.Passed);
+            if (!record.Passed) findings.Add(FindingFor(set, record));
+        }
+
+        if (toRead.Count == 0)
+        {
+            progress?.Report(sets.Count);
+            return findings;
+        }
+
+        var requests = toRead
+            .Select(s => (IReadOnlyList<string>)s.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList())
+            .ToList();
+
+        var done = sets.Count - toRead.Count;
+        var headers = await sql.RestoreHeaderOnlyBatchAsync(
+            server, requests,
+            new Progress<int>(n => progress?.Report(done + n)),
+            timing, ct);
+
+        var written = cached.Values.ToList();
+
+        for (var i = 0; i < toRead.Count; i++)
+        {
+            var set = toRead[i];
+            var header = i < headers.Count ? headers[i] : null;
+            var finding = Compare(set, header);
+
+            if (finding != null) findings.Add(finding);
+
+            var passed = finding == null;
+            MarkFiles(set, passed);
+
+            // Recorded whatever the verdict. A file that failed does not want re-reading either -
+            // the answer will not have changed, and it is the same round trip to find that out.
+            foreach (var file in set.Files)
+                written.Add(new AuditRecord(
+                    BackupAuditStore.KeyFor(file),
+                    passed,
+                    header?.DatabaseName,
+                    header?.BackupTypeCode,
+                    DateTime.Now));
+        }
+
+        store.Save(written);
+
+        return findings;
+    }
+
+    private static void MarkFiles(BackupSet set, bool passed)
+    {
+        foreach (var file in set.Files)
+            file.AuditState = passed ? BackupAuditState.Passed : BackupAuditState.Failed;
+    }
+
+    /// <summary>What the header says against what the path claimed, or null when they agree.</summary>
+    private static BackupAuditFinding? Compare(BackupSet set, BackupFileInfo? header)
+    {
+        var fileName = set.Files.FirstOrDefault()?.BlobName ?? set.SetId;
+
+        if (header == null)
+            return new BackupAuditFinding(set.SetId, fileName, BackupAuditVerdict.Unreadable,
+                set.TypeDisplay, "SQL Server could not read a backup header from it.");
+
+        // Type first: it is the disagreement that breaks a chain outright rather than misfiling it.
+        if (header.Type != BackupType.Unknown && header.Type != set.Type)
+            return new BackupAuditFinding(set.SetId, fileName, BackupAuditVerdict.WrongType,
+                set.TypeDisplay, header.Type.ToString());
+
+        if (!string.IsNullOrWhiteSpace(header.DatabaseName) &&
+            !string.Equals(header.DatabaseName, set.DatabaseName, StringComparison.OrdinalIgnoreCase))
+            return new BackupAuditFinding(set.SetId, fileName, BackupAuditVerdict.WrongDatabase,
+                set.DatabaseName ?? "(no database)", header.DatabaseName);
+
+        return null;
+    }
+
+    /// <summary>A disagreement remembered from a previous run, restated from what was cached.</summary>
+    private static BackupAuditFinding FindingFor(BackupSet set, AuditRecord record)
+    {
+        var fileName = set.Files.FirstOrDefault()?.BlobName ?? set.SetId;
+
+        return new BackupAuditFinding(
+            set.SetId, fileName, BackupAuditVerdict.WrongType,
+            set.TypeDisplay,
+            record.DatabaseName is { } db
+                ? $"{db} (from a previous audit)"
+                : "something else (from a previous audit)");
+    }
+}

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -262,7 +262,10 @@ public class BlobStorageService : IBlobStorageService
             blob.Name,
             blob.Properties.ContentLength ?? 0,
             blob.Properties.LastModified ?? DateTimeOffset.MinValue,
-            files);
+            files,
+            // Azure's identity for the blob's content. Carried through so an audit result can be
+            // cached against it and only re-read when the blob itself changes (#130).
+            blob.Properties.ETag?.ToString());
 
     /// <summary>
     /// Everything this app infers about a backup from where it sits in the container and what it is
@@ -277,7 +280,8 @@ public class BlobStorageService : IBlobStorageService
         string blobName,
         long sizeBytes,
         DateTimeOffset lastModified,
-        List<BackupFileInfo> files)
+        List<BackupFileInfo> files,
+        string? etag = null)
     {
         {
             var blobUrl = $"{config.ContainerUrl.TrimEnd('/')}/{blobName}";
@@ -288,7 +292,8 @@ public class BlobStorageService : IBlobStorageService
                 BlobUrl = blobUrl,
                 Type = BackupType.Unknown,
                 SizeBytes = sizeBytes,
-                LastModified = lastModified
+                LastModified = lastModified,
+                ETag = etag
             };
 
             var pathParts = file.BlobName.Split('/', StringSplitOptions.RemoveEmptyEntries);

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -30,6 +30,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
     private readonly IBlobStorageService _blob;
     private readonly ISqlServerService _sql;
     private readonly OperationLog _log;
+    private readonly IBackupAuditStore _auditStore;
     private readonly OperationCancellation _loadCancellation = new();
 
     /// <param name="log">
@@ -37,11 +38,16 @@ public partial class BackupInventoryViewModel : ViewModelBase
     /// put "[headeronly] fake: 1 statement(s)" into a real user's log file - a test run writing
     /// into the profile of whoever ran it, which is the same class of side effect #41 was about.
     /// </param>
-    public BackupInventoryViewModel(IBlobStorageService blob, ISqlServerService sql, OperationLog? log = null)
+    public BackupInventoryViewModel(
+        IBlobStorageService blob,
+        ISqlServerService sql,
+        OperationLog? log = null,
+        IBackupAuditStore? auditStore = null)
     {
         _blob = blob;
         _sql = sql;
         _log = log ?? App.Log;
+        _auditStore = auditStore ?? new BackupAuditStore();
     }
 
     /// <summary>Raised when the working set changes, so the chain and timeline can be rebuilt.</summary>
@@ -132,6 +138,117 @@ public partial class BackupInventoryViewModel : ViewModelBase
 
     [ObservableProperty]
     private string _identifyProgressText = string.Empty;
+
+    // ── auditing a database against its own headers (#130) ──────────────────────
+
+    /// <summary>What the audit disagreed with, newest run only.</summary>
+    [ObservableProperty]
+    private ObservableCollection<BackupAuditFinding> _auditFindings = [];
+
+    [ObservableProperty]
+    private bool _isAuditing;
+
+    /// <summary>How far through, as a percentage, for the bar.</summary>
+    [ObservableProperty]
+    private double _auditProgress;
+
+    [ObservableProperty]
+    private string _auditProgressText = string.Empty;
+
+    /// <summary>What the last audit concluded, or empty before one has run.</summary>
+    [ObservableProperty]
+    private string _auditSummary = string.Empty;
+
+    public bool HasAuditFindings => AuditFindings.Count > 0;
+    public bool HasAuditSummary => AuditSummary.Length > 0;
+
+    partial void OnAuditFindingsChanged(ObservableCollection<BackupAuditFinding> value)
+        => OnPropertyChanged(nameof(HasAuditFindings));
+
+    partial void OnAuditSummaryChanged(string value) => OnPropertyChanged(nameof(HasAuditSummary));
+
+    /// <summary>
+    /// What auditing the current selection would cost, said BEFORE it is started.
+    ///
+    /// A three-minute operation somebody did not expect reads as a hang. The number is not a guess:
+    /// a header read was measured at about 1.7 seconds against a real container, and what is already
+    /// cached is subtracted - so re-running after a fix says so rather than quoting the full price
+    /// again.
+    /// </summary>
+    public string AuditEstimate
+    {
+        get
+        {
+            if (WorkingSet.Count == 0) return string.Empty;
+
+            var toRead = BackupAuditor.NotYetAudited(WorkingSet, _auditStore.Load()).Count;
+            return BackupAuditor.DescribeEstimate(toRead);
+        }
+    }
+
+    public bool CanAudit => WorkingSet.Count > 0 && !IsAuditing;
+
+    /// <summary>
+    /// Reads every set in the current selection and reports where the headers disagree.
+    ///
+    /// Findings are reported, not applied. A database full of them almost always means the PATH
+    /// PATTERN is wrong, and correcting each symptom silently would hide the one thing worth
+    /// knowing.
+    /// </summary>
+    public async Task AuditAsync(ServerConnection server)
+    {
+        if (WorkingSet.Count == 0) return;
+
+        var sets = WorkingSet.ToList();
+        var ct = _loadCancellation.Begin();
+
+        IsAuditing = true;
+        AuditProgress = 0;
+        AuditFindings = [];
+        AuditSummary = string.Empty;
+        ClearStatus();
+        RaiseCancelStateChanged();
+
+        try
+        {
+            var auditor = new BackupAuditor(_sql, _auditStore);
+            var progress = new Progress<int>(n =>
+            {
+                AuditProgress = sets.Count == 0 ? 0 : 100.0 * n / sets.Count;
+                AuditProgressText = $"Checked {n:N0} of {sets.Count:N0} backup set(s)...";
+            });
+
+            var findings = await auditor.AuditAsync(
+                server, sets, progress, t => _log.Info($"[audit] {t}"), ct);
+
+            AuditFindings = new ObservableCollection<BackupAuditFinding>(findings);
+
+            AuditSummary = findings.Count == 0
+                ? $"All {sets.Count:N0} backup set(s) match their headers."
+                : $"{findings.Count:N0} of {sets.Count:N0} backup set(s) do not match their headers.";
+
+            SetStatus(AuditSummary);
+            _log.Info($"[audit] {AuditSummary}");
+        }
+        catch (OperationCanceledException)
+        {
+            // What it got through is cached, so stopping costs nothing already paid for.
+            SetStatus("Audit stopped. What it had already checked has been kept.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"The audit could not finish: {ex.Message}");
+        }
+        finally
+        {
+            _loadCancellation.End();
+            IsAuditing = false;
+            AuditProgressText = string.Empty;
+            RaiseCancelStateChanged();
+            OnPropertyChanged(nameof(AuditEstimate));
+            OnPropertyChanged(nameof(CanAudit));
+        }
+    }
 
     private void RefreshUnclassifiedCount()
         => UnclassifiedCount = _allBackups.Count(BackupHeaderIdentifier.NeedsIdentifying);
@@ -256,6 +373,14 @@ public partial class BackupInventoryViewModel : ViewModelBase
             sets = sets.Where(s => s.MatchesServer(SelectedServerName)).ToList();
 
         WorkingSet = sets;
+
+        // A different selection means a different estimate, and findings that belonged to the last
+        // one. Leaving either up attaches an answer to a question nobody asked.
+        AuditFindings = [];
+        AuditSummary = string.Empty;
+        OnPropertyChanged(nameof(AuditEstimate));
+        OnPropertyChanged(nameof(CanAudit));
+
         FullCount = sets.Count(s => s.Type == BackupType.Full);
         DiffCount = sets.Count(s => s.Type == BackupType.Differential);
         LogCount = sets.Count(s => s.Type == BackupType.TransactionLog);

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -811,6 +811,52 @@ public partial class RestoreViewModel : ViewModelBase
         OnPropertyChanged(nameof(CanIdentifyUnclassified));
         OnPropertyChanged(nameof(IdentifyBlockedReason));
         IdentifyUnclassifiedCommand.NotifyCanExecuteChanged();
+
+        OnPropertyChanged(nameof(CanAuditDatabase));
+        OnPropertyChanged(nameof(AuditBlockedReason));
+        AuditDatabaseCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// Checks every backup of the selected database against its own header (#130).
+    ///
+    /// Belt and braces rather than a fix: inference is right most of the time, and the times it is
+    /// not are invisible until a restore is needed. This is the button for when a set looks
+    /// fragmented, or a container is new and nobody has confirmed the path pattern yet.
+    /// </summary>
+    public bool CanAuditDatabase => Inventory.CanAudit && IsConnectedToServer;
+
+    public string AuditBlockedReason =>
+        Inventory.WorkingSet.Count == 0 ? string.Empty
+        : IsConnectedToServer ? string.Empty
+        : "Connect to a SQL Server instance to audit these backups - it is the server that reads the headers, not this app.";
+
+    [RelayCommand(CanExecute = nameof(CanAuditDatabase))]
+    private async Task AuditDatabaseAsync()
+    {
+        var server = ConnectedServer;
+        if (server == null) return;
+
+        await Inventory.AuditAsync(server);
+
+        // The audit marks the files it checked, and the chain on screen holds those same objects -
+        // but a list does not re-render because a property nobody is watching changed underneath it.
+        RefreshChainFiles();
+        RefreshIdentifyState();
+    }
+
+    /// <summary>
+    /// Re-publishes the chain's files so their audit pills appear.
+    ///
+    /// BackupFileInfo is a plain model with no change notification - deliberately, it is a
+    /// serialised listing rather than a viewmodel - so the collection is replaced rather than the
+    /// items being expected to announce themselves.
+    /// </summary>
+    private void RefreshChainFiles()
+    {
+        if (RestoreChain == null) return;
+
+        ChainFiles = new ObservableCollection<BackupFileInfo>(RestoreChain.AllFiles);
     }
 
     [RelayCommand]

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -322,6 +322,102 @@
                 </StackPanel>
             </Border>
 
+            <!-- Audit this database against its own headers (#130).
+
+                 Belt and braces rather than a fix. Path-and-filename inference is right most of the
+                 time and wrong in ways that stay invisible until a restore is needed, so this is
+                 the button for when a set looks fragmented or a container is new and nobody has
+                 confirmed the pattern yet.
+
+                 The estimate goes in FRONT of it because a three-minute operation nobody expected
+                 reads as a hang. -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
+                    Visibility="{Binding Inventory.BackupsLoaded, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Text="AUDIT THESE BACKUPS" Style="{StaticResource LabelText}" />
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,6,0,0"
+                               Text="Reads each backup's own header and checks it against what the path and filename claimed. The header is what a RESTORE reads, so it settles the question - a log filed as a full, or a backup filed under the wrong database, both look perfectly normal until the restore fails." />
+
+                    <TextBlock Text="{Binding Inventory.AuditEstimate}"
+                               Style="{StaticResource BodyText}"
+                               TextWrapping="Wrap"
+                               Margin="0,10,0,0"
+                               Visibility="{Binding Inventory.AuditEstimate, Converter={StaticResource NullToVis}}" />
+
+                    <TextBlock Text="{Binding AuditBlockedReason}"
+                               Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,8,0,0"
+                               Visibility="{Binding AuditBlockedReason, Converter={StaticResource NullToVis}}" />
+
+                    <WrapPanel Margin="0,10,0,0">
+                        <Button Content="Audit this database"
+                                Command="{Binding AuditDatabaseCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="14,7" Margin="0,0,8,0" />
+                        <Button Content="Stop"
+                                Command="{Binding CancelLoadCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="14,7" Margin="0,0,8,0"
+                                Visibility="{Binding Inventory.IsAuditing, Converter={StaticResource BoolToVis}}" />
+                    </WrapPanel>
+
+                    <StackPanel Margin="0,10,0,0"
+                                Visibility="{Binding Inventory.IsAuditing, Converter={StaticResource BoolToVis}}">
+                        <ProgressBar Value="{Binding Inventory.AuditProgress}"
+                                     Maximum="100"
+                                     Height="6"
+                                     Style="{StaticResource DarkProgressBar}" />
+                        <TextBlock Text="{Binding Inventory.AuditProgressText}"
+                                   Style="{StaticResource SecondaryText}"
+                                   Margin="0,6,0,0" />
+                    </StackPanel>
+
+                    <!-- Everything agreed: worth saying, because the whole value of the audit is
+                         being able to trust a chain that was assembled by inference. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,10,0,0"
+                            BorderThickness="1"
+                            Visibility="{Binding Inventory.HasAuditSummary, Converter={StaticResource BoolToVis}}">
+                        <!-- Green only when everything agreed. A summary that says one set does NOT
+                             match, in a success-coloured box, is one people read as a pass. -->
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Background" Value="{DynamicResource SuccessPanelBackgroundBrush}" />
+                                <Setter Property="BorderBrush" Value="{DynamicResource SuccessPanelBorderBrush}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Inventory.HasAuditFindings}" Value="True">
+                                        <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
+                                        <Setter Property="BorderBrush" Value="{DynamicResource WarningBrush}" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock Text="{Binding Inventory.AuditSummary}"
+                                   TextWrapping="Wrap"
+                                   Style="{StaticResource BodyText}" />
+                    </Border>
+
+                    <!-- Reported, not corrected. A database full of these almost always means the
+                         PATH PATTERN is wrong, and fixing each symptom quietly would hide it. -->
+                    <ItemsControl ItemsSource="{Binding Inventory.AuditFindings}" Margin="0,10,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,6"
+                                        Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                        BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                        BorderThickness="1">
+                                    <TextBlock Text="{Binding Description}"
+                                               TextWrapping="Wrap"
+                                               Style="{StaticResource BodyText}" />
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
             <!-- Findings about the discovered backups rather than the selected chain: things that
                  exist in the container but can never be offered as a restore point (#46).
 
@@ -996,10 +1092,37 @@
                                                 <TextBlock Text="{Binding TypeDisplay}" Foreground="{StaticResource BadgeTextBrush}"
                                                            FontSize="11" FontWeight="SemiBold" HorizontalAlignment="Center" />
                                             </Border>
-                                            <TextBlock Grid.Column="1" Text="{Binding BlobName}"
-                                                       Style="{StaticResource BodyText}" VerticalAlignment="Center"
-                                                       TextTrimming="CharacterEllipsis"
-                                                       ToolTip="{Binding BlobUrl}" />
+                                            <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                                <TextBlock Text="{Binding BlobName}"
+                                                           Style="{StaticResource BodyText}" VerticalAlignment="Center"
+                                                           TextTrimming="CharacterEllipsis"
+                                                           ToolTip="{Binding BlobUrl}" />
+
+                                                <!-- Checked against its own header (#130). A chain
+                                                     built from inference and one confirmed by the
+                                                     backups themselves look identical otherwise,
+                                                     and that difference is exactly what somebody
+                                                     wants to know before restoring from it. -->
+                                                <Border CornerRadius="8" Padding="7,1" Margin="8,0,0,0"
+                                                        VerticalAlignment="Center"
+                                                        Background="{DynamicResource SuccessBrush}"
+                                                        Visibility="{Binding AuditPassed, Converter={StaticResource BoolToVis}}"
+                                                        ToolTip="SQL Server read this backup's header and it matches what the path says it is.">
+                                                    <TextBlock Text="&#x2713; audited"
+                                                               Foreground="{StaticResource BadgeTextBrush}"
+                                                               FontSize="10" FontWeight="SemiBold" />
+                                                </Border>
+
+                                                <Border CornerRadius="8" Padding="7,1" Margin="8,0,0,0"
+                                                        VerticalAlignment="Center"
+                                                        Background="{DynamicResource ErrorBrush}"
+                                                        Visibility="{Binding AuditFailed, Converter={StaticResource BoolToVis}}"
+                                                        ToolTip="This backup's header does not match what the path says it is - see the audit findings above.">
+                                                    <TextBlock Text="&#x2717; mismatch"
+                                                               Foreground="{StaticResource BadgeTextBrush}"
+                                                               FontSize="10" FontWeight="SemiBold" />
+                                                </Border>
+                                            </StackPanel>
                                             <TextBlock Grid.Column="2" Text="{Binding SizeDisplay}"
                                                        Style="{StaticResource SecondaryText}" VerticalAlignment="Center" />
                                             <TextBlock Grid.Column="3"


### PR DESCRIPTION
The action the measurement was taken to size. At ~1.7s per header read, a database of a hundred sets is a few minutes and a whole container is most of an hour — which settles it as an explicit button with an estimate in front and a Stop behind, not a background sweep.

## What it is for

Belt and braces rather than a fix. Path-and-filename inference is right most of the time and wrong in ways that stay invisible until a restore is needed: a log filed as a full becomes a chain root and drops every earlier log (#44); a full filed as a differential never enters the fulls collection at all (#45). The header is what a `RESTORE` reads, so it settles both.

## The estimate goes in front of the button

> Reading 3 backup header(s) — about 10 seconds. SQL Server reads each backup to answer, so this is a network round trip per set. It can be stopped at any point, and what it has already checked is kept.

A three-minute operation nobody expected reads as a hang. The number is not a guess — the measured cost per set, times the sets **not already cached**, so re-running after a fix quotes what is left rather than the full price again. Progress bar and a Stop while it runs.

## Findings are reported, not applied

A database full of them almost always means the **path pattern** is wrong, and correcting each symptom quietly would hide the one thing worth knowing.

> `MyDb_LOG_20260802_000000.trn` was read as Log from its path, but its header says Differential.

## The pill

A file that passed carries a green `✓ audited` next to its name in the chain; one that disagreed carries a red `✗ mismatch`. An unaudited file carries neither, because "not checked" is not a claim about the backup.

A chain built from inference and a chain confirmed by the backups themselves look identical otherwise, and that difference is exactly what somebody wants to know before restoring from it.

## The cache

Written to `audit-cache.json` beside the config, keyed on the blob name and its **ETag**. A backup header never changes, so the only reason to read one twice is that the blob is a different blob — which is precisely when Azure changes the ETag. A file replaced under the same name is re-read; one merely listed again is not.

That turns the second run instant, which is the difference between a diagnostic and a habit. Same two rules as the restore history (#7): an unreadable cache comes back empty rather than being overwritten, and writes go through a temp file and an atomic swap.

## What rendering it caught

Two bugs nothing else would have:

- The finding text was bound to a **method**. A binding cannot call one, so WPF drew an empty amber box, threw nothing and traced nothing — on the panel whose entire job is reporting.
- A summary saying one set did **not** match was drawn in a success-coloured box, which reads as a pass.

Both are pinned by tests that assert on what is drawn.

1,203 tests pass.