### PR TITLE
Show the audit result where somebody is looking (#130)

### DIFF
--- a/src/NineLives.Tests/AuditButtonComesAliveTests.cs
+++ b/src/NineLives.Tests/AuditButtonComesAliveTests.cs
@@ -50,7 +50,7 @@ public class AuditButtonComesAliveTests
 
         return new RestoreViewModel(
             blob, new FakeSqlServerService(), new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeRestoreHistoryStore());
+            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeRestoreHistoryStore(), TestAuditStores.Temp());
     }
 
     private static void Connect(RestoreViewModel vm)

--- a/src/NineLives.Tests/AuditIsVisibleOnTheRowsTests.cs
+++ b/src/NineLives.Tests/AuditIsVisibleOnTheRowsTests.cs
@@ -1,0 +1,254 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// An audit that passed says so where somebody is looking (#130).
+///
+/// Reported from a real run: 98 sets audited, all matched, and nothing on any row said so. The
+/// pills existed only in the restore-chain panel, which is collapsed until somebody asks for it -
+/// so the result of a three-and-a-half minute operation was invisible unless you knew to go and
+/// open a panel and look.
+///
+/// Two things were wrong. The result was not on the grid somebody actually has open, and even where
+/// it was, RestorePoint and BackupSet are plain models with no change notification - so a property
+/// becoming true underneath a grid reaches no binding at all.
+/// </summary>
+public class AuditIsVisibleOnTheRowsTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupFileInfo File_(string name, BackupType type, DateTime at) => new()
+    {
+        BlobName = $"FULL/SRV01/MyDb/{name}",
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/{name}",
+        ETag = $"\"{name}\"",
+        Type = type,
+        InferredDatabaseName = "MyDb",
+        InferredServerName = "SRV01",
+        LastModified = new DateTimeOffset(at, TimeSpan.Zero)
+    };
+
+    private static RestoreViewModel Loaded()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        { Id = "c1", Name = "backups", ContainerUrl = "https://acct.blob.core.windows.net/backups" });
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                File_("MyDb_FULL_20260801_220000.bak", BackupType.Full, T0),
+                File_("MyDb_LOG_20260801_230000.trn", BackupType.TransactionLog, T0.AddHours(1))
+            ]
+        };
+
+        var vm = new RestoreViewModel(
+            // A header per file: a fake that answers "Full" for a log would report a mismatch that
+            // is an artefact of the fake rather than anything the audit found.
+            blob, new FakeSqlServerService
+            {
+                HeaderForUrls = urls => HeaderFor(
+                    urls.Any(u => u.EndsWith(".trn", StringComparison.Ordinal))
+                        ? BackupType.TransactionLog
+                        : BackupType.Full)
+            },
+            new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            TestLogs.Temp(), new FakeRestoreHistoryStore(), TestAuditStores.Temp());
+
+        vm.ConnectedServer = new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+        vm.IsConnectedToServer = true;
+
+        return vm;
+    }
+
+    private static BackupFileInfo HeaderFor(BackupType type) => new()
+    {
+        DatabaseName = "MyDb",
+        Type = type,
+        BackupTypeCode = type == BackupType.Full ? 1 : 2
+    };
+
+    // ── a set, and a point, know their own answer ───────────────────────────────
+
+    [Fact]
+    public void ASetWhoseFilesAllPassedReadsAsAudited()
+    {
+        var set = new BackupSet
+        {
+            SetId = "s1",
+            Files =
+            [
+                new BackupFileInfo { AuditState = BackupAuditState.Passed },
+                new BackupFileInfo { AuditState = BackupAuditState.Passed }
+            ]
+        };
+
+        Assert.True(set.AuditPassed);
+        Assert.Equal("✓ audited", set.AuditDisplay);
+    }
+
+    [Fact]
+    public void ASetWithAnyMismatchReadsAsAMismatch()
+    {
+        var set = new BackupSet
+        {
+            SetId = "s1",
+            Files =
+            [
+                new BackupFileInfo { AuditState = BackupAuditState.Passed },
+                new BackupFileInfo { AuditState = BackupAuditState.Failed }
+            ]
+        };
+
+        Assert.False(set.AuditPassed);
+        Assert.Equal("✗ mismatch", set.AuditDisplay);
+    }
+
+    /// <summary>
+    /// Blank until something has been checked. Not having asked is not a finding about the backup,
+    /// and a column full of crosses would say the opposite.
+    /// </summary>
+    [Fact]
+    public void AnUncheckedSetSaysNothingEitherWay()
+    {
+        var set = new BackupSet { SetId = "s1", Files = [new BackupFileInfo()] };
+
+        Assert.Equal(string.Empty, set.AuditDisplay);
+        Assert.False(set.AuditPassed);
+        Assert.False(set.AuditFailed);
+    }
+
+    /// <summary>
+    /// A restore point answers for its WHOLE chain, because that is the decision being made in the
+    /// grid: this is the moment somebody is about to restore to, and what they want to know is
+    /// whether every backup needed to get there has been confirmed.
+    /// </summary>
+    [Fact]
+    public void ARestorePointIsOnlyAuditedWhenEverySetItNeedsIs()
+    {
+        var full = new BackupSet
+        { SetId = "f", Files = [new BackupFileInfo { AuditState = BackupAuditState.Passed }] };
+
+        var unchecked_ = new BackupSet { SetId = "l", Files = [new BackupFileInfo()] };
+
+        var point = new RestorePoint
+        {
+            Timestamp = T0,
+            Type = BackupType.TransactionLog,
+            PrimarySet = unchecked_,
+            RequiredFullSet = full,
+            RequiredLogSets = [unchecked_]
+        };
+
+        Assert.False(point.AuditPassed);
+        Assert.Equal(string.Empty, point.AuditDisplay);
+    }
+
+    [Fact]
+    public void ARestorePointWhoseWholeChainPassedReadsAsAudited()
+    {
+        var full = new BackupSet
+        { SetId = "f", Files = [new BackupFileInfo { AuditState = BackupAuditState.Passed }] };
+        var log = new BackupSet
+        { SetId = "l", Files = [new BackupFileInfo { AuditState = BackupAuditState.Passed }] };
+
+        var point = new RestorePoint
+        {
+            Timestamp = T0,
+            Type = BackupType.TransactionLog,
+            PrimarySet = log,
+            RequiredFullSet = full,
+            RequiredLogSets = [log]
+        };
+
+        Assert.True(point.AuditPassed);
+        Assert.Equal("✓ audited", point.AuditDisplay);
+    }
+
+    /// <summary>One bad set in the chain is a mismatch for the whole point, not a partial pass.</summary>
+    [Fact]
+    public void ARestorePointWithOneBadSetReadsAsAMismatch()
+    {
+        var full = new BackupSet
+        { SetId = "f", Files = [new BackupFileInfo { AuditState = BackupAuditState.Passed }] };
+        var log = new BackupSet
+        { SetId = "l", Files = [new BackupFileInfo { AuditState = BackupAuditState.Failed }] };
+
+        var point = new RestorePoint
+        {
+            Timestamp = T0,
+            Type = BackupType.TransactionLog,
+            PrimarySet = log,
+            RequiredFullSet = full,
+            RequiredLogSets = [log]
+        };
+
+        Assert.True(point.AuditFailed);
+        Assert.Equal("✗ mismatch", point.AuditDisplay);
+    }
+
+    // ── and the grid is told to look again ──────────────────────────────────────
+
+    /// <summary>
+    /// The defect as reported. RestorePoint has no change notification, so an audit marking its
+    /// sets underneath a grid reaches no binding - the rows have to be re-published.
+    /// </summary>
+    [Fact]
+    public async Task AfterAnAuditTheRestorePointRowsAreRepublished()
+    {
+        var vm = Loaded();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.Inventory.SelectedServerName = "SRV01";
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+
+        var before = vm.Timeline.Points;
+        Assert.NotEmpty(before);
+
+        await vm.AuditDatabaseCommand.ExecuteAsync(null);
+
+        Assert.NotSame(before, vm.Timeline.Points);
+    }
+
+    /// <summary>
+    /// And the chosen restore point survives it. Losing it would move what is about to be restored,
+    /// as a side effect of something that was only supposed to be checking.
+    /// </summary>
+    [Fact]
+    public async Task TheChosenRestorePointSurvivesTheRefresh()
+    {
+        var vm = Loaded();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.Inventory.SelectedServerName = "SRV01";
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Last();
+
+        var chosen = vm.Timeline.SelectedPoint;
+
+        await vm.AuditDatabaseCommand.ExecuteAsync(null);
+
+        Assert.Same(chosen, vm.Timeline.SelectedPoint);
+    }
+
+    /// <summary>The rows say it too, not merely the summary line.</summary>
+    [Fact]
+    public async Task AfterAnAuditThePointsThemselvesReadAsAudited()
+    {
+        var vm = Loaded();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.Inventory.SelectedServerName = "SRV01";
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+
+        await vm.AuditDatabaseCommand.ExecuteAsync(null);
+
+        Assert.All(vm.Timeline.Points, p => Assert.Equal("✓ audited", p.AuditDisplay));
+    }
+}

--- a/src/NineLives.Tests/BackupInventorySeamTests.cs
+++ b/src/NineLives.Tests/BackupInventorySeamTests.cs
@@ -46,7 +46,7 @@ public class BackupInventorySeamTests
                 File("OtherDb", "SRV01", BackupType.Full, T0)
             ]
         };
-        return (new BackupInventoryViewModel(blob, new FakeSqlServerService(), TestLogs.Temp()), blob);
+        return (new BackupInventoryViewModel(blob, new FakeSqlServerService(), TestLogs.Temp(), TestAuditStores.Temp()), blob);
     }
 
     [Fact]

--- a/src/NineLives.Tests/BackupMediumTests.cs
+++ b/src/NineLives.Tests/BackupMediumTests.cs
@@ -46,7 +46,7 @@ public class BackupMediumTests
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), sql, new BackupChainBuilder(),
             new RestoreScriptGenerator(), store,
-            log: null, history: new FakeRestoreHistoryStore());
+            log: null, history: new FakeRestoreHistoryStore(), auditStore: TestAuditStores.Temp());
 
         vm.RefreshContainers();
         vm.SelectedMedium = BackupMedium.SharedPath;

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -197,6 +197,14 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>What the fake instance reads out of a backup header, or null for nothing.</summary>
     public BackupFileInfo? Header { get; set; }
 
+    /// <summary>
+    /// A header per request, when one answer for everything will not do.
+    ///
+    /// An audit reads a whole chain, and a fake that hands the same Full header back for a log
+    /// reports a mismatch that is an artefact of the fake rather than of the code under test.
+    /// </summary>
+    public Func<IReadOnlyList<string>, BackupFileInfo?>? HeaderForUrls { get; set; }
+
     /// <summary>Every set of URLs a header read was asked about, in order.</summary>
     public List<IReadOnlyList<string>> HeaderReads { get; } = [];
 
@@ -240,7 +248,8 @@ public sealed class FakeSqlServerService : ISqlServerService
             var unreadable = HeaderThrowsForUrlContaining != null &&
                 urls.Any(u => u.Contains(HeaderThrowsForUrlContaining, StringComparison.Ordinal));
 
-            results.Add(unreadable || Header == null ? null : Clone(Header));
+            var answer = HeaderForUrls?.Invoke(urls) ?? Header;
+            results.Add(unreadable || answer == null ? null : Clone(answer));
             progress?.Report(results.Count);
         }
 

--- a/src/NineLives.Tests/IdentifyThroughTheInventoryTests.cs
+++ b/src/NineLives.Tests/IdentifyThroughTheInventoryTests.cs
@@ -36,7 +36,7 @@ public class IdentifyThroughTheInventoryTests
     {
         var blob = new FakeBlobStorageService { Files = files.ToList() };
         var sql = new FakeSqlServerService();
-        return (new BackupInventoryViewModel(blob, sql, TestLogs.Temp()), sql);
+        return (new BackupInventoryViewModel(blob, sql, TestLogs.Temp(), TestAuditStores.Temp()), sql);
     }
 
     private static ServerConnection Server() =>
@@ -229,7 +229,7 @@ public class IdentifyThroughTheInventoryTests
             ]
         };
 
-        var vm = new BackupInventoryViewModel(new FakeBlobStorageService(), sql, TestLogs.Temp());
+        var vm = new BackupInventoryViewModel(new FakeBlobStorageService(), sql, TestLogs.Temp(), TestAuditStores.Temp());
 
         await vm.LoadAsync(BackupLocation.Shared(Server()));
 

--- a/src/NineLives.Tests/LogGoesWhereItIsToldTests.cs
+++ b/src/NineLives.Tests/LogGoesWhereItIsToldTests.cs
@@ -56,7 +56,7 @@ public class LogGoesWhereItIsToldTests
             ]
         };
 
-        var vm = new BackupInventoryViewModel(blob, new FakeSqlServerService(), log);
+        var vm = new BackupInventoryViewModel(blob, new FakeSqlServerService(), log, TestAuditStores.Temp());
 
         await vm.LoadAsync(Container());
         await vm.IdentifyUnclassifiedAsync(Server());

--- a/src/NineLives.Tests/TestLogs.cs
+++ b/src/NineLives.Tests/TestLogs.cs
@@ -19,3 +19,20 @@ public static class TestLogs
     public static OperationLog Temp() =>
         new(Path.Combine(Path.GetTempPath(), "ninelives-tests", Guid.NewGuid().ToString("n")));
 }
+
+/// <summary>
+/// An audit cache that lives somewhere disposable.
+///
+/// Same reason as <see cref="TestLogs"/>, and found the same way: left to find its own, the
+/// inventory finds the one in the user's profile. A test run then read and WROTE the real
+/// audit-cache.json.
+///
+/// Worse than the log leak, because the cache decides whether a header is re-read at all - so an
+/// entry written by one test silently decided the answer in another, and a test failed for a reason
+/// that had nothing to do with the code under test. It littered a file AND changed a result.
+/// </summary>
+public static class TestAuditStores
+{
+    public static BackupAuditStore Temp() =>
+        new(Path.Combine(Path.GetTempPath(), "ninelives-tests", Guid.NewGuid().ToString("n")));
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -931,7 +931,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
         var vm = new RestoreViewModel(
             blob, new FakeSqlServerService(), new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeRestoreHistoryStore());
+            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeRestoreHistoryStore(), TestAuditStores.Temp());
 
         vm.RefreshContainers();
         vm.LoadBackupsCommand.Execute(null);

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -340,6 +340,30 @@ public class BackupSet
     /// <summary>True when this set can be paired by LSN rather than by time.</summary>
     public bool HasLsns => CheckpointLsn.HasValue || DatabaseBackupLsn.HasValue;
 
+    // ── whether this set has been checked against its own header (#130) ─────────
+    //
+    // Derived from the files rather than stored, so there is one answer and it cannot drift from
+    // what the audit actually marked. A striped set is audited as a whole - one HEADERONLY covering
+    // every stripe - so its files always agree.
+
+    /// <summary>Every file checked, and every one of them matched.</summary>
+    public bool AuditPassed =>
+        Files.Count > 0 && Files.All(f => f.AuditState == BackupAuditState.Passed);
+
+    /// <summary>The header disagreed with what the path claimed, or could not be read.</summary>
+    public bool AuditFailed => Files.Any(f => f.AuditState == BackupAuditState.Failed);
+
+    /// <summary>
+    /// What to show in a grid column.
+    ///
+    /// Blank rather than "no" when nothing has been checked: not having asked is not a finding
+    /// about the backup, and a column full of crosses would say the opposite.
+    /// </summary>
+    public string AuditDisplay =>
+        AuditFailed ? "\u2717 mismatch"
+        : AuditPassed ? "\u2713 audited"
+        : string.Empty;
+
     /// <summary>Server as the filter dropdowns present it: <c>HOST\INSTANCE</c> or <c>HOST</c>.</summary>
     public string? ServerDisplay => ServerIdentity.Format(ServerName, InstanceName);
 
@@ -452,6 +476,38 @@ public class RestorePoint
             : $"Full + {RequiredLogSets.Count} Log(s)",
         _ => "Unknown"
     };
+
+    /// <summary>Every set this restore point needs, in the order a restore applies them.</summary>
+    public IEnumerable<BackupSet> AllRequiredSets
+    {
+        get
+        {
+            yield return RequiredFullSet;
+            foreach (var diff in RequiredDiffSets) yield return diff;
+            foreach (var log in RequiredLogSets) yield return log;
+        }
+    }
+
+    // ── whether this whole point has been checked against its headers (#130) ────
+    //
+    // Per POINT rather than per set, because that is the decision being made in this grid: this is
+    // the moment somebody is about to restore to, and what they want to know is whether every
+    // backup needed to get there has been confirmed - not whether some of them have.
+
+    /// <summary>Every set needed to reach this moment has been read and matched.</summary>
+    public bool AuditPassed => AllRequiredSets.All(s => s.AuditPassed);
+
+    /// <summary>At least one set needed to reach this moment did not match its header.</summary>
+    public bool AuditFailed => AllRequiredSets.Any(s => s.AuditFailed);
+
+    /// <summary>
+    /// Blank until something has been checked. Not having asked is not a finding about the backup,
+    /// and a column full of crosses would say the opposite.
+    /// </summary>
+    public string AuditDisplay =>
+        AuditFailed ? "✗ mismatch"
+        : AuditPassed ? "✓ audited"
+        : string.Empty;
 
     public int TotalFiles
     {

--- a/src/NineLives/Services/BackupAuditor.cs
+++ b/src/NineLives/Services/BackupAuditor.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -21,16 +21,21 @@ public class BackupAuditor(ISqlServerService sql, IBackupAuditStore store)
     /// <summary>
     /// What one header read costs, measured rather than guessed.
     ///
-    /// Two runs against a real container: 5.8s per statement with a fresh connection each time, and
-    /// 1.7s per statement once they shared one and connecting fell to nothing. The second is the
-    /// figure to plan with; it is a blob round trip plus SQL Server reading a header, and it is not
-    /// going to get much better.
+    /// Three runs against a real container, each a better sample than the last:
+    ///   3 sets, fresh connection per read - 5,800 ms per statement
+    ///   11 sets, one connection - 1,744 ms per statement
+    ///   98 sets, one connection - 2,101 ms per statement, over 152 files
+    ///
+    /// The last is the one to plan with: it is the only sample large enough to average out a single
+    /// slow blob, and it is a full audit of a real database rather than one chain. The 11-set run
+    /// quoted three minutes for that 98-set audit and it took three and a half - close, but under,
+    /// and an estimate that runs over reads as a fault where one that comes in early does not.
     ///
     /// Deliberately a stated constant rather than a running average. An estimate that changes
     /// between one glance and the next is one nobody trusts, and being roughly right in front of a
     /// three-minute operation is the whole job.
     /// </summary>
-    public static readonly TimeSpan MeasuredCostPerSet = TimeSpan.FromMilliseconds(1_700);
+    public static readonly TimeSpan MeasuredCostPerSet = TimeSpan.FromMilliseconds(2_100);
 
     /// <summary>How long auditing this many sets should take, given what is already cached.</summary>
     public static TimeSpan Estimate(int setsToRead) =>

--- a/src/NineLives/ViewModels/RestoreTimelineViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreTimelineViewModel.cs
@@ -98,6 +98,27 @@ public partial class RestoreTimelineViewModel : ObservableObject
     private DateTime? _to;
 
     /// <summary>
+    /// Re-publishes the rows so a grid re-reads what they say, without changing which rows they are.
+    ///
+    /// RestorePoint is a plain model with no change notification - deliberately, it is derived data
+    /// rather than a viewmodel - so a property that becomes true underneath it, like a set having
+    /// been audited, reaches no binding on its own. Replacing the collection is what makes a grid
+    /// look again.
+    ///
+    /// The selection is put back deliberately. Losing it would move the restore point somebody had
+    /// chosen, as a side effect of an audit finishing - a change to what would be restored, made by
+    /// something that was only supposed to be checking.
+    /// </summary>
+    public void RefreshRows()
+    {
+        var selected = SelectedPoint;
+
+        Points = new ObservableCollection<RestorePoint>(Points);
+
+        if (selected != null && Points.Contains(selected)) SelectedPoint = selected;
+    }
+
+    /// <summary>
     /// Takes a fresh set of restore points and shows them, with the filters wide open.
     ///
     /// Wide open because carrying a previous database's date range over would silently hide points

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -511,7 +511,8 @@ public partial class RestoreViewModel : ViewModelBase
         RestoreScriptGenerator scriptGenerator,
         ICredentialStore credentialStore,
         OperationLog? log = null,
-        IRestoreHistoryStore? history = null)
+        IRestoreHistoryStore? history = null,
+        IBackupAuditStore? auditStore = null)
     {
         _history = history ?? new RestoreHistoryStore();
 
@@ -526,7 +527,10 @@ public partial class RestoreViewModel : ViewModelBase
         // actual log file, which is the same class of side effect this whole change is about.
         _log = log ?? App.Log;
 
-        Inventory = new BackupInventoryViewModel(blobService, sqlService, _log);
+        // The audit cache is passed down for the same reason the log is: left to find its own, it
+        // finds the one in the user's profile - so a TEST run reads and writes the real cache, and
+        // a stale entry from one test then decides the answer in another (#130).
+        Inventory = new BackupInventoryViewModel(blobService, sqlService, _log, auditStore);
 
         // The chain and the timeline are built from whatever the inventory currently holds, so a
         // change there is the one signal that rebuilds them.
@@ -871,9 +875,15 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     private void RefreshChainFiles()
     {
+        // The restore points grid is what somebody is actually looking at when an audit finishes -
+        // the chain panel below it is collapsed until they ask for it - so that grid is the one
+        // that has to show the result. Reported: an audit passed 98 sets and nothing said so.
+        Timeline.RefreshRows();
+
         if (RestoreChain == null) return;
 
         ChainFiles = new ObservableCollection<BackupFileInfo>(RestoreChain.AllFiles);
+        ChainSets = new ObservableCollection<BackupSet>(RestoreChain.AllSets);
     }
 
     [RelayCommand]

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -735,6 +735,33 @@
 
                             <DataGridTextColumn Header="Restores" Width="*"
                                                 Binding="{Binding TypeDisplay}" />
+                            <!-- Whether this has been checked against its own header (#130).
+
+                                 Blank until something has been, because not having asked is not a
+                                 finding about the backup - a column of crosses would say the
+                                 opposite. Green and red only once there is an answer. -->
+                            <DataGridTextColumn Header="Audit" Width="90"
+                                                SortMemberPath="AuditDisplay"
+                                                Binding="{Binding AuditDisplay}">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="FontSize" Value="11" />
+                                        <Setter Property="FontWeight" Value="SemiBold" />
+                                        <Setter Property="VerticalAlignment" Value="Center" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding AuditPassed}" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                                <Setter Property="ToolTip" Value="SQL Server read the header of every backup needed here, and they match what the paths say." />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding AuditFailed}" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
+                                                <Setter Property="ToolTip" Value="At least one backup needed here does not match its header - see the audit findings above." />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+
                             <DataGridTextColumn Header="Files" Width="60"
                                                 SortMemberPath="TotalFiles"
                                                 Binding="{Binding TotalFiles}" />
@@ -780,6 +807,33 @@
                                     </Style>
                                 </DataGridTextColumn.ElementStyle>
                             </DataGridTextColumn>
+                            <!-- Whether this has been checked against its own header (#130).
+
+                                 Blank until something has been, because not having asked is not a
+                                 finding about the backup - a column of crosses would say the
+                                 opposite. Green and red only once there is an answer. -->
+                            <DataGridTextColumn Header="Audit" Width="90"
+                                                SortMemberPath="AuditDisplay"
+                                                Binding="{Binding AuditDisplay}">
+                                <DataGridTextColumn.ElementStyle>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="FontSize" Value="11" />
+                                        <Setter Property="FontWeight" Value="SemiBold" />
+                                        <Setter Property="VerticalAlignment" Value="Center" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding AuditPassed}" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                                <Setter Property="ToolTip" Value="SQL Server read the header of every backup needed here, and they match what the paths say." />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding AuditFailed}" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
+                                                <Setter Property="ToolTip" Value="At least one backup needed here does not match its header - see the audit findings above." />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </DataGridTextColumn.ElementStyle>
+                            </DataGridTextColumn>
+
                             <DataGridTextColumn Header="Files" Width="55"
                                                 Binding="{Binding FileCount}" />
                             <DataGridTextColumn Header="Striped" Width="60"


### PR DESCRIPTION
Reported from a real run: 98 sets audited, all matched, three and a half minutes — and nothing on any row said so.

```
[audit] 98 statement(s) over 152 file(s): 0 ms connecting, 205,936 ms reading (2,101 ms per statement, 1,355 ms per file).
[audit] All 98 backup set(s) match their headers.
```

The pills existed only in the restore-chain panel, which is collapsed until somebody asks for it. So the result of a three-and-a-half minute operation was invisible unless you knew to go and open a panel and look.

## An Audit column on the grids people actually have open

On the **restore points** grid and the **chain sets** grid.

On a restore *point* it answers for the whole chain, because that is the decision being made there: this is the moment somebody is about to restore to, and what they want to know is whether every backup needed to get there has been confirmed — not whether some of them have.

Blank until something has been checked. Not having asked is not a finding about the backup, and a column full of crosses would say the opposite.

## The rows had to be told to look again

`RestorePoint` and `BackupSet` are plain models with no change notification — deliberately, they are derived data rather than viewmodels — so an audit marking them underneath a grid reached no binding at all. The rows are re-published after a run.

The chosen restore point is deliberately put back: losing it would move what is about to be restored, as a side effect of something that was only supposed to be checking.

## The estimate is now based on a real sample

1,700 ms → **2,100 ms per set**. The 98-set run is a far better sample than the 3-set and 11-set ones — it quoted three minutes and took three and a half, and an estimate that runs over reads as a fault where one that comes in early does not.

## And a bug the new test found

It is the log-injection defect again, with worse consequences. The audit cache defaulted to the user's profile, so a **test run read and wrote the real `audit-cache.json`**. Because the cache decides whether a header is re-read at all, a stale entry written by one test silently decided the answer in another — it changed a test result, not merely littered a file. That is exactly how this surfaced: a new test failed for a reason that had nothing to do with the code under test.

The store is now passed down like the log, and `TestAuditStores.Temp` gives every test its own. Verified: a full test run no longer creates the file at all.

1,218 tests pass.