### PR TITLE
Show the logo, and let the mode cards be reopened (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ built for.
 
 ### Changed
 
+- **The mode cards can be reopened** from Settings, with the mode in force marked and a way to leave
+  without changing anything. They said what each mode turns on and were then shown once, replaced by
+  a drop-down of three names - which is the part of them worth the least (#191)
+- **The sidebar carries the logo** rather than the name typed out in bold, so the mark appears on the
+  screen people look at all day and not only on the splash. The strapline is now
+  RESTORE | RECOVER | RESUME: the old one named one medium and one direction (#191)
 - Chains are built from **LSNs** wherever the source knows them - which means anything read from an
   instance's `msdb`. A differential is paired with the full it was genuinely taken against rather
   than the nearest one by time, and a log joins a chain when it carries it forward rather than when
@@ -67,6 +73,9 @@ built for.
 
 ### Fixed
 
+- The mode picker in Settings showed a raw object - `ModeOption { Mode = Pro, Name` - instead of the
+  mode's name. The picker is gone in favour of the cards, and the buttons on those cards now line up
+  with each other rather than landing wherever the text above them ended (#191)
 - A differential whose base full is missing is no longer offered at all. It used to be paired with
   the nearest full by time, which SQL Server rejects - after `WITH REPLACE` has already dropped the
   target (#130)

--- a/src/NineLives.Tests/AppModeTests.cs
+++ b/src/NineLives.Tests/AppModeTests.cs
@@ -242,6 +242,99 @@ public class AppModeTests
         Assert.False(vm.ShowMediumChoice);
     }
 
+    // ── getting back to the cards (#191) ────────────────────────────────────────
+
+    /// <summary>
+    /// The cards say what each mode turns ON. Showing them once and then replacing them with a list
+    /// of three names kept the part worth the least.
+    /// </summary>
+    [Fact]
+    public void SettingsCanPutTheCardsBackUp()
+    {
+        var main = Chosen(AppMode.Standard);
+
+        main.Settings.ShowModeCardsCommand.Execute(null);
+
+        Assert.True(main.IsChoosingMode);
+        Assert.Same(main.ModeSelection, main.CurrentView);
+    }
+
+    /// <summary>Which one you are on, or the screen starts by making you work that out.</summary>
+    [Fact]
+    public void TheCardForTheModeInForceSaysSo()
+    {
+        var main = Chosen(AppMode.Standard);
+
+        main.Settings.ShowModeCardsCommand.Execute(null);
+
+        Assert.Equal(
+            AppMode.Standard,
+            main.ModeSelection.Cards.Single(c => c.IsCurrent).Mode);
+    }
+
+    /// <summary>
+    /// A way out, because the cards are now opened to READ as often as to choose - and a screen you
+    /// cannot leave without changing something is one people learn not to open.
+    /// </summary>
+    [Fact]
+    public void ReopenedCardsCanBeLeftWithoutChangingAnything()
+    {
+        var main = Chosen(AppMode.Standard);
+        main.Settings.ShowModeCardsCommand.Execute(null);
+
+        Assert.True(main.ModeSelection.CanCancel);
+
+        main.ModeSelection.CancelCommand.Execute(null);
+
+        Assert.False(main.IsChoosingMode);
+        Assert.Equal(AppMode.Standard, main.Mode);
+        Assert.Same(main.Settings, main.CurrentView);
+    }
+
+    /// <summary>
+    /// On first run there is nothing to go back TO. A way out here would be a way to reach an app
+    /// that has not been told how much of itself to show.
+    /// </summary>
+    [Fact]
+    public void FirstRunOffersNoWayOut()
+    {
+        var main = new MainViewModel(new FakeCredentialStore());
+
+        Assert.True(main.IsChoosingMode);
+        Assert.False(main.ModeSelection.CanCancel);
+        Assert.DoesNotContain(main.ModeSelection.Cards, c => c.IsCurrent);
+    }
+
+    [Fact]
+    public void ChoosingFromTheReopenedCardsChangesTheMode()
+    {
+        var main = Chosen(AppMode.Standard);
+        main.Settings.ShowModeCardsCommand.Execute(null);
+
+        var basic = main.ModeSelection.Cards.Single(c => c.Mode == AppMode.Basic);
+        main.ModeSelection.ChooseCommand.Execute(basic);
+
+        Assert.Equal(AppMode.Basic, main.Mode);
+        Assert.False(main.IsChoosingMode);
+    }
+
+    /// <summary>
+    /// Settings reads the mode from the shell. It used to own a copy, which is how it came to show
+    /// one thing while the app did another.
+    /// </summary>
+    [Fact]
+    public void SettingsNamesTheModeInForceAndFollowsIt()
+    {
+        var main = Chosen(AppMode.Standard);
+
+        Assert.Equal("Standard", main.Settings.CurrentModeTitle);
+        Assert.NotEmpty(main.Settings.CurrentModeTagline);
+
+        main.Mode = AppMode.Basic;
+
+        Assert.Equal("Basic", main.Settings.CurrentModeTitle);
+    }
+
     // ── what the cards say ──────────────────────────────────────────────────────
 
     [Fact]
@@ -270,6 +363,14 @@ public class AppModeTests
         var vm = new ModeSelectionViewModel(new FakeCredentialStore());
 
         Assert.Equal(3, vm.Cards.Select(c => c.AccentBrushKey).Distinct().Count());
+    }
+
+    /// <summary>A shell that is past the first-run question, with a mode already in force.</summary>
+    private static MainViewModel Chosen(AppMode mode)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = mode;
+        return new MainViewModel(store);
     }
 
     private static RestoreViewModel Restore(AppMode mode)

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -159,15 +159,35 @@
             <Border Grid.Column="0" Background="{DynamicResource SidebarBackgroundBrush}"
                     Visibility="{Binding IsChoosingMode, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                 <DockPanel>
-                    <!-- App Title -->
-                    <StackPanel DockPanel.Dock="Top" Margin="20,20,20,8">
-                        <TextBlock FontSize="18" FontWeight="Bold"
-                                   FontFamily="Segoe UI">
-                            <Run Text="Nine" Foreground="{DynamicResource PrimaryTextBrush}" /><Run Text=" Lives" Foreground="{DynamicResource AccentBrush}" />
+                    <!-- The mark itself, not a re-typed name (#191).
+                         The paw and the tracked wordmark are the brand; the sidebar used to spell
+                         "Nine Lives" in bold Segoe, so the one screen people look at all day was
+                         the one place the logo never appeared.
+
+                         Both come from Themes/Logo.xaml, shared with the splash - a second copy
+                         would be a second thing to keep in step, and the two sit side by side in
+                         the first few seconds of every launch. -->
+                    <StackPanel DockPanel.Dock="Top" Margin="20,18,20,8">
+                        <ContentControl Template="{StaticResource NineLivesLogo}"
+                                        Height="58"
+                                        HorizontalAlignment="Center" />
+
+                        <TextBlock Style="{StaticResource LogoWordmark}"
+                                   FontSize="16"
+                                   Margin="0,10,0,0">
+                            <!-- Tracking is per-Run: WPF has no letter-spacing, and the wide
+                                 tracking is what makes the wordmark the wordmark. -->
+                            <Run Text="N I N E" Foreground="{DynamicResource PrimaryTextBrush}" /><Run Text="  " /><Run Text="L I V E S" Foreground="{DynamicResource AccentBrush}" />
                         </TextBlock>
-                        <TextBlock Text="SQL Restore from Azure Blob"
+
+                        <!-- Not "SQL Restore from Azure Blob" any more: it names one medium and one
+                             direction, and the app now backs up as well as restores, to a file
+                             share as well as to blob. -->
+                        <TextBlock Text="RESTORE | RECOVER | RESUME"
                                    Style="{StaticResource SecondaryText}"
-                                   Margin="0,4,0,0" />
+                                   FontSize="9.5"
+                                   HorizontalAlignment="Center"
+                                   Margin="0,8,0,0" />
                     </StackPanel>
 
                     <Border DockPanel.Dock="Top"

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -8,9 +8,6 @@ namespace Blackcat.NineLives.ViewModels;
 /// <summary>A theme and the name shown for it.</summary>
 /// <param name="Value">The theme itself.</param>
 /// <param name="Name">What the picker calls it.</param>
-/// <summary>One mode in the Settings picker: what it is called and what it turns on (#176).</summary>
-public sealed record ModeOption(AppMode Mode, string Name, string Description);
-
 public sealed record ThemeOption(AppTheme Value, string Name)
 {
     /// <summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -44,6 +44,7 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(ShowBrowseBackups));
 
         Restore.Mode = value;
+        Settings.CurrentMode = value;
 
         // A screen that has just been hidden must not stay on display underneath a sidebar that no
         // longer offers it - which is what changing mode from Settings would otherwise do.
@@ -54,7 +55,29 @@ public partial class MainViewModel : ViewModelBase
     {
         Mode = mode;
         IsChoosingMode = false;
+
+        // Restore rather than back to Settings, deliberately: the point of changing the mode is the
+        // shape of the app, and landing on the settings page you came from shows none of it.
         NavigateTo(Nav.Restore);
+    }
+
+    /// <summary>
+    /// Puts the cards back up from Settings (#191).
+    ///
+    /// They used to be shown once and then reduced to a drop-down of three names, which is the part
+    /// of them worth the least - what each mode turns ON is written on the cards.
+    /// </summary>
+    private void ShowModeCards()
+    {
+        ModeSelection.ShowCurrent(Mode);
+        IsChoosingMode = true;
+        CurrentView = ModeSelection;
+    }
+
+    private void OnModeCardsCancelled()
+    {
+        IsChoosingMode = false;
+        NavigateTo(Nav.Settings);
     }
 
     /// <summary>Whether a sidebar entry is offered in the current mode.</summary>
@@ -144,6 +167,7 @@ public partial class MainViewModel : ViewModelBase
             log: null, history: _historyStore);
         ModeSelection = new ModeSelectionViewModel(_credentialStore);
         ModeSelection.Chosen += OnModeChosen;
+        ModeSelection.Cancelled += OnModeCardsCancelled;
 
         Backup = new BackupViewModel(_credentialStore, _sqlService);
         CopyDatabase = new CopyDatabaseViewModel(_credentialStore, _sqlService);
@@ -162,7 +186,7 @@ public partial class MainViewModel : ViewModelBase
         // Changing the mode from Settings has to move the app immediately - a sidebar that still
         // offers a screen the new mode hides, or a screen left on display underneath one that no
         // longer lists it, is worse than not offering the setting (#176).
-        Settings.ModeChanged += mode => Mode = mode;
+        Settings.ShowModeCardsRequested += ShowModeCards;
 
         // One place that answers "is it doing something?". Every screen already tracks its own
         // work; without this the answer depended on which part of a long page was scrolled into

--- a/src/NineLives/ViewModels/ModeSelectionViewModel.cs
+++ b/src/NineLives/ViewModels/ModeSelectionViewModel.cs
@@ -7,9 +7,19 @@ using CommunityToolkit.Mvvm.Input;
 namespace Blackcat.NineLives.ViewModels;
 
 /// <summary>One card. What the mode is, who it is for, and what it turns on.</summary>
-public sealed class ModeCard(AppMode mode)
+public sealed partial class ModeCard(AppMode mode) : ObservableObject
 {
     public AppMode Mode { get; } = mode;
+
+    /// <summary>
+    /// Whether this is the mode currently in force.
+    ///
+    /// Only ever true when the cards are reopened from Settings, which is the case where it
+    /// matters: the screen is being read to find out what the OTHER two contain, so the one you
+    /// are already on has to be obvious or every reading of it starts by working that out.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isCurrent;
 
     public string Title { get; } = AppModeCapabilities.Title(mode);
 
@@ -69,6 +79,36 @@ public partial class ModeSelectionViewModel : ViewModelBase
 
     /// <summary>Raised once a mode has been chosen and saved, so the shell can move on.</summary>
     public event Action<AppMode>? Chosen;
+
+    /// <summary>Raised when the cards are closed without changing anything.</summary>
+    public event Action? Cancelled;
+
+    /// <summary>
+    /// Whether there is anything to go back to.
+    ///
+    /// False on first run, because there is no mode yet and a way out would be a way to reach an
+    /// app that has not been told how much of itself to show. True whenever the cards are reopened
+    /// from Settings, where refusing to let somebody leave a screen they opened to READ would be
+    /// the surest way to stop them opening it.
+    /// </summary>
+    [ObservableProperty]
+    private bool _canCancel;
+
+    /// <summary>
+    /// Reopens the cards as a reference rather than as a first-run question (#191).
+    ///
+    /// A drop-down list of three names told you what the modes were CALLED. What is actually worth
+    /// knowing - what each one turns on, and who it is for - was written on the cards and then
+    /// shown once. This is the same screen, reachable.
+    /// </summary>
+    public void ShowCurrent(AppMode mode)
+    {
+        foreach (var card in Cards) card.IsCurrent = card.Mode == mode;
+        CanCancel = true;
+    }
+
+    [RelayCommand]
+    private void Cancel() => Cancelled?.Invoke();
 
     [RelayCommand]
     private void Choose(ModeCard? card)

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -37,7 +37,7 @@ public partial class SettingsViewModel : ViewModelBase
         {
             var config = _credentialStore.LoadConfig();
             _selectedTheme = ThemeManager.Current;
-            _selectedMode = config.Mode ?? AppMode.Pro;
+            _currentMode = config.Mode ?? AppMode.Pro;
             _checkForUpdates = config.CheckForUpdates;
             _logRetentionDays = config.LogRetentionDays;
         }
@@ -57,32 +57,30 @@ public partial class SettingsViewModel : ViewModelBase
 
     // ── how much of the app to show (#176) ──────────────────────────────────────
 
-    /// <summary>One entry per mode, with what it turns on, for the picker.</summary>
-    public IReadOnlyList<ModeOption> Modes { get; } =
-        new[] { AppMode.Basic, AppMode.Standard, AppMode.Pro }
-            .Select(m => new ModeOption(m, AppModeCapabilities.Title(m), AppModeCapabilities.Tagline(m)))
-            .ToList();
-
-    [ObservableProperty]
-    private AppMode _selectedMode = AppMode.Pro;
-
-    /// <summary>Raised so the shell can hide or show what the new mode decides.</summary>
-    public event Action<AppMode>? ModeChanged;
-
     /// <summary>
-    /// Changes what is on screen, and remembers it.
+    /// The mode in force. Kept in step by the shell, which owns it.
     ///
-    /// Nothing is deleted by narrowing the mode: a container, a server or a saved credential set up
-    /// under Pro is all still there under Basic, it is simply not shown. That has to stay true, or
-    /// the picker becomes a decision people are afraid to make.
+    /// Changing it is NOT done here: it reopens the cards, which is the screen that says what each
+    /// mode actually turns on. A drop-down of three names could only ever say what they were
+    /// called (#191).
     /// </summary>
-    partial void OnSelectedModeChanged(AppMode value)
-    {
-        if (_loading) return;
+    [ObservableProperty]
+    private AppMode _currentMode = AppMode.Pro;
 
-        ModeChanged?.Invoke(value);
-        Save(config => config.Mode = value, "The mode was applied, but could not be saved for next time");
+    public string CurrentModeTitle => AppModeCapabilities.Title(CurrentMode);
+    public string CurrentModeTagline => AppModeCapabilities.Tagline(CurrentMode);
+
+    partial void OnCurrentModeChanged(AppMode value)
+    {
+        OnPropertyChanged(nameof(CurrentModeTitle));
+        OnPropertyChanged(nameof(CurrentModeTagline));
     }
+
+    /// <summary>Raised so the shell can put the cards back up.</summary>
+    public event Action? ShowModeCardsRequested;
+
+    [RelayCommand]
+    private void ShowModeCards() => ShowModeCardsRequested?.Invoke();
 
     // ── appearance ──────────────────────────────────────────────────────────────
 

--- a/src/NineLives/Views/ModeSelectionView.xaml
+++ b/src/NineLives/Views/ModeSelectionView.xaml
@@ -31,14 +31,20 @@
                                 Background="{DynamicResource CardBackgroundBrush}"
                                 BorderBrush="{DynamicResource CardBorderBrush}"
                                 BorderThickness="1">
-                            <StackPanel>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+
                                 <!-- The shade. One accent getting stronger rather than a traffic
                                      light: these are more and less, not better and worse. -->
                                 <!-- The default lives in the Style, NOT as a local Background. A
                                      style setter cannot override a locally set value, so a local
                                      one here made every card the same colour and the triggers below
                                      silently did nothing - the same trap as the audit tick (#130). -->
-                                <Border Height="6" CornerRadius="8,8,0,0">
+                                <Border Grid.Row="0" Height="6" CornerRadius="8,8,0,0"
+                                        VerticalAlignment="Top">
                                     <Border.Style>
                                         <Style TargetType="Border">
                                             <Setter Property="Background" Value="{DynamicResource ModeBasicBrush}" />
@@ -54,10 +60,38 @@
                                     </Border.Style>
                                 </Border>
 
-                                <StackPanel Margin="20,18,20,20">
-                                    <TextBlock Text="{Binding Title}"
-                                               Style="{StaticResource SubHeaderText}"
-                                               FontSize="20" />
+                                <!-- Grid, not a StackPanel: the button lives in its own bottom row
+                                     so it sits on the card's edge rather than wherever the text
+                                     above it happened to end. The cards carry different numbers of
+                                     highlights and wrap to different depths, so stacked buttons
+                                     landed at three different heights (#191). -->
+                                <Grid Grid.Row="1" Margin="20,18,20,20">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="*" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+
+                                    <StackPanel Grid.Row="0">
+                                    <Grid>
+                                        <TextBlock Text="{Binding Title}"
+                                                   Style="{StaticResource SubHeaderText}"
+                                                   FontSize="20" />
+
+                                        <!-- Which one you are on. Only ever set when the cards are
+                                             reopened from Settings to read what the others do. -->
+                                        <Border Background="{DynamicResource AccentBrush}"
+                                                CornerRadius="3"
+                                                Padding="7,2"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Visibility="{Binding IsCurrent, Converter={StaticResource BoolToVis}}">
+                                            <TextBlock Text="CURRENT"
+                                                       FontSize="9.5"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="White" />
+                                        </Border>
+                                    </Grid>
 
                                     <TextBlock Text="{Binding Tagline}"
                                                Style="{StaticResource SecondaryText}"
@@ -92,16 +126,18 @@
                                             </DataTemplate>
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
+                                    </StackPanel>
 
-                                    <Button Content="{Binding ChooseLabel}"
+                                    <Button Grid.Row="2"
+                                            Content="{Binding ChooseLabel}"
                                             Command="{Binding DataContext.ChooseCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                             CommandParameter="{Binding}"
                                             Style="{StaticResource PrimaryButton}"
                                             Padding="16,9"
                                             Margin="0,18,0,0"
                                             HorizontalAlignment="Stretch" />
-                                </StackPanel>
-                            </StackPanel>
+                                </Grid>
+                            </Grid>
                         </Border>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
@@ -112,6 +148,17 @@
                        TextAlignment="Center"
                        Margin="0,20,0,0"
                        Text="Whatever you choose, none of your containers, servers or saved credentials are affected. A mode only decides what is shown." />
+
+            <!-- A way out, but only once there is something to go back to (#191). Absent on first
+                 run, where leaving would mean an app that has not been told how much to show; there
+                 whenever the cards are reopened from Settings, because refusing to let somebody
+                 leave a screen they opened to READ is how you stop them opening it. -->
+            <Button Content="Keep what I have"
+                    Command="{Binding CancelCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    HorizontalAlignment="Center"
+                    Margin="0,20,0,0"
+                    Visibility="{Binding CanCancel, Converter={StaticResource BoolToVis}}" />
 
             <ContentControl Style="{StaticResource ErrorBanner}" Margin="0,16,0,0" />
         </StackPanel>

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -17,14 +17,25 @@
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
                 <StackPanel>
                     <TextBlock Text="HOW MUCH OF THE APP TO SHOW" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
-                    <ComboBox ItemsSource="{Binding Modes}"
-                              DisplayMemberPath="Name"
-                              SelectedValuePath="Mode"
-                              SelectedValue="{Binding SelectedMode}"
-                              Style="{StaticResource DarkComboBox}"
-                              Width="240"
-                              HorizontalAlignment="Left"
-                              Margin="0,0,0,6" />
+
+                    <!-- The mode is READ here and CHANGED on the cards (#191).
+                         A drop-down of three names could only say what the modes were called; what
+                         each one turns on is written on the cards, and they were being shown once
+                         and then never again. -->
+                    <TextBlock Text="{Binding CurrentModeTitle}"
+                               Style="{StaticResource SubHeaderText}"
+                               FontSize="17" />
+                    <TextBlock Text="{Binding CurrentModeTagline}"
+                               Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,0" />
+
+                    <Button Content="Compare the modes..."
+                            Command="{Binding ShowModeCardsCommand}"
+                            Style="{StaticResource SecondaryButton}"
+                            HorizontalAlignment="Left"
+                            Margin="0,12,0,8" />
+
                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,0,0,20"
                                Text="Narrowing this hides screens and options; it never deletes anything. Containers, servers and saved credentials set up under a wider mode are all still there, and come back when you widen it again." />
 


### PR DESCRIPTION
Four things on the same seam — how the app presents itself now that the mode picker has landed.

## The drop-down showed a raw object, and was the wrong control anyway

Settings read `ModeOption { Mode = Pro, Name`. The combo box's own template renders the selected item through a plain `ContentPresenter`, which ignores `DisplayMemberPath` — `ThemeOption` already carries a `ToString()` override with a comment saying exactly that, and `ModeOption` was added later without one.

Gone rather than fixed. The cards say what each mode turns **on** and who it is for; they were shown once and then replaced by a list of three names, which is the part of them worth the least. Settings now names the mode in force and offers **Compare the modes…**, which puts the cards back up.

- The mode in force carries a **CURRENT** pill, or the screen starts by making you work that out.
- **Keep what I have** leaves without changing anything — the cards are now opened to *read* as often as to choose, and a screen you cannot leave without changing something is one people learn not to open.
- That way out is absent on first run, where leaving would mean reaching an app that has not been told how much of itself to show.

## The card buttons sat at three different heights

The cards carry different numbers of highlights and wrap to different depths, and the buttons were stacked after them. Each button now lives in its own bottom row, so it sits on the card's edge.

## The sidebar spelled the name instead of showing the mark

The paw and the tracked wordmark are in `Themes/Logo.xaml` and were used only by the splash — so the one screen people look at all day was the only place the logo never appeared. Both come from the shared resource rather than a second copy, since the two sit side by side in the first few seconds of every launch.

The strapline is now **RESTORE | RECOVER | RESUME**. "SQL Restore from Azure Blob" names one medium and one direction, and the app backs up as well as restores, to a file share as well as to blob.

---

Every screen here was rendered to PNG and looked at — that is how the button alignment and the pill were confirmed rather than assumed. 1,339 tests pass, six of them new and covering the reopen path.