### PR TITLE
Test the blob listing against a real blob API (#37)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,36 @@ jobs:
       # any drift. Two builds of the same commit therefore produce the same binaries, and a
       # dependency cannot change under us without a commit that says so. Updating a package
       # means running "dotnet restore --force-evaluate" and committing the new lock file.
+      # The blob listing and the path-pattern parsing that decides what each blob IS had no
+      # coverage against a real blob API - and everything downstream depends on it. Azurite is
+      # Microsoft's own emulator and runs on the hosted runner from npm (#37).
+      #
+      # --skipApiVersionCheck is required rather than optional: the pinned Azure SDK sends a newer
+      # x-ms-version than Azurite recognises, and without it every call is a 400.
+      - name: Start Azurite
+        shell: pwsh
+        run: |
+          npm install -g azurite
+          $log = Join-Path $env:RUNNER_TEMP 'azurite'
+          New-Item -ItemType Directory -Force -Path $log | Out-Null
+          Start-Process -FilePath "azurite-blob.cmd" `
+            -ArgumentList "--silent","--skipApiVersionCheck","--location",$log,"--blobHost","127.0.0.1","--blobPort","10000" `
+            -WindowStyle Hidden
+
+          # Waited for rather than assumed. The integration tests SKIP when nothing is listening,
+          # so an emulator that quietly failed to start would turn this whole job green while
+          # testing nothing at all - which is the exact failure mode the tests exist to prevent.
+          $deadline = (Get-Date).AddSeconds(60)
+          while ((Get-Date) -lt $deadline) {
+            if ((Test-NetConnection -ComputerName 127.0.0.1 -Port 10000 -InformationLevel Quiet -WarningAction SilentlyContinue)) {
+              Write-Host "Azurite is listening."
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+          Write-Error "Azurite did not start within 60s - the integration tests would silently skip."
+          exit 1
+
       - name: Restore dependencies
         run: dotnet restore NineLives.sln --locked-mode
 
@@ -70,11 +100,20 @@ jobs:
       - name: Run tests
         run: dotnet test src/NineLives.Tests/NineLives.Tests.csproj -c Release --no-build --verbosity normal
 
+      # Separate step so a blob-emulator failure is distinguishable at a glance from a logic
+      # failure - they have completely different causes and completely different fixes.
+      - name: Run integration tests (Azurite)
+        run: dotnet test src/NineLives.IntegrationTests/NineLives.IntegrationTests.csproj -c Release --no-build --verbosity normal
+
       # The shipping shape is a self-contained single-file exe — prove on every PR that it
-      # still publishes, not just that the solution compiles. (~2 min, and it is exactly
-      # what release.yml will do for real.)
+      # still publishes, not just that the solution compiles. (~2 min.)
+      #
+      # Through the PROFILE, so it is exactly what release.yml does rather than a fourth
+      # hand-repeated flag list. #39 unified release.yml and build_standalone.cmd onto the profile
+      # and this line was missed, so the smoke test was still proving that a DIFFERENT publish
+      # works - which is the whole failure mode that issue was about.
       - name: Publish smoke test (single-file exe)
-        run: dotnet publish src/NineLives/NineLives.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o publish
+        run: dotnet publish src/NineLives/NineLives.csproj -p:PublishProfile=SingleFileExe -o publish
 
       - name: Verify publish output
         shell: pwsh

--- a/NineLives.sln
+++ b/NineLives.sln
@@ -9,6 +9,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NineLives.Tests", "src\NineLives.Tests\NineLives.Tests.csproj", "{ECC80DE1-51B5-428C-A9C5-08BD871EA5D1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NineLives.IntegrationTests", "src\NineLives.IntegrationTests\NineLives.IntegrationTests.csproj", "{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,11 +45,24 @@ Global
 		{ECC80DE1-51B5-428C-A9C5-08BD871EA5D1}.Release|x64.Build.0 = Release|Any CPU
 		{ECC80DE1-51B5-428C-A9C5-08BD871EA5D1}.Release|x86.ActiveCfg = Release|Any CPU
 		{ECC80DE1-51B5-428C-A9C5-08BD871EA5D1}.Release|x86.Build.0 = Release|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Debug|x64.Build.0 = Debug|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Debug|x86.Build.0 = Debug|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Release|x64.ActiveCfg = Release|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Release|x64.Build.0 = Release|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Release|x86.ActiveCfg = Release|Any CPU
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{ECC80DE1-51B5-428C-A9C5-08BD871EA5D1} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{E5A2A6AD-AC52-448F-A7F9-4D1DF6F5A037} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/src/NineLives.IntegrationTests/Azurite.cs
+++ b/src/NineLives.IntegrationTests/Azurite.cs
@@ -1,0 +1,143 @@
+using System.IO;
+using System.Net.Sockets;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Sas;
+using Blackcat.NineLives.Models;
+using Xunit;
+
+namespace Blackcat.NineLives.IntegrationTests;
+
+/// <summary>
+/// A fact that needs the Azure Storage emulator, and skips when it is not there.
+///
+/// Skipping rather than failing, so somebody cloning this repo gets a green run without first
+/// installing anything. CI starts Azurite explicitly, so the coverage is real where it counts - and
+/// a silent skip in CI would defeat the whole point, which is why the workflow fails if the
+/// emulator did not come up.
+/// </summary>
+public sealed class AzuriteFactAttribute : FactAttribute
+{
+    public AzuriteFactAttribute()
+    {
+        if (!Azurite.IsRunning)
+            Skip = $"Azurite is not listening on {Azurite.Host}:{Azurite.BlobPort}. " +
+                   "Start it with: npx --package azurite azurite-blob --skipApiVersionCheck " +
+                   "--location <temp dir>";
+    }
+}
+
+/// <summary>
+/// The Azure Storage emulator, and the container-config plumbing to point the app at it (#37).
+///
+/// The gap this closes: <c>ListBackupFilesAsync</c> and the path-pattern parsing that decides what
+/// each blob actually IS had no coverage against a real blob API. Everything downstream - the
+/// chain, the timeline, the script - depends on that inference being right, and it has been wrong
+/// in several ways this repo has since fixed (#44, #45).
+///
+/// The unit tests exercise the parsing over hand-built objects. What they cannot show is that the
+/// enumeration hands the parser the shape it expects: a blob name with its full virtual path, a
+/// size, a last-modified, an ETag. That is the join these cover.
+///
+/// --skipApiVersionCheck is required, not optional. The Azure SDK this app pins sends a newer
+/// x-ms-version than Azurite recognises, and without the flag every single call comes back as
+/// HTTP 400 InvalidHeaderValue - which reads like a bug in the app rather than a version skew in
+/// the emulator. That will keep happening every time the SDK moves ahead of Azurite, so the flag
+/// is part of how this is run rather than a workaround for today.
+/// </summary>
+public static class Azurite
+{
+    public const string Host = "127.0.0.1";
+    public const int BlobPort = 10000;
+
+    /// <summary>The emulator's well-known development account. Public by design; not a secret.</summary>
+    public const string AccountName = "devstoreaccount1";
+
+    public const string AccountKey =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+    public static string ServiceUrl => $"http://{Host}:{BlobPort}/{AccountName}";
+
+    /// <summary>
+    /// Whether anything is listening, checked once per run.
+    ///
+    /// A socket probe rather than a blob call: a connection refused is instant, where an SDK call
+    /// against a dead endpoint spends its retry policy first - which would turn a skipped suite
+    /// into a slow one.
+    /// </summary>
+    public static bool IsRunning { get; } = Probe();
+
+    private static bool Probe()
+    {
+        try
+        {
+            using var client = new TcpClient();
+            return client.ConnectAsync(Host, BlobPort).Wait(TimeSpan.FromSeconds(2))
+                   && client.Connected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static StorageSharedKeyCredential Credential => new(AccountName, AccountKey);
+
+    /// <summary>A fresh, empty container with a name nothing else in the run will use.</summary>
+    public static async Task<BlobContainerClient> NewContainerAsync()
+    {
+        var name = $"ninelives-{Guid.NewGuid():n}";
+        var client = new BlobContainerClient(new Uri($"{ServiceUrl}/{name}"), Credential);
+
+        await client.CreateIfNotExistsAsync();
+        return client;
+    }
+
+    /// <summary>
+    /// Uploads a blob of a given size at a given virtual path.
+    ///
+    /// The content is zeros and the size is what the listing will report - these tests are about
+    /// what the app infers from a blob's NAME and metadata, not about reading backups.
+    /// </summary>
+    public static async Task PutAsync(BlobContainerClient container, string blobName, long sizeBytes = 1024)
+    {
+        using var content = new MemoryStream(new byte[sizeBytes]);
+        await container.GetBlobClient(blobName).UploadAsync(content, overwrite: true);
+    }
+
+    /// <summary>
+    /// The app's own config, pointed at an emulator container with a real SAS.
+    ///
+    /// A genuine SAS rather than a shared key, because that is the path the app actually takes -
+    /// CreateClient appends the token to the URL, and a test that used a different mechanism would
+    /// not exercise the code being tested.
+    /// </summary>
+    public static BlobContainerConfig ConfigFor(
+        BlobContainerClient container, string? pathPattern = null)
+    {
+        var sas = new BlobSasBuilder
+        {
+            BlobContainerName = container.Name,
+            Resource = "c",
+            ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        sas.SetPermissions(BlobContainerSasPermissions.Read | BlobContainerSasPermissions.List);
+
+        var token = sas.ToSasQueryParameters(Credential).ToString();
+
+        var config = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = container.Name,
+            ContainerUrl = container.Uri.ToString(),
+            PathPattern = pathPattern ?? BlobContainerConfig.DefaultPathPattern
+        };
+
+        // The unsaved token, so nothing reaches Windows Credential Manager - a test must not leave
+        // anything behind in the profile of whoever ran it.
+        config.UnsavedSasToken = token;
+
+        return config;
+    }
+}

--- a/src/NineLives.IntegrationTests/BlobListingTests.cs
+++ b/src/NineLives.IntegrationTests/BlobListingTests.cs
@@ -1,0 +1,268 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.IntegrationTests;
+
+/// <summary>
+/// What the app makes of a real container (#37).
+///
+/// The unit suite exercises the path-pattern parsing over hand-built objects. What it cannot show
+/// is that the ENUMERATION hands the parser the shape it expects - a blob name carrying its full
+/// virtual path, a size, a last-modified - and that is the join everything downstream rests on:
+/// the chain, the timeline and the script are all built from what this decides each blob is.
+///
+/// The gap has already had a consequence. Microsoft.Data.SqlClient was auto-bumped two major
+/// versions and CI stayed green because nothing exercised it. The Azure SDK is one dependency
+/// bump away from the same position.
+/// </summary>
+[Collection("Azurite")]
+public class BlobListingTests
+{
+    private static BlobStorageService Service() => new(new NoCredentialStore());
+
+    // ── the standalone layout ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// The default arrangement, and the one most containers this points at use: the folder says
+    /// what kind of backup it is, and the two below it say which server and database.
+    /// </summary>
+    [AzuriteFact]
+    public async Task ADefaultLayoutIsReadBackCorrectly()
+    {
+        var container = await Azurite.NewContainerAsync();
+        await Azurite.PutAsync(container, "FULL/SRV01/MyDb/MyDb_20260801_220000.bak", 5_000_000);
+        await Azurite.PutAsync(container, "DIFF/SRV01/MyDb/MyDb_20260802_060000.bak", 1_000_000);
+        await Azurite.PutAsync(container, "LOG/SRV01/MyDb/MyDb_20260802_070000.trn", 100_000);
+
+        var files = await Service().ListBackupFilesAsync(Azurite.ConfigFor(container));
+
+        Assert.Equal(3, files.Count);
+        Assert.All(files, f => Assert.Equal("MyDb", f.InferredDatabaseName));
+        Assert.All(files, f => Assert.Equal("SRV01", f.InferredServerName));
+
+        Assert.Equal(BackupType.Full, Find(files, "MyDb_20260801_220000.bak").Type);
+        Assert.Equal(BackupType.Differential, Find(files, "MyDb_20260802_060000.bak").Type);
+        Assert.Equal(BackupType.TransactionLog, Find(files, "MyDb_20260802_070000.trn").Type);
+    }
+
+    /// <summary>
+    /// The size and last-modified come from the blob rather than from the name, and the app relies
+    /// on both - the size for the disk-space preflight (#32) and the timestamp as the fallback
+    /// whenever a filename carries none.
+    /// </summary>
+    [AzuriteFact]
+    public async Task TheBlobsOwnMetadataComesBackWithIt()
+    {
+        var container = await Azurite.NewContainerAsync();
+        await Azurite.PutAsync(container, "FULL/SRV01/MyDb/MyDb_20260801_220000.bak", 4_096);
+
+        var file = Assert.Single(await Service().ListBackupFilesAsync(Azurite.ConfigFor(container)));
+
+        Assert.Equal(4_096, file.SizeBytes);
+        Assert.NotEqual(default, file.LastModified);
+
+        // The ETag is what an audit result is cached against (#130). A listing that stopped
+        // reporting it would silently make every audit re-read every header.
+        Assert.False(string.IsNullOrWhiteSpace(file.ETag));
+    }
+
+    /// <summary>
+    /// A named instance gets its own level, and the app has to keep the two apart - two instances
+    /// of one host routinely hold same-named databases, and merging them interleaves their backups
+    /// into a single timeline.
+    /// </summary>
+    [AzuriteFact]
+    public async Task AnInstanceLevelIsReadWhenThePatternSaysThereIsOne()
+    {
+        var container = await Azurite.NewContainerAsync();
+        await Azurite.PutAsync(container, "FULL/SRV01/PROD/MyDb/MyDb_20260801_220000.bak");
+        await Azurite.PutAsync(container, "FULL/SRV01/TEST/MyDb/MyDb_20260801_230000.bak");
+
+        var config = Azurite.ConfigFor(
+            container, "{BackupType}/{ServerName}/{InstanceName}/{DatabaseName}/{FileName}");
+
+        var files = await Service().ListBackupFilesAsync(config);
+
+        Assert.Equal(2, files.Count);
+        Assert.Contains(files, f => f.InferredInstanceName == "PROD");
+        Assert.Contains(files, f => f.InferredInstanceName == "TEST");
+        Assert.All(files, f => Assert.Equal("SRV01", f.InferredServerName));
+    }
+
+    // ── striping ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A striped backup is several blobs and ONE restorable set. Restoring three of four stripes
+    /// fails, so the grouping is not cosmetic.
+    /// </summary>
+    [AzuriteFact]
+    public async Task AStripedBackupIsOneSetAcrossSeveralBlobs()
+    {
+        var container = await Azurite.NewContainerAsync();
+        for (var i = 1; i <= 4; i++)
+            await Azurite.PutAsync(container, $"FULL/SRV01/MyDb/MyDb_20260801_220000_{i}.bak", 1_000_000);
+
+        var service = Service();
+        var files = await service.ListBackupFilesAsync(Azurite.ConfigFor(container));
+        var sets = service.GroupIntoBackupSets(files);
+
+        Assert.Equal(4, files.Count);
+
+        var set = Assert.Single(sets);
+        Assert.Equal(4, set.FileCount);
+        Assert.True(set.IsStriped);
+        Assert.Equal(4_000_000, set.TotalSizeBytes);
+    }
+
+    /// <summary>
+    /// Two servers writing a same-named database to one container in the same second must not
+    /// collapse into a single "striped" set - that would generate one RESTORE spanning both and
+    /// silently drop the second server's backup from its own timeline.
+    /// </summary>
+    [AzuriteFact]
+    public async Task TwoServersBackingUpAtTheSameInstantStayApart()
+    {
+        var container = await Azurite.NewContainerAsync();
+        await Azurite.PutAsync(container, "FULL/SRV01/Sales/Sales_20260801_220000.bak");
+        await Azurite.PutAsync(container, "FULL/SRV02/Sales/Sales_20260801_220000.bak");
+
+        var service = Service();
+        var sets = service.GroupIntoBackupSets(
+            await service.ListBackupFilesAsync(Azurite.ConfigFor(container)));
+
+        Assert.Equal(2, sets.Count);
+        Assert.All(sets, s => Assert.Equal(1, s.FileCount));
+    }
+
+    // ── availability groups ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Ola's default AG naming is flat - no folders at all - and everything about the backup is in
+    /// the filename. A container in that shape has no path structure for the pattern to read.
+    /// </summary>
+    [AzuriteFact]
+    public async Task OlaFlatAgNamingIsReadFromTheFilename()
+    {
+        var container = await Azurite.NewContainerAsync();
+        // The trailing _1 is the file number, and Ola always writes one - a name without it is not
+        // this layout at all. Left off first time round, and the test failed for exactly that
+        // reason, which is the sort of thing hand-built objects let you get away with.
+        await Azurite.PutAsync(container, "CLUSTER01$AG01_MyDb_FULL_20260801_220000_1.bak");
+
+        var config = Azurite.ConfigFor(container);
+        config.BackupSourceType = BackupSourceType.AvailabilityGroup;
+
+        var file = Assert.Single(await Service().ListBackupFilesAsync(config));
+
+        Assert.Equal(BackupType.Full, file.Type);
+        Assert.Equal("MyDb", file.InferredDatabaseName);
+        Assert.True(file.IsAgDefaultNaming);
+    }
+
+    // ── what the discovery lists offer ──────────────────────────────────────────
+
+    /// <summary>
+    /// The server and database dropdowns are built from what the listing found, so a container the
+    /// app cannot read produces a screen with nothing to choose.
+    /// </summary>
+    [AzuriteFact]
+    public async Task TheDiscoveredServersAndDatabasesComeFromWhatIsActuallyThere()
+    {
+        var container = await Azurite.NewContainerAsync();
+        await Azurite.PutAsync(container, "FULL/SRV01/Sales/Sales_20260801_220000.bak");
+        await Azurite.PutAsync(container, "FULL/SRV01/Payroll/Payroll_20260801_220000.bak");
+        await Azurite.PutAsync(container, "FULL/SRV02/Sales/Sales_20260801_220000.bak");
+
+        var service = Service();
+        var files = await service.ListBackupFilesAsync(Azurite.ConfigFor(container));
+
+        Assert.Equal(["SRV01", "SRV02"], service.GetDiscoveredServers(files).Order());
+        Assert.Equal(["Payroll", "Sales"], service.GetDiscoveredDatabases(files).Order());
+    }
+
+    /// <summary>
+    /// A copy-only full is a valid restore point and can anchor a log chain, but can never be a
+    /// differential's base - so recognising the marker in a real filename matters (#49).
+    /// </summary>
+    [AzuriteFact]
+    public async Task ACopyOnlyMarkerInTheFilenameIsRecognised()
+    {
+        var container = await Azurite.NewContainerAsync();
+        await Azurite.PutAsync(container, "FULL/SRV01/MyDb/MyDb_COPY_ONLY_20260801_220000.bak");
+        await Azurite.PutAsync(container, "FULL/SRV01/MyDb/MyDb_20260801_230000.bak");
+
+        var files = await Service().ListBackupFilesAsync(Azurite.ConfigFor(container));
+
+        Assert.True(Find(files, "MyDb_COPY_ONLY_20260801_220000.bak").IsCopyOnly);
+        Assert.False(Find(files, "MyDb_20260801_230000.bak").IsCopyOnly);
+    }
+
+    // ── an empty container is not an error ──────────────────────────────────────
+
+    [AzuriteFact]
+    public async Task AnEmptyContainerListsNothingRatherThanFailing()
+    {
+        var container = await Azurite.NewContainerAsync();
+
+        Assert.Empty(await Service().ListBackupFilesAsync(Azurite.ConfigFor(container)));
+    }
+
+    /// <summary>
+    /// A container holds things that are not backups. They must not stop the listing, and must not
+    /// be offered as restore points.
+    /// </summary>
+    [AzuriteFact]
+    public async Task FilesThatAreNotBackupsDoNotBreakTheListing()
+    {
+        var container = await Azurite.NewContainerAsync();
+        await Azurite.PutAsync(container, "FULL/SRV01/MyDb/MyDb_20260801_220000.bak");
+        await Azurite.PutAsync(container, "readme.txt");
+        await Azurite.PutAsync(container, "FULL/SRV01/MyDb/notes.txt");
+
+        var service = Service();
+        var files = await service.ListBackupFilesAsync(Azurite.ConfigFor(container));
+        var sets = service.GroupIntoBackupSets(files);
+
+        Assert.Contains(files, f => f.BlobName.EndsWith(".bak", StringComparison.Ordinal));
+        Assert.Contains(sets, s => s.Type == BackupType.Full);
+    }
+
+    private static BackupFileInfo Find(IEnumerable<BackupFileInfo> files, string endingWith)
+        => files.Single(f => f.BlobName.EndsWith(endingWith, StringComparison.Ordinal));
+}
+
+/// <summary>
+/// A credential store that holds nothing.
+///
+/// These tests hand the SAS token over on the config itself, so nothing should reach the real
+/// Windows Credential Manager - a test that writes to the profile of whoever ran it is the side
+/// effect #41 was about, and it has bitten this repo twice this week already.
+/// </summary>
+internal sealed class NoCredentialStore : ICredentialStore
+{
+    public AppConfig LoadConfig() => new();
+    public void SaveConfig(AppConfig config) { }
+
+    public void SaveSecret(string key, string username, string secret) { }
+    public (string? username, string? secret) ReadSecret(string key) => (null, null);
+    public bool DeleteSecret(string key) => false;
+    public List<string> ListCredentialKeys(string prefix) => [];
+
+    public void SaveSasToken(BlobContainerConfig config, string sasToken) { }
+    public string? GetSasToken(BlobContainerConfig config) => config.UnsavedSasToken;
+    public bool IsSasTokenExpired(BlobContainerConfig config) => false;
+    public DateTime? GetSasTokenExpiry(BlobContainerConfig config) => null;
+    public SasExpiryInfo ReadSasTokenExpiry(BlobContainerConfig config)
+        => config.ReadSasExpiry(config.UnsavedSasToken);
+
+    public void SaveSqlPassword(ServerConnection connection, string password) { }
+    public string? GetSqlPassword(ServerConnection connection) => connection.UnsavedPassword;
+}
+
+/// <summary>
+/// One container per test, but one emulator for the run - so the tests do not race each other over
+/// a shared service that starts slowly.
+/// </summary>
+[CollectionDefinition("Azurite")]
+public sealed class AzuriteCollection;

--- a/src/NineLives.IntegrationTests/NineLives.IntegrationTests.csproj
+++ b/src/NineLives.IntegrationTests/NineLives.IntegrationTests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Kept apart from NineLives.Tests deliberately (#37).
+
+    That suite is pure logic and runs in about seven seconds; these talk to a real Azure Blob API
+    over the network, even if the thing at the other end is an emulator on localhost. Mixing them
+    would make the fast suite slow and would make "the tests pass" depend on a service being up.
+
+    Everything here skips when Azurite is not reachable, so a clone with no emulator still gets a
+    green run - see AzuriteFact.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Blackcat.NineLives.IntegrationTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NineLives\NineLives.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NineLives.IntegrationTests/packages.lock.json
+++ b/src/NineLives.IntegrationTests/packages.lock.json
@@ -1,0 +1,400 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0-windows7.0": {
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.8.1, )",
+        "resolved": "18.8.1",
+        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.8.1",
+          "Microsoft.TestPlatform.TestHost": "18.8.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Azure.Core": {
+        "type": "Transitive",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Identity.Client": "4.83.1",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
+          "System.ClientModel": "1.11.0",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "Azure.Identity": {
+        "type": "Transitive",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "Transitive",
+        "resolved": "12.29.1",
+        "contentHash": "pWh7xZBto8YcwiO853AB3uijTfVqs9PDte0Bu9/Zd8O9nwKiitWm0Jej1vsNkmYUzeG1552f8vJPjmtW30pBUQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
+        }
+      },
+      "CommunityToolkit.Mvvm": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "WadCzGEc2U+3e20avRLng4qNtt4zoOGWrdUISqJWrHe3/FSnrYjuM5Sb4yQb09LhkBXrrI4Zt3dLKgRMbItsrg=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "TV62UsrJZPX6gbt3c4WrtXh7bmaDIcMqf9uft1cc4L6gJXOU07hDGEh+bFQh/L2Az0R1WVOkiT66lFqS6G2NmA=="
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "5T+bH3Lb1nEe8Hf/ixMxLmhlrx5wRi53wv7OhVwG2F1ZviW1ejFRS1NHur3uqPpJRGtkQwUchtY6zhVK2R+v+w=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "zwv76lANFQQI6Gmp6ntkzMWIWVqm8Wf4Mz00AeGCk1n8HCi5afi6bNynSe18uI0xeL0n6J+Myjk9AiIsL5oSqw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "9.0.13",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.SNI.runtime": "[6.0.2, 7.0.0)",
+          "Microsoft.Extensions.Caching.Memory": "9.0.13",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
+          "Microsoft.SqlServer.Server": "[1.0.0, 2.0.0)"
+        }
+      },
+      "Microsoft.Data.SqlClient.Extensions.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "Zx7z61fG2Nc6LdDn4jA7b5Aj1ABrljkOPRE31RvVUdjF6IgbG60leDUhMCafsnWFgaheiK3iqpLe+kbf5Z5L8Q==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)"
+        }
+      },
+      "Microsoft.Data.SqlClient.Extensions.Azure": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "mJhONie3MuVXvSfBbtqGQAOGgeQDbOTfO5d0ZYo3KE4Vb7mua4O23lPJrsTYzvWn5od2CPAh0dHMZEWtJXcpxQ==",
+        "dependencies": {
+          "Azure.Core": "1.51.1",
+          "Azure.Identity": "1.18.0",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "[7.0.2, 8.0.0)",
+          "Microsoft.Data.SqlClient.Internal.Logging": "[7.0.2, 8.0.0)",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.Broker": "4.84.2"
+        }
+      },
+      "Microsoft.Data.SqlClient.Internal.Logging": {
+        "type": "Transitive",
+        "resolved": "7.0.2",
+        "contentHash": "iqgYBbGSVy/DIYWjzmQOa964Kn4rs4wW5vg2IamqVK0fQqfTiILVR5hMK27XWqoyONtAZs+VxH354cPJBtSnbg=="
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "nTT90JYIpcXEy6fcU8LPVycONkO6wipROgP9pyC4uxBif4fazu2rDzlWSntqtzr5p8GbQL2EopsYuTZR3yoeag==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "9.0.13"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "OdQmN8LYcUEu20Fxii9mk68nHJGL+JPXF3w0+hxenf0oDDdDBA+ZV/S92FmIgAWAElowIiFA/g0x+8YB1g80Hg==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "9.0.13",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.13",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.13",
+          "Microsoft.Extensions.Options": "9.0.13",
+          "Microsoft.Extensions.Primitives": "9.0.13"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "xVDHL0+SIgemfh95fTO9cGLe17TWv/ZP0n7m01z8X6pzt2DmQpucioWR/mYZA1sRlkWnkXzfl0JweLNWmE9WMg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "bwGMrRcAMWx2s/RDgja97p27rxSz2pEQW0+rX5cWAUWVETVJ/eyxGfjAl8vuG5a+lckWmPIE+vcuaZNVB5YDdw=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "mQiTzAj7PIJ2A9YXR5QhgulS1fTWhmQc3ckd1Mrf3hKW07d03fBDqx8vVaFw+cRTebDOeB6pNqdWdnRxsi1hBA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Options": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "4TD9AXDRsipTmaemwnjt/DM5Ri0de2JzHQhvZ4woBTjUtL4XrPNsMrOk5oiLJAx1gTrE6pOIhxv+lEde5F6CZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "GdMpC10Jf6poxSvUJ4lgYpJ5F/kJeaAoJmrPufjBoPYyCTKKY5Dyl0rZA+LBNvFqTq1cZa/lhlptlUhNvU6xrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.3",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "lxl0WLk7ROgBFAsjcOYjQ8/DVK+VMszxGBzUhgtQmAsTNldLL5pk9NG/cWTsXHq0lUhUEAtZkEE7jOGOA8bGKQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "hU6WzGTPvPoLA2ng1ILvWQb3g0qORdlHNsxI8IcPLumJb3suimYUl+bbDzdo1V4KFsvVhnMWzysHpKbZaoDQPQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Primitives": "10.0.3"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "GEcpTwo7sUoLGGNTqV1FZEuL+tTD9m81NX/mh099dqGNna07/UGZShKQNZRw4hv6nlliSUwYQgSYc7OR99Jufg=="
+      },
+      "Microsoft.Identity.Client": {
+        "type": "Transitive",
+        "resolved": "4.84.2",
+        "contentHash": "Va9FjmABSgj/lcUfHH0pBNQkmS7SNyepz2ERV7Yynp6QgEYpFdSqR6Vzy1WWipN8GS5pBHuXoZbqaDWuARCrHQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
+        }
+      },
+      "Microsoft.Identity.Client.Broker": {
+        "type": "Transitive",
+        "resolved": "4.84.2",
+        "contentHash": "928ySLeGz1xtvydwq6h9tv7TbxrtA4ZzavLKUqRJh0PW6BGcEJwpI8W8vf2PlQdYemGm/oyGjdzYzdY/I8r/4A==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.84.2",
+          "Microsoft.Identity.Client.NativeInterop": "0.20.6"
+        }
+      },
+      "Microsoft.Identity.Client.Extensions.Msal": {
+        "type": "Transitive",
+        "resolved": "4.83.1",
+        "contentHash": "I3k4J4Hj4KbLEFanjeUzzDOVecukETaTgEkJ7h2pP/Yazs6SLp6TVUTo/Eo+ptPXMwvc+iX7rBFtMSUrA7R+Mg==",
+        "dependencies": {
+          "Microsoft.Identity.Client": "4.83.1"
+        }
+      },
+      "Microsoft.Identity.Client.NativeInterop": {
+        "type": "Transitive",
+        "resolved": "0.20.6",
+        "contentHash": "noyfdMfVxyWpM6xUDmlW6gUvZ5ci24z7Qoy15JvynTQfZV5vTD2NEdsnT5Gy4ngViwgdIp5iRjRy10jAKXFAgw=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "h4yVXyJsEBBX5lg2G5ftMsi5JzcNEGAzrNphA6DQ6eOd8P0s+cDCOyPwVTYLePZvJL5unbPvYIvzrbTXzFjXnQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "System.IdentityModel.Tokens.Jwt": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.IdentityModel.Logging": "8.16.0"
+        }
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+        }
+      },
+      "System.ClientModel": {
+        "type": "Transitive",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.3",
+          "System.Memory.Data": "10.0.3"
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rrs2u7DRMXQG2yh0oVyF/vLwosfRv20Ld2iEpYcKwQWXHjfV+gFXNQsQ9p008kR9Ou4pxBs68Q6/9zC8Gi1wjg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+      },
+      "System.Memory.Data": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "MaGhRfGunmrj/nHjtsi9XkhlYJ/ERGWrbA+BiSKNtGnAjc9XlG5EhAvak6VRcX5LYzPF6pBO8nJ613dTgzabig=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "ninelives": {
+        "type": "Project",
+        "dependencies": {
+          "Azure.Identity": "[1.21.0, )",
+          "Azure.Storage.Blobs": "[12.29.1, )",
+          "CommunityToolkit.Mvvm": "[8.4.2, )",
+          "Microsoft.Data.SqlClient": "[7.0.2, )",
+          "Microsoft.Data.SqlClient.Extensions.Azure": "[7.0.2, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The path-pattern parsing that decides what each blob actually **is** had no coverage against anything but hand-built objects — and everything downstream rests on it. The chain, the timeline and the script are all built from what it decides, and it has been wrong in several ways this repo has since fixed (#44, #45).

## What is covered

Ten tests against [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite), in a separate project so the seven-second unit suite stays that way:

- the default layout, and that each type is read from its folder
- the blob's own metadata — size (which the disk-space preflight now depends on) and **ETag** (which audit results are cached against)
- a named instance level, kept apart from another instance of the same host
- striping: four blobs, one restorable set, size summed once
- two servers writing the same database in the same second, which must **not** collapse into one "striped" set
- Ola's flat AG naming
- the discovered server and database lists
- copy-only markers
- an empty container, and files that are not backups at all

## Two things fell out of writing them

**`--skipApiVersionCheck` is required, not optional.** The pinned Azure SDK sends a newer `x-ms-version` than Azurite recognises, so without it *every* call comes back `HTTP 400 InvalidHeaderValue` — which reads like a bug in the app rather than version skew in the emulator. That will recur every time the SDK moves ahead of Azurite, so it is documented as part of how this is run rather than as a workaround for today.

**The AG fixture was wrong first time.** Ola always writes a trailing file number, and a name without one is not that layout at all. Hand-built objects let that pass; a real listing did not.

## CI fails if the emulator does not start

The tests **skip** when nothing is listening — right for a clone with no emulator, and it would otherwise turn the whole job green while testing nothing at all. So the workflow waits up to 60s and fails explicitly if Azurite never comes up.

## Also

Unifies the publish smoke test onto the publish profile. #39 moved `release.yml` and `build_standalone.cmd` onto it and missed this one, so the smoke test was proving a *different* publish works — the exact failure that issue was about, still sitting in the workflow meant to catch it.

1,288 unit tests and 10 integration tests pass, both run locally against a live Azurite.