### PR TITLE
Choose how much of the app to show (#176)

### DIFF
--- a/src/NineLives.Tests/AppModeTests.cs
+++ b/src/NineLives.Tests/AppModeTests.cs
@@ -1,0 +1,287 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// How much of the app is on screen (#176).
+///
+/// The app grew from "restore a database from a blob container" into a backup and restore
+/// orchestrator with two media, a copy action, a header audit and a credential panel - all of it
+/// visible to everybody. Somebody whose job is "restore last night's full onto the test box" should
+/// not read past four steps and seven sidebar entries to do it.
+///
+/// The promise the picker makes, and the one these mostly guard: narrowing NEVER deletes anything.
+/// If that stopped being true it would become a decision people are afraid to make, and the whole
+/// idea would do nothing.
+/// </summary>
+public class AppModeTests
+{
+    // ── what each mode turns on ─────────────────────────────────────────────────
+
+    /// <summary>Basic is what the app originally was: restore, from a container.</summary>
+    [Fact]
+    public void BasicIsTheOriginalApp()
+    {
+        Assert.False(AppModeCapabilities.CanBackUp(AppMode.Basic));
+        Assert.False(AppModeCapabilities.CanUseSharedPath(AppMode.Basic));
+        Assert.False(AppModeCapabilities.CanCopyBetweenServers(AppMode.Basic));
+        Assert.False(AppModeCapabilities.CanVerifyAndAudit(AppMode.Basic));
+        Assert.False(AppModeCapabilities.CanRestoreToAPointInTime(AppMode.Basic));
+    }
+
+    [Fact]
+    public void StandardAddsTheSecondMediumAndTakingBackups()
+    {
+        Assert.True(AppModeCapabilities.CanBackUp(AppMode.Standard));
+        Assert.True(AppModeCapabilities.CanUseSharedPath(AppMode.Standard));
+        Assert.True(AppModeCapabilities.CanRestoreToAPointInTime(AppMode.Standard));
+        Assert.True(AppModeCapabilities.CanRelocateFiles(AppMode.Standard));
+    }
+
+    /// <summary>
+    /// The Pro-only ones are the features that answer a question somebody has to know to ask - and
+    /// the ones that cost minutes and reach across the network.
+    /// </summary>
+    [Fact]
+    public void ProAddsTheChecksAndTheThingsThatTouchTwoServers()
+    {
+        Assert.True(AppModeCapabilities.CanCopyBetweenServers(AppMode.Pro));
+        Assert.True(AppModeCapabilities.CanVerifyAndAudit(AppMode.Pro));
+        Assert.True(AppModeCapabilities.CanManageServerCredentials(AppMode.Pro));
+        Assert.True(AppModeCapabilities.CanScriptAsAgentJob(AppMode.Pro));
+
+        Assert.False(AppModeCapabilities.CanCopyBetweenServers(AppMode.Standard));
+        Assert.False(AppModeCapabilities.CanVerifyAndAudit(AppMode.Standard));
+    }
+
+    /// <summary>
+    /// Every capability is monotonic: nothing available in a narrower mode disappears in a wider
+    /// one. A card that says "everything in Standard" has to be true, and somebody widening the
+    /// mode to get one feature must not silently lose another.
+    /// </summary>
+    [Fact]
+    public void NothingAvailableInANarrowerModeVanishesInAWiderOne()
+    {
+        Func<AppMode, bool>[] capabilities =
+        [
+            AppModeCapabilities.CanBackUp,
+            AppModeCapabilities.CanCopyBetweenServers,
+            AppModeCapabilities.CanBrowseBackups,
+            AppModeCapabilities.CanUseSharedPath,
+            AppModeCapabilities.CanRestoreToAPointInTime,
+            AppModeCapabilities.CanRelocateFiles,
+            AppModeCapabilities.CanVerifyAndAudit,
+            AppModeCapabilities.CanManageServerCredentials,
+            AppModeCapabilities.CanScriptAsAgentJob,
+            AppModeCapabilities.CanUseAdvancedRestoreOptions
+        ];
+
+        foreach (var can in capabilities)
+        {
+            if (can(AppMode.Basic)) Assert.True(can(AppMode.Standard));
+            if (can(AppMode.Standard)) Assert.True(can(AppMode.Pro));
+        }
+    }
+
+    /// <summary>Restoring is what the app is for, and no mode takes it away.</summary>
+    [Theory]
+    [InlineData(AppMode.Basic)]
+    [InlineData(AppMode.Standard)]
+    [InlineData(AppMode.Pro)]
+    public void EveryModeCanStillRestore(AppMode mode)
+    {
+        var vm = Restore(mode);
+
+        Assert.NotNull(vm.LoadBackupsCommand);
+        Assert.NotNull(vm.ExecuteScriptCommand);
+    }
+
+    // ── the first-run screen ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Asked once. Being asked on every launch would be a worse problem than the clutter this
+    /// exists to fix.
+    /// </summary>
+    [Fact]
+    public void WithNoModeChosenTheCardsAreShown()
+    {
+        var main = new MainViewModel(new FakeCredentialStore());
+
+        Assert.True(main.IsChoosingMode);
+        Assert.Same(main.ModeSelection, main.CurrentView);
+    }
+
+    [Fact]
+    public void OnceChosenTheCardsDoNotComeBack()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Basic;
+
+        var main = new MainViewModel(store);
+
+        Assert.False(main.IsChoosingMode);
+        Assert.Equal(AppMode.Basic, main.Mode);
+        Assert.NotSame(main.ModeSelection, main.CurrentView);
+    }
+
+    /// <summary>The choice is remembered, or it would be asked again next time.</summary>
+    [Fact]
+    public void ChoosingAModeSavesIt()
+    {
+        var store = new FakeCredentialStore();
+        var vm = new ModeSelectionViewModel(store);
+
+        vm.ChooseCommand.Execute(vm.Cards.Single(c => c.Mode == AppMode.Standard));
+
+        Assert.Equal(AppMode.Standard, store.Config.Mode);
+    }
+
+    /// <summary>
+    /// A config that failed to LOAD must not be written back - saving over it turns a transient read
+    /// failure into permanent data loss, which is the whole of #7.
+    /// </summary>
+    [Fact]
+    public void AConfigThatWouldNotLoadIsNotOverwrittenByTheChoice()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.LoadError = "config.json could not be read";
+
+        var vm = new ModeSelectionViewModel(store);
+        vm.ChooseCommand.Execute(vm.Cards.First());
+
+        Assert.Equal(0, store.SaveConfigCalls);
+    }
+
+    /// <summary>
+    /// An unreadable or unrecognised mode lands on Pro, not Basic. Hiding features from somebody
+    /// whose config got mangled looks like the app has lost a capability; showing too many is merely
+    /// untidy.
+    /// </summary>
+    [Fact]
+    public void AConfigThatWillNotLoadShowsEverythingRatherThanNothing()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.LoadError = "unreadable";
+
+        Assert.Equal(AppMode.Pro, new MainViewModel(store).Mode);
+    }
+
+    // ── changing it later ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The promise the picker makes. If narrowing deleted anything it would become a decision people
+    /// are afraid to make.
+    /// </summary>
+    [Fact]
+    public void NarrowingTheModeDeletesNothing()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Pro;
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        { Id = "c1", Name = "backups", ContainerUrl = "https://acct.blob.core.windows.net/backups" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+
+        var main = new MainViewModel(store);
+        main.Mode = AppMode.Basic;
+
+        Assert.Single(store.Config.BlobContainers);
+        Assert.Single(store.Config.Servers);
+    }
+
+    /// <summary>
+    /// A screen the new mode hides must not stay on display underneath a sidebar that no longer
+    /// offers it - there would be no way back to it and no way to tell why.
+    /// </summary>
+    [Fact]
+    public void NarrowingTheModeMovesOffAScreenThatIsNoLongerOffered()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Pro;
+
+        var main = new MainViewModel(store);
+        main.NavigateToCommand.Execute(MainViewModel.Nav.CopyDatabase);
+        Assert.Same(main.CopyDatabase, main.CurrentView);
+
+        main.Mode = AppMode.Basic;
+
+        Assert.NotSame(main.CopyDatabase, main.CurrentView);
+        Assert.Same(main.Restore, main.CurrentView);
+    }
+
+    [Fact]
+    public void AScreenTheModeStillOffersIsLeftAlone()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Pro;
+
+        var main = new MainViewModel(store);
+        main.NavigateToCommand.Execute(MainViewModel.Nav.History);
+
+        main.Mode = AppMode.Standard;
+
+        Assert.Same(main.History, main.CurrentView);
+    }
+
+    /// <summary>
+    /// Narrowing out of a shared-path restore must not leave the medium selected with nothing on
+    /// screen saying so - the app would be restoring FROM DISK while looking like blob.
+    /// </summary>
+    [Fact]
+    public void NarrowingToBasicPutsTheMediumBackToBlob()
+    {
+        var vm = Restore(AppMode.Standard);
+        vm.SelectedMedium = BackupMedium.SharedPath;
+
+        vm.Mode = AppMode.Basic;
+
+        Assert.Equal(BackupMedium.AzureBlob, vm.SelectedMedium);
+        Assert.False(vm.ShowMediumChoice);
+    }
+
+    // ── what the cards say ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void EveryCardSaysWhoItIsForAndWhatItTurnsOn()
+    {
+        var vm = new ModeSelectionViewModel(new FakeCredentialStore());
+
+        Assert.Equal(3, vm.Cards.Count);
+
+        foreach (var card in vm.Cards)
+        {
+            Assert.NotEmpty(card.Title);
+            Assert.NotEmpty(card.Tagline);
+            Assert.NotEmpty(card.WhoFor);
+            Assert.NotEmpty(card.Highlights);
+        }
+    }
+
+    /// <summary>
+    /// Three distinct shades, and deliberately not a traffic light - the modes are more and less,
+    /// not better and worse.
+    /// </summary>
+    [Fact]
+    public void EachCardHasItsOwnShade()
+    {
+        var vm = new ModeSelectionViewModel(new FakeCredentialStore());
+
+        Assert.Equal(3, vm.Cards.Select(c => c.AccentBrushKey).Distinct().Count());
+    }
+
+    private static RestoreViewModel Restore(AppMode mode)
+    {
+        var store = new FakeCredentialStore();
+
+        return new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(),
+            new FakeRestoreHistoryStore(), TestAuditStores.Temp())
+        {
+            Mode = mode
+        };
+    }
+}

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
@@ -1004,6 +1005,104 @@ public class XamlLoadTests(WpfFixture wpf)
             var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
 
             Assert.DoesNotContain(shown, t => t.Contains("not on the timeline", StringComparison.Ordinal));
+        });
+    }
+
+    // ── the mode cards (#176) ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ModeSelectionViewLoads()
+        => Check("ModeSelectionView", () =>
+            new ModeSelectionView { DataContext = new ModeSelectionViewModel(Store()) });
+
+    /// <summary>
+    /// Each card takes its own shade.
+    ///
+    /// Found by rendering it: the default was a LOCAL Background, and a style setter cannot override
+    /// a local value - so all three bars were the same blue and the triggers silently did nothing.
+    /// The identical trap to the audit tick (#130), repeated a few hours later, which is why it is
+    /// pinned here rather than left to a comment.
+    /// </summary>
+    [Fact]
+    public void EachModeCardTakesItsOwnShade()
+    {
+        wpf.Invoke(() =>
+        {
+            var view = new ModeSelectionView { DataContext = new ModeSelectionViewModel(Store()) };
+            Realise(view);
+
+            // The 6px bars: every Border that is exactly that tall and actually painted.
+            var shades = FindAll<Border>(view)
+                .Where(IsShown)
+                .Where(b => Math.Abs(b.ActualHeight - 6) < 0.5)
+                .Select(b => (b.Background as SolidColorBrush)?.Color)
+                .Where(c => c != null)
+                .ToList();
+
+            Assert.Equal(3, shades.Count);
+            Assert.Equal(3, shades.Distinct().Count());
+        });
+    }
+
+    /// <summary>
+    /// The button says what pressing it does.
+    ///
+    /// Also found by rendering: Button.Content is an object, so a StringFormat on the binding is
+    /// quietly ignored - the button read "Basic" rather than "Use Basic", a label describing the
+    /// card rather than the action.
+    /// </summary>
+    [Fact]
+    public void EachCardsButtonSaysWhatPressingItDoes()
+    {
+        wpf.Invoke(() =>
+        {
+            var view = new ModeSelectionView { DataContext = new ModeSelectionViewModel(Store()) };
+            Realise(view);
+
+            var labels = VisibleButtons(view).Select(b => b.Content as string).ToList();
+
+            Assert.Contains("Use Basic", labels);
+            Assert.Contains("Use Standard", labels);
+            Assert.Contains("Use Pro", labels);
+        });
+    }
+
+    /// <summary>
+    /// Basic does not offer what it cannot do. A medium selector with one option, or an audit panel
+    /// for a check the mode has turned off, would be the clutter this whole idea exists to remove.
+    /// </summary>
+    [Fact]
+    public void TheRestoreScreenInBasicDoesNotOfferWhatBasicCannotDo()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.Mode = AppMode.Basic;
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.DoesNotContain("WHERE THE BACKUPS LIVE", shown);
+            Assert.DoesNotContain("AUDIT THESE BACKUPS", shown);
+        });
+    }
+
+    [Fact]
+    public void TheRestoreScreenInProOffersThemAgain()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.Mode = AppMode.Pro;
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.Contains("WHERE THE BACKUPS LIVE", shown);
         });
     }
 

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -53,6 +53,9 @@
         <DataTemplate DataType="{x:Type vm:BlobBrowserViewModel}">
             <views:BlobBrowserView />
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:ModeSelectionViewModel}">
+            <views:ModeSelectionView />
+        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:BackupViewModel}">
             <views:BackupView />
         </DataTemplate>
@@ -149,8 +152,12 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <!-- Sidebar -->
-            <Border Grid.Column="0" Background="{DynamicResource SidebarBackgroundBrush}">
+            <!-- Sidebar.
+                 Hidden while the mode cards are up (#176): a sidebar sitting behind a choice about
+                 what the sidebar should contain would be answering the question twice, and the
+                 entries it shows would be the ones about to change. -->
+            <Border Grid.Column="0" Background="{DynamicResource SidebarBackgroundBrush}"
+                    Visibility="{Binding IsChoosingMode, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                 <DockPanel>
                     <!-- App Title -->
                     <StackPanel DockPanel.Dock="Top" Margin="20,20,20,8">
@@ -263,6 +270,7 @@
                         <RadioButton Style="{StaticResource SidebarButton}"
                                      IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Browse Backups'}"
                                      Command="{Binding NavigateToCommand}"
+                                     Visibility="{Binding ShowBrowseBackups, Converter={StaticResource BoolToVis}}"
                                      CommandParameter="Browse Backups">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#x1F4C2;" FontSize="15" VerticalAlignment="Center" Width="24" />
@@ -273,6 +281,7 @@
                         <RadioButton Style="{StaticResource SidebarButton}"
                                      IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Back Up'}"
                                      Command="{Binding NavigateToCommand}"
+                                     Visibility="{Binding ShowBackup, Converter={StaticResource BoolToVis}}"
                                      CommandParameter="Back Up">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#x1F4BE;" FontSize="15" VerticalAlignment="Center" Width="24" />
@@ -293,6 +302,7 @@
                         <RadioButton Style="{StaticResource SidebarButton}"
                                      IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Copy Database'}"
                                      Command="{Binding NavigateToCommand}"
+                                     Visibility="{Binding ShowCopyDatabase, Converter={StaticResource BoolToVis}}"
                                      CommandParameter="Copy Database">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#x21C4;" FontSize="15" VerticalAlignment="Center" Width="24" />

--- a/src/NineLives/Models/AppMode.cs
+++ b/src/NineLives/Models/AppMode.cs
@@ -1,0 +1,158 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// How much of the app to show (#176).
+///
+/// The problem this solves is growth. Nine Lives started as "restore a database from a blob
+/// container" and is now a backup and restore orchestrator across two media, with a
+/// copy-between-servers action, a header audit, chain validation, point-in-time recovery, MOVE,
+/// tail-log handling and a credential panel - all of it on screen for everybody, all the time.
+///
+/// Somebody whose entire job is "restore last night's full onto the test box" should not have to
+/// read past four collapsible steps and seven sidebar entries to do it. Growth made the app more
+/// capable and less approachable, and those do not have to be a trade.
+///
+/// A mode rather than an "advanced options" toggle, deliberately: a collapsed section still tells
+/// you there is something you are not using. A mode says the app is smaller today and means it.
+/// </summary>
+public enum AppMode
+{
+    /// <summary>
+    /// Restore a database from a blob container. What the app originally did, and what most people
+    /// want most of the time.
+    /// </summary>
+    Basic = 0,
+
+    /// <summary>Adds the second medium, taking backups, point-in-time recovery and file relocation.</summary>
+    Standard = 1,
+
+    /// <summary>Everything.</summary>
+    Pro = 2
+}
+
+/// <summary>
+/// What each mode turns on.
+///
+/// One place that answers it, rather than a switch at every call site - a feature that appears in
+/// Basic's navigation and then finds its screen half-hidden is worse than either.
+///
+/// The honest test for each line below is "does somebody who has never heard of this need to see it
+/// to do their job?". Where the answer was unclear the feature went in the LOWER tier, because a
+/// mode that hides something people need teaches them to switch to Pro and never look back - which
+/// would leave the whole idea doing nothing.
+/// </summary>
+public static class AppModeCapabilities
+{
+    // ── screens ─────────────────────────────────────────────────────────────────
+
+    /// <summary>Taking a backup at all.</summary>
+    public static bool CanBackUp(AppMode mode) => mode >= AppMode.Standard;
+
+    /// <summary>Copying a database between servers - two servers, one of them overwritten.</summary>
+    public static bool CanCopyBetweenServers(AppMode mode) => mode >= AppMode.Pro;
+
+    /// <summary>Browsing a container without restoring from it.</summary>
+    public static bool CanBrowseBackups(AppMode mode) => mode >= AppMode.Standard;
+
+    // ── the restore screen ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Restoring from a path both servers can see.
+    ///
+    /// Standard rather than Pro: an estate that backs up to a file share is not an advanced user,
+    /// it is a different ordinary arrangement - and in Basic there is nothing to choose, so the
+    /// medium selector does not appear at all.
+    /// </summary>
+    public static bool CanUseSharedPath(AppMode mode) => mode >= AppMode.Standard;
+
+    /// <summary>
+    /// Restoring to a moment rather than to a backup.
+    ///
+    /// Standard, and it was the hardest call here. Point-in-time is close to the heart of what this
+    /// app is for, but it is also the thing somebody restoring last night's full will never touch -
+    /// and STOPAT with nothing selected is a checkbox that does nothing, which is its own kind of
+    /// clutter.
+    /// </summary>
+    public static bool CanRestoreToAPointInTime(AppMode mode) => mode >= AppMode.Standard;
+
+    /// <summary>Relocating the database files. Needed whenever the target's layout differs.</summary>
+    public static bool CanRelocateFiles(AppMode mode) => mode >= AppMode.Standard;
+
+    /// <summary>
+    /// The chain checks, the VERIFYONLY pass and the header audit.
+    ///
+    /// Pro: every one of them answers a question somebody has to know to ask. They are also the
+    /// features that cost minutes and reach across the network, and offering those to somebody who
+    /// has not asked for them is how an app earns a reputation for being slow.
+    /// </summary>
+    public static bool CanVerifyAndAudit(AppMode mode) => mode >= AppMode.Pro;
+
+    /// <summary>
+    /// The server-side credential panel.
+    ///
+    /// Pro, because Basic and Standard can present connecting as one step rather than four things
+    /// that each need it. The credential still has to exist for a restore to work - what changes is
+    /// whether the app makes that somebody's problem before they have hit it.
+    /// </summary>
+    public static bool CanManageServerCredentials(AppMode mode) => mode >= AppMode.Pro;
+
+    /// <summary>Handing a restore over as an Agent job.</summary>
+    public static bool CanScriptAsAgentJob(AppMode mode) => mode >= AppMode.Pro;
+
+    /// <summary>The less common RESTORE options - KEEP_REPLICATION, the broker flags, CHECKSUM.</summary>
+    public static bool CanUseAdvancedRestoreOptions(AppMode mode) => mode >= AppMode.Pro;
+
+    // ── what a mode is, in words ────────────────────────────────────────────────
+
+    public static string Title(AppMode mode) => mode switch
+    {
+        AppMode.Basic => "Basic",
+        AppMode.Standard => "Standard",
+        _ => "Pro"
+    };
+
+    public static string Tagline(AppMode mode) => mode switch
+    {
+        AppMode.Basic => "Restore a database from a blob container.",
+        AppMode.Standard => "Back up and restore, to blob or a file share, with point-in-time recovery.",
+        _ => "Everything, including copying between servers and auditing backups."
+    };
+
+    /// <summary>What it turns on, for the card. Short lines, because a card nobody reads is a gate.</summary>
+    public static IReadOnlyList<string> Highlights(AppMode mode) => mode switch
+    {
+        AppMode.Basic =>
+        [
+            "Pick a container, pick a restore point, restore",
+            "The full restore chain worked out for you",
+            "Nothing else on screen"
+        ],
+
+        AppMode.Standard =>
+        [
+            "Everything in Basic",
+            "Back up a database, to blob or a file share",
+            "Restore from a path both servers can see",
+            "Restore to a moment in time, and relocate files"
+        ],
+
+        _ =>
+        [
+            "Everything in Standard",
+            "Copy a database onto another server in one action",
+            "Verify and audit backups against their own headers",
+            "Manage server-side credentials, and script as an Agent job"
+        ]
+    };
+
+    /// <summary>
+    /// Who it is for. Named rather than described, because somebody choosing between three cards on
+    /// first run is asking "which one am I?" rather than "what does each contain?".
+    /// </summary>
+    public static string WhoFor(AppMode mode) => mode switch
+    {
+        AppMode.Basic => "You need last night's backup on another server, and nothing more.",
+        AppMode.Standard => "You look after the backups as well as the restores.",
+        _ => "You want every check the tool can make, and are happy to be asked."
+    };
+}

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -297,6 +297,19 @@ public class AppConfig
     public List<ServerConnection> Servers { get; set; } = [];
     public string? LastSelectedContainer { get; set; }
     public string? LastSelectedServer { get; set; }
+
+    /// <summary>
+    /// How much of the app to show (#176).
+    ///
+    /// Null until somebody has chosen, which is what makes the mode cards a FIRST-RUN screen rather
+    /// than a gate on every launch. Being asked every time would be worse than the clutter it is
+    /// meant to fix.
+    ///
+    /// An unknown value degrades to Pro rather than Basic: hiding features from somebody whose
+    /// config got mangled is a worse failure than showing them too many, because the second is
+    /// merely untidy and the first looks like the app has lost a capability.
+    /// </summary>
+    public AppMode? Mode { get; set; }
 
     /// <summary>Check GitHub for a newer release at startup. Turn off for offline installs.</summary>
     public bool CheckForUpdates { get; set; } = true;

--- a/src/NineLives/Themes/Palette.Dark.xaml
+++ b/src/NineLives/Themes/Palette.Dark.xaml
@@ -79,6 +79,17 @@
     <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
     <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
     <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
+    <!-- The three mode cards (#176).
+
+         One accent getting stronger rather than a traffic light: the modes are more and less, not
+         better and worse, and green-amber-red would read as "the safe one and the dangerous ones".
+
+         High contrast takes the three pure hues it already uses elsewhere, because a 6px bar
+         distinguished only by saturation is exactly what that theme exists to avoid. -->
+    <SolidColorBrush x:Key="ModeBasicBrush" Color="#3B83E9" />
+    <SolidColorBrush x:Key="ModeStandardBrush" Color="#7C5CE0" />
+    <SolidColorBrush x:Key="ModeProBrush" Color="#C2557A" />
+
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />

--- a/src/NineLives/Themes/Palette.HighContrast.xaml
+++ b/src/NineLives/Themes/Palette.HighContrast.xaml
@@ -86,6 +86,17 @@
     <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
     <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
     <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
+    <!-- The three mode cards (#176).
+
+         One accent getting stronger rather than a traffic light: the modes are more and less, not
+         better and worse, and green-amber-red would read as "the safe one and the dangerous ones".
+
+         High contrast takes the three pure hues it already uses elsewhere, because a 6px bar
+         distinguished only by saturation is exactly what that theme exists to avoid. -->
+    <SolidColorBrush x:Key="ModeBasicBrush" Color="#00FFFF" />
+    <SolidColorBrush x:Key="ModeStandardBrush" Color="#FFFF00" />
+    <SolidColorBrush x:Key="ModeProBrush" Color="#FF00FF" />
+
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />

--- a/src/NineLives/Themes/Palette.Light.xaml
+++ b/src/NineLives/Themes/Palette.Light.xaml
@@ -77,6 +77,17 @@
     <SolidColorBrush x:Key="InputBackgroundBrush" Color="{StaticResource InputBackgroundColor}" />
     <SolidColorBrush x:Key="InputBorderBrush" Color="{StaticResource InputBorderColor}" />
     <SolidColorBrush x:Key="InputFocusBorderBrush" Color="{StaticResource InputFocusBorderColor}" />
+    <!-- The three mode cards (#176).
+
+         One accent getting stronger rather than a traffic light: the modes are more and less, not
+         better and worse, and green-amber-red would read as "the safe one and the dangerous ones".
+
+         High contrast takes the three pure hues it already uses elsewhere, because a 6px bar
+         distinguished only by saturation is exactly what that theme exists to avoid. -->
+    <SolidColorBrush x:Key="ModeBasicBrush" Color="#2C6FD1" />
+    <SolidColorBrush x:Key="ModeStandardBrush" Color="#6A46CC" />
+    <SolidColorBrush x:Key="ModeProBrush" Color="#AE4468" />
+
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />
     <SolidColorBrush x:Key="AccentPressedBrush" Color="{StaticResource AccentPressedColor}" />

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Blackcat.NineLives.Models;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Services;
 
@@ -7,6 +8,9 @@ namespace Blackcat.NineLives.ViewModels;
 /// <summary>A theme and the name shown for it.</summary>
 /// <param name="Value">The theme itself.</param>
 /// <param name="Name">What the picker calls it.</param>
+/// <summary>One mode in the Settings picker: what it is called and what it turns on (#176).</summary>
+public sealed record ModeOption(AppMode Mode, string Name, string Description);
+
 public sealed record ThemeOption(AppTheme Value, string Name)
 {
     /// <summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -23,6 +23,49 @@ public partial class MainViewModel : ViewModelBase
     // startup - it used to be a hardcoded IsChecked="True" on the first one (#117 item 5).
     private string _currentViewName = Nav.BlobStorage;
 
+    /// <summary>How much of the app is on screen (#176).</summary>
+    [ObservableProperty]
+    private AppMode _mode = AppMode.Pro;
+
+    /// <summary>True while the mode cards are up, which is once, on first run.</summary>
+    [ObservableProperty]
+    private bool _isChoosingMode;
+
+    // Each of these is asked by the navigation and by the screens themselves, so they live here
+    // rather than being recomputed from Mode at every binding.
+    public bool ShowBackup => AppModeCapabilities.CanBackUp(Mode);
+    public bool ShowCopyDatabase => AppModeCapabilities.CanCopyBetweenServers(Mode);
+    public bool ShowBrowseBackups => AppModeCapabilities.CanBrowseBackups(Mode);
+
+    partial void OnModeChanged(AppMode value)
+    {
+        OnPropertyChanged(nameof(ShowBackup));
+        OnPropertyChanged(nameof(ShowCopyDatabase));
+        OnPropertyChanged(nameof(ShowBrowseBackups));
+
+        Restore.Mode = value;
+
+        // A screen that has just been hidden must not stay on display underneath a sidebar that no
+        // longer offers it - which is what changing mode from Settings would otherwise do.
+        if (!IsViewAvailable(CurrentViewName)) NavigateTo(Nav.Restore);
+    }
+
+    private void OnModeChosen(AppMode mode)
+    {
+        Mode = mode;
+        IsChoosingMode = false;
+        NavigateTo(Nav.Restore);
+    }
+
+    /// <summary>Whether a sidebar entry is offered in the current mode.</summary>
+    public bool IsViewAvailable(string viewName) => viewName switch
+    {
+        Nav.Backup => ShowBackup,
+        Nav.CopyDatabase => ShowCopyDatabase,
+        Nav.BrowseBackups => ShowBrowseBackups,
+        _ => true
+    };
+
     [ObservableProperty]
     private string _globalStatus = "Ready";
 
@@ -50,6 +93,7 @@ public partial class MainViewModel : ViewModelBase
     public BlobConfigViewModel BlobConfig { get; }
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }
+    public ModeSelectionViewModel ModeSelection { get; }
     public BackupViewModel Backup { get; }
     public CopyDatabaseViewModel CopyDatabase { get; }
     public RestoreViewModel Restore { get; }
@@ -98,6 +142,9 @@ public partial class MainViewModel : ViewModelBase
         Restore = new RestoreViewModel(
             _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
             log: null, history: _historyStore);
+        ModeSelection = new ModeSelectionViewModel(_credentialStore);
+        ModeSelection.Chosen += OnModeChosen;
+
         Backup = new BackupViewModel(_credentialStore, _sqlService);
         CopyDatabase = new CopyDatabaseViewModel(_credentialStore, _sqlService);
         History = new HistoryViewModel(_historyStore);
@@ -112,12 +159,36 @@ public partial class MainViewModel : ViewModelBase
 
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
 
+        // Changing the mode from Settings has to move the app immediately - a sidebar that still
+        // offers a screen the new mode hides, or a screen left on display underneath one that no
+        // longer lists it, is worse than not offering the setting (#176).
+        Settings.ModeChanged += mode => Mode = mode;
+
         // One place that answers "is it doing something?". Every screen already tracks its own
         // work; without this the answer depended on which part of a long page was scrolled into
         // view, and the Restore screen's own status line is below the fold most of the time (#128).
         WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Backup, Restore, CopyDatabase);
 
-        CurrentView = BlobConfig;
+        // How much of the app to show (#176). Unknown means nobody has chosen yet, which is what
+        // makes the cards a first-run screen rather than a gate on every launch.
+        //
+        // An unreadable or unrecognised value lands on Pro rather than Basic: hiding features from
+        // somebody whose config got mangled is a worse failure than showing too many, because the
+        // second is untidy and the first looks like the app has lost a capability.
+        var savedMode = _credentialStore.LoadConfig().Mode;
+        Mode = savedMode ?? AppMode.Pro;
+
+        if (savedMode == null)
+        {
+            // First run. Nothing else is shown until the question is answered - a sidebar behind a
+            // choice about what the sidebar contains would be answering it twice.
+            IsChoosingMode = true;
+            CurrentView = ModeSelection;
+        }
+        else
+        {
+            CurrentView = BlobConfig;
+        }
 
         // Fire and forget - startup must not wait on the network.
         _ = CheckForUpdatesAsync();

--- a/src/NineLives/ViewModels/ModeSelectionViewModel.cs
+++ b/src/NineLives/ViewModels/ModeSelectionViewModel.cs
@@ -1,0 +1,99 @@
+using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>One card. What the mode is, who it is for, and what it turns on.</summary>
+public sealed class ModeCard(AppMode mode)
+{
+    public AppMode Mode { get; } = mode;
+
+    public string Title { get; } = AppModeCapabilities.Title(mode);
+
+    /// <summary>
+    /// The button's text, built here rather than by a StringFormat on the binding.
+    ///
+    /// Button.Content is an object, so a StringFormat on it is quietly ignored - the button read
+    /// "Basic" where it should have said "Use Basic", which is a label describing the card rather
+    /// than the action.
+    /// </summary>
+    public string ChooseLabel { get; } = $"Use {AppModeCapabilities.Title(mode)}";
+    public string Tagline { get; } = AppModeCapabilities.Tagline(mode);
+    public string WhoFor { get; } = AppModeCapabilities.WhoFor(mode);
+
+    public IReadOnlyList<string> Highlights { get; } = AppModeCapabilities.Highlights(mode);
+
+    /// <summary>
+    /// Which shade the card takes.
+    ///
+    /// Deliberately not a traffic light. These are not better and worse, they are more and less -
+    /// so the progression is one accent getting stronger rather than green-amber-red, which would
+    /// read as "the safe one and the dangerous ones".
+    /// </summary>
+    public string AccentBrushKey { get; } = mode switch
+    {
+        AppMode.Basic => "ModeBasicBrush",
+        AppMode.Standard => "ModeStandardBrush",
+        _ => "ModeProBrush"
+    };
+}
+
+/// <summary>
+/// The first thing somebody sees, once (#176).
+///
+/// Once, not every launch - the choice is remembered and changed from Settings. Being asked on
+/// every start would be a worse problem than the clutter this exists to fix.
+///
+/// It is also not a wall: whichever card is chosen, nothing is deleted and nothing is unavailable
+/// forever. That matters for the honesty of the screen - somebody who picks Basic and later needs
+/// to take a backup has not lost anything, they change a setting.
+/// </summary>
+public partial class ModeSelectionViewModel : ViewModelBase
+{
+    private readonly ICredentialStore _store;
+
+    public ModeSelectionViewModel(ICredentialStore store)
+    {
+        _store = store;
+    }
+
+    public ObservableCollection<ModeCard> Cards { get; } =
+    [
+        new(AppMode.Basic),
+        new(AppMode.Standard),
+        new(AppMode.Pro)
+    ];
+
+    /// <summary>Raised once a mode has been chosen and saved, so the shell can move on.</summary>
+    public event Action<AppMode>? Chosen;
+
+    [RelayCommand]
+    private void Choose(ModeCard? card)
+    {
+        if (card == null) return;
+
+        try
+        {
+            var config = _store.LoadConfig();
+
+            // A config that failed to LOAD must not be written back - saving over it would turn a
+            // transient read failure into permanent data loss, which is the whole of #7.
+            if (config.LoadError == null)
+            {
+                config.Mode = card.Mode;
+                _store.SaveConfig(config);
+            }
+        }
+        catch (Exception ex)
+        {
+            // The choice still takes effect for this session. Failing to persist a preference is
+            // not a reason to refuse to start.
+            SetError($"Your choice could not be saved, so it will be asked again next time: {ex.Message}");
+        }
+
+        Chosen?.Invoke(card.Mode);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -328,8 +328,41 @@ public partial class RestoreViewModel : ViewModelBase
     // whole of what a second medium changes on this screen: which inputs step 1 offers, and whether
     // the server-side credential is applicable at all.
 
+    /// <summary>
+    /// How much of this screen to show (#176).
+    ///
+    /// Pro by default, so anything that constructs this without a shell - a test, a future CLI -
+    /// gets the whole thing rather than silently losing capability.
+    /// </summary>
+    [ObservableProperty]
+    private AppMode _mode = AppMode.Pro;
+
     [ObservableProperty]
     private BackupMedium _selectedMedium = BackupMedium.AzureBlob;
+
+    public bool ShowMediumChoice => AppModeCapabilities.CanUseSharedPath(Mode);
+    public bool ShowPointInTime => AppModeCapabilities.CanRestoreToAPointInTime(Mode);
+    public bool ShowFileRelocation => AppModeCapabilities.CanRelocateFiles(Mode);
+    public bool ShowVerifyAndAudit => AppModeCapabilities.CanVerifyAndAudit(Mode);
+    public bool ShowCredentialPanel => AppModeCapabilities.CanManageServerCredentials(Mode) && CredentialApplies;
+    public bool ShowAgentJob => AppModeCapabilities.CanScriptAsAgentJob(Mode);
+    public bool ShowAdvancedOptions => AppModeCapabilities.CanUseAdvancedRestoreOptions(Mode);
+
+    partial void OnModeChanged(AppMode value)
+    {
+        OnPropertyChanged(nameof(ShowMediumChoice));
+        OnPropertyChanged(nameof(ShowPointInTime));
+        OnPropertyChanged(nameof(ShowFileRelocation));
+        OnPropertyChanged(nameof(ShowVerifyAndAudit));
+        OnPropertyChanged(nameof(ShowCredentialPanel));
+        OnPropertyChanged(nameof(ShowAgentJob));
+        OnPropertyChanged(nameof(ShowAdvancedOptions));
+
+        // A medium that is no longer offered must not stay selected underneath a hidden control -
+        // the screen would be restoring FROM DISK with nothing on screen saying so.
+        if (!ShowMediumChoice && SelectedMedium != BackupMedium.AzureBlob)
+            SelectedMedium = BackupMedium.AzureBlob;
+    }
 
     public bool MediumIsBlob => SelectedMedium == BackupMedium.AzureBlob;
     public bool MediumIsSharedPath => SelectedMedium == BackupMedium.SharedPath;
@@ -348,6 +381,7 @@ public partial class RestoreViewModel : ViewModelBase
         OnPropertyChanged(nameof(MediumIsBlob));
         OnPropertyChanged(nameof(MediumIsSharedPath));
         OnPropertyChanged(nameof(CredentialApplies));
+        OnPropertyChanged(nameof(ShowCredentialPanel));
 
         // Same rule as changing the container, for the same reason: what is on screen came from the
         // other medium entirely, and an armed Execute that survives the switch is aimed at

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -1,4 +1,5 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using Blackcat.NineLives.Models;
 using System.IO;
 using Blackcat.NineLives.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -36,6 +37,7 @@ public partial class SettingsViewModel : ViewModelBase
         {
             var config = _credentialStore.LoadConfig();
             _selectedTheme = ThemeManager.Current;
+            _selectedMode = config.Mode ?? AppMode.Pro;
             _checkForUpdates = config.CheckForUpdates;
             _logRetentionDays = config.LogRetentionDays;
         }
@@ -51,6 +53,35 @@ public partial class SettingsViewModel : ViewModelBase
         {
             _loading = false;
         }
+    }
+
+    // ── how much of the app to show (#176) ──────────────────────────────────────
+
+    /// <summary>One entry per mode, with what it turns on, for the picker.</summary>
+    public IReadOnlyList<ModeOption> Modes { get; } =
+        new[] { AppMode.Basic, AppMode.Standard, AppMode.Pro }
+            .Select(m => new ModeOption(m, AppModeCapabilities.Title(m), AppModeCapabilities.Tagline(m)))
+            .ToList();
+
+    [ObservableProperty]
+    private AppMode _selectedMode = AppMode.Pro;
+
+    /// <summary>Raised so the shell can hide or show what the new mode decides.</summary>
+    public event Action<AppMode>? ModeChanged;
+
+    /// <summary>
+    /// Changes what is on screen, and remembers it.
+    ///
+    /// Nothing is deleted by narrowing the mode: a container, a server or a saved credential set up
+    /// under Pro is all still there under Basic, it is simply not shown. That has to stay true, or
+    /// the picker becomes a decision people are afraid to make.
+    /// </summary>
+    partial void OnSelectedModeChanged(AppMode value)
+    {
+        if (_loading) return;
+
+        ModeChanged?.Invoke(value);
+        Save(config => config.Mode = value, "The mode was applied, but could not be saved for next time");
     }
 
     // ── appearance ──────────────────────────────────────────────────────────────

--- a/src/NineLives/Views/ModeSelectionView.xaml
+++ b/src/NineLives/Views/ModeSelectionView.xaml
@@ -1,0 +1,119 @@
+﻿<UserControl x:Class="Blackcat.NineLives.Views.ModeSelectionView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel MaxWidth="1100" HorizontalAlignment="Center" Margin="0,24,0,24">
+
+            <TextBlock Text="How much of Nine Lives do you need?"
+                       Style="{StaticResource HeaderText}"
+                       HorizontalAlignment="Center" />
+
+            <TextBlock Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap"
+                       TextAlignment="Center"
+                       MaxWidth="760"
+                       Margin="0,8,0,0"
+                       Text="Pick the one that sounds like you. Nothing is locked away - this is only about what is on screen, and you can change it at any time in Settings." />
+
+            <!-- Three cards, one row. Deliberately not a wizard: this is one choice, and putting it
+                 behind a Next button would make it feel like setup rather than a preference. -->
+            <ItemsControl ItemsSource="{Binding Cards}" Margin="0,24,0,0">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <UniformGrid Rows="1" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border CornerRadius="8" Margin="8" Padding="0"
+                                Background="{DynamicResource CardBackgroundBrush}"
+                                BorderBrush="{DynamicResource CardBorderBrush}"
+                                BorderThickness="1">
+                            <StackPanel>
+                                <!-- The shade. One accent getting stronger rather than a traffic
+                                     light: these are more and less, not better and worse. -->
+                                <!-- The default lives in the Style, NOT as a local Background. A
+                                     style setter cannot override a locally set value, so a local
+                                     one here made every card the same colour and the triggers below
+                                     silently did nothing - the same trap as the audit tick (#130). -->
+                                <Border Height="6" CornerRadius="8,8,0,0">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="{DynamicResource ModeBasicBrush}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding AccentBrushKey}" Value="ModeStandardBrush">
+                                                    <Setter Property="Background" Value="{DynamicResource ModeStandardBrush}" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding AccentBrushKey}" Value="ModeProBrush">
+                                                    <Setter Property="Background" Value="{DynamicResource ModeProBrush}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                </Border>
+
+                                <StackPanel Margin="20,18,20,20">
+                                    <TextBlock Text="{Binding Title}"
+                                               Style="{StaticResource SubHeaderText}"
+                                               FontSize="20" />
+
+                                    <TextBlock Text="{Binding Tagline}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap"
+                                               Margin="0,6,0,0" />
+
+                                    <!-- Who it is for, before what it contains. Somebody choosing
+                                         between three cards is asking "which one am I?" rather than
+                                         "what does each include?". -->
+                                    <TextBlock Text="{Binding WhoFor}"
+                                               Style="{StaticResource BodyText}"
+                                               TextWrapping="Wrap"
+                                               FontStyle="Italic"
+                                               Margin="0,14,0,0" />
+
+                                    <ItemsControl ItemsSource="{Binding Highlights}" Margin="0,14,0,0">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Grid Margin="0,0,0,6">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBlock Grid.Column="0" Text="&#x2713;"
+                                                               Foreground="{DynamicResource SuccessBrush}"
+                                                               Margin="0,0,8,0"
+                                                               VerticalAlignment="Top" />
+                                                    <TextBlock Grid.Column="1" Text="{Binding}"
+                                                               Style="{StaticResource SecondaryText}"
+                                                               TextWrapping="Wrap" />
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+
+                                    <Button Content="{Binding ChooseLabel}"
+                                            Command="{Binding DataContext.ChooseCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                            CommandParameter="{Binding}"
+                                            Style="{StaticResource PrimaryButton}"
+                                            Padding="16,9"
+                                            Margin="0,18,0,0"
+                                            HorizontalAlignment="Stretch" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <TextBlock Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap"
+                       TextAlignment="Center"
+                       Margin="0,20,0,0"
+                       Text="Whatever you choose, none of your containers, servers or saved credentials are affected. A mode only decides what is shown." />
+
+            <ContentControl Style="{StaticResource ErrorBanner}" Margin="0,16,0,0" />
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/NineLives/Views/ModeSelectionView.xaml.cs
+++ b/src/NineLives/Views/ModeSelectionView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class ModeSelectionView : UserControl
+{
+    public ModeSelectionView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -98,7 +98,8 @@
                          the timeline, the chain, the options, the script, the execute path - works
                          the same either way, which is why this is a selector here rather than a
                          second screen. -->
-                    <StackPanel Margin="0,0,0,14">
+                    <StackPanel Margin="0,0,0,14"
+                                Visibility="{Binding ShowMediumChoice, Converter={StaticResource BoolToVis}}">
                         <TextBlock Text="WHERE THE BACKUPS LIVE" Style="{StaticResource LabelText}" />
                         <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                             <RadioButton Content="Azure Blob Storage"
@@ -339,8 +340,8 @@
                  The estimate goes in FRONT of it because a three-minute operation nobody expected
                  reads as a hang. -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
-                    Visibility="{Binding Inventory.BackupsLoaded, Converter={StaticResource BoolToVis}}">
-                <StackPanel>
+                    Visibility="{Binding ShowVerifyAndAudit, Converter={StaticResource BoolToVis}}">
+                <StackPanel Visibility="{Binding Inventory.BackupsLoaded, Converter={StaticResource BoolToVis}}">
                     <TextBlock Text="AUDIT THESE BACKUPS" Style="{StaticResource LabelText}" />
                     <TextBlock Style="{StaticResource SecondaryText}"
                                TextWrapping="Wrap"
@@ -1250,6 +1251,7 @@
                                       ToolTip="SET SINGLE_USER WITH ROLLBACK IMMEDIATE before restore." />
 
                             <CheckBox Content="KEEP_REPLICATION"
+                                      Visibility="{Binding ShowAdvancedOptions, Converter={StaticResource BoolToVis}}"
                                       IsChecked="{Binding Options.KeepReplication}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
@@ -1287,6 +1289,7 @@
                                        Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
 
                             <CheckBox Content="WITH MOVE (relocate files)"
+                                      Visibility="{Binding ShowFileRelocation, Converter={StaticResource BoolToVis}}"
                                       IsChecked="{Binding UseWithMove}"
                                       Style="{StaticResource DarkCheckBox}"
                                       Margin="0,0,0,12"
@@ -1497,7 +1500,8 @@
                             <!-- Point-in-time (STOPAT): only shown for a log restore point, where
                                  stopping partway through the log is meaningful. -->
                             <StackPanel Visibility="{Binding PointInTime.CanUse, Converter={StaticResource BoolToVis}}">
-                                <TextBlock Text="POINT IN TIME" Style="{StaticResource LabelText}" />
+                                <TextBlock Text="POINT IN TIME" Style="{StaticResource LabelText}"
+                                           Visibility="{Binding ShowPointInTime, Converter={StaticResource BoolToVis}}" />
                                 <CheckBox Content="Stop at a specific time (STOPAT)"
                                           IsChecked="{Binding PointInTime.Use}"
                                           Style="{StaticResource DarkCheckBox}"
@@ -1552,11 +1556,11 @@
                             </Border>
 
                             <TextBlock Text="SQL CREDENTIAL NAME" Style="{StaticResource LabelText}"
-                                       Visibility="{Binding CredentialApplies, Converter={StaticResource BoolToVis}}" />
+                                       Visibility="{Binding ShowCredentialPanel, Converter={StaticResource BoolToVis}}" />
                             <TextBox Text="{Binding Credential.Name, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,8"
-                                     Visibility="{Binding CredentialApplies, Converter={StaticResource BoolToVis}}"
+                                     Visibility="{Binding ShowCredentialPanel, Converter={StaticResource BoolToVis}}"
                                      ToolTip="Defaults to the container URL. The credential on the server must match this name (container URL) for RESTORE FROM URL." />
 
                             <!-- Which identity the credential holds (#147).
@@ -1567,7 +1571,7 @@
                                  the credential this app wrote was always a SAS. On an Entra
                                  container the button failed outright with "no SAS token stored",
                                  which is true, by design, and useless. -->
-                            <StackPanel Visibility="{Binding CredentialApplies, Converter={StaticResource BoolToVis}}"
+                            <StackPanel Visibility="{Binding ShowCredentialPanel, Converter={StaticResource BoolToVis}}"
                                         Margin="0,0,0,10">
                                 <TextBlock Text="AUTHENTICATE AS" Style="{StaticResource LabelText}" />
                                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
@@ -1623,7 +1627,7 @@
                                             <MultiDataTrigger>
                                                 <MultiDataTrigger.Conditions>
                                                     <Condition Binding="{Binding Credential.SectionVisible}" Value="True" />
-                                                    <Condition Binding="{Binding CredentialApplies}" Value="True" />
+                                                    <Condition Binding="{Binding ShowCredentialPanel}" Value="True" />
                                                 </MultiDataTrigger.Conditions>
                                                 <Setter Property="Visibility" Value="Visible" />
                                             </MultiDataTrigger>
@@ -1770,6 +1774,7 @@
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding CopyAsAgentJobCommand}"
                                 IsEnabled="{Binding HasScript}"
+                                Visibility="{Binding ShowAgentJob, Converter={StaticResource BoolToVis}}"
                                 Margin="0,0,8,0"
                                 ToolTip="Wraps this restore as a SQL Server Agent job, one step per batch. The job is created DISABLED and with no schedule - enable or start it when the restore should actually happen." />
                         <Button Content="{Binding Execution.ButtonText}"

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -16,6 +16,18 @@
             <!-- Appearance -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
                 <StackPanel>
+                    <TextBlock Text="HOW MUCH OF THE APP TO SHOW" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                    <ComboBox ItemsSource="{Binding Modes}"
+                              DisplayMemberPath="Name"
+                              SelectedValuePath="Mode"
+                              SelectedValue="{Binding SelectedMode}"
+                              Style="{StaticResource DarkComboBox}"
+                              Width="240"
+                              HorizontalAlignment="Left"
+                              Margin="0,0,0,6" />
+                    <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,20"
+                               Text="Narrowing this hides screens and options; it never deletes anything. Containers, servers and saved credentials set up under a wider mode are all still there, and come back when you widen it again." />
+
                     <TextBlock Text="APPEARANCE" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
                     <ComboBox ItemsSource="{Binding Themes}"
                               DisplayMemberPath="Name"


### PR DESCRIPTION
Closes #176.

Nine Lives started as "restore a database from a blob container" and is now an orchestrator across two media, with a copy action, a header audit, chain validation, point-in-time, MOVE and a credential panel — all of it on screen for everybody. Somebody whose entire job is *"restore last night's full onto the test box"* should not read past four steps and seven sidebar entries to do it.

Growth made the app more capable and less approachable, and those do not have to be a trade.

## Three cards, once

Not every launch — being asked repeatedly would be worse than the clutter this fixes — and changeable from Settings afterwards. The sidebar is hidden while the cards are up: a sidebar sitting behind a choice about what the sidebar contains would be answering the question twice.

A **mode** rather than an "advanced options" toggle, deliberately: a collapsed section still tells you there is something you are not using. A mode says the app is smaller today and means it.

## Where the lines fell

You flagged the Standard/Pro split as a decision, so here is the rule I used and wrote into the code: a feature went in the **lower** tier wherever *"does somebody who has never heard of this need to see it?"* was unclear — because a mode that hides something people need teaches them to switch to Pro and never look back, which would leave the whole idea doing nothing.

- **Basic** — restore from a container. The original app.
- **Standard** — adds the shared-path medium, taking backups, point-in-time, and file relocation.
- **Pro** — adds copy-between-servers, verify and audit, the credential panel, the Agent job export and the less common RESTORE options.

**Point-in-time was the hardest call** and went to Standard. It is close to the heart of what this app is for, but it is also what somebody restoring last night's full will never touch.

## The promise, and what the tests guard

**Narrowing never deletes anything.** Containers, servers and saved credentials set up under Pro are all still there under Basic. If that stopped being true it would become a decision people are afraid to make.

Two consequences, also pinned:

- A screen the new mode hides does not stay on display underneath a sidebar that no longer offers it.
- Narrowing out of a shared-path restore puts the medium back to blob, rather than leaving the app restoring `FROM DISK` with nothing on screen saying so.

Every capability is monotonic — a test walks all ten and asserts nothing available in a narrower mode vanishes in a wider one, so a card saying "everything in Standard" stays true.

An unreadable config lands on **Pro**, not Basic: hiding features from somebody whose config got mangled looks like the app has lost a capability; showing too many is merely untidy.

## What rendering caught

- **All three accent bars were the same blue.** The default was a *local* `Background`, and a style setter cannot override a local value — the identical trap as the audit tick a few hours earlier today. I had even written that one up. Pinned now, and I verified the pin by reintroducing the bug and watching it fail.
- **The buttons read "Basic" rather than "Use Basic".** `Button.Content` is an object, so a `StringFormat` on the binding is quietly ignored — a label describing the card rather than the action.

The CLI (#63) is unaffected: the mode lives in the shell and the viewmodels, and `RestoreViewModel` defaults to Pro so anything constructing it without a shell gets the whole thing.

1,325 unit + 10 integration tests pass.