### PR TITLE
Publish a win-arm64 build alongside x64 (#39)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,15 @@ jobs:
       # Through the publish PROFILE, not a hand-repeated flag list. The two had drifted - the
       # profile asked for ReadyToRun and this line did not - and nothing compares them, so the
       # difference went unnoticed through three releases (#39).
-      - name: Publish single-file exe
+      - name: Publish single-file exe (x64)
         run: dotnet publish src/NineLives/NineLives.csproj -p:PublishProfile=SingleFileExe -o publish
+
+      # Windows on ARM is ordinary on new laptops now, and an x64 build runs there only through
+      # emulation - slower, and with its own class of oddity. The profile was written with its
+      # RuntimeIdentifier overridable from the command line precisely so a second architecture is
+      # one more line rather than a second copy of every flag (#39).
+      - name: Publish single-file exe (arm64)
+        run: dotnet publish src/NineLives/NineLives.csproj -p:PublishProfile=SingleFileExe -p:RuntimeIdentifier=win-arm64 -o publish-arm64
 
       - name: Package release assets
         shell: pwsh
@@ -64,8 +71,16 @@ jobs:
 
           # The exe IS the product (portable, no installer) - ship it directly, plus a
           # versioned zip for anyone whose tooling wants an archive.
+          #
+          # The bare NineLives.exe stays x64 and unsuffixed. It is what every existing link, the
+          # README and the update check all point at, and what somebody who just wants the app
+          # clicks - so the architecture that runs everywhere keeps the plain name, and arm64 is
+          # named for what it is rather than quietly becoming the default for people on x64.
           Copy-Item publish/NineLives.exe releases/NineLives.exe
           Compress-Archive -Path publish/NineLives.exe -DestinationPath "releases/NineLives-$version-win-x64.zip" -Force
+
+          Copy-Item publish-arm64/NineLives.exe releases/NineLives-arm64.exe
+          Compress-Archive -Path publish-arm64/NineLives.exe -DestinationPath "releases/NineLives-$version-win-arm64.zip" -Force
 
           $checksums = Get-ChildItem releases/NineLives* | ForEach-Object {
             $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
@@ -89,9 +104,11 @@ jobs:
         with:
           subject-path: |
             releases/NineLives.exe
+            releases/NineLives-arm64.exe
             releases/NineLives-${{ steps.version.outputs.VERSION }}-win-x64.zip
+            releases/NineLives-${{ steps.version.outputs.VERSION }}-win-arm64.zip
 
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} releases/NineLives.exe "releases/NineLives-${{ steps.version.outputs.VERSION }}-win-x64.zip" releases/SHA256SUMS.txt --clobber
+        run: gh release upload ${{ github.event.release.tag_name }} releases/NineLives.exe releases/NineLives-arm64.exe "releases/NineLives-${{ steps.version.outputs.VERSION }}-win-x64.zip" "releases/NineLives-${{ steps.version.outputs.VERSION }}-win-arm64.zip" releases/SHA256SUMS.txt --clobber

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Download the latest release from the [Releases page](https://github.com/jakemorg
 
 The application is distributed as a single self-contained executable (`NineLives.exe`) — no installation required. Simply download and run.
 
+On a Windows-on-ARM machine, take `NineLives-arm64.exe` instead. The plain `NineLives.exe` is x64 and will run there under emulation, just more slowly.
+
 ## Why Nine Lives?
 
 Restoring a native SQL Server backup is painful with existing tooling when the destination server has no msdb backup history — the normal case for DR, environment refreshes, and migrations:


### PR DESCRIPTION
The last item left in #39. The other four were done in passing, and the publish-definition drift got a measured answer rather than a guess — worth reading the note in `SingleFileExe.pubxml` for why ReadyToRun ended up off.

## Why

Windows on ARM is ordinary on new laptops, and an x64 build runs there only through emulation: slower, and with its own class of oddity. The publish profile was written with its `RuntimeIdentifier` overridable from the command line precisely so a second architecture is one more line rather than a second copy of every flag.

## The naming

The bare `NineLives.exe` **stays x64 and unsuffixed**. Every existing link, the README and the in-app update check point at that name, and it is what somebody who just wants the app clicks. So the architecture that runs everywhere keeps the plain name, and arm64 is named for what it is — rather than quietly becoming the default for the majority who are on x64.

Both binaries are attested and checksummed, not just the one.

## Verified rather than assumed

I ran the arm64 publish locally and read the PE header of what came out:

```
machine: 0xaa64 ARM64
```

So it is genuinely ARM64, not an x64 binary under a different name — which is exactly the sort of thing that would otherwise be discovered by the first person to download it.

README updated to say which to take.