### PR TITLE
Three views of one app, centred in the window (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ built for.
 
 ### Changed
 
+- **The modes are named for the work, not for a rank.** "Restore only", "Back up and restore" and
+  "Everything", rather than Basic/Standard/Pro with a column of ticks against a column of features,
+  an "everything in Basic" ladder and a "Use Pro" button. They are three views of one application
+  and none of them costs anything; the screen should not suggest otherwise (#191)
 - **The mode cards can be reopened** from Settings, with the mode in force marked and a way to leave
   without changing anything. They said what each mode turns on and were then shown once, replaced by
   a drop-down of three names - which is the part of them worth the least (#191)
@@ -73,6 +77,9 @@ built for.
 
 ### Fixed
 
+- The mode cards sat at the top of the window and off to the right of it. Hiding the sidebar left
+  its 220px column behind, because a ColumnDefinition keeps its width whatever happens to the
+  element inside it (#191)
 - The mode picker in Settings showed a raw object - `ModeOption { Mode = Pro, Name` - instead of the
   mode's name. The picker is gone in favour of the cards, and the buttons on those cards now line up
   with each other rather than landing wherever the text above them ended (#191)

--- a/src/NineLives.Tests/AppModeTests.cs
+++ b/src/NineLives.Tests/AppModeTests.cs
@@ -327,12 +327,12 @@ public class AppModeTests
     {
         var main = Chosen(AppMode.Standard);
 
-        Assert.Equal("Standard", main.Settings.CurrentModeTitle);
+        Assert.Equal(AppModeCapabilities.Title(AppMode.Standard), main.Settings.CurrentModeTitle);
         Assert.NotEmpty(main.Settings.CurrentModeTagline);
 
         main.Mode = AppMode.Basic;
 
-        Assert.Equal("Basic", main.Settings.CurrentModeTitle);
+        Assert.Equal(AppModeCapabilities.Title(AppMode.Basic), main.Settings.CurrentModeTitle);
     }
 
     // ── what the cards say ──────────────────────────────────────────────────────

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -1045,26 +1045,56 @@ public class XamlLoadTests(WpfFixture wpf)
     }
 
     /// <summary>
-    /// The button says what pressing it does.
+    /// The button says what pressing it does, and does NOT repeat the card's own title.
     ///
-    /// Also found by rendering: Button.Content is an object, so a StringFormat on the binding is
-    /// quietly ignored - the button read "Basic" rather than "Use Basic", a label describing the
-    /// card rather than the action.
+    /// Found by rendering: Button.Content is an object, so a StringFormat on the binding is quietly
+    /// ignored, and the button read "Basic" - a label describing the card rather than the action.
+    ///
+    /// The same words on all three since #191. "Use Pro" under a Basic/Standard/Pro heading was
+    /// most of what made this screen feel like a checkout, and the titles now name the work.
     /// </summary>
     [Fact]
     public void EachCardsButtonSaysWhatPressingItDoes()
     {
         wpf.Invoke(() =>
         {
-            var view = new ModeSelectionView { DataContext = new ModeSelectionViewModel(Store()) };
+            var vm = new ModeSelectionViewModel(Store());
+            var view = new ModeSelectionView { DataContext = vm };
             Realise(view);
 
             var labels = VisibleButtons(view).Select(b => b.Content as string).ToList();
 
-            Assert.Contains("Use Basic", labels);
-            Assert.Contains("Use Standard", labels);
-            Assert.Contains("Use Pro", labels);
+            foreach (var card in vm.Cards)
+            {
+                Assert.Contains(card.ChooseLabel, labels);
+                Assert.NotEqual(card.Title, card.ChooseLabel);
+            }
         });
+    }
+
+    /// <summary>
+    /// Nothing on this screen ranks the modes.
+    ///
+    /// It read as a price list: Basic/Standard/Pro, a column of green ticks against a column of
+    /// features, "Everything in Basic" laddering upwards, and a "Use Pro" button. They are three
+    /// views of one application, and none of them costs anything (#191).
+    /// </summary>
+    [Fact]
+    public void NothingOnTheCardsReadsLikeAPriceList()
+    {
+        var words = new[] { "Basic", "Standard", "Pro", "Everything in", "upgrade", "plan", "tier" };
+
+        foreach (var mode in new[] { AppMode.Basic, AppMode.Standard, AppMode.Pro })
+        {
+            var copy = string.Join(" ",
+                [AppModeCapabilities.Title(mode),
+                 AppModeCapabilities.Tagline(mode),
+                 AppModeCapabilities.WhoFor(mode),
+                 .. AppModeCapabilities.Highlights(mode)]);
+
+            foreach (var word in words)
+                Assert.DoesNotContain(word, copy, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     /// <summary>

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -148,7 +148,9 @@
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="220" />
+                <!-- Bound, because collapsing the sidebar does not collapse the space it sits in
+                     and the cards centre in what is left (#191). -->
+                <ColumnDefinition Width="{Binding SidebarWidth}" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 

--- a/src/NineLives/Models/AppMode.cs
+++ b/src/NineLives/Models/AppMode.cs
@@ -104,21 +104,35 @@ public static class AppModeCapabilities
 
     // ── what a mode is, in words ────────────────────────────────────────────────
 
+    /// <summary>
+    /// Named for the WORK, not for a rank.
+    ///
+    /// Basic/Standard/Pro reads as a price list, which is the wrong idea twice over: nothing here
+    /// is bought, and nothing is withheld. The enum keeps those names because they are already in
+    /// everybody's config.json and renaming them would reset the setting - what changes is what
+    /// anybody is shown (#191).
+    /// </summary>
     public static string Title(AppMode mode) => mode switch
     {
-        AppMode.Basic => "Basic",
-        AppMode.Standard => "Standard",
-        _ => "Pro"
+        AppMode.Basic => "Restore only",
+        AppMode.Standard => "Back up and restore",
+        _ => "Everything"
     };
 
+    /// <summary>One line on what is on SCREEN - not on what the mode is worth.</summary>
     public static string Tagline(AppMode mode) => mode switch
     {
-        AppMode.Basic => "Restore a database from a blob container.",
-        AppMode.Standard => "Back up and restore, to blob or a file share, with point-in-time recovery.",
-        _ => "Everything, including copying between servers and auditing backups."
+        AppMode.Basic => "The restore screen, and nothing else.",
+        AppMode.Standard => "Restoring, plus taking the backups yourself.",
+        _ => "Every screen, including the checks."
     };
 
-    /// <summary>What it turns on, for the card. Short lines, because a card nobody reads is a gate.</summary>
+    /// <summary>
+    /// What is on screen. Short lines, because a card nobody reads is a gate.
+    ///
+    /// The wider modes say what they ADD rather than "everything in Basic, plus" - the ladder
+    /// phrasing is what made three views of one app read as three tiers of a product.
+    /// </summary>
     public static IReadOnlyList<string> Highlights(AppMode mode) => mode switch
     {
         AppMode.Basic =>
@@ -130,29 +144,37 @@ public static class AppModeCapabilities
 
         AppMode.Standard =>
         [
-            "Everything in Basic",
-            "Back up a database, to blob or a file share",
-            "Restore from a path both servers can see",
-            "Restore to a moment in time, and relocate files"
+            "Taking a backup, to blob or a file share",
+            "Restoring from a path both servers can see",
+            "Restoring to a moment in time",
+            "Putting the database files somewhere else"
         ],
 
         _ =>
         [
-            "Everything in Standard",
-            "Copy a database onto another server in one action",
-            "Verify and audit backups against their own headers",
-            "Manage server-side credentials, and script as an Agent job"
+            "Copying a database onto another server",
+            "Verifying and auditing backups against their headers",
+            "Server-side credentials, and handing a restore to an Agent job"
         ]
     };
 
     /// <summary>
-    /// Who it is for. Named rather than described, because somebody choosing between three cards on
-    /// first run is asking "which one am I?" rather than "what does each contain?".
+    /// What the list underneath is. Said once, above it, rather than "Adds:" on every line - which
+    /// is what the phrasing had degenerated into once the "everything in Basic" ladder came out.
+    /// </summary>
+    public static string HighlightsLabel(AppMode mode) =>
+        mode == AppMode.Basic ? "On screen" : "Adds";
+
+    /// <summary>
+    /// Which one to pick, in terms of the job rather than the person.
+    ///
+    /// It used to say "you want every check the tool can make", which quietly makes the narrow
+    /// modes the choice of somebody who wants less - and nobody picks that about themselves.
     /// </summary>
     public static string WhoFor(AppMode mode) => mode switch
     {
-        AppMode.Basic => "You need last night's backup on another server, and nothing more.",
-        AppMode.Standard => "You look after the backups as well as the restores.",
-        _ => "You want every check the tool can make, and are happy to be asked."
+        AppMode.Basic => "Pick this if someone else looks after the backups.",
+        AppMode.Standard => "Pick this if the backups are yours too.",
+        _ => "Pick this if you would rather have everything to hand."
     };
 }

--- a/src/NineLives/Themes/Palette.Dark.xaml
+++ b/src/NineLives/Themes/Palette.Dark.xaml
@@ -87,8 +87,8 @@
          High contrast takes the three pure hues it already uses elsewhere, because a 6px bar
          distinguished only by saturation is exactly what that theme exists to avoid. -->
     <SolidColorBrush x:Key="ModeBasicBrush" Color="#3B83E9" />
-    <SolidColorBrush x:Key="ModeStandardBrush" Color="#7C5CE0" />
-    <SolidColorBrush x:Key="ModeProBrush" Color="#C2557A" />
+    <SolidColorBrush x:Key="ModeStandardBrush" Color="#3E9C8F" />
+    <SolidColorBrush x:Key="ModeProBrush" Color="#7C5CE0" />
 
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />

--- a/src/NineLives/Themes/Palette.Light.xaml
+++ b/src/NineLives/Themes/Palette.Light.xaml
@@ -85,8 +85,8 @@
          High contrast takes the three pure hues it already uses elsewhere, because a 6px bar
          distinguished only by saturation is exactly what that theme exists to avoid. -->
     <SolidColorBrush x:Key="ModeBasicBrush" Color="#2C6FD1" />
-    <SolidColorBrush x:Key="ModeStandardBrush" Color="#6A46CC" />
-    <SolidColorBrush x:Key="ModeProBrush" Color="#AE4468" />
+    <SolidColorBrush x:Key="ModeStandardBrush" Color="#2F7F74" />
+    <SolidColorBrush x:Key="ModeProBrush" Color="#6A46CC" />
 
     <SolidColorBrush x:Key="AccentBrush" Color="{StaticResource AccentColor}" />
     <SolidColorBrush x:Key="AccentHoverBrush" Color="{StaticResource AccentHoverColor}" />

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Blackcat.NineLives.Models;
@@ -30,6 +31,18 @@ public partial class MainViewModel : ViewModelBase
     /// <summary>True while the mode cards are up, which is once, on first run.</summary>
     [ObservableProperty]
     private bool _isChoosingMode;
+
+    /// <summary>
+    /// How much room the sidebar's COLUMN takes.
+    ///
+    /// Collapsing the sidebar itself is not enough: a ColumnDefinition keeps its width whatever
+    /// happens to the element inside it, so hiding the sidebar left 220px of nothing on the left
+    /// and pushed the mode cards - which centre inside the remaining column - visibly off to the
+    /// right of the window (#191).
+    /// </summary>
+    public GridLength SidebarWidth => IsChoosingMode ? new GridLength(0) : new GridLength(220);
+
+    partial void OnIsChoosingModeChanged(bool value) => OnPropertyChanged(nameof(SidebarWidth));
 
     // Each of these is asked by the navigation and by the screens themselves, so they live here
     // rather than being recomputed from Mode at every binding.

--- a/src/NineLives/ViewModels/ModeSelectionViewModel.cs
+++ b/src/NineLives/ViewModels/ModeSelectionViewModel.cs
@@ -27,21 +27,24 @@ public sealed partial class ModeCard(AppMode mode) : ObservableObject
     /// The button's text, built here rather than by a StringFormat on the binding.
     ///
     /// Button.Content is an object, so a StringFormat on it is quietly ignored - the button read
-    /// "Basic" where it should have said "Use Basic", which is a label describing the card rather
-    /// than the action.
+    /// "Basic" where it should have said what pressing it does.
+    ///
+    /// The same words on all three now that the titles name the work: "Use Pro" alongside a price
+    /// -list heading was most of what made this screen feel like a checkout (#191).
     /// </summary>
-    public string ChooseLabel { get; } = $"Use {AppModeCapabilities.Title(mode)}";
+    public string ChooseLabel { get; } = "Show me this view";
     public string Tagline { get; } = AppModeCapabilities.Tagline(mode);
     public string WhoFor { get; } = AppModeCapabilities.WhoFor(mode);
 
     public IReadOnlyList<string> Highlights { get; } = AppModeCapabilities.Highlights(mode);
+    public string HighlightsLabel { get; } = AppModeCapabilities.HighlightsLabel(mode);
 
     /// <summary>
     /// Which shade the card takes.
     ///
-    /// Deliberately not a traffic light. These are not better and worse, they are more and less -
-    /// so the progression is one accent getting stronger rather than green-amber-red, which would
-    /// read as "the safe one and the dangerous ones".
+    /// Deliberately not a traffic light, and deliberately not a gradient from cool to hot either -
+    /// three unrelated colours, because a progression is exactly the thing this screen should not
+    /// suggest. They are three views of one app, not three rungs.
     /// </summary>
     public string AccentBrushKey { get; } = mode switch
     {

--- a/src/NineLives/Views/ModeSelectionView.xaml
+++ b/src/NineLives/Views/ModeSelectionView.xaml
@@ -17,16 +17,18 @@
                     VerticalAlignment="Center"
                     Margin="0,24,0,24">
 
-            <TextBlock Text="How much of Nine Lives do you need?"
+            <!-- "How much do you NEED" asks people to rank themselves, which is half of why this
+                 screen read like a price list. It is a view setting (#191). -->
+            <TextBlock Text="How much do you want on screen?"
                        Style="{StaticResource HeaderText}"
                        HorizontalAlignment="Center" />
 
             <TextBlock Style="{StaticResource SecondaryText}"
                        TextWrapping="Wrap"
                        TextAlignment="Center"
-                       MaxWidth="760"
+                       MaxWidth="780"
                        Margin="0,8,0,0"
-                       Text="Pick the one that sounds like you. Nothing is locked away - this is only about what is on screen, and you can change it at any time in Settings." />
+                       Text="All three are the same application - this only sets how many options it puts in front of you. Nothing is locked, nothing is bought, and you can change it whenever you like in Settings." />
 
             <!-- Three cards, one row. Deliberately not a wizard: this is one choice, and putting it
                  behind a Next button would make it feel like setup rather than a preference. -->
@@ -49,8 +51,9 @@
                                     <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
 
-                                <!-- The shade. One accent getting stronger rather than a traffic
-                                     light: these are more and less, not better and worse. -->
+                                <!-- The shade. Three unrelated colours rather than a progression -
+                                     the old run went blue to purple to pink, and a gradient reads
+                                     as a ladder however carefully the words are chosen (#191). -->
                                 <!-- The default lives in the Style, NOT as a local Background. A
                                      style setter cannot override a locally set value, so a local
                                      one here made every card the same colour and the triggers below
@@ -119,7 +122,11 @@
                                                FontStyle="Italic"
                                                Margin="0,14,0,0" />
 
-                                    <ItemsControl ItemsSource="{Binding Highlights}" Margin="0,14,0,0">
+                                    <TextBlock Text="{Binding HighlightsLabel}"
+                                               Style="{StaticResource LabelText}"
+                                               Margin="0,16,0,6" />
+
+                                    <ItemsControl ItemsSource="{Binding Highlights}">
                                         <ItemsControl.ItemTemplate>
                                             <DataTemplate>
                                                 <Grid Margin="0,0,0,6">
@@ -127,8 +134,13 @@
                                                         <ColumnDefinition Width="Auto" />
                                                         <ColumnDefinition Width="*" />
                                                     </Grid.ColumnDefinitions>
-                                                    <TextBlock Grid.Column="0" Text="&#x2713;"
-                                                               Foreground="{DynamicResource SuccessBrush}"
+                                                    <!-- A quiet dot, not a green tick. A column of
+                                                         ticks against a column of features is the
+                                                         shape of a pricing table, and it made three
+                                                         views of one app read as three tiers of a
+                                                         product (#191). -->
+                                                    <TextBlock Grid.Column="0" Text="&#x2022;"
+                                                               Style="{StaticResource SecondaryText}"
                                                                Margin="0,0,8,0"
                                                                VerticalAlignment="Top" />
                                                     <TextBlock Grid.Column="1" Text="{Binding}"


### PR DESCRIPTION
## The cards were off-centre

Not the panel's doing — it centres inside the column it is given. Hiding the sidebar left the sidebar's **220px column** behind, because a `ColumnDefinition` keeps its width whatever happens to the element inside it. The column now collapses with the sidebar.

## And the screen read like a price list

Which is the wrong idea twice over: nothing here is bought, and nothing is withheld. Every ingredient of a pricing table was present —

| was | now |
| --- | --- |
| Basic / Standard / Pro | **Restore only** / **Back up and restore** / **Everything** — named for the work |
| a column of green ticks against a column of features | quiet dots |
| "Everything in Basic", "Everything in Standard" | each card says what it **adds**, said once above the list |
| "Use Pro" | every button says "Show me this view" |
| "You want every check the tool can make" | "Pick this if you would rather have everything to hand" |
| blue → purple → pink | three unrelated colours — a gradient reads as a ladder however carefully the words are chosen |

The header asked "How much of Nine Lives do you **need**?", which invites people to rank themselves. It is a view setting: "How much do you want on screen?"

**The enum keeps `Basic`/`Standard`/`Pro`.** Those names are in everybody's `config.json` already and renaming them would silently reset the setting. Only what people are shown has changed.

Pinned by a test that fails if "Basic", "Standard", "Pro", "Everything in", "upgrade", "plan" or "tier" reappears anywhere in the card copy. 1,340 tests pass.