### PR TITLE
Finish the deduplication items still outstanding in #42

### DIFF
--- a/src/NineLives.Tests/CopyPathTests.cs
+++ b/src/NineLives.Tests/CopyPathTests.cs
@@ -1,0 +1,51 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The two screens that list blobs copy the same path (#42).
+///
+/// They had a copy of this each, identical apart from a null check. Worth sharing rather than
+/// leaving alone because these paths get pasted into tickets and scripts, and a divergence where
+/// one of them started including a SAS token would be genuinely dangerous - a token in a ticket is
+/// a token in whatever the ticket system indexes.
+/// </summary>
+public class CopyPathTests
+{
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = "c1",
+        Name = "backups",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups"
+    };
+
+    /// <summary>
+    /// No SAS token, ever. The URL is built for a human to read, not for a machine to authenticate
+    /// with - and the app never displays stored tokens anywhere else either.
+    /// </summary>
+    [Fact]
+    public void TheHttpsPathCarriesNoToken()
+    {
+        var container = Container();
+        container.CacheSasToken("sv=2026-01-01&sig=SHOULDNOTAPPEAR");
+
+        var url = BlobStorageService.BuildBlobUrl(container, "FULL/SRV01/MyDb/full.bak");
+
+        Assert.Equal("https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/full.bak", url);
+        Assert.DoesNotContain("sig=", url);
+        Assert.DoesNotContain("?", url);
+    }
+
+    [Fact]
+    public void ATrailingSlashOnTheContainerUrlDoesNotDoubleUp()
+    {
+        var container = Container();
+        container.ContainerUrl = "https://acct.blob.core.windows.net/backups/";
+
+        var url = BlobStorageService.BuildBlobUrl(container, "full.bak");
+
+        Assert.DoesNotContain("backups//full.bak", url);
+    }
+}

--- a/src/NineLives/Models/BlobContainerConfig.cs
+++ b/src/NineLives/Models/BlobContainerConfig.cs
@@ -109,7 +109,18 @@ public class BlobContainerConfig : INotifyPropertyChanged
     /// Supported tokens: {BackupType}, {ServerName}, {InstanceName}, {DatabaseName}, {FileName}
     /// Default: {BackupType}/{ServerName}/{DatabaseName}/{FileName}
     /// </summary>
-    public string PathPattern { get; set; } = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
+    public string PathPattern { get; set; } = DefaultPathPattern;
+
+    /// <summary>
+    /// The layout the app assumes when nobody has said otherwise - Ola Hallengren's, which is what
+    /// most containers this points at were written by.
+    ///
+    /// One constant rather than five copies of the literal (#42). It was written out separately in
+    /// the config default, the edit form's initial value, the reset-to-default, the AG fallback and
+    /// the "new container" default - so changing the app's idea of a default meant finding all five,
+    /// and a container created from one path could disagree with the pattern used to read it back.
+    /// </summary>
+    public const string DefaultPathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
 
     /// <summary>
     /// When BackupSourceType is Mixed or AvailabilityGroup, optional path pattern for AG backups.

--- a/src/NineLives/Services/BlobStorageService.cs
+++ b/src/NineLives/Services/BlobStorageService.cs
@@ -317,7 +317,7 @@ public class BlobStorageService : IBlobStorageService
 
             if (!file.IsAgDefaultNaming)
             {
-                var agPattern = config.AgPathPattern ?? "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
+                var agPattern = config.AgPathPattern ?? BlobContainerConfig.DefaultPathPattern;
                 if (pathParts.Length > 1 && config.BackupSourceType == BackupSourceType.AvailabilityGroup)
                 {
                     // AG container with path: e.g. BackupType/ClusterName$AGName/DatabaseName/FileName

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -287,22 +287,14 @@ public partial class BlobBrowserViewModel : ViewModelBase
     private static bool MatchesServerSet(BackupSet set, string serverFilter)
         => set.MatchesServer(serverFilter);
 
+    // The ?? SelectedFile is the one real difference between the two screens and is kept: here the
+    // command is also reachable from a toolbar button with no row passed, where falling back to the
+    // selection is what makes it work at all.
     [RelayCommand]
     private void CopyPathHttps(BackupFileInfo? file)
-    {
-        var target = file ?? SelectedFile;
-        if (target == null || SelectedContainer == null) return;
-        TryCopyToClipboard(
-            BlobStorageService.BuildBlobUrl(SelectedContainer, target.BlobName),
-            "HTTPS path copied to clipboard (no SAS token).");
-    }
+        => CopyBlobHttpsPath(file ?? SelectedFile, SelectedContainer);
 
     [RelayCommand]
     private void CopyPathContainer(BackupFileInfo? file)
-    {
-        var target = file ?? SelectedFile;
-        if (target == null || SelectedContainer == null) return;
-        var containerName = SelectedContainer.ContainerName ?? "container";
-        TryCopyToClipboard($"{containerName}/{target.BlobName}", "Container path copied to clipboard.");
-    }
+        => CopyBlobContainerPath(file ?? SelectedFile, SelectedContainer);
 }

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -51,7 +51,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     private string _editSasToken = string.Empty;
 
     [ObservableProperty]
-    private string _editPathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
+    private string _editPathPattern = BlobContainerConfig.DefaultPathPattern;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsMixedSourceType))]
@@ -382,7 +382,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     private void SyncAgPathElementsFromPattern()
     {
         var pattern = string.IsNullOrWhiteSpace(EditAgPathPattern)
-            ? "{BackupType}/{ServerName}/{DatabaseName}/{FileName}"
+            ? BlobContainerConfig.DefaultPathPattern
             : EditAgPathPattern;
         var active = PathElement.ParsePattern(pattern);
         AgActivePathElements = new ObservableCollection<PathElement>(active);
@@ -453,7 +453,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditContainerUrl = string.Empty;
         EditAuthMode = BlobAuthMode.SasToken;
         EditSasToken = string.Empty;
-        EditPathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}";
+        EditPathPattern = BlobContainerConfig.DefaultPathPattern;
         EditBackupSourceType = BackupSourceType.Standalone;
         EditAgPathPattern = null;
         EditBackupServerTimeZone = TimeZoneOption.Unknown;

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1568,21 +1568,10 @@ public partial class RestoreViewModel : ViewModelBase
         => TryCopyToClipboard(GeneratedScript, "Script copied to clipboard.");
 
     [RelayCommand]
-    private void CopyPathHttps(BackupFileInfo? file)
-    {
-        if (file == null || SelectedContainer == null) return;
-        TryCopyToClipboard(
-            BlobStorageService.BuildBlobUrl(SelectedContainer, file.BlobName),
-            "HTTPS path copied to clipboard (no SAS token).");
-    }
+    private void CopyPathHttps(BackupFileInfo? file) => CopyBlobHttpsPath(file, SelectedContainer);
 
     [RelayCommand]
-    private void CopyPathContainer(BackupFileInfo? file)
-    {
-        if (file == null || SelectedContainer == null) return;
-        var containerName = SelectedContainer.ContainerName ?? "container";
-        TryCopyToClipboard($"{containerName}/{file.BlobName}", "Container path copied to clipboard.");
-    }
+    private void CopyPathContainer(BackupFileInfo? file) => CopyBlobContainerPath(file, SelectedContainer);
 
     [RelayCommand(CanExecute = nameof(CanFetchLogicalNames))]
     private async Task FetchLogicalNamesAsync()

--- a/src/NineLives/ViewModels/ViewModelBase.cs
+++ b/src/NineLives/ViewModels/ViewModelBase.cs
@@ -1,5 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Windows;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -87,6 +89,32 @@ public abstract partial class ViewModelBase : ObservableObject
     /// clipboard managers, and it was reproduced while the issue was being written. A failed copy
     /// deserves a line in the status bar, not a crash.
     /// </summary>
+    /// <summary>
+    /// Copies a backup's full HTTPS path, without a SAS token.
+    ///
+    /// Shared because it was written twice, identically apart from a null check, on the two screens
+    /// that list blobs (#42). Both feed a context menu on a file row, and a path that differs
+    /// between them - one with a token, one without - would be a genuinely dangerous divergence:
+    /// these get pasted into tickets.
+    /// </summary>
+    protected void CopyBlobHttpsPath(BackupFileInfo? file, BlobContainerConfig? container)
+    {
+        if (file == null || container == null) return;
+
+        TryCopyToClipboard(
+            BlobStorageService.BuildBlobUrl(container, file.BlobName),
+            "HTTPS path copied to clipboard (no SAS token).");
+    }
+
+    /// <summary>The container-relative path, for pasting into SSMS or a script.</summary>
+    protected void CopyBlobContainerPath(BackupFileInfo? file, BlobContainerConfig? container)
+    {
+        if (file == null || container == null) return;
+
+        var containerName = container.ContainerName ?? "container";
+        TryCopyToClipboard($"{containerName}/{file.BlobName}", "Container path copied to clipboard.");
+    }
+
     protected bool TryCopyToClipboard(string? text, string successMessage)
     {
         if (string.IsNullOrEmpty(text)) return false;


### PR DESCRIPTION
Most of #42's list has been done in passing since it was written — the byte formatter, `MatchesServerSet` ignoring the instance, the delete confirmation, config-corruption reporting, the dead `RestoreOptions` fields and the `null!` annotations are all already gone. I checked each before touching anything.

Two were genuinely outstanding.

## The default path pattern was a literal in five places

The config default, the edit form's initial value, the reset-to-default, the AG fallback and the new-container default. Changing the app's idea of a default meant finding all five — and a container created from one could disagree with the pattern used to read it back.

## The copy-path commands existed twice

Identical apart from a null check. Shared onto the base, with the one real difference kept and explained: the browser's version also serves a toolbar button with no row passed, where falling back to the selection is what makes it work at all.

Worth sharing rather than leaving alone, because these paths get pasted into tickets and scripts. A divergence where one screen started including a SAS token would be genuinely dangerous — a token in a ticket is a token in whatever indexes the ticket. Pinned by a test that the HTTPS path carries no token even when one is cached.

1,270 tests pass.

I have left the remaining #42 items alone deliberately: the standalone-vs-AG path builder deduplication is a real refactor of drag-and-drop code with no test coverage, and `RefreshContainers` on the two screens now genuinely does different things.