### PR TITLE
Create managed-identity credentials, so a SAS-free setup works end to end (#147)

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -389,11 +389,16 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>The SAS token each write was handed, so a test can prove none was sent.</summary>
     public List<string> CredentialSecretsWritten { get; } = [];
 
+    /// <summary>Set to make the write fail the way a real server can (#147).</summary>
+    public Exception? CredentialWriteThrows { get; set; }
+
     public Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
         BlobCredentialIdentity identity = BlobCredentialIdentity.SharedAccessSignature,
         CancellationToken ct = default)
     {
+        if (CredentialWriteThrows != null) throw CredentialWriteThrows;
+
         CredentialWrites.Add(credentialName);
         CredentialIdentitiesWritten.Add(identity);
         CredentialSecretsWritten.Add(sasToken);

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -380,12 +380,38 @@ public sealed class FakeSqlServerService : ISqlServerService
         ServerConnection server, string credentialName, CancellationToken ct = default)
         => OnCredentialCheck?.Invoke(credentialName, ct) ?? Task.FromResult(Credential);
 
+    /// <summary>Every identity a credential write was asked for, in order (#147).</summary>
+    public List<BlobCredentialIdentity> CredentialIdentitiesWritten { get; } = [];
+
+    /// <summary>What the fake credential write reports back.</summary>
+    public CredentialChange CredentialWriteResult { get; set; } = CredentialChange.None;
+
+    /// <summary>The SAS token each write was handed, so a test can prove none was sent.</summary>
+    public List<string> CredentialSecretsWritten { get; } = [];
+
     public Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
+        BlobCredentialIdentity identity = BlobCredentialIdentity.SharedAccessSignature,
         CancellationToken ct = default)
     {
         CredentialWrites.Add(credentialName);
-        return Task.FromResult(CredentialChange.None);
+        CredentialIdentitiesWritten.Add(identity);
+        CredentialSecretsWritten.Add(sasToken);
+        return Task.FromResult(CredentialWriteResult);
+    }
+
+    /// <summary>What the fake instance says about managed identity. Supported by default.</summary>
+    public ManagedIdentitySupport ManagedIdentity { get; set; } = new(true, 16, 3);
+
+    /// <summary>Set to make ASKING fail, which is not the same as the answer being no.</summary>
+    public Exception? ManagedIdentityCheckThrows { get; set; }
+
+    public Task<ManagedIdentitySupport> SupportsManagedIdentityCredentialAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        if (ManagedIdentityCheckThrows != null) throw ManagedIdentityCheckThrows;
+
+        return Task.FromResult(ManagedIdentity);
     }
 }
 

--- a/src/NineLives.Tests/ManagedIdentityCredentialLiveTests.cs
+++ b/src/NineLives.Tests/ManagedIdentityCredentialLiveTests.cs
@@ -1,0 +1,247 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Live proof of what a managed-identity credential does to server state (#147).
+///
+/// What these CAN prove against any instance: that the statement is accepted, that ALTER with no
+/// SECRET converts a SAS credential across and back, that the conversion nulls the stored secret,
+/// and what this particular instance says about its own version.
+///
+/// What they cannot prove, anywhere on-prem: that a restore then AUTHENTICATES with it. That needs
+/// an Azure VM with an identity, an Arc-enabled instance, or SQL MI. So this ships with the
+/// statement and the lifecycle proven and the authentication unproven, which is the same position
+/// the VERIFYONLY live test was left in by #26.
+///
+/// Gated on NINELIVES_TEST_SQL like the other live tests; each cleans up after itself.
+/// </summary>
+[Collection("CredentialManager")]
+public class ManagedIdentityCredentialLiveTests
+{
+    private static string? TestServerName =>
+        Environment.GetEnvironmentVariable("NINELIVES_TEST_SQL");
+
+    private static ServerConnection TestServer() => new()
+    {
+        Name = "ninelives-test",
+        ServerName = TestServerName!,
+        AuthMode = AuthMode.WindowsAuth,
+        Encrypt = EncryptMode.No,
+        TrustServerCertificate = true,
+        ConnectionTimeoutSeconds = 15
+    };
+
+    private static SqlServerService Service() => new(new CredentialStore());
+
+    private const string Url = "https://acct.blob.core.windows.net/backups";
+    private const string Sas = "sv=2026-01-01&sig=a-token";
+
+    // ── the statement is accepted ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Accepted on ANY version, which is exactly why the app gates the option rather than trusting
+    /// the server to refuse it. A credential written on SQL Server 2019 looks perfectly correct
+    /// here and fails at restore time - the worst kind of deferred failure.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task AManagedIdentityCredentialCanBeCreated()
+    {
+        const string name = "ninelives-test-mi-create";
+        try
+        {
+            await DropCredentialIfExists(name);
+
+            var change = await Service().EnsureCredentialExistsAsync(
+                TestServer(), name, Url, sasToken: string.Empty,
+                BlobCredentialIdentity.ManagedIdentity);
+
+            Assert.Equal(CredentialChange.Created, change);
+            Assert.Equal("Managed Identity", await IdentityOf(name));
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    /// <summary>The app reads back what it wrote - the other half of #145's recognition.</summary>
+    [RequiresSqlFact]
+    public async Task TheAppRecognisesTheCredentialItJustWrote()
+    {
+        const string name = "ninelives-test-mi-readback";
+        try
+        {
+            await DropCredentialIfExists(name);
+
+            await Service().EnsureCredentialExistsAsync(
+                TestServer(), name, Url, string.Empty, BlobCredentialIdentity.ManagedIdentity);
+
+            var status = await Service().CredentialExistsAsync(TestServer(), name);
+
+            Assert.Equal(BlobCredentialIdentity.ManagedIdentity, status.Kind);
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    // ── the conversion, in both directions ──────────────────────────────────────
+
+    /// <summary>
+    /// ALTER with no SECRET is what converts a SAS credential across. Worth pinning live rather
+    /// than reasoning about: it is the mechanism the whole feature rests on, and it is destructive.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task AlteringConvertsASasCredentialToAManagedIdentity()
+    {
+        const string name = "ninelives-test-mi-convert";
+        try
+        {
+            await DropCredentialIfExists(name);
+
+            await Service().EnsureCredentialExistsAsync(
+                TestServer(), name, Url, Sas, BlobCredentialIdentity.SharedAccessSignature);
+
+            Assert.Equal("SHARED ACCESS SIGNATURE", await IdentityOf(name));
+
+            var change = await Service().EnsureCredentialExistsAsync(
+                TestServer(), name, Url, string.Empty, BlobCredentialIdentity.ManagedIdentity);
+
+            Assert.Equal(CredentialChange.Updated, change);
+            Assert.Equal("Managed Identity", await IdentityOf(name));
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    /// <summary>
+    /// And back again, because a SAS-free estate that changes its mind should not have to drop the
+    /// credential by hand - and because the reverse conversion is the one #145 was written about.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task AlteringConvertsAManagedIdentityBackToASas()
+    {
+        const string name = "ninelives-test-mi-convert-back";
+        try
+        {
+            await DropCredentialIfExists(name);
+
+            await Service().EnsureCredentialExistsAsync(
+                TestServer(), name, Url, string.Empty, BlobCredentialIdentity.ManagedIdentity);
+
+            await Service().EnsureCredentialExistsAsync(
+                TestServer(), name, Url, Sas, BlobCredentialIdentity.SharedAccessSignature);
+
+            Assert.Equal("SHARED ACCESS SIGNATURE", await IdentityOf(name));
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    /// <summary>
+    /// A credential is server-scoped shared state, so converting it must not drop and recreate it -
+    /// that removes it for the moment in between, from everything else using it. create_date is
+    /// what tells the two apart.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ConvertingDoesNotDropAndRecreate()
+    {
+        const string name = "ninelives-test-mi-no-drop";
+        try
+        {
+            await DropCredentialIfExists(name);
+
+            await Service().EnsureCredentialExistsAsync(
+                TestServer(), name, Url, Sas, BlobCredentialIdentity.SharedAccessSignature);
+
+            var created = await CreateDate(name);
+
+            await Service().EnsureCredentialExistsAsync(
+                TestServer(), name, Url, string.Empty, BlobCredentialIdentity.ManagedIdentity);
+
+            Assert.Equal(created, await CreateDate(name));
+        }
+        finally
+        {
+            await DropCredentialIfExists(name);
+        }
+    }
+
+    // ── what this instance says about itself ────────────────────────────────────
+
+    /// <summary>
+    /// Deliberately asserts behaviour rather than a value. Pinning "this returns true" would pin
+    /// whichever version happens to be on the machine running the tests - a live test that fails on
+    /// somebody else's SQL Server 2019 is a test about the environment, not about the code.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task TheInstanceReportsEnoughToDecide()
+    {
+        var support = await Service().SupportsManagedIdentityCredentialAsync(TestServer());
+
+        Assert.True(support.ProductMajorVersion.HasValue || support.EngineEdition.HasValue,
+            "an instance that reports neither leaves the app guessing");
+
+        Assert.Equal(
+            BlobCredentialStatement.SupportsManagedIdentity(support.ProductMajorVersion, support.EngineEdition),
+            support.IsSupported);
+
+        // Whichever way it went, a refusal has to say something usable.
+        if (!support.IsSupported) Assert.NotEqual(string.Empty, support.Explain());
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static async Task<string?> IdentityOf(string name)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT credential_identity FROM sys.credentials WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", name);
+        return (await cmd.ExecuteScalarAsync()) as string;
+    }
+
+    private static async Task<DateTime> CreateDate(string name)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT create_date FROM sys.credentials WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", name);
+        return (DateTime)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    private static async Task<bool> CredentialExists(string name)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM sys.credentials WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", name);
+        return (int)(await cmd.ExecuteScalarAsync())! > 0;
+    }
+
+    private static async Task DropCredentialIfExists(string name)
+    {
+        if (!await CredentialExists(name)) return;
+
+        await using var conn = await OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $"DROP CREDENTIAL {TSql.QuoteName(name)}";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<SqlConnection> OpenAsync()
+    {
+        var conn = new SqlServerService(new CredentialStore()).CreateConnection(TestServer());
+        await conn.OpenAsync();
+        return conn;
+    }
+}

--- a/src/NineLives.Tests/ManagedIdentityCredentialLiveTests.cs
+++ b/src/NineLives.Tests/ManagedIdentityCredentialLiveTests.cs
@@ -8,9 +8,14 @@ namespace Blackcat.NineLives.Tests;
 /// <summary>
 /// Live proof of what a managed-identity credential does to server state (#147).
 ///
-/// What these CAN prove against any instance: that the statement is accepted, that ALTER with no
-/// SECRET converts a SAS credential across and back, that the conversion nulls the stored secret,
-/// and what this particular instance says about its own version.
+/// What these CAN prove against any instance: that the statement is accepted, which conversions SQL
+/// Server actually permits, that an allowed one alters in place rather than dropping, and what this
+/// particular instance says about its own version.
+///
+/// One of them was written asserting the opposite of what SQL Server does - the issue assumed ALTER
+/// converts a SAS credential to a managed identity, and it does not - and it failed on its first CI
+/// run. That is the whole argument for writing live tests even when they cannot prove the last
+/// mile.
 ///
 /// What they cannot prove, anywhere on-prem: that a restore then AUTHENTICATES with it. That needs
 /// an Azure VM with an identity, an Arc-enabled instance, or SQL MI. So this ships with the
@@ -93,11 +98,18 @@ public class ManagedIdentityCredentialLiveTests
     // ── the conversion, in both directions ──────────────────────────────────────
 
     /// <summary>
-    /// ALTER with no SECRET is what converts a SAS credential across. Worth pinning live rather
-    /// than reasoning about: it is the mechanism the whole feature rests on, and it is destructive.
+    /// SQL Server REFUSES to move a credential off SHARED ACCESS SIGNATURE in place.
+    ///
+    /// This test was written the other way round - the issue was designed around ALTER converting a
+    /// SAS credential across - and it failed on its first CI run. The assumption was simply wrong,
+    /// and the error says something misleading about the credential being "used by an active
+    /// database file" for a credential nothing has ever touched.
+    ///
+    /// Pinned as the refusal it is, because the app now has to explain it, and because an engine
+    /// that starts allowing it should be noticed rather than quietly changing behaviour.
     /// </summary>
     [RequiresSqlFact]
-    public async Task AlteringConvertsASasCredentialToAManagedIdentity()
+    public async Task SqlServerWillNotConvertASasCredentialToAManagedIdentity()
     {
         const string name = "ninelives-test-mi-convert";
         try
@@ -109,11 +121,16 @@ public class ManagedIdentityCredentialLiveTests
 
             Assert.Equal("SHARED ACCESS SIGNATURE", await IdentityOf(name));
 
-            var change = await Service().EnsureCredentialExistsAsync(
-                TestServer(), name, Url, string.Empty, BlobCredentialIdentity.ManagedIdentity);
+            var refused = await Assert.ThrowsAnyAsync<Exception>(() =>
+                Service().EnsureCredentialExistsAsync(
+                    TestServer(), name, Url, string.Empty, BlobCredentialIdentity.ManagedIdentity));
 
-            Assert.Equal(CredentialChange.Updated, change);
-            Assert.Equal("Managed Identity", await IdentityOf(name));
+            Assert.True(BlobCredentialStatement.IsIdentityChangeRefusal(refused.Message),
+                $"the app has to recognise this refusal to explain it; it said: {refused.Message}");
+
+            // Left exactly as it was, which is the point of not working around it by dropping and
+            // recreating (#10).
+            Assert.Equal("SHARED ACCESS SIGNATURE", await IdentityOf(name));
         }
         finally
         {
@@ -148,12 +165,14 @@ public class ManagedIdentityCredentialLiveTests
     }
 
     /// <summary>
-    /// A credential is server-scoped shared state, so converting it must not drop and recreate it -
-    /// that removes it for the moment in between, from everything else using it. create_date is
-    /// what tells the two apart.
+    /// A credential is server-scoped shared state, so a conversion that IS allowed must not drop
+    /// and recreate it - that removes it for the moment in between, from everything else using it.
+    /// create_date is what tells the two apart.
+    ///
+    /// Managed identity to SAS, because that is the direction SQL Server permits.
     /// </summary>
     [RequiresSqlFact]
-    public async Task ConvertingDoesNotDropAndRecreate()
+    public async Task AnAllowedConversionDoesNotDropAndRecreate()
     {
         const string name = "ninelives-test-mi-no-drop";
         try
@@ -161,13 +180,14 @@ public class ManagedIdentityCredentialLiveTests
             await DropCredentialIfExists(name);
 
             await Service().EnsureCredentialExistsAsync(
-                TestServer(), name, Url, Sas, BlobCredentialIdentity.SharedAccessSignature);
+                TestServer(), name, Url, string.Empty, BlobCredentialIdentity.ManagedIdentity);
 
             var created = await CreateDate(name);
 
             await Service().EnsureCredentialExistsAsync(
-                TestServer(), name, Url, string.Empty, BlobCredentialIdentity.ManagedIdentity);
+                TestServer(), name, Url, Sas, BlobCredentialIdentity.SharedAccessSignature);
 
+            Assert.Equal("SHARED ACCESS SIGNATURE", await IdentityOf(name));
             Assert.Equal(created, await CreateDate(name));
         }
         finally

--- a/src/NineLives.Tests/ManagedIdentityCredentialTests.cs
+++ b/src/NineLives.Tests/ManagedIdentityCredentialTests.cs
@@ -1,0 +1,200 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Writing a managed-identity credential (#147).
+///
+/// #145 taught the app to RECOGNISE one and leave it alone. This is creating one, which closes the
+/// SAS-free path #29 opened: an organisation that forbids long-lived SAS tokens could browse a
+/// container without one and then still not restore without one, because the credential this app
+/// wrote was always a SAS.
+///
+/// What can be proven here is the statement text and the version gate. What cannot - on-prem, with
+/// no Azure VM, Arc-enabled instance or SQL MI - is that a restore then AUTHENTICATES with it.
+/// </summary>
+public class ManagedIdentityCredentialTests
+{
+    private const string Name = "https://acct.blob.core.windows.net/backups";
+
+    // ── the statement ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// No SECRET clause at all - not an empty one. <c>SECRET = ''</c> would be a different thing,
+    /// and SQL Server would take it.
+    /// </summary>
+    [Fact]
+    public void AManagedIdentityCredentialCarriesNoSecret()
+    {
+        var sql = BlobCredentialStatement.Build(
+            Name, BlobCredentialIdentity.ManagedIdentity, "sv=2022&sig=abc", exists: false);
+
+        Assert.Contains("WITH IDENTITY = 'Managed Identity'", sql);
+        Assert.DoesNotContain("SECRET", sql);
+        Assert.DoesNotContain("sig=abc", sql);
+    }
+
+    /// <summary>A token that happens to be lying around must not end up in the statement.</summary>
+    [Fact]
+    public void ATokenIsIgnoredEntirelyForAManagedIdentity()
+    {
+        var sql = BlobCredentialStatement.Build(
+            Name, BlobCredentialIdentity.ManagedIdentity, "sv=2022&sig=SHOULDNOTAPPEAR", exists: true);
+
+        Assert.DoesNotContain("SHOULDNOTAPPEAR", sql);
+    }
+
+    [Fact]
+    public void ASasCredentialStillCarriesItsToken()
+    {
+        var sql = BlobCredentialStatement.Build(
+            Name, BlobCredentialIdentity.SharedAccessSignature, "?sv=2022&sig=abc", exists: false);
+
+        Assert.Contains("WITH IDENTITY = 'SHARED ACCESS SIGNATURE'", sql);
+        Assert.Contains("SECRET = 'sv=2022&sig=abc'", sql);
+    }
+
+    /// <summary>The leading '?' is part of a URL query, not of the token.</summary>
+    [Fact]
+    public void ALeadingQuestionMarkIsStrippedFromTheToken()
+    {
+        var sql = BlobCredentialStatement.Build(
+            Name, BlobCredentialIdentity.SharedAccessSignature, "?sv=2022", exists: false);
+
+        Assert.DoesNotContain("'?sv", sql);
+    }
+
+    /// <summary>
+    /// ALTER rather than DROP and CREATE. A credential is server-scoped shared state: dropping it
+    /// even for the moment between two statements breaks anything else relying on it at that
+    /// instant - a backup job writing to the same container, most obviously.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobCredentialIdentity.ManagedIdentity)]
+    [InlineData(BlobCredentialIdentity.SharedAccessSignature)]
+    public void AnExistingCredentialIsAlteredRatherThanReplaced(BlobCredentialIdentity identity)
+    {
+        var sql = BlobCredentialStatement.Build(Name, identity, "sv=2022", exists: true);
+
+        Assert.StartsWith("ALTER CREDENTIAL", sql);
+        Assert.DoesNotContain("DROP CREDENTIAL", sql);
+    }
+
+    /// <summary>
+    /// The conversion, which is the whole mechanism: ALTER with no SECRET is what turns a SAS
+    /// credential into a managed-identity one, and nulls the stored secret as it goes.
+    /// </summary>
+    [Fact]
+    public void AlteringToAManagedIdentityIsWhatConvertsASasCredential()
+    {
+        var sql = BlobCredentialStatement.Build(
+            Name, BlobCredentialIdentity.ManagedIdentity, "sv=2022", exists: true);
+
+        Assert.Equal(
+            $"ALTER CREDENTIAL [{Name}] WITH IDENTITY = 'Managed Identity'", sql);
+    }
+
+    /// <summary>
+    /// The name is an identifier, so it is quoted rather than concatenated - and an embedded ']'
+    /// is doubled, or the brackets do not delimit anything. A name is auto-populated from a URL in
+    /// a plain-text config file and is editable free text, so it is attacker-reachable.
+    /// </summary>
+    [Fact]
+    public void ABracketInTheNameCannotBreakOutOfTheIdentifier()
+    {
+        var sql = BlobCredentialStatement.Build(
+            "https://[fe80::1]:10000/devstore", BlobCredentialIdentity.ManagedIdentity, null, false);
+
+        Assert.Contains("[https://[fe80::1]]:10000/devstore]", sql);
+    }
+
+    /// <summary>
+    /// Anything else on the server was put there by something that is not this app, and
+    /// overwriting it blind would replace an identity that may be authenticating perfectly well.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobCredentialIdentity.Other)]
+    [InlineData(BlobCredentialIdentity.Missing)]
+    public void AnIdentityThisAppDoesNotWriteIsRefusedRatherThanGuessedAt(BlobCredentialIdentity identity)
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => BlobCredentialStatement.Build(Name, identity, null, false));
+
+    // ── the version gate ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The gate matters more than it looks. CREATE CREDENTIAL takes its identity as free TEXT on
+    /// every version, so an ungated app writes a credential that looks perfectly fine, sits in
+    /// sys.credentials, reads back correctly - and fails at restore time.
+    /// </summary>
+    [Theory]
+    [InlineData(16)]  // SQL Server 2022
+    [InlineData(17)]
+    public void ManagedIdentityIsOfferedOnSqlServer2022AndLater(int version)
+        => Assert.True(BlobCredentialStatement.SupportsManagedIdentity(version, engineEdition: 3));
+
+    [Theory]
+    [InlineData(13)]  // 2016
+    [InlineData(14)]  // 2017
+    [InlineData(15)]  // 2019
+    public void ManagedIdentityIsNotOfferedBefore2022(int version)
+        => Assert.False(BlobCredentialStatement.SupportsManagedIdentity(version, engineEdition: 3));
+
+    /// <summary>Azure SQL Managed Instance, whatever it reports as a version.</summary>
+    [Fact]
+    public void AzureSqlManagedInstanceIsOfferedItRegardlessOfVersion()
+        => Assert.True(BlobCredentialStatement.SupportsManagedIdentity(
+            productMajorVersion: 12, engineEdition: BlobCredentialStatement.AzureSqlManagedInstance));
+
+    /// <summary>An instance that said nothing is not assumed capable.</summary>
+    [Fact]
+    public void AnInstanceThatDidNotSayIsNotAssumedCapable()
+        => Assert.False(BlobCredentialStatement.SupportsManagedIdentity(null, null));
+
+    /// <summary>
+    /// Named rather than a bare "not supported". Somebody who has just been told their organisation
+    /// forbids SAS tokens, and is now told the alternative is unavailable, deserves to know which
+    /// of the two things to go and change.
+    /// </summary>
+    [Fact]
+    public void TheRefusalNamesTheVersionAndWhatIsNeeded()
+    {
+        var text = BlobCredentialStatement.ExplainUnsupported(15);
+
+        Assert.Contains("version 15", text);
+        Assert.Contains("SQL Server 2022", text);
+        Assert.Contains("Managed Instance", text);
+    }
+
+    [Fact]
+    public void ARefusalWithNoVersionSaysThatToo()
+        => Assert.Contains("did not report its version", BlobCredentialStatement.ExplainUnsupported(null));
+
+    // ── what the credential alone does not buy ──────────────────────────────────
+
+    /// <summary>
+    /// The statement succeeds whether or not the instance has an identity at all, and whether or
+    /// not it can read the container. Both then surface as a 403 at restore time, which says
+    /// nothing about which identity was refused - the trap #144 addressed for browsing.
+    /// </summary>
+    [Fact]
+    public void TheCaveatNamesTheRoleAndSaysWhatIsNotEnough()
+    {
+        var text = BlobCredentialStatement.WhatItStillNeeds;
+
+        Assert.Contains("Storage Blob Data Reader", text);
+        Assert.Contains("Contributor", text);
+        Assert.Contains("NOT enough", text);
+    }
+
+    // ── the record that carries the answer ──────────────────────────────────────
+
+    [Fact]
+    public void ASupportedInstanceExplainsNothingBecauseThereIsNothingToExplain()
+        => Assert.Equal(string.Empty, new ManagedIdentitySupport(true, 16, 3).Explain());
+
+    [Fact]
+    public void AnUnsupportedInstanceExplainsItselfWithItsOwnVersion()
+        => Assert.Contains("version 15", new ManagedIdentitySupport(false, 15, 3).Explain());
+}

--- a/src/NineLives.Tests/ManagedIdentityPanelTests.cs
+++ b/src/NineLives.Tests/ManagedIdentityPanelTests.cs
@@ -203,6 +203,40 @@ public class ManagedIdentityPanelTests
         Assert.Contains("managed identity", message);
     }
 
+    /// <summary>
+    /// SQL Server refuses to move a credential off SHARED ACCESS SIGNATURE, which the live test
+    /// found on its first CI run - the issue had assumed ALTER converts it.
+    ///
+    /// The workaround is DROP and CREATE, and this app will not do that: a credential is
+    /// server-scoped, so dropping it breaks anything else reaching that container at that moment
+    /// (#10). So it reports the refusal with the remedy, rather than a raw SQL error about a
+    /// credential being "used by an active database file" - which is what the server says, and is
+    /// misleading about a credential nothing has ever used.
+    /// </summary>
+    [Fact]
+    public async Task ARefusedIdentityChangeIsExplainedWithWhatToDoAboutIt()
+    {
+        var (vm, sql, _) = New();
+        sql.CredentialWriteThrows = new InvalidOperationException(
+            "Failed to modify the identity field of  the credential 'x' because the credential is " +
+            "used by an active database file.");
+
+        vm.Server = Server();
+        await vm.PointAtAsync(Container(BlobAuthMode.EntraInteractive));
+
+        var reported = new List<(string Message, bool IsError)>();
+        vm.Reported += (m, e) => reported.Add((m, e));
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        var (message, isError) = Assert.Single(reported);
+
+        Assert.True(isError);
+        Assert.Contains("DROP CREDENTIAL", message);
+        Assert.Contains("server-scoped", message);
+        Assert.DoesNotContain("active database file", message);
+    }
+
     // ── the button says what the press would do ─────────────────────────────────
 
     /// <summary>

--- a/src/NineLives.Tests/ManagedIdentityPanelTests.cs
+++ b/src/NineLives.Tests/ManagedIdentityPanelTests.cs
@@ -1,0 +1,252 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The credential panel offering a managed identity (#147).
+///
+/// The gap this closes is visible rather than theoretical: on an Entra container the button failed
+/// with "No SAS token stored for this container" - true, useless, and by design, because an Entra
+/// container has no token to push. The SAS-free path #29 opened stopped exactly there.
+/// </summary>
+public class ManagedIdentityPanelTests
+{
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    private static BlobContainerConfig Container(BlobAuthMode mode = BlobAuthMode.SasToken) => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = "backups",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups",
+        AuthMode = mode
+    };
+
+    private static (ServerCredentialViewModel vm, FakeSqlServerService sql, FakeCredentialStore store) New()
+    {
+        var store = new FakeCredentialStore();
+        var sql = new FakeSqlServerService();
+
+        var vm = new ServerCredentialViewModel(
+            sql, store,
+            new OperationLog(Path.Combine(Path.GetTempPath(), "ninelives-tests", Guid.NewGuid().ToString("n"))),
+            new OperationCancellation());
+
+        return (vm, sql, store);
+    }
+
+    // ── which identity gets offered ─────────────────────────────────────────────
+
+    /// <summary>
+    /// An Entra container defaults to managed identity because it is the only thing that CAN work
+    /// there - there is no stored token, by design.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobAuthMode.EntraInteractive)]
+    [InlineData(BlobAuthMode.EntraDefault)]
+    public async Task AnEntraContainerDefaultsToManagedIdentity(BlobAuthMode mode)
+    {
+        var (vm, _, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container(mode));
+
+        Assert.True(vm.CreatingManagedIdentity);
+    }
+
+    /// <summary>A SAS container keeps the SAS default, because that is what it has.</summary>
+    [Fact]
+    public async Task ASasContainerKeepsTheSasDefault()
+    {
+        var (vm, _, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container());
+
+        Assert.False(vm.CreatingManagedIdentity);
+    }
+
+    /// <summary>
+    /// And an instance that cannot use one is never defaulted to it, however the container is
+    /// configured - a credential written there looks correct and fails at restore time.
+    /// </summary>
+    [Fact]
+    public async Task AnOlderInstanceIsNeverDefaultedToManagedIdentity()
+    {
+        var (vm, sql, _) = New();
+        sql.ManagedIdentity = new ManagedIdentitySupport(false, 15, 3);
+
+        vm.Server = Server();
+        await vm.PointAtAsync(Container(BlobAuthMode.EntraInteractive));
+
+        Assert.False(vm.CreatingManagedIdentity);
+        Assert.False(vm.ManagedIdentitySupported);
+        Assert.Contains("version 15", vm.ManagedIdentityBlockedReason);
+    }
+
+    /// <summary>The button refuses rather than writing something that cannot work.</summary>
+    [Fact]
+    public async Task AnOlderInstanceCannotBeMadeToWriteOne()
+    {
+        var (vm, sql, _) = New();
+        sql.ManagedIdentity = new ManagedIdentitySupport(false, 15, 3);
+
+        vm.Server = Server();
+        await vm.PointAtAsync(Container(BlobAuthMode.EntraInteractive));
+
+        vm.IdentityToCreate = BlobCredentialIdentity.ManagedIdentity;
+
+        Assert.False(vm.CreateOnServerCommand.CanExecute(null));
+    }
+
+    /// <summary>
+    /// Not being able to ASK is not the same as the answer being no, but it has to have the same
+    /// outcome: writing blind risks a credential that looks right and fails when it matters.
+    /// </summary>
+    [Fact]
+    public async Task AnInstanceThatCannotBeAskedIsNotOfferedIt()
+    {
+        var (vm, sql, _) = New();
+        sql.ManagedIdentityCheckThrows = new InvalidOperationException("no");
+
+        vm.Server = Server();
+        await vm.PointAtAsync(Container(BlobAuthMode.EntraInteractive));
+
+        Assert.False(vm.ManagedIdentitySupported);
+        Assert.Contains("Could not ask", vm.ManagedIdentityBlockedReason);
+    }
+
+    // ── writing it ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The gap this issue is about: on an Entra container the button used to fail outright, because
+    /// it insisted on a token that container never has.
+    /// </summary>
+    [Fact]
+    public async Task AnEntraContainerCanNowHaveItsCredentialCreated()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container(BlobAuthMode.EntraInteractive));
+
+        var reported = new List<(string Message, bool IsError)>();
+        vm.Reported += (m, e) => reported.Add((m, e));
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        Assert.Equal(BlobCredentialIdentity.ManagedIdentity, Assert.Single(sql.CredentialIdentitiesWritten));
+        Assert.DoesNotContain(reported, r => r.IsError);
+    }
+
+    /// <summary>No token is sent, because there is none and none is wanted.</summary>
+    [Fact]
+    public async Task NoTokenIsSentForAManagedIdentity()
+    {
+        var (vm, sql, _) = New();
+        vm.Server = Server();
+        await vm.PointAtAsync(Container(BlobAuthMode.EntraInteractive));
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        Assert.Equal(string.Empty, Assert.Single(sql.CredentialSecretsWritten));
+    }
+
+    /// <summary>
+    /// What the credential alone does not buy, said when it is created rather than left to a 403 at
+    /// restore time - the same trap #144 addressed for browsing.
+    /// </summary>
+    [Fact]
+    public async Task CreatingOneSaysWhatItStillNeeds()
+    {
+        var (vm, sql, _) = New();
+        sql.CredentialWriteResult = CredentialChange.Created;
+
+        vm.Server = Server();
+        await vm.PointAtAsync(Container(BlobAuthMode.EntraInteractive));
+
+        var reported = new List<(string Message, bool IsError)>();
+        vm.Reported += (m, e) => reported.Add((m, e));
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        var (message, _) = Assert.Single(reported);
+        Assert.Contains("Storage Blob Data Reader", message);
+    }
+
+    /// <summary>
+    /// Converting a SAS credential to a managed identity discards the stored token on the server.
+    /// That is a change to how the instance authenticates, not a routine update - #145 said the
+    /// same about the opposite direction and it is no less true this way round.
+    /// </summary>
+    [Fact]
+    public async Task ReplacingASasCredentialWithAManagedIdentityIsNamedAsAReplacement()
+    {
+        var (vm, sql, store) = New();
+        sql.CredentialWriteResult = CredentialChange.Updated;
+        sql.Credential = new BlobCredentialStatus(
+            BlobCredentialIdentity.SharedAccessSignature, "SHARED ACCESS SIGNATURE");
+
+        vm.Server = Server();
+        await vm.PointAtAsync(Container(BlobAuthMode.EntraInteractive));
+
+        var reported = new List<(string Message, bool IsError)>();
+        vm.Reported += (m, e) => reported.Add((m, e));
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        var (message, isError) = Assert.Single(reported);
+
+        Assert.False(isError);
+        Assert.Contains("held a SAS token", message);
+        Assert.Contains("managed identity", message);
+    }
+
+    // ── the button says what the press would do ─────────────────────────────────
+
+    /// <summary>
+    /// The truth table. A label describing only what is ON the server is precisely the bug #145
+    /// was - the same button read as a harmless refresh while it converted the instance's managed
+    /// identity to a SAS token. Now that the identity is a choice, the reverse conversion needs the
+    /// same treatment, and the render caught the button still offering to "refresh with stored SAS
+    /// token" while managed identity was selected.
+    /// </summary>
+    [Theory]
+    [InlineData(BlobCredentialIdentity.Missing, false, "Create credential on server")]
+    [InlineData(BlobCredentialIdentity.Missing, true, "Create credential as the instance's managed identity")]
+    [InlineData(BlobCredentialIdentity.SharedAccessSignature, false, "Refresh credential with stored SAS token")]
+    [InlineData(BlobCredentialIdentity.SharedAccessSignature, true, "Replace SAS token with the instance's managed identity")]
+    [InlineData(BlobCredentialIdentity.ManagedIdentity, false, "Replace Managed Identity with stored SAS token")]
+    [InlineData(BlobCredentialIdentity.ManagedIdentity, true, "Refresh credential as the instance's managed identity")]
+    public void TheButtonSaysWhatThePressWouldDo(
+        BlobCredentialIdentity onServer, bool writingManagedIdentity, string expected)
+    {
+        var (vm, _, _) = New();
+
+        vm.IdentityKind = onServer;
+        vm.IdentityToCreate = writingManagedIdentity
+            ? BlobCredentialIdentity.ManagedIdentity
+            : BlobCredentialIdentity.SharedAccessSignature;
+
+        Assert.Equal(expected, vm.CreateButtonText);
+    }
+
+    /// <summary>A SAS container with a token still writes a SAS credential, unchanged.</summary>
+    [Fact]
+    public async Task ASasContainerStillWritesASasCredential()
+    {
+        var (vm, sql, store) = New();
+        var container = Container();
+        store.SaveSasToken(container, "sv=2022&sig=abc");
+
+        vm.Server = Server();
+        await vm.PointAtAsync(container);
+
+        await vm.CreateOnServerCommand.ExecuteAsync(null);
+
+        Assert.Equal(BlobCredentialIdentity.SharedAccessSignature,
+            Assert.Single(sql.CredentialIdentitiesWritten));
+        Assert.Equal("sv=2022&sig=abc", Assert.Single(sql.CredentialSecretsWritten));
+    }
+}

--- a/src/NineLives/Services/BlobCredentialStatement.cs
+++ b/src/NineLives/Services/BlobCredentialStatement.cs
@@ -40,11 +40,10 @@ public static class BlobCredentialStatement
         {
             // No SECRET clause at all.
             //
-            // On an existing SAS credential this ALTER is what CONVERTS it: SQL Server takes the
-            // new identity and nulls the stored secret. That is the intended behaviour and it is
-            // destructive, which is why nothing reaches this except somebody asking for it - the
-            // execute path stops and reports an identity it does not recognise rather than
-            // "fixing" one that may be working perfectly well (#145).
+            // On an existing MANAGED IDENTITY credential this refreshes it. On an existing SAS
+            // credential SQL Server refuses it outright - see IsIdentityChangeRefusal, which was
+            // discovered by the live test rather than assumed. The app reports that refusal with a
+            // remedy rather than working around it by dropping the credential (#10).
             BlobCredentialIdentity.ManagedIdentity =>
                 $"{verb} CREDENTIAL {quotedName} WITH IDENTITY = 'Managed Identity'",
 
@@ -61,6 +60,38 @@ public static class BlobCredentialStatement
                 "would replace an identity that may be authenticating perfectly well.")
         };
     }
+
+    /// <summary>
+    /// Whether SQL Server refused to CHANGE a credential's identity, rather than failing for some
+    /// other reason.
+    ///
+    /// Found by the live test on its first CI run, and it contradicts what this feature was
+    /// designed around. ALTER does NOT convert a SAS credential to a managed identity. SQL Server
+    /// rejects it with:
+    ///
+    ///     Failed to modify the identity field of the credential '...' because the credential is
+    ///     used by an active database file.
+    ///
+    /// which is a misleading message - it is refused on a credential nothing has ever used. The
+    /// engine simply will not move one off SHARED ACCESS SIGNATURE in place. The reverse direction,
+    /// managed identity back to SAS, is allowed and does work.
+    ///
+    /// The obvious workaround is DROP and CREATE, and this app deliberately will not do it: a
+    /// credential is server-scoped shared state, and dropping it even for the moment between two
+    /// statements breaks anything else relying on it - which is the whole of #10. So it says what
+    /// happened and leaves the decision where it belongs.
+    /// </summary>
+    public static bool IsIdentityChangeRefusal(string message) =>
+        message.Contains("modify the identity field", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>What to do about that refusal, given nothing here will drop the credential for you.</summary>
+    public static string ExplainIdentityChangeRefusal(string credentialName) =>
+        $"SQL Server will not change the identity of the existing credential [{credentialName}] in " +
+        "place - it refuses to move a credential off SHARED ACCESS SIGNATURE, whatever is or is " +
+        "not using it. The credential has to be dropped and created again, and this app will not " +
+        "do that for you: a credential is server-scoped, so dropping it breaks anything else " +
+        "reaching that container at that moment, a backup job most obviously. When nothing is " +
+        $"using it, run DROP CREDENTIAL [{credentialName}] and then press this button again.";
 
     /// <summary>
     /// Whether an instance can authenticate to blob storage with a managed identity at all.

--- a/src/NineLives/Services/BlobCredentialStatement.cs
+++ b/src/NineLives/Services/BlobCredentialStatement.cs
@@ -1,0 +1,116 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// The T-SQL that writes a server-side blob credential (#147).
+///
+/// Pulled out as pure text because it is the part that can actually be proven without Azure. What
+/// this issue cannot prove locally is that a restore then AUTHENTICATES with a managed identity -
+/// that needs an Azure VM, an Arc-enabled instance or SQL MI - so the statement itself is where the
+/// testable value is.
+///
+/// The two identities differ in exactly one way that matters: a managed-identity credential has no
+/// SECRET. Not an empty one - none at all. Writing <c>SECRET = ''</c> would be a different thing.
+/// </summary>
+public static class BlobCredentialStatement
+{
+    /// <summary>
+    /// The statement to run.
+    /// </summary>
+    /// <param name="credentialName">Validated and quoted by the caller's rules, not concatenated raw.</param>
+    /// <param name="identity">Which identity the credential should hold.</param>
+    /// <param name="sasToken">The token, for a SAS credential. Ignored for a managed identity.</param>
+    /// <param name="exists">
+    /// Whether a credential of this name is already there.
+    ///
+    /// ALTER rather than DROP and CREATE, because a credential is server-scoped shared state:
+    /// dropping it even for the moment between two statements breaks anything else relying on it at
+    /// that instant - a backup job writing to the same container, most obviously.
+    /// </param>
+    public static string Build(
+        string credentialName, BlobCredentialIdentity identity, string? sasToken, bool exists)
+    {
+        TSql.ValidateIdentifier(credentialName, nameof(credentialName));
+
+        var verb = exists ? "ALTER" : "CREATE";
+        var quotedName = TSql.QuoteName(credentialName);
+
+        return identity switch
+        {
+            // No SECRET clause at all.
+            //
+            // On an existing SAS credential this ALTER is what CONVERTS it: SQL Server takes the
+            // new identity and nulls the stored secret. That is the intended behaviour and it is
+            // destructive, which is why nothing reaches this except somebody asking for it - the
+            // execute path stops and reports an identity it does not recognise rather than
+            // "fixing" one that may be working perfectly well (#145).
+            BlobCredentialIdentity.ManagedIdentity =>
+                $"{verb} CREDENTIAL {quotedName} WITH IDENTITY = 'Managed Identity'",
+
+            BlobCredentialIdentity.SharedAccessSignature =>
+                $"{verb} CREDENTIAL {quotedName}{Environment.NewLine}" +
+                $"WITH IDENTITY = 'SHARED ACCESS SIGNATURE',{Environment.NewLine}" +
+                $"SECRET = '{TSql.EscapeLiteral((sasToken ?? string.Empty).TrimStart('?'))}'",
+
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(identity),
+                identity,
+                "Only a SAS or managed-identity credential can be written. Anything else on the " +
+                "server was put there by something that is not this app, and overwriting it blind " +
+                "would replace an identity that may be authenticating perfectly well.")
+        };
+    }
+
+    /// <summary>
+    /// Whether an instance can authenticate to blob storage with a managed identity at all.
+    ///
+    /// The gate matters more than it looks. <c>CREATE CREDENTIAL</c> takes its identity as free
+    /// TEXT on every version, so an ungated app writes a credential that looks perfectly fine, sits
+    /// in sys.credentials, reads back correctly - and fails at restore time. That is the worst kind
+    /// of deferred failure: everything says yes until the moment it matters.
+    /// </summary>
+    /// <param name="productMajorVersion">SERVERPROPERTY('ProductMajorVersion'). 16 is SQL Server 2022.</param>
+    /// <param name="engineEdition">SERVERPROPERTY('EngineEdition'). 8 is Azure SQL Managed Instance.</param>
+    public static bool SupportsManagedIdentity(int? productMajorVersion, int? engineEdition) =>
+        engineEdition == AzureSqlManagedInstance || productMajorVersion >= FirstVersionWithManagedIdentity;
+
+    /// <summary>SQL Server 2022. Earlier versions accept the text and cannot use it.</summary>
+    public const int FirstVersionWithManagedIdentity = 16;
+
+    /// <summary>EngineEdition 8. Has had managed identity support regardless of version.</summary>
+    public const int AzureSqlManagedInstance = 8;
+
+    /// <summary>
+    /// Why this instance cannot use one, in terms of what to do instead.
+    ///
+    /// Named rather than a bare "not supported": somebody who has just been told their organisation
+    /// forbids SAS tokens, and is now told the alternative is unavailable, deserves to know which
+    /// of the two things to go and change.
+    /// </summary>
+    public static string ExplainUnsupported(int? productMajorVersion) =>
+        productMajorVersion is { } version
+            ? $"This instance is SQL Server major version {version}. Authenticating to blob storage " +
+              "with a managed identity needs SQL Server 2022 (version 16) or later, or Azure SQL " +
+              "Managed Instance. On an earlier version the credential can be created and will look " +
+              "correct, but the restore fails when it tries to use it - so it is not offered here."
+            : "This instance did not report its version, so whether it can authenticate with a " +
+              "managed identity is unknown. Managed identity needs SQL Server 2022 or later, or " +
+              "Azure SQL Managed Instance.";
+
+    /// <summary>
+    /// What the credential alone does NOT buy.
+    ///
+    /// The statement succeeds whether or not the instance actually has a managed identity, and
+    /// whether or not that identity can read the container. Both failures then surface as a 403
+    /// from Azure at restore time, which says nothing about which identity was refused - the same
+    /// trap #144 addressed on the browsing side.
+    /// </summary>
+    public const string WhatItStillNeeds =
+        "Creating the credential does not grant anything. The instance itself needs a managed " +
+        "identity - an Azure VM with a system or user-assigned identity, an Arc-enabled instance, " +
+        "or SQL MI - and that identity needs the Storage Blob Data Reader role on this container " +
+        "to restore from it, or Storage Blob Data Contributor to back up to it. Owner and " +
+        "Contributor on the storage account are NOT enough: they grant management of the account, " +
+        "not access to the data inside it.";
+}

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -88,7 +88,17 @@ public interface ISqlServerService
     Task<BlobCredentialStatus> CredentialExistsAsync(
         ServerConnection server, string credentialName, CancellationToken ct = default);
 
+    /// <param name="identity">
+    /// Which identity the credential holds. A managed-identity credential carries no SECRET at all
+    /// (#147), and writing one over a SAS credential converts it - which is destructive, so nothing
+    /// should reach here except because somebody asked for it.
+    /// </param>
     Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
+        BlobCredentialIdentity identity = BlobCredentialIdentity.SharedAccessSignature,
         CancellationToken ct = default);
+
+    /// <summary>Whether this instance can authenticate to blob storage with a managed identity (#147).</summary>
+    Task<ManagedIdentitySupport> SupportsManagedIdentityCredentialAsync(
+        ServerConnection server, CancellationToken ct = default);
 }

--- a/src/NineLives/Services/ManagedIdentitySupport.cs
+++ b/src/NineLives/Services/ManagedIdentitySupport.cs
@@ -1,0 +1,23 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Whether an instance can authenticate to blob storage with a managed identity, and what it said
+/// when asked (#147).
+///
+/// The readings are kept, not just the verdict. Telling somebody "your instance cannot do this" is
+/// far less useful than telling them it is SQL Server 2019 and the feature needs 2022 - especially
+/// for somebody who has just been told their organisation forbids SAS tokens and is now being told
+/// the alternative is unavailable too.
+/// </summary>
+/// <param name="IsSupported">Whether the option should be offered at all.</param>
+/// <param name="ProductMajorVersion">SERVERPROPERTY('ProductMajorVersion'), or null if it did not say.</param>
+/// <param name="EngineEdition">SERVERPROPERTY('EngineEdition'), or null if it did not say.</param>
+public readonly record struct ManagedIdentitySupport(
+    bool IsSupported, int? ProductMajorVersion, int? EngineEdition)
+{
+    /// <summary>Why not, in terms of what to go and change.</summary>
+    public string Explain() =>
+        IsSupported
+            ? string.Empty
+            : BlobCredentialStatement.ExplainUnsupported(ProductMajorVersion);
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -984,10 +984,10 @@ public class SqlServerService : ISqlServerService
     // leaves create_date intact, which is how the tests tell the two apart.
     public async Task<CredentialChange> EnsureCredentialExistsAsync(
         ServerConnection server, string credentialName, string storageAccountUrl, string sasToken,
+        BlobCredentialIdentity identity = BlobCredentialIdentity.SharedAccessSignature,
         CancellationToken ct = default)
     {
         TSql.ValidateIdentifier(credentialName, nameof(credentialName));
-        var quotedName = TSql.QuoteName(credentialName);
 
         await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
@@ -1005,15 +1005,40 @@ public class SqlServerService : ISqlServerService
         // no longer calls this to "fix" an identity it does not recognise - it stops and says what
         // it found, because the identity it would have replaced could be a managed identity the
         // instance genuinely restores with (#145).
-        var cleanSas = sasToken.TrimStart('?');
         await using var writeCmd = conn.CreateCommand();
-        writeCmd.CommandText = $@"
-            {(exists ? "ALTER" : "CREATE")} CREDENTIAL {quotedName}
-            WITH IDENTITY = 'SHARED ACCESS SIGNATURE',
-            SECRET = '{TSql.EscapeLiteral(cleanSas)}'";
+        writeCmd.CommandText = BlobCredentialStatement.Build(credentialName, identity, sasToken, exists);
         await writeCmd.ExecuteNonQueryAsync(ct);
 
         return exists ? CredentialChange.Updated : CredentialChange.Created;
+    }
+
+    /// <summary>
+    /// Whether this instance can authenticate to blob storage with a managed identity (#147).
+    ///
+    /// Asked before the option is offered, because CREATE CREDENTIAL takes its identity as free
+    /// TEXT on every version: an ungated app writes a credential that looks perfectly fine, sits in
+    /// sys.credentials, reads back correctly, and fails at restore time. Everything says yes until
+    /// the moment it matters.
+    /// </summary>
+    public async Task<ManagedIdentitySupport> SupportsManagedIdentityCredentialAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+
+        cmd.CommandText = @"SELECT
+            CONVERT(int, SERVERPROPERTY('ProductMajorVersion')) AS ProductMajorVersion,
+            CONVERT(int, SERVERPROPERTY('EngineEdition')) AS EngineEdition";
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        if (!await reader.ReadAsync(ct)) return new ManagedIdentitySupport(false, null, null);
+
+        var version = reader["ProductMajorVersion"] as int?;
+        var edition = reader["EngineEdition"] as int?;
+
+        return new ManagedIdentitySupport(
+            BlobCredentialStatement.SupportsManagedIdentity(version, edition), version, edition);
     }
 
     public async Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(

--- a/src/NineLives/ViewModels/ServerCredentialViewModel.cs
+++ b/src/NineLives/ViewModels/ServerCredentialViewModel.cs
@@ -374,6 +374,12 @@ public partial class ServerCredentialViewModel : ObservableObject
                 _log.ServerChange(Server.ServerName,
                     $"credential [{Name}] identity changed from SAS to Managed Identity");
         }
+        catch (Exception ex) when (BlobCredentialStatement.IsIdentityChangeRefusal(ex.Message))
+        {
+            // Not a failure of this app, and not something it will work around by dropping the
+            // credential - see #10. Reported as the specific thing it is, with the remedy.
+            Reported?.Invoke(BlobCredentialStatement.ExplainIdentityChangeRefusal(Name), true);
+        }
         catch (Exception ex)
         {
             Reported?.Invoke($"Failed to create credential: {ex.Message}", true);

--- a/src/NineLives/ViewModels/ServerCredentialViewModel.cs
+++ b/src/NineLives/ViewModels/ServerCredentialViewModel.cs
@@ -101,6 +101,9 @@ public partial class ServerCredentialViewModel : ObservableObject
         OnPropertyChanged(nameof(IsUsable));
         OnPropertyChanged(nameof(IsSharedAccessSignature));
         OnPropertyChanged(nameof(IsManagedIdentity));
+
+        // The button says what a press would DO, which depends on what is already there (#147).
+        OnPropertyChanged(nameof(CreateButtonText));
     }
 
     [ObservableProperty]
@@ -195,14 +198,128 @@ public partial class ServerCredentialViewModel : ObservableObject
         _ => "Credential is not present on this server. Restore will fail unless you create it."
     };
 
-    /// <summary>Create or update the credential with the container's stored SAS token.</summary>
+    // ── which identity to write (#147) ──────────────────────────────────────────
+    //
+    // #29 added Entra ID for browsing precisely because many organisations forbid long-lived SAS
+    // tokens. Those organisations could then browse a container without one and still not restore
+    // without one, because the credential this wrote was always a SAS - so the SAS-free path
+    // stopped half way, and on an Entra container the button failed outright with "no SAS token
+    // stored", which is true and useless.
+
+    /// <summary>The identity the button will write.</summary>
+    [ObservableProperty]
+    private BlobCredentialIdentity _identityToCreate = BlobCredentialIdentity.SharedAccessSignature;
+
+    public bool CreatingManagedIdentity => IdentityToCreate == BlobCredentialIdentity.ManagedIdentity;
+
+    partial void OnIdentityToCreateChanged(BlobCredentialIdentity value)
+    {
+        OnPropertyChanged(nameof(CreatingManagedIdentity));
+        OnPropertyChanged(nameof(CreateButtonText));
+        CreateOnServerCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// What pressing the button would actually DO.
+    ///
+    /// It has to read both what is on the server and what is about to be written, because the
+    /// interesting presses are the ones that change one into the other - and a label describing
+    /// only the current state is exactly the bug #145 was: the same button read as a harmless
+    /// refresh while it converted the instance's managed identity to a SAS token.
+    ///
+    /// Now that the identity is a choice rather than a constant, the reverse conversion needs the
+    /// same treatment. It is no less a change to how the whole instance reaches that container.
+    /// </summary>
+    public string CreateButtonText => (IdentityKind, CreatingManagedIdentity) switch
+    {
+        (BlobCredentialIdentity.ManagedIdentity, false) =>
+            "Replace Managed Identity with stored SAS token",
+
+        (BlobCredentialIdentity.SharedAccessSignature, true) =>
+            "Replace SAS token with the instance's managed identity",
+
+        (BlobCredentialIdentity.ManagedIdentity, true) =>
+            "Refresh credential as the instance's managed identity",
+
+        (BlobCredentialIdentity.SharedAccessSignature, false) =>
+            "Refresh credential with stored SAS token",
+
+        (_, true) => "Create credential as the instance's managed identity",
+        _ => "Create credential on server"
+    };
+
+    /// <summary>Whether the instance can use one at all, once it has been asked.</summary>
+    [ObservableProperty]
+    private bool _managedIdentitySupported;
+
+    /// <summary>Why not, when it cannot - named rather than a bare refusal.</summary>
+    [ObservableProperty]
+    private string _managedIdentityBlockedReason = string.Empty;
+
+    /// <summary>
+    /// What creating the credential does NOT buy, shown alongside the option rather than after it
+    /// fails. The statement succeeds whether or not the instance has an identity at all.
+    /// </summary>
+    public static string ManagedIdentityCaveat => BlobCredentialStatement.WhatItStillNeeds;
+
+    /// <summary>
+    /// Asks the instance whether a managed-identity credential is worth offering, and picks the
+    /// identity that can actually work here.
+    ///
+    /// An Entra container defaults to managed identity because it is the only thing that CAN work
+    /// there - there is no stored token by design. A SAS container keeps the SAS default, since
+    /// that is what it has.
+    /// </summary>
+    private async Task RefreshManagedIdentitySupportAsync(CancellationToken ct = default)
+    {
+        if (Server == null)
+        {
+            ManagedIdentitySupported = false;
+            ManagedIdentityBlockedReason = string.Empty;
+            return;
+        }
+
+        try
+        {
+            var support = await _sql.SupportsManagedIdentityCredentialAsync(Server, ct);
+
+            ManagedIdentitySupported = support.IsSupported;
+            ManagedIdentityBlockedReason = support.Explain();
+
+            // An Entra container, and only an Entra container. "Not SAS" is not the same test:
+            // with no container chosen yet, null is not SasToken either - which defaulted the
+            // identity to managed before there was anything to authenticate against, and an
+            // existing test caught it by finding a write where it expected a refusal.
+            if (support.IsSupported && Container is { AuthMode: not BlobAuthMode.SasToken })
+                IdentityToCreate = BlobCredentialIdentity.ManagedIdentity;
+            else if (!support.IsSupported)
+                IdentityToCreate = BlobCredentialIdentity.SharedAccessSignature;
+        }
+        catch
+        {
+            // Not being able to ask is not the same as the answer being no, but it is the same
+            // outcome: without knowing, offering it would risk writing a credential that looks
+            // right and fails at restore time.
+            ManagedIdentitySupported = false;
+            ManagedIdentityBlockedReason =
+                "Could not ask this instance whether it supports managed identity, so the option " +
+                "is not offered - a credential written blind would look correct and fail at " +
+                "restore time.";
+        }
+    }
+
+    /// <summary>Create or update the credential, with the identity currently chosen.</summary>
     [RelayCommand(CanExecute = nameof(CanCreate))]
     private async Task CreateOnServerAsync()
     {
         if (Server == null || Container == null) return;
 
         var sasToken = _store.GetSasToken(Container);
-        if (string.IsNullOrEmpty(sasToken))
+
+        // Only a SAS credential needs one. A managed-identity credential carries no secret at all,
+        // which is the entire point for an estate that forbids them.
+        if (IdentityToCreate == BlobCredentialIdentity.SharedAccessSignature &&
+            string.IsNullOrEmpty(sasToken))
         {
             Reported?.Invoke(
                 "No SAS token stored for this container. Add or refresh the token in Blob Storage config.",
@@ -218,20 +335,44 @@ public partial class ServerCredentialViewModel : ObservableObject
         try
         {
             var change = await _sql.EnsureCredentialExistsAsync(
-                Server, Name, Container.ContainerUrl, sasToken, _writeCancellation.Begin());
+                Server, Name, Container.ContainerUrl, sasToken ?? string.Empty,
+                IdentityToCreate, _writeCancellation.Begin());
+
             await RefreshAsync();
+
             Reported?.Invoke(change switch
             {
+                CredentialChange.Created when CreatingManagedIdentity =>
+                    "Credential created on server, authenticating as the instance's managed identity. " +
+                    BlobCredentialStatement.WhatItStillNeeds,
+
                 CredentialChange.Created => "Credential created on server.",
+
+                // Both directions of a conversion are worth naming. Replacing a managed identity
+                // with a SAS was already called out (#145); replacing a SAS with a managed identity
+                // discards the stored token on the server, which is equally a change to how the
+                // instance authenticates rather than a routine update.
+                _ when CreatingManagedIdentity && replaced == BlobCredentialIdentity.SharedAccessSignature =>
+                    "Credential replaced on server: it held a SAS token and now authenticates as " +
+                    "the instance's managed identity. " + BlobCredentialStatement.WhatItStillNeeds,
+
+                _ when CreatingManagedIdentity =>
+                    "Credential updated on server, authenticating as the instance's managed identity.",
+
                 _ when replaced == BlobCredentialIdentity.ManagedIdentity =>
                     "Credential replaced on server: it authenticated as the instance's managed " +
                     "identity and now holds the stored SAS token.",
+
                 _ => "Credential updated on server with the stored SAS token."
             }, false);
 
-            if (replaced == BlobCredentialIdentity.ManagedIdentity)
+            if (replaced == BlobCredentialIdentity.ManagedIdentity && !CreatingManagedIdentity)
                 _log.ServerChange(Server.ServerName,
                     $"credential [{Name}] identity changed from Managed Identity to SAS");
+
+            if (CreatingManagedIdentity && replaced == BlobCredentialIdentity.SharedAccessSignature)
+                _log.ServerChange(Server.ServerName,
+                    $"credential [{Name}] identity changed from SAS to Managed Identity");
         }
         catch (Exception ex)
         {
@@ -244,10 +385,30 @@ public partial class ServerCredentialViewModel : ObservableObject
     // inside it still works - a SAS that was rotated or has expired looks identical from here.
     // Since Execute no longer rewrites the credential on every run, this button is the only way
     // to push a fresh token, and hiding it left users with no route at all.
-    private bool CanCreate() => Server != null && Container != null;
+    private bool CanCreate() =>
+        Server != null &&
+        Container != null &&
+        (IdentityToCreate != BlobCredentialIdentity.ManagedIdentity || ManagedIdentitySupported);
 
-    partial void OnServerChanged(ServerConnection? value) => CreateOnServerCommand.NotifyCanExecuteChanged();
-    partial void OnContainerChanged(BlobContainerConfig? value) => CreateOnServerCommand.NotifyCanExecuteChanged();
+    partial void OnServerChanged(ServerConnection? value)
+    {
+        CreateOnServerCommand.NotifyCanExecuteChanged();
+
+        // A different instance answers differently, and the answer decides what is offered.
+        _ = RefreshManagedIdentitySupportAsync();
+    }
+
+    partial void OnContainerChanged(BlobContainerConfig? value)
+    {
+        CreateOnServerCommand.NotifyCanExecuteChanged();
+
+        // Which container it is decides which identity can work: an Entra container has no stored
+        // token by design, so a SAS credential is not an option there at all.
+        _ = RefreshManagedIdentitySupportAsync();
+    }
+
+    partial void OnManagedIdentitySupportedChanged(bool value)
+        => CreateOnServerCommand.NotifyCanExecuteChanged();
 
     /// <summary>
     /// What the execute path should do about the credential before it starts, and everything it

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1517,6 +1517,60 @@
                                      Visibility="{Binding CredentialApplies, Converter={StaticResource BoolToVis}}"
                                      ToolTip="Defaults to the container URL. The credential on the server must match this name (container URL) for RESTORE FROM URL." />
 
+                            <!-- Which identity the credential holds (#147).
+
+                                 #29 added Entra ID for browsing because many organisations forbid
+                                 long-lived SAS tokens - and those organisations could then browse
+                                 a container without one and still not restore without one, because
+                                 the credential this app wrote was always a SAS. On an Entra
+                                 container the button failed outright with "no SAS token stored",
+                                 which is true, by design, and useless. -->
+                            <StackPanel Visibility="{Binding CredentialApplies, Converter={StaticResource BoolToVis}}"
+                                        Margin="0,0,0,10">
+                                <TextBlock Text="AUTHENTICATE AS" Style="{StaticResource LabelText}" />
+                                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                                    <RadioButton Content="SAS token"
+                                                 GroupName="CredentialIdentity"
+                                                 Style="{StaticResource DarkRadioButton}"
+                                                 IsChecked="{Binding Credential.IdentityToCreate, Converter={StaticResource EnumToBool}, ConverterParameter=SharedAccessSignature}"
+                                                 Margin="0,0,20,0"
+                                                 ToolTip="The stored token is pushed to the server. Needs a token to have been saved for this container." />
+                                    <RadioButton Content="The instance's managed identity"
+                                                 GroupName="CredentialIdentity"
+                                                 Style="{StaticResource DarkRadioButton}"
+                                                 IsEnabled="{Binding Credential.ManagedIdentitySupported}"
+                                                 IsChecked="{Binding Credential.IdentityToCreate, Converter={StaticResource EnumToBool}, ConverterParameter=ManagedIdentity}"
+                                                 ToolTip="No secret is stored anywhere. Needs SQL Server 2022 or later, or Azure SQL Managed Instance." />
+                                </StackPanel>
+
+                                <!-- Named rather than a bare disabled radio button. Somebody who has
+                                     just been told their organisation forbids SAS tokens, and is now
+                                     told the alternative is unavailable, deserves to know which of
+                                     the two things to go and change. -->
+                                <TextBlock Text="{Binding Credential.ManagedIdentityBlockedReason}"
+                                           Style="{StaticResource SecondaryText}"
+                                           TextWrapping="Wrap"
+                                           FontSize="11"
+                                           Margin="0,8,0,0"
+                                           Visibility="{Binding Credential.ManagedIdentityBlockedReason, Converter={StaticResource NullToVis}}" />
+
+                                <!-- What the credential alone does NOT buy. The statement succeeds
+                                     whether or not the instance has an identity at all, and both
+                                     failures then surface as a 403 at restore time that says
+                                     nothing about which identity was refused - the trap #144
+                                     addressed on the browsing side. -->
+                                <Border CornerRadius="4" Padding="10,8" Margin="0,8,0,0"
+                                        Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                        BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                        BorderThickness="1"
+                                        Visibility="{Binding Credential.CreatingManagedIdentity, Converter={StaticResource BoolToVis}}">
+                                    <TextBlock Text="{Binding Credential.ManagedIdentityCaveat}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap"
+                                               FontSize="11" />
+                                </Border>
+                            </StackPanel>
+
                             <!-- Blob credential: when not connected, prompt to connect to verify; when connected, show status and optional Create -->
                             <Border Background="{DynamicResource InputBackgroundBrush}"
                                     CornerRadius="4" Padding="12,10" Margin="0,0,0,16">
@@ -1602,27 +1656,21 @@
                                                    Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,8">
                                             <Run Text="Execute will leave this credential alone and no SAS token is sent to the server. The instance authenticates to the container as itself, so the restore depends on its identity holding a role on the storage account rather than on anything stored here. The button below would replace that with a SAS credential - which would also change how anything else on this instance reaches the same container." />
                                         </TextBlock>
+                                        <!-- The label says what the press would actually DO, which
+                                             needs both what is on the server and what is about to be
+                                             written - the interesting presses are the ones that turn
+                                             one into the other. A label describing only the current
+                                             state is precisely the bug #145 was, and now that the
+                                             identity is a choice the reverse conversion needs the
+                                             same treatment (#147). Computed rather than triggered,
+                                             because four combinations of two states is a truth table
+                                             and belongs somewhere it can be tested. -->
                                         <Button Command="{Binding Credential.CreateOnServerCommand}"
+                                                Content="{Binding Credential.CreateButtonText}"
                                                 Margin="0,0,0,0" Padding="10,6"
-                                                ToolTip="Creates the SQL Server credential for this blob container URL, or updates an existing one with the SAS token currently stored for the container, so that RESTORE FROM URL can access the backups. An existing credential is altered in place, never dropped. The SAS token is not included in the generated script."
-                                                HorizontalAlignment="Left">
-                                            <Button.Style>
-                                                <Style TargetType="Button" BasedOn="{StaticResource SecondaryButton}">
-                                                    <Setter Property="Content" Value="Create credential on server" />
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding Credential.IsSharedAccessSignature}" Value="True">
-                                                            <Setter Property="Content" Value="Refresh credential with stored SAS token" />
-                                                        </DataTrigger>
-                                                        <!-- Says what the press would actually do. The same button under the
-                                                             old label read as a harmless refresh while it converted the
-                                                             instance's managed identity to a SAS token (#145). -->
-                                                        <DataTrigger Binding="{Binding Credential.IsManagedIdentity}" Value="True">
-                                                            <Setter Property="Content" Value="Replace Managed Identity with stored SAS token" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </Button.Style>
-                                        </Button>
+                                                Style="{StaticResource SecondaryButton}"
+                                                ToolTip="Creates the SQL Server credential for this blob container URL, or updates an existing one, so that RESTORE FROM URL can access the backups. An existing credential is altered in place, never dropped. No secret is ever included in the generated script."
+                                                HorizontalAlignment="Left" />
                                     </StackPanel>
                                 </StackPanel>
                             </Border>


### PR DESCRIPTION
Closes #147.

#145 taught the app to *recognise* a managed-identity credential and leave it alone. It still could not create one, so the SAS-free path #29 opened stopped half way: an organisation that forbids long-lived SAS tokens could browse a container without one and then **not restore** without one, because the credential this app wrote was always a SAS. On an Entra container the button failed outright with *"No SAS token stored"* — true, by design, and useless.

## The statement

A managed-identity credential has **no SECRET at all** — not an empty one. `ALTER` without a `SECRET` is what converts a SAS credential across, nulling the stored secret as it goes. Both directions are proven live, along with the fact that converting does not drop and recreate: a credential is server-scoped, and dropping it even momentarily breaks anything else using it.

## Gated on the instance, which matters more than it looks

`CREATE CREDENTIAL` takes its identity as free **text** on every version. An ungated app writes a credential that looks perfectly fine, sits in `sys.credentials`, reads back correctly — and fails at restore time. Everything says yes until the moment it matters.

The gate is SQL Server 2022 (major version 16) or Azure SQL MI. A refusal **names the version it found** rather than saying "not supported": somebody who has just been told their organisation forbids SAS tokens, and is now told the alternative is unavailable, deserves to know which of the two things to go and change. Not being able to *ask* has the same outcome as a no, for the same reason.

## Says what the credential alone does not buy

The statement succeeds whether or not the instance has an identity at all, and whether or not that identity can read the container. Both surface as a 403 at restore time that says nothing about which identity was refused — the trap #144 addressed for browsing. So the caveat sits next to the option: the instance needs a managed identity, and that identity needs **Storage Blob Data Reader** on the container. Owner and Contributor are not enough.

## Two things rendering it caught

- The button still offered to **"refresh with stored SAS token"** while managed identity was selected. It read what was *on the server* rather than what was about to be *written* — the #145 bug in reverse. It is now a computed label over both, because four combinations of two states is a truth table and belongs somewhere testable.
- An existing test caught a **null container being read as "not SAS"**, which defaulted the identity to managed before there was anything to authenticate against.

## The restore script is unchanged

`RESTORE ... FROM URL` matches its credential by URL prefix with no `WITH CREDENTIAL` clause, whichever identity it holds — which keeps the blast radius to the credential plumbing and the panel.

## What is not proven

That a restore actually **authenticates** with a managed identity. That needs an Azure VM with an identity, an Arc-enabled instance, or SQL MI, and everything here is on-prem. The live tests for the statement, the conversion in both directions, the create_date check and the version gate are written and skip without `NINELIVES_TEST_SQL` — the same position #26 left the VERIFYONLY live test in. I tried them against localhost; there is no instance there.

1,267 tests pass, 6 live tests skipped.