### PR TITLE
Centre the mode cards in the window (#191)

### DIFF
--- a/src/NineLives/Views/ModeSelectionView.xaml
+++ b/src/NineLives/Views/ModeSelectionView.xaml
@@ -2,8 +2,20 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel MaxWidth="1100" HorizontalAlignment="Center" Margin="0,24,0,24">
+    <ScrollViewer x:Name="Scroller" VerticalScrollBarVisibility="Auto">
+        <!-- Centred in the window, not parked at the top (#191).
+             This is the whole screen while it is up, so it should sit in the middle of it rather
+             than leaving a third of the window empty underneath.
+
+             MinHeight tracks the viewport so the panel has a full screen to centre within. Without
+             it the Grid would be only as tall as the cards and VerticalAlignment would have nothing
+             to work against; with it, a window too short for the cards still scrolls normally,
+             because the content then exceeds the viewport and the Grid grows past it. -->
+        <Grid MinHeight="{Binding ViewportHeight, ElementName=Scroller}">
+        <StackPanel MaxWidth="1100"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Margin="0,24,0,24">
 
             <TextBlock Text="How much of Nine Lives do you need?"
                        Style="{StaticResource HeaderText}"
@@ -162,5 +174,6 @@
 
             <ContentControl Style="{StaticResource ErrorBanner}" Margin="0,16,0,0" />
         </StackPanel>
+        </Grid>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
They sat at the top with a third of the window empty underneath. This is the whole screen while it is up, so it belongs in the middle of it.

The panel centres inside a `Grid` whose `MinHeight` tracks the ScrollViewer's viewport. Without that the Grid would be only as tall as the cards and `VerticalAlignment` would have nothing to work against; with it, a window **too short** for the cards still scrolls normally, because the content then exceeds the viewport and the Grid grows past it rather than clipping.

Rendered at both a full window and one too short to fit — neither the compiler nor a test says anything about where a panel ends up. No test here for that reason: this is layout, and the render is the check.