### PR TITLE
Recognise backups a previous run already audited (#130)

### DIFF
--- a/src/NineLives.Tests/AuditSurvivesARestartTests.cs
+++ b/src/NineLives.Tests/AuditSurvivesARestartTests.cs
@@ -1,0 +1,211 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// An audit survives closing the app (#130).
+///
+/// The results were already written to disk, but nothing read them back until somebody pressed
+/// Audit again - so relaunching threw away the visible result of a three-and-a-half minute
+/// operation. The cache still held it and the re-run would have been instant, but you would first
+/// have to guess that a button you had already pressed needed pressing again.
+///
+/// A backup header never changes. An answer from last week is as good as one from this second, and
+/// applying it costs one local file read rather than a round trip per set.
+/// </summary>
+public class AuditSurvivesARestartTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupFileInfo File_(string name, BackupType type, string etag) => new()
+    {
+        BlobName = $"FULL/SRV01/MyDb/{name}",
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/{name}",
+        ETag = etag,
+        Type = type,
+        InferredDatabaseName = "MyDb",
+        InferredServerName = "SRV01",
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    private static BackupLocation Container() => BackupLocation.Blob(new BlobContainerConfig
+    {
+        Id = "c1",
+        Name = "backups",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups"
+    });
+
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    /// <summary>A fresh inventory over the same blobs - the app having been closed and reopened.</summary>
+    private static BackupInventoryViewModel Relaunched(IBackupAuditStore store, params BackupFileInfo[] files)
+        => new(new FakeBlobStorageService { Files = files.ToList() },
+               new FakeSqlServerService { Header = Header() },
+               TestLogs.Temp(),
+               store);
+
+    private static BackupFileInfo Header(BackupType type = BackupType.Full) => new()
+    {
+        DatabaseName = "MyDb",
+        Type = type,
+        BackupTypeCode = type == BackupType.Full ? 1 : 2
+    };
+
+    // ── the thing that was missing ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Load, audit, close, reopen, load again - the backups come back already marked, with nothing
+    /// pressed and nothing read from the server.
+    /// </summary>
+    [Fact]
+    public async Task BackupsAuditedInAPreviousRunComeBackAlreadyMarked()
+    {
+        var store = TestAuditStores.Temp();
+
+        var first = Relaunched(store, File_("MyDb_FULL_20260801_220000.bak", BackupType.Full, "\"aaa\""));
+        await first.LoadAsync(Container());
+        first.SelectedDatabaseName = "MyDb";
+        await first.AuditAsync(Server());
+
+        Assert.True(first.WorkingSet.Single().AuditPassed);
+
+        // Reopened: a new viewmodel, new file objects, the same blobs and the same cache.
+        var second = Relaunched(store, File_("MyDb_FULL_20260801_220000.bak", BackupType.Full, "\"aaa\""));
+        await second.LoadAsync(Container());
+        second.SelectedDatabaseName = "MyDb";
+
+        Assert.True(second.WorkingSet.Single().AuditPassed);
+        Assert.Equal(1, second.PreAuditedCount);
+    }
+
+    /// <summary>Nothing goes to the server to find that out.</summary>
+    [Fact]
+    public async Task NothingIsReadFromTheServerToRecogniseThem()
+    {
+        var store = TestAuditStores.Temp();
+
+        var first = Relaunched(store, File_("a.bak", BackupType.Full, "\"aaa\""));
+        await first.LoadAsync(Container());
+        first.SelectedDatabaseName = "MyDb";
+        await first.AuditAsync(Server());
+
+        var blob = new FakeBlobStorageService { Files = [File_("a.bak", BackupType.Full, "\"aaa\"")] };
+        var sql = new FakeSqlServerService { Header = Header() };
+        var second = new BackupInventoryViewModel(blob, sql, TestLogs.Temp(), store);
+
+        await second.LoadAsync(Container());
+        second.SelectedDatabaseName = "MyDb";
+
+        Assert.Empty(sql.HeaderBatches);
+        Assert.True(second.WorkingSet.Single().AuditPassed);
+    }
+
+    /// <summary>And the estimate agrees, so nobody is quoted three minutes for work already done.</summary>
+    [Fact]
+    public async Task TheEstimateSaysThereIsNothingLeftToRead()
+    {
+        var store = TestAuditStores.Temp();
+
+        var first = Relaunched(store, File_("a.bak", BackupType.Full, "\"aaa\""));
+        await first.LoadAsync(Container());
+        first.SelectedDatabaseName = "MyDb";
+        await first.AuditAsync(Server());
+
+        var second = Relaunched(store, File_("a.bak", BackupType.Full, "\"aaa\""));
+        await second.LoadAsync(Container());
+        second.SelectedDatabaseName = "MyDb";
+
+        Assert.Contains("instant", second.AuditEstimate);
+    }
+
+    /// <summary>A mismatch is remembered too - it is at least as worth knowing as a pass.</summary>
+    [Fact]
+    public async Task AMismatchFromAPreviousRunComesBackAsAMismatch()
+    {
+        var store = TestAuditStores.Temp();
+
+        var blob = new FakeBlobStorageService { Files = [File_("a.trn", BackupType.TransactionLog, "\"aaa\"")] };
+        var first = new BackupInventoryViewModel(
+            blob, new FakeSqlServerService { Header = Header(BackupType.Full) }, TestLogs.Temp(), store);
+
+        await first.LoadAsync(Container());
+        first.SelectedDatabaseName = "MyDb";
+        await first.AuditAsync(Server());
+
+        Assert.True(first.WorkingSet.Single().AuditFailed);
+
+        var second = Relaunched(store, File_("a.trn", BackupType.TransactionLog, "\"aaa\""));
+        await second.LoadAsync(Container());
+        second.SelectedDatabaseName = "MyDb";
+
+        Assert.True(second.WorkingSet.Single().AuditFailed);
+    }
+
+    // ── and what it must NOT do ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// A blob replaced under the same name is a different blob, and its old answer is worthless.
+    /// The ETag is the whole reason the key is what it is.
+    /// </summary>
+    [Fact]
+    public async Task AReplacedBackupIsNotRecognisedFromTheOldAnswer()
+    {
+        var store = TestAuditStores.Temp();
+
+        var first = Relaunched(store, File_("a.bak", BackupType.Full, "\"aaa\""));
+        await first.LoadAsync(Container());
+        first.SelectedDatabaseName = "MyDb";
+        await first.AuditAsync(Server());
+
+        // Same name, different content.
+        var second = Relaunched(store, File_("a.bak", BackupType.Full, "\"bbb\""));
+        await second.LoadAsync(Container());
+        second.SelectedDatabaseName = "MyDb";
+
+        Assert.False(second.WorkingSet.Single().AuditPassed);
+        Assert.Equal(0, second.PreAuditedCount);
+    }
+
+    /// <summary>Backups nobody has ever audited come back unmarked, not assumed good.</summary>
+    [Fact]
+    public async Task BackupsNeverAuditedComeBackUnmarked()
+    {
+        var vm = Relaunched(TestAuditStores.Temp(), File_("a.bak", BackupType.Full, "\"aaa\""));
+
+        await vm.LoadAsync(Container());
+        vm.SelectedDatabaseName = "MyDb";
+
+        var set = vm.WorkingSet.Single();
+
+        Assert.False(set.AuditPassed);
+        Assert.False(set.AuditFailed);
+        Assert.Equal(string.Empty, set.AuditDisplay);
+        Assert.Equal(0, vm.PreAuditedCount);
+    }
+
+    /// <summary>
+    /// A striped set is audited as a whole - one HEADERONLY covering every stripe - so a cache that
+    /// only answers for some of its files is one where a stripe has been replaced. That has to go
+    /// back to the server rather than be counted as known.
+    /// </summary>
+    [Fact]
+    public void ASetTheCacheOnlyPartlyAnswersForIsNotMarked()
+    {
+        var one = File_("p1.bak", BackupType.Full, "\"aaa\"");
+        var two = File_("p2.bak", BackupType.Full, "\"bbb\"");
+
+        var set = new BackupSet { SetId = "s", Type = BackupType.Full, Files = [one, two] };
+
+        var cached = new Dictionary<string, AuditRecord>
+        {
+            [BackupAuditStore.KeyFor(one)] = new("k", true, "MyDb", 1, T0)
+        };
+
+        Assert.Equal(0, BackupAuditor.ApplyCached([set], cached));
+        Assert.False(set.AuditPassed);
+    }
+}

--- a/src/NineLives/Services/BackupAuditor.cs
+++ b/src/NineLives/Services/BackupAuditor.cs
@@ -62,10 +62,46 @@ public class BackupAuditor(ISqlServerService sql, IBackupAuditStore store)
                "It can be stopped at any point, and what it has already checked is kept.";
     }
 
+    /// <summary>
+    /// Marks every set the cache already has an answer for, without reading anything.
+    ///
+    /// Applied when a container is LOADED, not only when an audit is run. A backup header never
+    /// changes, so an answer from last week is as good as one from this second - and without this,
+    /// closing the app threw away the visible result of a three-minute operation. The cache still
+    /// held it, and pressing Audit again would have been instant, but somebody would first have to
+    /// guess that a button they had already pressed needed pressing again.
+    /// </summary>
+    /// <returns>How many sets the cache could answer for.</returns>
+    public static int ApplyCached(
+        IEnumerable<BackupSet> sets, IReadOnlyDictionary<string, AuditRecord> cached)
+    {
+        if (cached.Count == 0) return 0;
+
+        var marked = 0;
+
+        foreach (var set in sets)
+        {
+            // Every file of a set, because a set is audited as a whole - one HEADERONLY covering
+            // all its stripes. A set the cache only partly answers for is one where a stripe has
+            // been replaced, and that has to go back to the server.
+            var records = set.Files
+                .Select(f => cached.GetValueOrDefault(BackupAuditStore.KeyFor(f)))
+                .ToList();
+
+            if (records.Count == 0 || records.Any(r => r == null)) continue;
+
+            MarkFiles(set, records.All(r => r!.Passed));
+            marked++;
+        }
+
+        return marked;
+    }
+
     /// <summary>Sets whose files are not already in the cache, and therefore have to be read.</summary>
     public static List<BackupSet> NotYetAudited(
         IEnumerable<BackupSet> sets, IReadOnlyDictionary<string, AuditRecord> cached) =>
-        sets.Where(s => s.Files.Any(f => !cached.ContainsKey(BackupAuditStore.KeyFor(f)))).ToList();
+        sets.Where(s => s.Files.Count == 0
+                     || s.Files.Any(f => !cached.ContainsKey(BackupAuditStore.KeyFor(f)))).ToList();
 
     /// <summary>
     /// Reads the header of every set not already known, and reports where they disagree.

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -181,7 +181,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
         {
             if (WorkingSet.Count == 0) return string.Empty;
 
-            var toRead = BackupAuditor.NotYetAudited(WorkingSet, _auditStore.Load()).Count;
+            var toRead = BackupAuditor.NotYetAudited(WorkingSet, _cachedAudit).Count;
             return BackupAuditor.DescribeEstimate(toRead);
         }
     }
@@ -223,6 +223,9 @@ public partial class BackupInventoryViewModel : ViewModelBase
 
             AuditFindings = new ObservableCollection<BackupAuditFinding>(findings);
 
+            // The audit just wrote to it, so the estimate for a re-run has to see the new answers.
+            _cachedAudit = _auditStore.Load();
+
             AuditSummary = findings.Count == 0
                 ? $"All {sets.Count:N0} backup set(s) match their headers."
                 : $"{findings.Count:N0} of {sets.Count:N0} backup set(s) do not match their headers.";
@@ -252,6 +255,38 @@ public partial class BackupInventoryViewModel : ViewModelBase
 
     private void RefreshUnclassifiedCount()
         => UnclassifiedCount = _allBackups.Count(BackupHeaderIdentifier.NeedsIdentifying);
+
+    /// <summary>
+    /// Marks everything a previous audit already answered for, before anybody presses anything.
+    ///
+    /// A backup header never changes, so an answer from last week is as good as one from this
+    /// second - and reading it costs one local file rather than a round trip per set. Without this,
+    /// closing the app threw away the visible result of a three-minute operation: the cache still
+    /// held it and pressing Audit again would have been instant, but somebody would first have to
+    /// guess that a button they had already pressed needed pressing again.
+    /// </summary>
+    private void ApplyCachedAudit()
+    {
+        try
+        {
+            // Read once per load and kept. AuditEstimate is a property a binding re-reads whenever
+            // it feels like it, and going to disk on each get would be a file read per repaint.
+            _cachedAudit = _auditStore.Load();
+            PreAuditedCount = BackupAuditor.ApplyCached(_allSets, _cachedAudit);
+        }
+        catch
+        {
+            // A cache that will not load is a slower audit, not a failed load.
+            _cachedAudit = new Dictionary<string, AuditRecord>();
+            PreAuditedCount = 0;
+        }
+    }
+
+    private IReadOnlyDictionary<string, AuditRecord> _cachedAudit = new Dictionary<string, AuditRecord>();
+
+    /// <summary>How many sets arrived already answered for by a previous run.</summary>
+    [ObservableProperty]
+    private int _preAuditedCount;
 
     /// <summary>
     /// Asks SQL Server what those files actually are, and regroups.
@@ -290,6 +325,8 @@ public partial class BackupInventoryViewModel : ViewModelBase
             // keyed on the database and type that have just been corrected.
             _allSets = _blob.GroupIntoBackupSets(
                 _allBackups, LoadedFrom?.Container?.BackupServerTimeZoneId);
+
+            ApplyCachedAudit();
 
             DiscoveredServers = new ObservableCollection<string>(_blob.GetDiscoveredServers(_allBackups));
             DiscoveredDatabases = new ObservableCollection<string>(_blob.GetDiscoveredDatabases(_allBackups));
@@ -438,6 +475,8 @@ public partial class BackupInventoryViewModel : ViewModelBase
             // Stated, not assumed: everything derived from here belongs to THIS location.
             LoadedFrom = location;
 
+            ApplyCachedAudit();
+
             DiscoveredServers = new ObservableCollection<string>(_blob.GetDiscoveredServers(files));
             DiscoveredDatabases = new ObservableCollection<string>(_blob.GetDiscoveredDatabases(files));
             BackupsLoaded = files.Count > 0;
@@ -496,6 +535,8 @@ public partial class BackupInventoryViewModel : ViewModelBase
         _allBackups = sets.SelectMany(s => s.Files).ToList();
         _allSets = sets;
         LoadedFrom = location;
+
+        ApplyCachedAudit();
 
         DiscoveredServers = new ObservableCollection<string>(
             sets.Select(s => s.ServerDisplay)


### PR DESCRIPTION
The results were being written to disk all along — but nothing read them back until somebody pressed Audit again. So closing the app threw away the visible result of a three-and-a-half minute operation. The cache still held it and the re-run would have been instant, but you would first have to guess that a button you had already pressed needed pressing again.

## Applied on load, not on demand

A backup header never changes, so an answer from last week is as good as one from this second — and applying it costs **one local file read** rather than a round trip per set.

Reopen the app, load the same container, and the sets come back already marked with nothing pressed and nothing asked of the server. The estimate agrees, so nobody is quoted three minutes for work already done:

> Everything here has been audited already - this will be instant.

Mismatches are remembered too. A backup that failed is at least as worth knowing about as one that passed.

## What it deliberately does not do

- **A set the cache only partly answers for is not marked.** A striped set is audited as a whole — one `HEADERONLY` covering every stripe — so a partial answer means a stripe has been replaced, and that has to go back to the server.
- **A blob replaced under the same name is not recognised from the old answer.** It is a different blob and its old answer is worthless, which is exactly what keying on the ETag is for.
- **Backups nobody has ever audited come back unmarked**, not assumed good.

## Also

The cache is read once per load rather than per property get. `AuditEstimate` is a property a binding re-reads whenever it likes, and going to disk on each one would be a file read per repaint.

1,225 tests pass.