### PR TITLE
Browse what a server has backed up, not only a container (#197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ built for.
 
 ### Changed
 
+- **Browse Backups can read a server's backup history**, not only a blob container. Backing up and
+  restoring have taken either medium since #165 and this screen did not come along, so the one
+  screen whose whole purpose is looking could not look at half of what the app writes. A share is
+  not walked as a directory - a folder of .bak files says nothing about which database each belongs
+  to - so the instance that took them is asked what it recorded (#197)
 - **The modes are named for the work, not for a rank.** "Restore only", "Back up and restore" and
   "Everything", rather than Basic/Standard/Pro with a column of ticks against a column of features,
   an "everything in Basic" ladder and a "Use Pro" button. They are three views of one application

--- a/src/NineLives.Tests/BrowseFromServerHistoryTests.cs
+++ b/src/NineLives.Tests/BrowseFromServerHistoryTests.cs
@@ -1,0 +1,213 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Browsing what a server has recorded backing up (#197).
+///
+/// Backing up and restoring have both taken either medium since #165, and Browse Backups did not
+/// come along - so the one screen whose entire purpose is LOOKING was the one that could not look
+/// at half of what the app writes.
+///
+/// A share is not browsed by walking a directory: a folder of .bak files says nothing about which
+/// database each belongs to, what type it is, or which full a differential was taken against, and
+/// inferring that from filenames is the whole reason #130 exists. The instance that TOOK the
+/// backups recorded all of it, so that is what is read.
+/// </summary>
+public class BrowseFromServerHistoryTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 7, 22, 0, 0);
+
+    private static ServerConnection Server(string name = "SRV01") =>
+        new() { Id = ServerConnection.NewId(), Name = name, ServerName = name };
+
+    private static BackupHistoryEntry Entry(string database, BackupType type, string file) => new()
+    {
+        DatabaseName = database,
+        ServerName = "SRV01",
+        Type = type,
+        FinishedAt = T0,
+        Files = [file]
+    };
+
+    /// <summary>A store holding one container and one server, so either source can be chosen.</summary>
+    private static FakeCredentialStore Store()
+    {
+        var store = new FakeCredentialStore();
+
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+        store.Config.Servers.Add(Server());
+
+        return store;
+    }
+
+    private static (BlobBrowserViewModel vm, FakeSqlServerService sql) New(FakeCredentialStore? store = null)
+    {
+        store ??= Store();
+
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                Entry("Sales", BackupType.Full, @"\\nas01\sql\Sales_FULL.bak"),
+                Entry("Sales", BackupType.TransactionLog, @"\\nas01\sql\Sales_LOG.trn"),
+                Entry("Payroll", BackupType.Full, @"\\nas01\sql\Payroll_FULL.bak")
+            ]
+        };
+
+        return (new BlobBrowserViewModel(new FakeBlobStorageService(), sql, store), sql);
+    }
+
+    // ── the second source ───────────────────────────────────────────────────────
+
+    /// <summary>Blob by default: it is what this screen has always done.</summary>
+    [Fact]
+    public void TheScreenStartsOnBlob()
+    {
+        var (vm, _) = New();
+
+        Assert.Equal(BackupMedium.AzureBlob, vm.SelectedMedium);
+        Assert.True(vm.MediumIsBlob);
+        Assert.False(vm.MediumIsSharedPath);
+    }
+
+    /// <summary>The servers come from the same config the rest of the app reads.</summary>
+    [Fact]
+    public void TheConfiguredServersAreOffered()
+    {
+        var (vm, _) = New();
+
+        Assert.Single(vm.Servers);
+        Assert.Equal("SRV01", vm.SourceServer?.Name);
+    }
+
+    [Fact]
+    public async Task AServersHistoryIsReadAndShown()
+    {
+        var (vm, _) = New();
+        vm.SelectedMedium = BackupMedium.SharedPath;
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.True(vm.HasFiles);
+        Assert.Contains("Sales", vm.DiscoveredDatabases);
+        Assert.Contains("Payroll", vm.DiscoveredDatabases);
+    }
+
+    /// <summary>
+    /// The paths shown are the ones the source actually wrote. No mapping is applied, because
+    /// nothing is being restored here - there is no target to reach the files by another route.
+    /// </summary>
+    [Fact]
+    public async Task ThePathsShownAreTheOnesTheSourceWrote()
+    {
+        var (vm, _) = New();
+        vm.SelectedMedium = BackupMedium.SharedPath;
+        vm.SelectedDatabase = null;
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // LocalPath, not BlobUrl: BlobUrl is deliberately left empty for a file on disk, because
+        // filling one in with a path would be the kind of quiet lie that ends in a restore aimed
+        // at the wrong device.
+        Assert.Contains(vm.FilteredFiles, f => f.IsOnDisk
+                                            && f.RestoreDevice.StartsWith(@"\\nas01\sql\", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── what is on screen belongs to what is named above it ─────────────────────
+
+    /// <summary>
+    /// Switching source empties the list. A container's files sitting under a server's name is
+    /// worse than an empty screen, because it reads as an answer.
+    /// </summary>
+    [Fact]
+    public async Task ChangingTheMediumEmptiesWhatWasLoaded()
+    {
+        var (vm, _) = New();
+        vm.SelectedMedium = BackupMedium.SharedPath;
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        Assert.True(vm.HasFiles);
+
+        vm.SelectedMedium = BackupMedium.AzureBlob;
+
+        Assert.False(vm.HasFiles);
+        Assert.Empty(vm.FilteredFiles);
+        Assert.Empty(vm.DiscoveredDatabases);
+    }
+
+    [Fact]
+    public async Task ChangingTheServerEmptiesWhatWasLoaded()
+    {
+        var store = Store();
+        store.Config.Servers.Add(Server("SRV02"));
+
+        var (vm, _) = New(store);
+        vm.SelectedMedium = BackupMedium.SharedPath;
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        Assert.True(vm.HasFiles);
+
+        vm.SourceServer = vm.Servers.Single(s => s.Name == "SRV02");
+
+        Assert.False(vm.HasFiles);
+        Assert.Empty(vm.FilteredFiles);
+    }
+
+    // ── nothing chosen ──────────────────────────────────────────────────────────
+
+    /// <summary>Says which thing is missing, rather than complaining about a container.</summary>
+    [Fact]
+    public async Task WithNoServerChosenItAsksForOne()
+    {
+        var store = new FakeCredentialStore();
+        var (vm, _) = New(store);
+
+        vm.SelectedMedium = BackupMedium.SharedPath;
+        Assert.Null(vm.SourceServer);
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.True(vm.HasError);
+        Assert.Contains("server", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>An instance with no history says so rather than looking like a failure.</summary>
+    [Fact]
+    public async Task AServerWithNoHistorySaysSo()
+    {
+        var (vm, sql) = New();
+        sql.BackupHistory.Clear();
+
+        vm.SelectedMedium = BackupMedium.SharedPath;
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.False(vm.HasError);
+        Assert.False(vm.HasFiles);
+        Assert.Contains("no backup history", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── the assumption this screen rests on ─────────────────────────────────────
+
+    /// <summary>
+    /// The medium choice is offered here without a mode gate, because every mode that offers this
+    /// screen at all also offers the shared path. That is true today and is not a law - so it is
+    /// asserted, rather than left as a coincidence for somebody to discover by finding a radio
+    /// button that selects a medium the mode does not otherwise allow.
+    /// </summary>
+    [Theory]
+    [InlineData(AppMode.Basic)]
+    [InlineData(AppMode.Standard)]
+    [InlineData(AppMode.Pro)]
+    public void AnyModeThatCanBrowseCanAlsoUseAServersHistory(AppMode mode)
+    {
+        if (AppModeCapabilities.CanBrowseBackups(mode))
+            Assert.True(AppModeCapabilities.CanUseSharedPath(mode));
+    }
+}

--- a/src/NineLives.Tests/ThemeTests.cs
+++ b/src/NineLives.Tests/ThemeTests.cs
@@ -405,7 +405,7 @@ public class ThemeTests(WpfFixture wpf)
                     new AboutView { DataContext = new AboutViewModel(store) },
                     new BlobConfigView { DataContext = new BlobConfigViewModel(store, new BlobStorageService(store)) },
                     new ServerManagerView { DataContext = new ServerManagerViewModel(store, new SqlServerService(store)) },
-                    new BlobBrowserView { DataContext = new BlobBrowserViewModel(new BlobStorageService(store), store) },
+                    new BlobBrowserView { DataContext = new BlobBrowserViewModel(new BlobStorageService(store), new FakeSqlServerService(), store) },
                     new HistoryView { DataContext = new HistoryViewModel(new FakeRestoreHistoryStore()) },
                 ];
 

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -136,7 +136,7 @@ public class XamlLoadTests(WpfFixture wpf)
     [Fact]
     public void BlobBrowserViewLoads()
         => Check("BlobBrowserView", () =>
-            new BlobBrowserView { DataContext = new BlobBrowserViewModel(new BlobStorageService(Store()), Store()) });
+            new BlobBrowserView { DataContext = new BlobBrowserViewModel(new BlobStorageService(Store()), new FakeSqlServerService(), Store()) });
 
     [Fact]
     public void SettingsViewLoads()
@@ -396,7 +396,7 @@ public class XamlLoadTests(WpfFixture wpf)
     {
         wpf.Invoke(() =>
         {
-            var vm = new BlobBrowserViewModel(new BlobStorageService(Store()), Store())
+            var vm = new BlobBrowserViewModel(new BlobStorageService(Store()), new FakeSqlServerService(), Store())
             {
                 IsBusy = true,
                 CanCancelLoad = true

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -10,6 +10,7 @@ namespace Blackcat.NineLives.ViewModels;
 public partial class BlobBrowserViewModel : ViewModelBase
 {
     private readonly IBlobStorageService _blobService;
+    private readonly ISqlServerService _sqlService;
     private readonly ICredentialStore _credentialStore;
     private readonly OperationCancellation _loadCancellation = new();
 
@@ -68,18 +69,68 @@ public partial class BlobBrowserViewModel : ViewModelBase
     [ObservableProperty]
     private string _dbSummaryText = string.Empty;
 
-    public BlobBrowserViewModel(IBlobStorageService blobService, ICredentialStore credentialStore)
+    public BlobBrowserViewModel(
+        IBlobStorageService blobService,
+        ISqlServerService sqlService,
+        ICredentialStore credentialStore)
     {
         _blobService = blobService;
+        _sqlService = sqlService;
         _credentialStore = credentialStore;
         RefreshContainers();
     }
 
+    /// <summary>
+    /// Where to look (#197).
+    ///
+    /// This screen could only ever see a container, while backing up and restoring have both taken
+    /// either medium since #165 - so the one screen whose whole purpose is LOOKING was the one that
+    /// could not look at half of what the app writes.
+    /// </summary>
+    [ObservableProperty]
+    private BackupMedium _selectedMedium = BackupMedium.AzureBlob;
+
+    public bool MediumIsBlob => SelectedMedium == BackupMedium.AzureBlob;
+    public bool MediumIsSharedPath => SelectedMedium == BackupMedium.SharedPath;
+
+    partial void OnSelectedMediumChanged(BackupMedium value)
+    {
+        OnPropertyChanged(nameof(MediumIsBlob));
+        OnPropertyChanged(nameof(MediumIsSharedPath));
+
+        // What is on screen came from the other source and no longer belongs to what is selected
+        // above it. Leaving it there would put a container's files under a server's name.
+        Clear();
+    }
+
+    /// <summary>
+    /// The instances whose backup history can be read.
+    ///
+    /// A share is NOT browsed by walking a directory: a folder of .bak files says nothing about
+    /// which database each belongs to, what type it is, or which full a differential was taken
+    /// against - inferring that from filenames is the whole reason #130 exists. The instance that
+    /// TOOK the backups recorded all of it, so that is what gets read.
+    /// </summary>
+    [ObservableProperty]
+    private ObservableCollection<ServerConnection> _servers = [];
+
+    [ObservableProperty]
+    private ServerConnection? _sourceServer;
+
+    partial void OnSourceServerChanged(ServerConnection? value) => Clear();
+
     public void RefreshContainers()
     {
         var previous = SelectedContainer?.Name;
+        var previousServer = SourceServer?.Id;
         var config = _credentialStore.LoadConfig();
         Containers = new ObservableCollection<BlobContainerConfig>(config.BlobContainers);
+
+        Servers = new ObservableCollection<ServerConnection>(config.Servers);
+        if (previousServer != null)
+            SourceServer = Servers.FirstOrDefault(s => s.Id == previousServer);
+        if (SourceServer == null && Servers.Count > 0)
+            SourceServer = Servers[0];
         foreach (var c in Containers)
         {
             var sas = _credentialStore.GetSasToken(c);
@@ -92,7 +143,15 @@ public partial class BlobBrowserViewModel : ViewModelBase
             SelectedContainer = Containers[0];
     }
 
-    partial void OnSelectedContainerChanged(BlobContainerConfig? value)
+    partial void OnSelectedContainerChanged(BlobContainerConfig? value) => Clear();
+
+    /// <summary>
+    /// Empties the screen. Called whenever the SOURCE changes, whichever part of it changed.
+    ///
+    /// One method rather than three copies: what is listed belongs to the thing named above it, and
+    /// a screen that keeps one source's files under another's name is worse than an empty one.
+    /// </summary>
+    private void Clear()
     {
         _allFiles.Clear();
         _allSets.Clear();
@@ -134,9 +193,15 @@ public partial class BlobBrowserViewModel : ViewModelBase
     [RelayCommand]
     private async Task LoadBackupsAsync()
     {
-        if (SelectedContainer == null)
+        if (MediumIsBlob && SelectedContainer == null)
         {
             SetError("Please select a container first.");
+            return;
+        }
+
+        if (MediumIsSharedPath && SourceServer == null)
+        {
+            SetError("Please select a server first.");
             return;
         }
 
@@ -146,7 +211,13 @@ public partial class BlobBrowserViewModel : ViewModelBase
         ClearStatus();
         try
         {
-            _allFiles = await _blobService.ListBackupFilesAsync(SelectedContainer, ct);
+            if (MediumIsSharedPath)
+            {
+                await LoadFromHistoryAsync(ct);
+                return;
+            }
+
+            _allFiles = await _blobService.ListBackupFilesAsync(SelectedContainer!, ct);
             _allSets = _blobService.GroupIntoBackupSets(
                 _allFiles, SelectedContainer?.BackupServerTimeZoneId);
             HasFiles = _allFiles.Count > 0;
@@ -183,6 +254,51 @@ public partial class BlobBrowserViewModel : ViewModelBase
             IsBusy = false;
             CanCancelLoad = false;
         }
+    }
+
+    /// <summary>
+    /// Reads what an instance recorded backing up (#197).
+    ///
+    /// The same two calls the restore screen makes, because it is the same question - what backups
+    /// exist and how do they group into sets. No path mapping is applied: nothing is being restored
+    /// here, so the paths worth showing are the ones the source actually wrote.
+    /// </summary>
+    private async Task LoadFromHistoryAsync(CancellationToken ct)
+    {
+        var source = SourceServer!;
+        var history = await _sqlService.ReadBackupHistoryAsync(source, null, ct);
+        var sets = BackupHistoryInventory.ToSets(history, BackupPathMapping.None);
+
+        _allSets = sets;
+        _allFiles = sets.SelectMany(s => s.Files).ToList();
+        HasFiles = _allFiles.Count > 0;
+
+        // Built from the sets rather than from filenames: msdb recorded each backup's database and
+        // server, so there is nothing here to infer.
+        DiscoveredServers = new ObservableCollection<string>(
+            sets.Select(s => s.ServerDisplay)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)!);
+
+        DiscoveredDatabases = new ObservableCollection<string>(
+            sets.Select(s => s.DatabaseName)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)!);
+
+        if (DiscoveredServers.Count > 0)
+            SelectedServer = DiscoveredServers[0];
+        else if (DiscoveredDatabases.Count > 0)
+            SelectedDatabase = DiscoveredDatabases[0];
+
+        ApplyFilter();
+        UpdateFilteredSummary();
+
+        SetStatus(sets.Count == 0
+            ? $"{source.ServerName} has no backup history."
+            : $"Read {_allFiles.Count} file(s) in {sets.Count} backup set(s) from "
+              + $"{source.ServerName} across {DiscoveredDatabases.Count} database(s).");
     }
 
     /// <summary>
@@ -297,4 +413,21 @@ public partial class BlobBrowserViewModel : ViewModelBase
     [RelayCommand]
     private void CopyPathContainer(BackupFileInfo? file)
         => CopyBlobContainerPath(file ?? SelectedFile, SelectedContainer);
+
+    /// <summary>
+    /// The path a file on disk actually has (#197).
+    ///
+    /// The two blob copies mean nothing here - there is no URL and no container - and offering them
+    /// against a file read from msdb would put an empty string on the clipboard, which is worse
+    /// than offering nothing.
+    /// </summary>
+    [RelayCommand]
+    private void CopyLocalPath(BackupFileInfo? file)
+    {
+        var target = file ?? SelectedFile;
+        if (target?.IsOnDisk != true) return;
+
+        Clipboard.SetText(target.RestoreDevice);
+        SetStatus("Path copied to clipboard.");
+    }
 }

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -170,7 +170,7 @@ public partial class MainViewModel : ViewModelBase
 
         BlobConfig = new BlobConfigViewModel(_credentialStore, _blobService);
         ServerManager = new ServerManagerViewModel(_credentialStore, _sqlService);
-        BlobBrowser = new BlobBrowserViewModel(_blobService, _credentialStore);
+        BlobBrowser = new BlobBrowserViewModel(_blobService, _sqlService, _credentialStore);
         // One store, shared: the Restore screen writes to it and the History screen reads it back,
         // and two instances pointed at the same file would be a way to lose an entry.
         _historyStore = new RestoreHistoryStore();

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -5,6 +5,7 @@
 
     <UserControl.Resources>
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+        <converters:EnumToBoolConverter x:Key="EnumToBool" />
         <converters:NullToVisibilityConverter x:Key="NullToVis" />
         <converters:FileSizeConverter x:Key="FileSize" />
         <converters:BackupTypeToColorConverter x:Key="TypeToColor" />
@@ -23,7 +24,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Browse Backups"
                        Style="{StaticResource HeaderText}" />
-            <TextBlock Text="View and explore backup files stored in your Azure Blob container."
+            <TextBlock Text="Look at what is in a blob container, or at what a SQL Server has recorded backing up."
                        Style="{StaticResource SecondaryText}"
                        Margin="0,4,0,0" />
         </StackPanel>
@@ -31,6 +32,25 @@
         <!-- Container + Database Selector -->
         <Border Grid.Row="1" Style="{StaticResource CardBorder}" Margin="0,0,0,12">
             <StackPanel>
+                <!-- Where to look (#197). Same two media as backing up and restoring, in the same
+                     order and with the same radio pair, because it is the same choice. -->
+                <TextBlock Text="WHERE TO LOOK" Style="{StaticResource LabelText}" Margin="0,0,0,6" />
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                    <RadioButton Content="Azure Blob Storage"
+                                 GroupName="BrowseMedium"
+                                 Style="{StaticResource DarkRadioButton}"
+                                 IsChecked="{Binding SelectedMedium, Converter={StaticResource EnumToBool}, ConverterParameter=AzureBlob}"
+                                 Margin="0,0,20,0"
+                                 ToolTip="Lists the container. Everything about each backup is inferred from its path and filename." />
+                    <!-- Not "a path both servers can see": nothing is being restored here, so there
+                         is no second server. What is read is one instance's own record. -->
+                    <RadioButton Content="A server's backup history"
+                                 GroupName="BrowseMedium"
+                                 Style="{StaticResource DarkRadioButton}"
+                                 IsChecked="{Binding SelectedMedium, Converter={StaticResource EnumToBool}, ConverterParameter=SharedPath}"
+                                 ToolTip="Reads msdb on the instance that took the backups, so each one's database, type and size are recorded fact rather than inference." />
+                </StackPanel>
+
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -38,12 +58,33 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
-                    <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                    <StackPanel Grid.Column="0" Margin="0,0,12,0"
+                                Visibility="{Binding MediumIsBlob, Converter={StaticResource BoolToVis}}">
                         <TextBlock Text="CONTAINER" Style="{StaticResource LabelText}" />
                         <ComboBox ItemsSource="{Binding Containers}"
                                   SelectedItem="{Binding SelectedContainer}"
                                   DisplayMemberPath="Name"
                                   Style="{StaticResource DarkComboBox}" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="0" Margin="0,0,12,0"
+                                Visibility="{Binding MediumIsSharedPath, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="SERVER" Style="{StaticResource LabelText}" />
+                        <!-- ItemTemplate, not DisplayMemberPath. The combo box's own template
+                             renders the SELECTED item through a plain ContentPresenter, which
+                             ignores DisplayMemberPath and falls back to ToString - and
+                             ServerConnection has no override, so the closed box read
+                             "Blackcat.NineLives.Models.ServerConnection". Every other server picker
+                             in the app already uses an ItemTemplate for exactly this reason. -->
+                        <ComboBox ItemsSource="{Binding Servers}"
+                                  SelectedItem="{Binding SourceServer}"
+                                  Style="{StaticResource DarkComboBox}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Name}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
                     </StackPanel>
 
                     <Button Grid.Column="1"
@@ -58,7 +99,7 @@
                             Style="{StaticResource SecondaryButton}"
                             Command="{Binding RefreshCommand}"
                             VerticalAlignment="Bottom"
-                            ToolTip="Refresh container list" />
+                            ToolTip="Refresh the container and server lists" />
                 </Grid>
 
                 <!-- Server + Database Filters (shown after loading) -->
@@ -188,10 +229,18 @@
                     <TextBlock Text="No backup files loaded"
                                Style="{StaticResource BodyText}"
                                HorizontalAlignment="Center" />
+                    <!-- Names the thing actually being asked for. Telling somebody who has chosen a
+                         server to select a container is an instruction they cannot follow (#197). -->
                     <TextBlock Text="Select a container and click Load Backups to browse."
                                Style="{StaticResource SecondaryText}"
                                HorizontalAlignment="Center"
-                               Margin="0,4,0,0" />
+                               Margin="0,4,0,0"
+                               Visibility="{Binding MediumIsBlob, Converter={StaticResource BoolToVis}}" />
+                    <TextBlock Text="Select a server and click Load Backups to read what it has backed up."
+                               Style="{StaticResource SecondaryText}"
+                               HorizontalAlignment="Center"
+                               Margin="0,4,0,0"
+                               Visibility="{Binding MediumIsSharedPath, Converter={StaticResource BoolToVis}}" />
                 </StackPanel>
 
                 <!-- DataGrid -->
@@ -201,12 +250,20 @@
                           Visibility="{Binding HasFiles, Converter={StaticResource BoolToVis}}">
                     <DataGrid.ContextMenu>
                         <ContextMenu>
+                            <!-- A URL and a container path mean nothing for a file read from msdb,
+                                 and copying one would put an empty string on the clipboard (#197). -->
                             <MenuItem Header="Copy path (HTTPS)"
                                       Command="{Binding CopyPathHttpsCommand}"
-                                      CommandParameter="{Binding SelectedFile}" />
+                                      CommandParameter="{Binding SelectedFile}"
+                                      Visibility="{Binding MediumIsBlob, Converter={StaticResource BoolToVis}}" />
                             <MenuItem Header="Copy path (container)"
                                       Command="{Binding CopyPathContainerCommand}"
-                                      CommandParameter="{Binding SelectedFile}" />
+                                      CommandParameter="{Binding SelectedFile}"
+                                      Visibility="{Binding MediumIsBlob, Converter={StaticResource BoolToVis}}" />
+                            <MenuItem Header="Copy path"
+                                      Command="{Binding CopyLocalPathCommand}"
+                                      CommandParameter="{Binding SelectedFile}"
+                                      Visibility="{Binding MediumIsSharedPath, Converter={StaticResource BoolToVis}}" />
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                     <DataGrid.Columns>


### PR DESCRIPTION
Backing up and restoring have both taken either medium since #165, and this screen did not come along — so the one screen whose entire purpose is **looking** was the one that could not look at half of what the app writes.

## A share is not a directory listing

Correcting what I wrote on the issue: a folder of `.bak` files says nothing about which database each belongs to, what type it is, or which full a differential was taken against — inferring that from filenames is the whole reason #130 exists. So the second source is not a path picker. The instance that **took** the backups recorded all of it, and that is what gets read, via the same two calls the restore screen already makes.

No path mapping is applied. Nothing is being restored here, so the paths worth showing are the ones the source actually wrote.

Changing the source empties the list, whichever part of the source changed — a container's files sitting under a server's name is worse than an empty screen, because it reads as an answer.

## Two things the render caught

Neither the compiler nor a test would have found either:

- **The server picker read `Blackcat.NineLives.Models.ServerConnection`.** The combo box's own template renders the *selected* item through a plain `ContentPresenter`, which ignores `DisplayMemberPath` and falls back to `ToString` — and `ServerConnection` has no override. Every other server picker in the app already uses an `ItemTemplate` for exactly this reason; this one now does too. (`BlobContainerConfig` has a `ToString`, which is why the container picker beside it never showed the fault.)
- **The empty state told somebody who had chosen a server to select a container** — an instruction they cannot follow. The context menu had the same shape of problem: a URL and a container path mean nothing for a file read from msdb, and copying one would have put an empty string on the clipboard.

## One assumption, asserted

The medium choice is offered here without a mode gate, because every mode that offers this screen also offers the shared path. True today, not a law — so there is a test for it rather than a coincidence for somebody to discover via a radio button selecting a medium their mode does not otherwise allow.

11 new tests, 1,354 pass.