### PR TITLE
Keep the restore summary on screen while the rest scrolls

### DIFF
--- a/src/NineLives.Tests/RestoreSummaryStaysPutTests.cs
+++ b/src/NineLives.Tests/RestoreSummaryStaysPutTests.cs
@@ -1,0 +1,144 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The restore summary stays on screen while the rest scrolls.
+///
+/// "THIS RESTORE WILL ..." is the one sentence saying what is about to happen to a database. It was
+/// moved out of the accordion in #117 because it was invisible whenever another step was open - and
+/// it was then invisible whenever anybody scrolled, which on this screen is constantly: the four
+/// steps run well past a screen height, so the sentence describing the restore was off-screen at
+/// exactly the moment somebody was setting it up.
+///
+/// The test is structural rather than visual, because that is what can actually be checked: the
+/// banner must not be inside the thing that scrolls.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class RestoreSummaryStaysPutTests(WpfFixture wpf)
+{
+    [Fact]
+    public void TheSummaryIsNotInsideTheScroller()
+    {
+        wpf.Invoke(() =>
+        {
+            var view = Realised();
+
+            var summary = FindSummaryBanner(view);
+            Assert.NotNull(summary);
+
+            Assert.False(HasAncestorOfType<ScrollViewer>(summary),
+                "the summary scrolls away with the content it is describing");
+        });
+    }
+
+    /// <summary>
+    /// And the steps still scroll. Pinning everything would be the same bug the other way round -
+    /// four steps in a fixed panel simply do not fit.
+    /// </summary>
+    [Fact]
+    public void TheStepsStillScroll()
+    {
+        wpf.Invoke(() =>
+        {
+            var view = Realised();
+
+            var stepHeader = FindAll<TextBlock>(view)
+                .FirstOrDefault(t => t.Text.Contains("Select a backup source", StringComparison.Ordinal));
+
+            Assert.NotNull(stepHeader);
+            Assert.True(HasAncestorOfType<ScrollViewer>(stepHeader),
+                "the page content has to scroll - the steps do not fit a screen");
+        });
+    }
+
+    /// <summary>
+    /// Docked rather than overlaid, so it never covers the controls underneath. A banner floating
+    /// on top of the first step would hide the container dropdown at exactly the wrong moment.
+    /// </summary>
+    [Fact]
+    public void TheSummaryDoesNotOverlapTheContent()
+    {
+        wpf.Invoke(() =>
+        {
+            var view = Realised();
+
+            var summary = FindSummaryBanner(view)!;
+            var scroller = FindAll<ScrollViewer>(view).First();
+
+            var summaryBottom = summary.TranslatePoint(new Point(0, summary.ActualHeight), view).Y;
+            var scrollerTop = scroller.TranslatePoint(new Point(0, 0), view).Y;
+
+            Assert.True(summaryBottom <= scrollerTop + 1,
+                $"the summary ends at {summaryBottom} and the content starts at {scrollerTop}");
+        });
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static FrameworkElement Realised()
+    {
+        var store = new FakeCredentialStore();
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(),
+            new Blackcat.NineLives.Services.BackupChainBuilder(),
+            new Blackcat.NineLives.Services.RestoreScriptGenerator(),
+            store, TestLogs.Temp(), new FakeRestoreHistoryStore(), TestAuditStores.Temp())
+        {
+            // The banner is collapsed with nothing to say, and a collapsed element is not somewhere
+            // a person can fail to see - so it needs something to say before any of this means
+            // anything. A first attempt at these tests measured the collapsed one and proved
+            // nothing.
+            RestoreSummaryText = "Restore 'MyDb' as 'MyDb_Restored' using 1 Full + 2 Log(s)."
+        };
+
+        var view = new RestoreView { DataContext = vm };
+        view.ApplyTemplate();
+        view.Measure(new Size(1280, 900));
+        view.Arrange(new Rect(0, 0, 1280, 900));
+        view.UpdateLayout();
+
+        return view;
+    }
+
+    /// <summary>
+    /// The banner itself, not its label - the label is a few pixels tall wherever it sits, so
+    /// measuring it would say nothing about where the banner is.
+    /// </summary>
+    private static FrameworkElement? FindSummaryBanner(DependencyObject root)
+    {
+        var label = FindAll<TextBlock>(root).FirstOrDefault(t => t.Text == "THIS RESTORE WILL");
+        if (label == null) return null;
+
+        for (DependencyObject? node = label; node != null; node = VisualTreeHelper.GetParent(node))
+            if (node is Border border) return border;
+
+        return null;
+    }
+
+    private static bool HasAncestorOfType<T>(DependencyObject node) where T : DependencyObject
+    {
+        for (var current = VisualTreeHelper.GetParent(node); current != null;
+             current = VisualTreeHelper.GetParent(current))
+        {
+            if (current is T) return true;
+        }
+        return false;
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is T match) yield return match;
+            foreach (var descendant in FindAll<T>(child)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -13,7 +13,36 @@
         <converters:TickPositionConverter x:Key="TickPos" />
     </UserControl.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <DockPanel>
+        <!-- The live summary of what a restore would do, PINNED (#117 item 3, and then some).
+
+             It is not a step - it is the answer the steps are building towards, and it changes with
+             every option above it. It was moved out of the accordion because it was invisible
+             whenever another pane was open; it is docked here because it was then invisible whenever
+             anybody scrolled, which on this screen is constantly. The steps run well past a screen
+             height, so the sentence describing what is about to happen to a database was off-screen
+             at exactly the moment somebody was setting up the thing it describes.
+
+             Docked rather than overlaid, so it never covers the controls underneath it - the same
+             way the connection status sits above the content rather than floating on top of it. -->
+        <Border DockPanel.Dock="Top"
+                CornerRadius="6" Padding="14,12" Margin="0,0,0,16"
+                Background="{DynamicResource WarningPanelBackgroundBrush}"
+                BorderBrush="{DynamicResource WarningBrush}"
+                BorderThickness="1"
+                Visibility="{Binding RestoreSummaryText, Converter={StaticResource NullToVis}}">
+            <StackPanel>
+                <TextBlock Text="THIS RESTORE WILL"
+                           Style="{StaticResource LabelText}"
+                           Margin="0,0,0,6" />
+                <TextBlock Text="{Binding RestoreSummaryText}"
+                           Style="{StaticResource BodyText}"
+                           TextWrapping="Wrap"
+                           LineHeight="22" />
+            </StackPanel>
+        </Border>
+
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
             <!-- Header -->
             <StackPanel Margin="0,0,0,20">
@@ -52,28 +81,6 @@
                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap">
                         <Run Text="Add one on the Blob Storage screen and it will appear here. A restore also needs a SQL Server connection, on the SQL Servers screen, to run against." />
                     </TextBlock>
-                </StackPanel>
-            </Border>
-
-            <!-- The live summary of what a restore would do, at the top rather than buried
-                 between steps 3 and 4 (#117 item 3).
-
-                 It is not a step - it is the answer the steps are building towards, and it changes
-                 with every option above it. Sitting inside the accordion it was invisible whenever
-                 another pane was open, which is most of the time. -->
-            <Border CornerRadius="6" Padding="14,12" Margin="0,0,0,16"
-                    Background="{DynamicResource WarningPanelBackgroundBrush}"
-                    BorderBrush="{DynamicResource WarningBrush}"
-                    BorderThickness="1"
-                    Visibility="{Binding RestoreSummaryText, Converter={StaticResource NullToVis}}">
-                <StackPanel>
-                    <TextBlock Text="THIS RESTORE WILL"
-                               Style="{StaticResource LabelText}"
-                               Margin="0,0,0,6" />
-                    <TextBlock Text="{Binding RestoreSummaryText}"
-                               Style="{StaticResource BodyText}"
-                               TextWrapping="Wrap"
-                               LineHeight="22" />
                 </StackPanel>
             </Border>
 
@@ -1956,5 +1963,6 @@
                        Margin="0,4,0,16"
                        Visibility="{Binding StatusMessage, Converter={StaticResource NullToVis}}" />
         </StackPanel>
-    </ScrollViewer>
+        </ScrollViewer>
+    </DockPanel>
 </UserControl>


### PR DESCRIPTION
"THIS RESTORE WILL ..." is the one sentence saying what is about to happen to a database.

#117 moved it out of the accordion because it was invisible whenever another step was open. It was then invisible whenever anybody **scrolled**, which on this screen is constantly — the four steps run well past a screen height, so the sentence describing the restore was off-screen at exactly the moment somebody was setting it up.

## Docked, not overlaid

It sits above the scroller rather than floating on top of it — the same way the connection status does. A banner overlaying the first step would hide the container dropdown at the wrong moment.

The steps still scroll, which is the other half of getting this right: pinning everything would be the same bug the other way round.

## Tests

Structural rather than visual, because that is what can actually be checked — the banner must not be inside the thing that scrolls, the steps must be, and the two must not overlap.

Worth recording that the first version of them measured the banner while it was **collapsed**, and proved nothing. It needs something to say before where it sits means anything.

1,228 tests pass.