### PR TITLE
Warn before a restore that cannot physically fit (#32)

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -180,6 +180,20 @@ public sealed class FakeSqlServerService : ISqlServerService
     public Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
         => Task.FromResult(DatabaseList);
 
+    /// <summary>What the fake instance says it has free, by mount point.</summary>
+    public Dictionary<string, long> VolumeFreeSpace { get; set; } = [];
+
+    /// <summary>Set to make asking about volumes fail - which must not become a warning (#32).</summary>
+    public Exception? VolumeCheckThrows { get; set; }
+
+    public Task<Dictionary<string, long>> GetVolumeFreeSpaceAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        if (VolumeCheckThrows != null) throw VolumeCheckThrows;
+
+        return Task.FromResult(VolumeFreeSpace);
+    }
+
     public Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(ServerConnection server, CancellationToken ct = default)
         => Task.FromResult((@"D:\Data", @"D:\Logs"));
 
@@ -190,9 +204,12 @@ public sealed class FakeSqlServerService : ISqlServerService
     public Task ExecuteRecoveryActionAsync(ServerConnection server, string sql, CancellationToken ct = default)
         => Task.CompletedTask;
 
+    /// <summary>The logical files the fake backup contains, with their sizes (#32).</summary>
+    public List<FileMoveOption> FileList { get; set; } = [];
+
     public Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
         ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
-        => Task.FromResult(new List<FileMoveOption>());
+        => Task.FromResult(FileList);
 
     /// <summary>What the fake instance reads out of a backup header, or null for nothing.</summary>
     public BackupFileInfo? Header { get; set; }

--- a/src/NineLives.Tests/RestoreSpaceCheckTests.cs
+++ b/src/NineLives.Tests/RestoreSpaceCheckTests.cs
@@ -1,0 +1,180 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Whether a restore can physically fit, asked before it starts (#32).
+///
+/// A restore that runs out of disk fails part-way - and by then WITH REPLACE has already dropped
+/// the database it was replacing, so the target is gone and the replacement is incomplete. That is
+/// the worst outcome this app can produce, and it is entirely predictable: FILELISTONLY already
+/// reports how big each file will be, and SQL Server already knows how much room each volume has.
+/// The app was reading the first number and throwing it away.
+/// </summary>
+public class RestoreSpaceCheckTests
+{
+    private const long Gb = 1024L * 1024 * 1024;
+
+    private static FileMoveOption File_(string to, long sizeBytes) => new()
+    {
+        LogicalName = "MyDb",
+        PhysicalName = @"E:\Original\MyDb.mdf",
+        Type = "D",
+        NewPhysicalName = to,
+        SizeBytes = sizeBytes
+    };
+
+    // ── the arithmetic that matters ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Per VOLUME, not per file. Four 10 GB files on one drive is 40 GB, and checking them
+    /// individually would pass every one of them while the restore still fails.
+    /// </summary>
+    [Fact]
+    public void FilesLandingOnTheSameVolumeAreAddedUp()
+    {
+        var volumes = RestoreSpaceCheck.Check(
+        [
+            File_(@"D:\Data\a.mdf", 10 * Gb),
+            File_(@"D:\Data\b.ndf", 10 * Gb),
+            File_(@"D:\Data\c.ndf", 10 * Gb),
+            File_(@"D:\Data\d.ndf", 10 * Gb)
+        ],
+        new Dictionary<string, long> { [@"D:\"] = 25 * Gb });
+
+        var volume = Assert.Single(volumes);
+
+        Assert.Equal(40 * Gb, volume.RequiredBytes);
+        Assert.False(volume.Fits);
+        Assert.Equal(15 * Gb, volume.ShortfallBytes);
+    }
+
+    /// <summary>Data and log on different drives is the normal arrangement, and each is its own question.</summary>
+    [Fact]
+    public void EachVolumeIsAnsweredSeparately()
+    {
+        var volumes = RestoreSpaceCheck.Check(
+        [
+            File_(@"D:\Data\MyDb.mdf", 100 * Gb),
+            File_(@"L:\Logs\MyDb_log.ldf", 10 * Gb)
+        ],
+        new Dictionary<string, long> { [@"D:\"] = 200 * Gb, [@"L:\"] = 5 * Gb });
+
+        Assert.Equal(2, volumes.Count);
+        Assert.True(volumes.Single(v => v.Volume == @"D:\").Fits);
+        Assert.False(volumes.Single(v => v.Volume == @"L:\").Fits);
+    }
+
+    [Fact]
+    public void ARestoreThatFitsSaysNothing()
+    {
+        var volumes = RestoreSpaceCheck.Check(
+            [File_(@"D:\Data\MyDb.mdf", 10 * Gb)],
+            new Dictionary<string, long> { [@"D:\"] = 500 * Gb });
+
+        Assert.True(Assert.Single(volumes).Fits);
+        Assert.Equal(string.Empty, RestoreSpaceCheck.Warn(volumes));
+    }
+
+    /// <summary>
+    /// The warning says what would happen, not just that something is tight. WITH REPLACE having
+    /// already dropped the target is the part somebody needs to weigh.
+    /// </summary>
+    [Fact]
+    public void TheWarningSaysWhatWouldActuallyHappen()
+    {
+        var volumes = RestoreSpaceCheck.Check(
+            [File_(@"D:\Data\MyDb.mdf", 100 * Gb)],
+            new Dictionary<string, long> { [@"D:\"] = 10 * Gb });
+
+        var warning = RestoreSpaceCheck.Warn(volumes);
+
+        Assert.Contains("may not fit", warning);
+        Assert.Contains("short by", warning);
+        Assert.Contains("dropped before that happens", warning);
+    }
+
+    // ── where the files are actually going ──────────────────────────────────────
+
+    /// <summary>
+    /// The path the restore will WRITE to, not the one recorded in the backup. Checking the source's
+    /// path would measure a drive on a different machine - and with WITH MOVE in use, the whole
+    /// point is that the two differ.
+    /// </summary>
+    [Fact]
+    public void TheVolumeCheckedIsWhereTheFileIsGoingNotWhereItCameFrom()
+    {
+        var file = File_(@"D:\Data\MyDb.mdf", 10 * Gb);
+        file.PhysicalName = @"Z:\SomewhereElse\MyDb.mdf";
+
+        var volume = Assert.Single(RestoreSpaceCheck.Check(
+            [file], new Dictionary<string, long> { [@"D:\"] = 500 * Gb, [@"Z:\"] = 0 }));
+
+        Assert.Equal(@"D:\", volume.Volume);
+        Assert.True(volume.Fits);
+    }
+
+    [Theory]
+    [InlineData(@"D:\Data\MyDb.mdf", @"D:\")]
+    [InlineData(@"d:\data\mydb.mdf", @"D:\")]
+    [InlineData(@"E:\MyDb.mdf", @"E:\")]
+    public void AVolumeIsTheDriveAPathLandsOn(string path, string expected)
+        => Assert.Equal(expected, RestoreSpaceCheck.VolumeOf(path));
+
+    /// <summary>
+    /// A UNC path has no drive letter, and dm_os_volume_stats does not describe a share - so this
+    /// check simply does not cover it, and says so by not inventing an answer.
+    /// </summary>
+    [Theory]
+    [InlineData(@"\\nas01\sql\MyDb.mdf")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void APathWithNoDriveLetterIsNotGuessedAt(string? path)
+        => Assert.Null(RestoreSpaceCheck.VolumeOf(path));
+
+    // ── not knowing is not the same as fitting ──────────────────────────────────
+
+    /// <summary>
+    /// A volume the target never reported on comes back as having nothing, so it is raised rather
+    /// than silently passing. sys.dm_os_volume_stats only sees volumes the instance already has a
+    /// database file on, so a brand-new empty drive is exactly this case.
+    /// </summary>
+    [Fact]
+    public void AVolumeTheServerSaidNothingAboutIsReportedRatherThanAssumedFine()
+    {
+        var volumes = RestoreSpaceCheck.Check(
+            [File_(@"X:\Data\MyDb.mdf", 10 * Gb)],
+            new Dictionary<string, long> { [@"D:\"] = 500 * Gb });
+
+        var volume = Assert.Single(volumes);
+
+        Assert.Equal(@"X:\", volume.Volume);
+        Assert.False(volume.Fits);
+    }
+
+    /// <summary>
+    /// A mount point may or may not carry its trailing separator depending on how it was mounted,
+    /// so a miss on the exact string is not yet a miss.
+    /// </summary>
+    [Fact]
+    public void AMountPointReportedWithoutItsSeparatorStillMatches()
+    {
+        var volumes = RestoreSpaceCheck.Check(
+            [File_(@"D:\Data\MyDb.mdf", 10 * Gb)],
+            new Dictionary<string, long> { ["D:"] = 500 * Gb });
+
+        Assert.True(Assert.Single(volumes).Fits);
+    }
+
+    [Fact]
+    public void FilesOnAShareAreLeftOutRatherThanCountedAgainstNothing()
+    {
+        var volumes = RestoreSpaceCheck.Check(
+            [File_(@"\\nas01\sql\MyDb.mdf", 10 * Gb)],
+            new Dictionary<string, long> { [@"D:\"] = 500 * Gb });
+
+        Assert.Empty(volumes);
+    }
+}

--- a/src/NineLives.Tests/SpaceCheckOnTheScreenTests.cs
+++ b/src/NineLives.Tests/SpaceCheckOnTheScreenTests.cs
@@ -1,0 +1,148 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The space check as the Restore screen runs it (#32).
+///
+/// The behaviour that needs holding down is what happens when the check CANNOT be made. This is a
+/// courtesy check over somebody else's storage, and an instance that will not report its volumes -
+/// permissions, an edition that does not expose the DMV - must not turn that into a frightening
+/// message about a restore that is very probably fine.
+/// </summary>
+public class SpaceCheckOnTheScreenTests
+{
+    private const long Gb = 1024L * 1024 * 1024;
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static (RestoreViewModel vm, FakeSqlServerService sql) New()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        { Id = "c1", Name = "backups", ContainerUrl = "https://acct.blob.core.windows.net/backups" });
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = "FULL/SRV01/MyDb/MyDb_FULL_20260801_220000.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/MyDb_FULL_20260801_220000.bak",
+                    Type = BackupType.Full,
+                    InferredDatabaseName = "MyDb",
+                    InferredServerName = "SRV01",
+                    LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+                }
+            ]
+        };
+
+        var sql = new FakeSqlServerService
+        {
+            FileList =
+            [
+                new FileMoveOption
+                {
+                    LogicalName = "MyDb", Type = "ROWS",
+                    PhysicalName = @"E:\Source\MyDb.mdf",
+                    NewPhysicalName = @"D:\Data\MyDb.mdf",
+                    SizeBytes = 100 * Gb
+                }
+            ]
+        };
+
+        var vm = new RestoreViewModel(
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            TestLogs.Temp(), new FakeRestoreHistoryStore(), TestAuditStores.Temp());
+
+        vm.RefreshContainers();
+        vm.ConnectedServer = new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+        vm.IsConnectedToServer = true;
+
+        // Where the files will actually land. The screen rewrites every NewPhysicalName to these
+        // when it reads the logical names, so THESE are the volumes the check must measure - not
+        // the paths recorded inside the backup, which belong to the source machine.
+        vm.MoveDataFilePath = @"D:\Data\MyDb.mdf";
+        vm.MoveLogFilePath = @"D:\Logs\MyDb_log.ldf";
+
+        return (vm, sql);
+    }
+
+    private static async Task ReadyAsync(RestoreViewModel vm)
+    {
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.Inventory.SelectedServerName = "SRV01";
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Last();
+        await vm.FetchLogicalNamesCommand.ExecuteAsync(null);
+    }
+
+    [Fact]
+    public async Task ARestoreThatDoesNotFitIsWarnedAbout()
+    {
+        var (vm, sql) = New();
+        sql.VolumeFreeSpace = new Dictionary<string, long> { [@"D:\"] = 10 * Gb };
+
+        await ReadyAsync(vm);
+
+        Assert.True(vm.HasSpaceWarning);
+        Assert.Contains("short by", vm.SpaceWarning);
+    }
+
+    [Fact]
+    public async Task ARestoreThatFitsSaysNothing()
+    {
+        var (vm, sql) = New();
+        sql.VolumeFreeSpace = new Dictionary<string, long> { [@"D:\"] = 500 * Gb };
+
+        await ReadyAsync(vm);
+
+        Assert.False(vm.HasSpaceWarning,
+            "volumes: " + string.Join(" | ", vm.VolumeSpace.Select(v => v.Describe)));
+        Assert.True(vm.VolumeSpace.All(v => v.Fits));
+    }
+
+    /// <summary>
+    /// The part worth guarding. Not being able to ask is not the same as the answer being no - and
+    /// unlike the shared-path readability check, where refusing was right, here a false alarm about
+    /// somebody else's storage is the greater harm. Logged, not shown.
+    /// </summary>
+    [Fact]
+    public async Task AnInstanceThatWillNotReportItsVolumesRaisesNoAlarm()
+    {
+        var (vm, sql) = New();
+        sql.VolumeCheckThrows = new InvalidOperationException("no permission on the DMV");
+
+        await ReadyAsync(vm);
+
+        Assert.False(vm.HasSpaceWarning);
+        Assert.False(vm.HasError);
+        Assert.Empty(vm.VolumeSpace);
+    }
+
+    /// <summary>
+    /// And it comes with the file list rather than as a separate step: the sizes were in that same
+    /// result set, so this costs one query rather than another read of the backup.
+    /// </summary>
+    [Fact]
+    public async Task TheCheckHappensWhenTheFileNamesAreRead()
+    {
+        var (vm, sql) = New();
+        sql.VolumeFreeSpace = new Dictionary<string, long> { [@"D:\"] = 500 * Gb };
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.Inventory.SelectedServerName = "SRV01";
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Last();
+
+        Assert.Empty(vm.VolumeSpace);
+
+        await vm.FetchLogicalNamesCommand.ExecuteAsync(null);
+
+        Assert.NotEmpty(vm.VolumeSpace);
+    }
+}

--- a/src/NineLives/Models/RestoreOptions.cs
+++ b/src/NineLives/Models/RestoreOptions.cs
@@ -66,6 +66,16 @@ public partial class FileMoveOption : ObservableObject
     public string PhysicalName { get; set; } = string.Empty;
     public string Type { get; set; } = string.Empty;
 
+    /// <summary>
+    /// How big this file will be once restored, from RESTORE FILELISTONLY's Size column.
+    ///
+    /// It was being read and discarded. Summed per volume against what the target says it has free,
+    /// it answers whether the restore can physically fit - which matters because a restore that
+    /// runs out of disk fails part-way, after WITH REPLACE has already dropped the database it was
+    /// replacing (#32).
+    /// </summary>
+    public long SizeBytes { get; set; }
+
     [ObservableProperty]
     private string _newPhysicalName = string.Empty;
 }

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -20,6 +20,15 @@ public interface ISqlServerService
 
     Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default);
 
+    /// <summary>
+    /// What each volume on this instance has free, keyed by mount point (#32).
+    ///
+    /// Asked of the SERVER rather than measured from here: this app's process may not see those
+    /// volumes at all, and where it can, what it sees is not what the service account writes to.
+    /// </summary>
+    Task<Dictionary<string, long>> GetVolumeFreeSpaceAsync(
+        ServerConnection server, CancellationToken ct = default);
+
     Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(
         ServerConnection server, CancellationToken ct = default);
 

--- a/src/NineLives/Services/RestoreSpaceCheck.cs
+++ b/src/NineLives/Services/RestoreSpaceCheck.cs
@@ -1,0 +1,125 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>What one volume the restore writes to has, and needs.</summary>
+/// <param name="Volume">The mount point as SQL Server reports it, e.g. <c>D:\</c>.</param>
+/// <param name="RequiredBytes">The size of the database files landing there.</param>
+/// <param name="FreeBytes">What the volume has left, as the SQL Server service account sees it.</param>
+public sealed record VolumeSpace(string Volume, long RequiredBytes, long FreeBytes)
+{
+    public bool Fits => FreeBytes >= RequiredBytes;
+
+    public long ShortfallBytes => Math.Max(0, RequiredBytes - FreeBytes);
+
+    /// <summary>
+    /// A property, not a method: a binding cannot call one, and WPF renders nothing and says
+    /// nothing when asked to - which shipped as an empty panel once already this week (#130).
+    /// </summary>
+    public string Describe =>
+        Fits
+            ? $"{Volume} needs {ByteSize.Format(RequiredBytes)} and has {ByteSize.Format(FreeBytes)} free."
+            : $"{Volume} needs {ByteSize.Format(RequiredBytes)} and has only " +
+              $"{ByteSize.Format(FreeBytes)} free - short by {ByteSize.Format(ShortfallBytes)}.";
+}
+
+/// <summary>
+/// Whether a restore can physically fit before it is started (#32).
+///
+/// A restore that runs out of disk fails part-way, and by then WITH REPLACE has already dropped the
+/// database it was replacing - so the target is gone and the thing that was going to replace it is
+/// incomplete. That is the worst outcome this app can produce, and it is entirely predictable:
+/// RESTORE FILELISTONLY already reports how big each file will be, and SQL Server already knows how
+/// much room each volume has.
+///
+/// Both numbers come from the TARGET instance rather than from here, for the same reason the
+/// shared-path readability check does: the app's process may not even be able to see those volumes,
+/// and where it can, what it sees is not necessarily what the service account can write to.
+/// </summary>
+public static class RestoreSpaceCheck
+{
+    /// <summary>
+    /// What each volume needs, given where the files are actually going.
+    ///
+    /// Grouped by volume rather than reported per file, because the question is whether the volume
+    /// fits the total - four files of 10 GB on one drive is 40 GB, and checking them individually
+    /// would pass each one while the restore still fails.
+    /// </summary>
+    /// <param name="files">
+    /// The logical files, with the paths the restore will actually write to - which is
+    /// <c>NewPhysicalName</c>, not the source's path, or this checks the wrong drive entirely.
+    /// </param>
+    /// <param name="freeByVolume">What each volume has left, as the target reported it.</param>
+    public static List<VolumeSpace> Check(
+        IEnumerable<FileMoveOption> files, IReadOnlyDictionary<string, long> freeByVolume)
+    {
+        var required = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in files)
+        {
+            var volume = VolumeOf(file.NewPhysicalName);
+            if (volume == null) continue;
+
+            required[volume] = required.GetValueOrDefault(volume) + Math.Max(0, file.SizeBytes);
+        }
+
+        return required
+            .Select(pair => new VolumeSpace(
+                pair.Key,
+                pair.Value,
+                // A volume the target did not report on is treated as having nothing, so it is
+                // reported rather than silently passing. Not knowing is not the same as fitting.
+                MatchVolume(freeByVolume, pair.Key)))
+            .OrderBy(v => v.Volume, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>
+    /// The volume a path lands on: <c>D:\Data\MyDb.mdf</c> to <c>D:\</c>.
+    ///
+    /// A UNC path has no drive letter and comes back null rather than being guessed at - SQL Server
+    /// can restore to a share, and sys.dm_os_volume_stats does not describe one, so the honest
+    /// answer is that this check does not cover it.
+    /// </summary>
+    public static string? VolumeOf(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+        if (path.StartsWith(@"\\", StringComparison.Ordinal)) return null;
+        if (path.Length < 2 || path[1] != ':') return null;
+
+        return path[..2].ToUpperInvariant() + @"\";
+    }
+
+    private static long MatchVolume(IReadOnlyDictionary<string, long> freeByVolume, string volume)
+    {
+        if (freeByVolume.TryGetValue(volume, out var free)) return free;
+
+        // sys.dm_os_volume_stats reports a mount point that may or may not carry the trailing
+        // separator depending on how the volume was mounted, so a miss on the exact string is not
+        // yet a miss.
+        var trimmed = volume.TrimEnd('\\');
+        foreach (var (key, value) in freeByVolume)
+            if (string.Equals(key.TrimEnd('\\'), trimmed, StringComparison.OrdinalIgnoreCase))
+                return value;
+
+        return 0;
+    }
+
+    /// <summary>
+    /// What to say before starting, or empty when everything fits.
+    ///
+    /// Deliberately not a refusal. SQL Server can grow a file onto space that frees up, a volume can
+    /// be extended while the restore runs, and this app is not the authority on somebody else's
+    /// storage - but a restore that is 200 GB short is worth stopping to look at.
+    /// </summary>
+    public static string Warn(IReadOnlyList<VolumeSpace> volumes)
+    {
+        var tight = volumes.Where(v => !v.Fits).ToList();
+        if (tight.Count == 0) return string.Empty;
+
+        return "This restore may not fit. " + string.Join(" ", tight.Select(v => v.Describe)) +
+               " The restore would fail part-way, and with WITH REPLACE the database being " +
+               "restored over is dropped before that happens - so it would be gone and the " +
+               "replacement incomplete.";
+    }
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -411,7 +411,11 @@ public class SqlServerService : ISqlServerService
                     LogicalName = reader.GetString(reader.GetOrdinal("LogicalName")),
                     PhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName")),
                     Type = reader.GetString(reader.GetOrdinal("Type")),
-                    NewPhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName"))
+                    NewPhysicalName = reader.GetString(reader.GetOrdinal("PhysicalName")),
+
+                    // Already in the result set and previously discarded. It is what makes a
+                    // disk-space preflight possible without a second round trip (#32).
+                    SizeBytes = GetLongFromReader(reader, "Size") ?? 0
                 });
             }
             return files;
@@ -799,6 +803,30 @@ public class SqlServerService : ISqlServerService
     }
 
     /// <summary>RESTORE HEADERONLY returns BackupType as tinyint/smallint; avoid invalid cast.</summary>
+    /// <summary>
+    /// A whole number that may arrive as any width SQL Server felt like.
+    ///
+    /// FILELISTONLY's Size is numeric(20,0) and dm_os_volume_stats' available_bytes is bigint, so
+    /// neither fits an int and both can arrive as decimal - which is what caught the
+    /// family_sequence_number tinyint before this pattern existed.
+    /// </summary>
+    private static long? GetLongFromReader(SqlDataReader reader, string columnName)
+    {
+        var ordinal = reader.GetOrdinal(columnName);
+        if (reader.IsDBNull(ordinal)) return null;
+
+        return reader.GetValue(ordinal) switch
+        {
+            long l => l,
+            int i => i,
+            short sh => sh,
+            byte b => b,
+            decimal d => (long)d,
+            double db => (long)db,
+            _ => null
+        };
+    }
+
     private static int? GetIntFromReader(SqlDataReader reader, string columnName)
     {
         var ordinal = reader.GetOrdinal(columnName);
@@ -1039,6 +1067,50 @@ public class SqlServerService : ISqlServerService
 
         return new ManagedIdentitySupport(
             BlobCredentialStatement.SupportsManagedIdentity(version, edition), version, edition);
+    }
+
+    /// <summary>
+    /// What each volume on the target has left, keyed by mount point (#32).
+    ///
+    /// Asked of the TARGET rather than measured from here, for the same reason the shared-path
+    /// readability check is: this app's process may not be able to see those volumes at all, and
+    /// where it can, what it sees is not necessarily what the SQL Server service account can write
+    /// to. sys.dm_os_volume_stats reports what the engine itself can see.
+    ///
+    /// Only volumes the instance already has a database file on are visible to it, which is the
+    /// limitation of this approach - a brand-new drive with nothing on it does not appear, and a
+    /// restore aimed there is simply not covered rather than being reported as full.
+    /// </summary>
+    public async Task<Dictionary<string, long>> GetVolumeFreeSpaceAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        var free = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+
+        cmd.CommandText = @"
+            SELECT DISTINCT
+                vs.volume_mount_point AS MountPoint,
+                vs.available_bytes    AS AvailableBytes
+            FROM sys.master_files AS mf
+            CROSS APPLY sys.dm_os_volume_stats(mf.database_id, mf.file_id) AS vs";
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var mount = reader["MountPoint"]?.ToString();
+            if (string.IsNullOrWhiteSpace(mount)) continue;
+
+            // Largest wins on a duplicate: the same mount point can be reported more than once, and
+            // understating free space would produce a warning that is not true.
+            var available = GetLongFromReader(reader, "AvailableBytes") ?? 0;
+            if (!free.TryGetValue(mount, out var existing) || available > existing)
+                free[mount] = available;
+        }
+
+        return free;
     }
 
     public async Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1528,6 +1528,61 @@ public partial class RestoreViewModel : ViewModelBase
         return fileMoves;
     }
 
+    // ── will it fit (#32) ───────────────────────────────────────────────────────
+    //
+    // A restore that runs out of disk fails part-way, and by then WITH REPLACE has already dropped
+    // the database it was replacing - so the target is gone and the replacement is incomplete. That
+    // is the worst outcome this screen can produce and it is entirely predictable: FILELISTONLY
+    // already reports how big each file will be, and the instance already knows what it has free.
+
+    /// <summary>Per-volume space, once the file list and the server's volumes are both known.</summary>
+    [ObservableProperty]
+    private ObservableCollection<VolumeSpace> _volumeSpace = [];
+
+    /// <summary>What to say about it, or empty when everything fits.</summary>
+    [ObservableProperty]
+    private string _spaceWarning = string.Empty;
+
+    public bool HasSpaceWarning => SpaceWarning.Length > 0;
+
+    partial void OnSpaceWarningChanged(string value) => OnPropertyChanged(nameof(HasSpaceWarning));
+
+    /// <summary>
+    /// Asks the target what it has free and compares it with what the restore will write.
+    ///
+    /// Failing to answer is not a warning. This is a courtesy check over somebody else's storage,
+    /// and an instance that will not report its volumes - permissions, an edition that does not
+    /// expose the DMV - must not turn that into a scary message about a restore that is probably
+    /// fine.
+    /// </summary>
+    private async Task CheckSpaceAsync(CancellationToken ct)
+    {
+        VolumeSpace = [];
+        SpaceWarning = string.Empty;
+
+        if (ConnectedServer == null || FetchedFileMoves.Count == 0) return;
+
+        try
+        {
+            var free = await _sqlService.GetVolumeFreeSpaceAsync(ConnectedServer, ct);
+            var volumes = RestoreSpaceCheck.Check(FetchedFileMoves, free);
+
+            VolumeSpace = new ObservableCollection<VolumeSpace>(volumes);
+            SpaceWarning = RestoreSpaceCheck.Warn(volumes);
+
+            if (HasSpaceWarning) _log.Warn($"[space] {SpaceWarning}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Logged rather than shown. Not being able to check is not the same as not fitting.
+            _log.Info($"[space] could not check free space: {ex.Message}");
+        }
+    }
+
     /// <summary>
     /// Rebuilds the script from the current settings, silently.
     ///
@@ -1610,6 +1665,10 @@ public partial class RestoreViewModel : ViewModelBase
             FetchedFileMoves = new ObservableCollection<FileMoveOption>(list);
             HasFetchedFileMoves = FetchedFileMoves.Count > 0;
             SetStatus($"Read {FetchedFileMoves.Count} logical file name(s) from the backup. Edit the target paths above, and tick WITH MOVE to use them.");
+
+            // The sizes came back in the same result set, so the question of whether this can
+            // physically fit costs one more query rather than another read of the backup (#32).
+            await CheckSpaceAsync(ct);
         }
         catch (Exception ex)
         {

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1389,6 +1389,48 @@
                                             />
                                 </WrapPanel>
 
+                                <!-- Whether it can physically fit (#32).
+
+                                     A restore that runs out of disk fails part-way, and by then
+                                     WITH REPLACE has already dropped the database it was replacing
+                                     - so the target is gone and the replacement is incomplete.
+                                     Entirely predictable: the file sizes came back with the logical
+                                     names, and the instance knows what it has free.
+
+                                     A warning rather than a block. SQL Server can grow onto space
+                                     that frees up and a volume can be extended mid-restore; this
+                                     app is not the authority on somebody else's storage. -->
+                                <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,10"
+                                        Background="{DynamicResource DangerPanelBackgroundBrush}"
+                                        BorderBrush="{DynamicResource ErrorBrush}"
+                                        BorderThickness="1"
+                                        Visibility="{Binding HasSpaceWarning, Converter={StaticResource BoolToVis}}">
+                                    <TextBlock Text="{Binding SpaceWarning}"
+                                               TextWrapping="Wrap"
+                                               Style="{StaticResource BodyText}" />
+                                </Border>
+
+                                <ItemsControl ItemsSource="{Binding VolumeSpace}" Margin="0,0,0,10">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Describe}"
+                                                       TextWrapping="Wrap"
+                                                       FontSize="11"
+                                                       Margin="0,0,0,2">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Fits}" Value="False">
+                                                                <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+
                                 <Border Visibility="{Binding HasFetchedFileMoves, Converter={StaticResource BoolToVis}}"
                                         Background="{DynamicResource InputBackgroundBrush}"
                                         CornerRadius="4" Padding="8" Margin="0,0,0,8">


### PR DESCRIPTION
A restore that runs out of disk fails part-way — and by then `WITH REPLACE` has already dropped the database it was replacing, so the target is gone and the replacement is incomplete. That is the worst outcome this app can produce, and it was entirely predictable: `RESTORE FILELISTONLY` already returns how big each file will be, and the app was reading that column and **throwing it away**.

## Both halves come from the target

The sizes arrive with the logical names, so the check costs one extra query rather than another read of the backup. `sys.dm_os_volume_stats` reports what the **engine** can see — this app's process may not see those volumes at all, and where it can, what it sees is not what the service account writes to. Same reasoning as the shared-path readability check.

## The arithmetic

- Summed **per volume**, not per file. Four 10 GB files on one drive is 40 GB, and checking them individually would pass every one while the restore still fails.
- Measured against where the files are **going**, not where they came from. With `WITH MOVE` in use the whole point is that the two differ.
- A volume the server never reported on is raised rather than silently passing — not knowing is not the same as fitting. `dm_os_volume_stats` only sees volumes the instance already has a file on, so a brand-new empty drive is exactly that case.

## A warning, not a refusal

SQL Server can grow onto space that frees up, a volume can be extended mid-restore, and this app is not the authority on somebody else's storage.

**And not being able to ask raises nothing at all.** An instance that will not report its volumes — permissions, an edition without the DMV — must not turn that into a frightening message about a restore that is very probably fine. That is the *opposite* call from the shared-path readability check, where refusing was right, and the difference is which way the harm runs: there, proceeding destroys a database; here, a false alarm stops a restore that would have worked.

## Not covered

A restore to a UNC path. It has no drive letter and `dm_os_volume_stats` does not describe a share, so those are left out rather than counted against nothing.

1,288 tests pass.