### PR TITLE
Audit a whole container, not just one database (#130)

### DIFF
--- a/src/NineLives.Tests/AuditWholeContainerTests.cs
+++ b/src/NineLives.Tests/AuditWholeContainerTests.cs
@@ -1,0 +1,223 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Auditing a whole container rather than one database (#130).
+///
+/// The last piece of that issue, and the one its title actually asks about. It only became small
+/// once the estimate, the cache, the progress and the Stop already existed - what is left is the
+/// scope, and making sure the estimate and the run cannot disagree about it.
+///
+/// That last part is the whole risk here. At ~2.1s per set a database is a coffee and a container
+/// can be most of an hour, so the estimate is the only thing standing between somebody and an
+/// unexpected forty minutes. An estimate for one scope and a run over another would be worse than
+/// no estimate at all.
+/// </summary>
+public class AuditWholeContainerTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupFileInfo File_(string database, string name) => new()
+    {
+        BlobName = $"FULL/SRV01/{database}/{name}",
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/FULL/SRV01/{database}/{name}",
+        ETag = $"\"{database}-{name}\"",
+        Type = BackupType.Full,
+        InferredDatabaseName = database,
+        InferredServerName = "SRV01",
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    private static BackupLocation Container() => BackupLocation.Blob(new BlobContainerConfig
+    {
+        Id = "c1",
+        Name = "backups",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups"
+    });
+
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    /// <summary>Three databases, one set each, so the two scopes are 1 and 3.</summary>
+    private static (BackupInventoryViewModel vm, FakeSqlServerService sql) New()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                File_("Sales", "Sales_20260801_220000.bak"),
+                File_("Payroll", "Payroll_20260801_220000.bak"),
+                File_("Archive", "Archive_20260801_220000.bak")
+            ]
+        };
+
+        var sql = new FakeSqlServerService
+        {
+            // A header per file, or a Sales header answering for Payroll would report a mismatch
+            // that is an artefact of the fake.
+            HeaderForUrls = urls => new BackupFileInfo
+            {
+                DatabaseName = DatabaseIn(urls[0]),
+                Type = BackupType.Full,
+                BackupTypeCode = 1
+            }
+        };
+
+        return (new BackupInventoryViewModel(blob, sql, TestLogs.Temp(), TestAuditStores.Temp()), sql);
+    }
+
+    private static string DatabaseIn(string url) => url.Split('/')[^2];
+
+    // ── the scope ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WithoutTheSwitchOnlyTheChosenDatabaseIsRead()
+    {
+        var (vm, sql) = New();
+
+        await vm.LoadAsync(Container());
+        vm.SelectedDatabaseName = "Sales";
+
+        await vm.AuditAsync(Server());
+
+        Assert.Single(sql.HeaderReads);
+    }
+
+    [Fact]
+    public async Task WithTheSwitchEveryDatabaseInTheContainerIsRead()
+    {
+        var (vm, sql) = New();
+
+        await vm.LoadAsync(Container());
+        vm.SelectedDatabaseName = "Sales";
+        vm.AuditWholeContainer = true;
+
+        await vm.AuditAsync(Server());
+
+        Assert.Equal(3, sql.HeaderReads.Count);
+    }
+
+    /// <summary>
+    /// The wider scope does not need a database chosen at all - it is not about the selection, and
+    /// requiring one would be a step that means nothing.
+    /// </summary>
+    [Fact]
+    public async Task TheWiderScopeWorksWithNoDatabaseChosen()
+    {
+        var (vm, sql) = New();
+
+        await vm.LoadAsync(Container());
+        vm.AuditWholeContainer = true;
+
+        Assert.True(vm.CanAudit);
+
+        await vm.AuditAsync(Server());
+
+        Assert.Equal(3, sql.HeaderReads.Count);
+    }
+
+    /// <summary>And without it, no selection means nothing to audit.</summary>
+    [Fact]
+    public async Task TheNarrowScopeStillNeedsADatabase()
+    {
+        var (vm, _) = New();
+
+        await vm.LoadAsync(Container());
+
+        Assert.False(vm.CanAudit);
+    }
+
+    // ── the estimate and the run agree ──────────────────────────────────────────
+
+    /// <summary>
+    /// The one that matters. The estimate is the only thing standing between somebody and an
+    /// unexpected forty minutes, so an estimate for one scope and a run over another would be worse
+    /// than no estimate at all.
+    /// </summary>
+    [Fact]
+    public async Task TheEstimateCountsWhatTheRunWillActuallyRead()
+    {
+        var (vm, sql) = New();
+
+        await vm.LoadAsync(Container());
+        vm.SelectedDatabaseName = "Sales";
+
+        Assert.Contains("1 backup header(s)", vm.AuditEstimate);
+
+        vm.AuditWholeContainer = true;
+        Assert.Contains("3 backup header(s)", vm.AuditEstimate);
+
+        await vm.AuditAsync(Server());
+        Assert.Equal(3, sql.HeaderReads.Count);
+    }
+
+    /// <summary>The wider scope says so, because forty minutes is not a thing to discover mid-run.</summary>
+    [Fact]
+    public async Task TheWiderEstimateSaysItCoversTheWholeContainer()
+    {
+        var (vm, _) = New();
+
+        await vm.LoadAsync(Container());
+        vm.AuditWholeContainer = true;
+
+        Assert.Contains("Every database in this container", vm.AuditEstimate);
+    }
+
+    [Fact]
+    public async Task TheSummarySaysWhichScopeItCovered()
+    {
+        var (vm, _) = New();
+
+        await vm.LoadAsync(Container());
+        vm.AuditWholeContainer = true;
+        await vm.AuditAsync(Server());
+
+        Assert.Contains("in this container", vm.AuditSummary);
+    }
+
+    // ── the cache carries across scopes ─────────────────────────────────────────
+
+    /// <summary>
+    /// Auditing one database and then the container reads only what is left. The cache is keyed on
+    /// the blob, not on the scope that happened to reach it - which is what makes the wider scope
+    /// approachable at all: run it once, then it only ever costs the new backups.
+    /// </summary>
+    [Fact]
+    public async Task AuditingOneDatabaseFirstMakesTheContainerCheaper()
+    {
+        var store = TestAuditStores.Temp();
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                File_("Sales", "Sales_20260801_220000.bak"),
+                File_("Payroll", "Payroll_20260801_220000.bak"),
+                File_("Archive", "Archive_20260801_220000.bak")
+            ]
+        };
+
+        var sql = new FakeSqlServerService
+        {
+            HeaderForUrls = urls => new BackupFileInfo
+            { DatabaseName = DatabaseIn(urls[0]), Type = BackupType.Full, BackupTypeCode = 1 }
+        };
+
+        var vm = new BackupInventoryViewModel(blob, sql, TestLogs.Temp(), store);
+
+        await vm.LoadAsync(Container());
+        vm.SelectedDatabaseName = "Sales";
+        await vm.AuditAsync(Server());
+        Assert.Single(sql.HeaderReads);
+
+        vm.AuditWholeContainer = true;
+        await vm.AuditAsync(Server());
+
+        // Two more, not three - Sales was already answered.
+        Assert.Equal(3, sql.HeaderReads.Count);
+    }
+}

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -168,6 +168,32 @@ public partial class BackupInventoryViewModel : ViewModelBase
     partial void OnAuditSummaryChanged(string value) => OnPropertyChanged(nameof(HasAuditSummary));
 
     /// <summary>
+    /// Whether the audit covers the whole container rather than the chosen database (#130).
+    ///
+    /// Off by default, and it should stay that way. At ~2.1s per set a database is a coffee and a
+    /// container can be most of an hour, so the wider scope is something to opt into having read
+    /// what it costs - which is exactly why the estimate is next to the switch.
+    /// </summary>
+    [ObservableProperty]
+    private bool _auditWholeContainer;
+
+    partial void OnAuditWholeContainerChanged(bool value)
+    {
+        OnPropertyChanged(nameof(AuditEstimate));
+        OnPropertyChanged(nameof(CanAudit));
+    }
+
+    /// <summary>
+    /// What the audit would actually read: the chosen database, or everything loaded.
+    ///
+    /// One place that answers it, so the estimate and the run cannot disagree about scope - which
+    /// would be the worst possible way to get this wrong, since the estimate is the only thing
+    /// standing between somebody and an unexpected forty minutes.
+    /// </summary>
+    public IReadOnlyList<BackupSet> AuditScope =>
+        AuditWholeContainer ? AllSets : WorkingSet;
+
+    /// <summary>
     /// What auditing the current selection would cost, said BEFORE it is started.
     ///
     /// A three-minute operation somebody did not expect reads as a hang. The number is not a guess:
@@ -179,14 +205,19 @@ public partial class BackupInventoryViewModel : ViewModelBase
     {
         get
         {
-            if (WorkingSet.Count == 0) return string.Empty;
+            var scope = AuditScope;
+            if (scope.Count == 0) return string.Empty;
 
-            var toRead = BackupAuditor.NotYetAudited(WorkingSet, _cachedAudit).Count;
-            return BackupAuditor.DescribeEstimate(toRead);
+            var toRead = BackupAuditor.NotYetAudited(scope, _cachedAudit).Count;
+            var estimate = BackupAuditor.DescribeEstimate(toRead);
+
+            return AuditWholeContainer
+                ? $"Every database in this container. {estimate}"
+                : estimate;
         }
     }
 
-    public bool CanAudit => WorkingSet.Count > 0 && !IsAuditing;
+    public bool CanAudit => AuditScope.Count > 0 && !IsAuditing;
 
     /// <summary>
     /// Reads every set in the current selection and reports where the headers disagree.
@@ -197,9 +228,8 @@ public partial class BackupInventoryViewModel : ViewModelBase
     /// </summary>
     public async Task AuditAsync(ServerConnection server)
     {
-        if (WorkingSet.Count == 0) return;
-
-        var sets = WorkingSet.ToList();
+        var sets = AuditScope.ToList();
+        if (sets.Count == 0) return;
         var ct = _loadCancellation.Begin();
 
         IsAuditing = true;
@@ -226,9 +256,11 @@ public partial class BackupInventoryViewModel : ViewModelBase
             // The audit just wrote to it, so the estimate for a re-run has to see the new answers.
             _cachedAudit = _auditStore.Load();
 
+            var where = AuditWholeContainer ? " in this container" : string.Empty;
+
             AuditSummary = findings.Count == 0
-                ? $"All {sets.Count:N0} backup set(s) match their headers."
-                : $"{findings.Count:N0} of {sets.Count:N0} backup set(s) do not match their headers.";
+                ? $"All {sets.Count:N0} backup set(s){where} match their headers."
+                : $"{findings.Count:N0} of {sets.Count:N0} backup set(s){where} do not match their headers.";
 
             SetStatus(AuditSummary);
             _log.Info($"[audit] {AuditSummary}");
@@ -415,6 +447,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
         // one. Leaving either up attaches an answer to a question nobody asked.
         AuditFindings = [];
         AuditSummary = string.Empty;
+        OnPropertyChanged(nameof(AuditScope));
         OnPropertyChanged(nameof(AuditEstimate));
         OnPropertyChanged(nameof(CanAudit));
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -882,7 +882,7 @@ public partial class RestoreViewModel : ViewModelBase
     public bool CanAuditDatabase => Inventory.CanAudit && IsConnectedToServer;
 
     public string AuditBlockedReason =>
-        Inventory.WorkingSet.Count == 0 ? string.Empty
+        Inventory.AuditScope.Count == 0 ? string.Empty
         : IsConnectedToServer ? string.Empty
         : "Connect to a SQL Server instance to audit these backups - it is the server that reads the headers, not this app.";
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -348,6 +348,14 @@
                                Margin="0,6,0,0"
                                Text="Reads each backup's own header and checks it against what the path and filename claimed. The header is what a RESTORE reads, so it settles the question - a log filed as a full, or a backup filed under the wrong database, both look perfectly normal until the restore fails." />
 
+                    <!-- Opt-in, and next to the estimate rather than anywhere else: at ~2.1s per
+                         set a database is a coffee and a container can be most of an hour, so the
+                         number and the switch have to be read together (#130). -->
+                    <CheckBox Content="Every database in this container, not just the selected one"
+                              IsChecked="{Binding Inventory.AuditWholeContainer}"
+                              Style="{StaticResource DarkCheckBox}"
+                              Margin="0,10,0,0" />
+
                     <TextBlock Text="{Binding Inventory.AuditEstimate}"
                                Style="{StaticResource BodyText}"
                                TextWrapping="Wrap"


### PR DESCRIPTION
The last piece of #130, and the one its title actually asks about. It only became small once the estimate, the cache, the progress and the Stop already existed — what is left is the scope.

## Opt-in, next to the number

Off by default. At ~2.1s per set a database is a coffee and a container can be most of an hour, so the wider scope is something to choose *after* reading what it costs — which is why the switch sits beside the estimate rather than anywhere else.

> Every database in this container. Reading 3 backup header(s) — about 10 seconds.

## The estimate and the run cannot disagree

One property answers what the audit will read, and both use it. That is the whole risk here: the estimate is the only thing standing between somebody and an unexpected forty minutes, and an estimate for one scope with a run over another would be worse than no estimate at all. Pinned by a test that flips the switch and checks the count in the estimate against the number of reads the run makes.

## Two smaller decisions

- **The wider scope needs no database chosen**, because it is not about the selection — requiring one would be a step that means nothing.
- **The cache carries across scopes**, since it is keyed on the blob rather than on whatever reached it. Auditing one database and then the container reads only what is left, which is what makes the wider scope approachable at all: run it once, and after that it only ever costs the new backups.

1,333 tests pass.