### PR TITLE
Do not draw a card around nothing (#195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ built for.
 
 ### Fixed
 
+- The widest mode drew an empty bordered box under the source picker. The audit card's border was
+  gated on the mode while its contents waited on the backups, so between "this mode can audit" and
+  "there is something to audit" the chrome outlived its own contents (#195)
 - The mode cards sat at the top of the window and off to the right of it. Hiding the sidebar left
   its 220px column behind, because a ColumnDefinition keeps its width whatever happens to the
   element inside it (#191)

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -1045,6 +1045,49 @@ public class XamlLoadTests(WpfFixture wpf)
     }
 
     /// <summary>
+    /// No mode shows a card with nothing in it.
+    ///
+    /// Found by rendering the restore screen in all three modes: the audit card's BORDER was shown
+    /// on the mode alone while its contents waited for backups to be loaded, so the widest mode met
+    /// an empty bordered box under the source picker before it had anything to audit (#195).
+    ///
+    /// Written against every card rather than that one, because the shape of the mistake - chrome
+    /// gated on one condition and contents on another - is the kind that arrives again the next
+    /// time a panel learns a second reason to be hidden.
+    /// </summary>
+    [Theory]
+    [InlineData(AppMode.Basic)]
+    [InlineData(AppMode.Standard)]
+    [InlineData(AppMode.Pro)]
+    public void NoModeDrawsACardAroundNothing(AppMode mode)
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            vm.Mode = mode;
+
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            // Cards only. Every control template in the app is full of Borders, and a hidden child
+            // inside one of those is ordinary - it is the CARD chrome that must not outlive its
+            // own contents.
+            var cardStyle = view.TryFindResource("CardBorder") as Style;
+            Assert.NotNull(cardStyle);
+
+            foreach (var card in FindAll<Border>(view).Where(b => b.Style == cardStyle).Where(IsShown))
+            {
+                if (card.Child is not FrameworkElement child) continue;
+
+                Assert.True(
+                    IsShown(child),
+                    $"A card is visible in {mode} with its contents hidden - a border drawn around "
+                    + $"nothing. First label inside: {FirstLabel(card) ?? "(none)"}");
+            }
+        });
+    }
+
+    /// <summary>
     /// The button says what pressing it does, and does NOT repeat the card's own title.
     ///
     /// Found by rendering: Button.Content is an object, so a StringFormat on the binding is quietly
@@ -1458,6 +1501,9 @@ public class XamlLoadTests(WpfFixture wpf)
     /// </summary>
     private static List<Button> VisibleButtons(DependencyObject root)
         => FindAll<Button>(root).Where(IsShown).ToList();
+
+    private static string? FirstLabel(DependencyObject card)
+        => FindAll<TextBlock>(card).Select(t => t.Text).FirstOrDefault(t => !string.IsNullOrWhiteSpace(t));
 
     private static bool IsShown(FrameworkElement element)
     {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -344,6 +344,15 @@ public partial class RestoreViewModel : ViewModelBase
     public bool ShowPointInTime => AppModeCapabilities.CanRestoreToAPointInTime(Mode);
     public bool ShowFileRelocation => AppModeCapabilities.CanRelocateFiles(Mode);
     public bool ShowVerifyAndAudit => AppModeCapabilities.CanVerifyAndAudit(Mode);
+
+    /// <summary>
+    /// Whether the audit card appears at all.
+    ///
+    /// The mode AND something to audit. The card used to be shown on the mode alone while its
+    /// contents waited on the backups, so anybody in the widest mode met an empty bordered box
+    /// sitting under the source picker before they had loaded anything (#195).
+    /// </summary>
+    public bool ShowAuditPanel => ShowVerifyAndAudit && Inventory.BackupsLoaded;
     public bool ShowCredentialPanel => AppModeCapabilities.CanManageServerCredentials(Mode) && CredentialApplies;
     public bool ShowAgentJob => AppModeCapabilities.CanScriptAsAgentJob(Mode);
     public bool ShowAdvancedOptions => AppModeCapabilities.CanUseAdvancedRestoreOptions(Mode);
@@ -354,6 +363,7 @@ public partial class RestoreViewModel : ViewModelBase
         OnPropertyChanged(nameof(ShowPointInTime));
         OnPropertyChanged(nameof(ShowFileRelocation));
         OnPropertyChanged(nameof(ShowVerifyAndAudit));
+        OnPropertyChanged(nameof(ShowAuditPanel));
         OnPropertyChanged(nameof(ShowCredentialPanel));
         OnPropertyChanged(nameof(ShowAgentJob));
         OnPropertyChanged(nameof(ShowAdvancedOptions));
@@ -614,6 +624,11 @@ public partial class RestoreViewModel : ViewModelBase
                     break;
 
                 case nameof(BackupInventoryViewModel.BackupsLoaded):
+                    OnPropertyChanged(nameof(ShowAuditPanel));
+                    RefreshSteps();
+                    RefreshCheckState();
+                    break;
+
                 case nameof(BackupInventoryViewModel.SelectedServerName):
                     RefreshSteps();
                     RefreshCheckState();

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -339,9 +339,11 @@
 
                  The estimate goes in FRONT of it because a three-minute operation nobody expected
                  reads as a hang. -->
+            <!-- One condition on the CARD, not the mode on the border and the backups on what is
+                 inside it - that combination drew the chrome around nothing (#195). -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
-                    Visibility="{Binding ShowVerifyAndAudit, Converter={StaticResource BoolToVis}}">
-                <StackPanel Visibility="{Binding Inventory.BackupsLoaded, Converter={StaticResource BoolToVis}}">
+                    Visibility="{Binding ShowAuditPanel, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
                     <TextBlock Text="AUDIT THESE BACKUPS" Style="{StaticResource LabelText}" />
                     <TextBlock Style="{StaticResource SecondaryText}"
                                TextWrapping="Wrap"


### PR DESCRIPTION
Found by rendering the restore screen in all three modes before rolling v1.4 — the sweep I should have run when the modes landed rather than after two rounds of feedback.

The audit card's **border** was gated on the mode while its **contents** were gated on `Inventory.BackupsLoaded`, so between "this mode can audit" and "there is something to audit" the chrome outlived its own contents. One condition on the card now.

The test is written against every card rather than that one — chrome gated on one condition and contents on another is the kind of mistake that arrives again the next time a panel learns a second reason to be hidden. It is scoped to the `CardBorder` style, since every control template in the app is full of Borders and a hidden child inside one of those is ordinary; scoping it that way is also what turned two false positives into a clean pass.

Checked by reintroducing the bug: the widest mode fails, the other two do not. 1,343 tests pass.