### PR TITLE
Let a restore chain span containers (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ built for.
 
 ### Changed
 
+- **A restore chain can span containers** - a full archived to cool storage with the logs that
+  carry it forward still in the hot one. Additional containers are ticked alongside the selected
+  one, which stays the primary: it is what the credential panel points at and the script header
+  names. Every container the chain actually uses is checked for a credential on the target before
+  the restore starts, because RESTORE FROM URL matches a credential by container URL and the
+  failure would otherwise land after WITH REPLACE had dropped the target (#32)
 - **Browse Backups can read a server's backup history**, not only a blob container. Backing up and
   restoring have taken either medium since #165 and this screen did not come along, so the one
   screen whose whole purpose is looking could not look at half of what the app writes. A share is

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -71,6 +71,19 @@ public sealed class FakeBlobStorageService : IBlobStorageService
 
     public List<BackupFileInfo> Files { get; set; } = [];
 
+    /// <summary>
+    /// What each container holds, keyed by container NAME (#32).
+    ///
+    /// <see cref="Files"/> answers for every container, which is fine when there is one and useless
+    /// for the case multi-container exists for: a full in one container and the logs that carry it
+    /// forward in another. A container with no entry here falls back to Files.
+    /// </summary>
+    public Dictionary<string, List<BackupFileInfo>> FilesByContainer { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Every container listed, in order, so a test can prove which were read.</summary>
+    public List<string> ListedContainers { get; } = [];
+
     /// <summary>Throw instead of listing, for the failure paths.</summary>
     public Exception? ListThrows { get; set; }
 
@@ -109,12 +122,45 @@ public sealed class FakeBlobStorageService : IBlobStorageService
     {
         ListCalls++;
         LastScope = scope;
+        LastConfig = config;
+        ListedContainers.Add(config.Name);
         ct.ThrowIfCancellationRequested();
         if (ListThrows != null) throw ListThrows;
 
-        progress?.Report(Files.Count);
-        return Task.FromResult(Files.ToList());
+        var files = FilesByContainer.TryGetValue(config.Name, out var forContainer)
+            ? forContainer
+            : Files;
+
+        progress?.Report(files.Count);
+
+        // A copy per call. The real service returns fresh objects each time, and handing the same
+        // instances back twice would let one listing's ContainerId stamp overwrite another's.
+        return Task.FromResult(files.Select(Copy).ToList());
     }
+
+    /// <summary>
+    /// A shallow copy, so one listing cannot mutate another's file objects.
+    ///
+    /// Only the fields the inventory reads. Enough for the tests, and it keeps the fake honest
+    /// about the real service returning fresh objects per call.
+    /// </summary>
+    private static BackupFileInfo Copy(BackupFileInfo f) => new()
+    {
+        BlobName = f.BlobName,
+        BlobUrl = f.BlobUrl,
+        ETag = f.ETag,
+        LocalPath = f.LocalPath,
+        ContainerId = f.ContainerId,
+        Type = f.Type,
+        BackupTypeCode = f.BackupTypeCode,
+        SizeBytes = f.SizeBytes,
+        LastModified = f.LastModified,
+        DatabaseName = f.DatabaseName,
+        InferredDatabaseName = f.InferredDatabaseName,
+        InferredServerName = f.InferredServerName,
+        InferredInstanceName = f.InferredInstanceName,
+        InferredSetId = f.InferredSetId
+    };
 
     public ContainerSummary GetContainerSummary(List<BackupFileInfo> files) => _real.GetContainerSummary(files);
     public ContainerSummary GetSetBasedSummary(List<BackupSet> sets) => _real.GetSetBasedSummary(sets);

--- a/src/NineLives.Tests/MultiContainerRestoreTests.cs
+++ b/src/NineLives.Tests/MultiContainerRestoreTests.cs
@@ -1,0 +1,240 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A chain whose parts live in different containers (#32).
+///
+/// The layout this exists for is asymmetric: full backups archived to cool storage while the logs
+/// that carry them forward stay in the hot container. So the model is primary-plus-additional
+/// rather than a set of peers - there is a container somebody is working in, which the credential
+/// panel points at and the script header names, and others that happen to hold parts of the chain.
+///
+/// The restore itself needed no change. RESTORE ... FROM URL matches its credential by URL prefix
+/// and BlobUrl is already absolute, so a chain spanning containers restores correctly as long as
+/// each container has a credential on the instance. That last clause is the whole of the risk, and
+/// most of what is tested here.
+/// </summary>
+public class MultiContainerRestoreTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 7, 22, 0, 0);
+
+    private static BlobContainerConfig Container(string id, string name) => new()
+    {
+        Id = id,
+        Name = name,
+        ContainerUrl = $"https://acct.blob.core.windows.net/{name}"
+    };
+
+    private static BackupFileInfo File_(string container, string database, string name, BackupType type) => new()
+    {
+        BlobName = $"{database}/{name}",
+        BlobUrl = $"https://acct.blob.core.windows.net/{container}/{database}/{name}",
+        ETag = $"\"{container}-{name}\"",
+        Type = type,
+        InferredDatabaseName = database,
+        InferredServerName = "SRV01",
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    /// <summary>Fulls in "archive", logs in "hot" - the layout the issue describes.</summary>
+    private static FakeBlobStorageService SplitAcrossContainers() => new()
+    {
+        FilesByContainer =
+        {
+            ["archive"] = [File_("archive", "Sales", "Sales_20260807_220000.bak", BackupType.Full)],
+            ["hot"] = [File_("hot", "Sales", "Sales_20260807_223000.trn", BackupType.TransactionLog)]
+        }
+    };
+
+    // ── loading ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EveryChosenContainerIsRead()
+    {
+        var blob = SplitAcrossContainers();
+        var vm = new BackupInventoryViewModel(blob, new FakeSqlServerService(), TestLogs.Temp(), TestAuditStores.Temp());
+
+        await vm.LoadAsync(BackupLocation.Blob([Container("c1", "archive"), Container("c2", "hot")]));
+
+        Assert.Equal(2, vm.AllSets.Count);
+    }
+
+    /// <summary>
+    /// Every file knows which container it came from. This is what the credential check reads, and
+    /// without it a chain spanning two containers has no way to say which one is missing a
+    /// credential.
+    /// </summary>
+    [Fact]
+    public async Task EveryFileKnowsWhichContainerItCameFrom()
+    {
+        var blob = SplitAcrossContainers();
+        var vm = new BackupInventoryViewModel(blob, new FakeSqlServerService(), TestLogs.Temp(), TestAuditStores.Temp());
+
+        await vm.LoadAsync(BackupLocation.Blob([Container("c1", "archive"), Container("c2", "hot")]));
+
+        var files = vm.AllSets.SelectMany(s => s.Files).ToList();
+
+        Assert.Equal(2, files.Count);
+        Assert.All(files, f => Assert.False(string.IsNullOrEmpty(f.ContainerId)));
+        Assert.Equal(["c1", "c2"], files.Select(f => f.ContainerId!).OrderBy(x => x));
+    }
+
+    /// <summary>One container behaves exactly as it always did.</summary>
+    [Fact]
+    public async Task OneContainerIsUnchanged()
+    {
+        var blob = SplitAcrossContainers();
+        var vm = new BackupInventoryViewModel(blob, new FakeSqlServerService(), TestLogs.Temp(), TestAuditStores.Temp());
+
+        await vm.LoadAsync(BackupLocation.Blob(Container("c1", "archive")));
+
+        Assert.Single(vm.AllSets);
+    }
+
+    // ── the location itself ─────────────────────────────────────────────────────
+
+    /// <summary>The first is the primary - what the credential panel and script header use.</summary>
+    [Fact]
+    public void TheFirstContainerIsThePrimary()
+    {
+        var location = BackupLocation.Blob([Container("c1", "archive"), Container("c2", "hot")]);
+
+        Assert.Equal("c1", location.Container?.Id);
+        Assert.Equal(2, location.Containers.Count);
+    }
+
+    /// <summary>
+    /// A chain built while a second container was also being read is not a chain from the primary
+    /// alone. Treating them as the same place is exactly the assumption #112 was about.
+    /// </summary>
+    [Fact]
+    public void ReadingASecondContainerMakesItADifferentPlace()
+    {
+        var one = BackupLocation.Blob(Container("c1", "archive"));
+        var two = BackupLocation.Blob([Container("c1", "archive"), Container("c2", "hot")]);
+
+        Assert.False(one.SamePlaceAs(two));
+        Assert.True(one.SamePlaceAs(BackupLocation.Blob(Container("c1", "archive"))));
+    }
+
+    [Fact]
+    public void SeveralContainersSaySoWhenNamingThemselves()
+    {
+        var location = BackupLocation.Blob([Container("c1", "archive"), Container("c2", "hot")]);
+
+        Assert.Contains("archive", location.Describe());
+        Assert.Contains("other container", location.Describe());
+    }
+
+    // ── what a load will read ───────────────────────────────────────────────────
+
+    /// <summary>The primary is never offered as an addition to itself.</summary>
+    [Fact]
+    public void ThePrimaryIsNotOfferedAsAnExtra()
+    {
+        var vm = Restore(out _);
+
+        Assert.DoesNotContain(vm.AdditionalContainers, c => c.Container.Id == vm.SelectedContainer?.Id);
+    }
+
+    [Fact]
+    public void TickingAContainerAddsItToWhatWillBeRead()
+    {
+        var vm = Restore(out _);
+        Assert.Single(vm.ContainersToRead);
+
+        vm.AdditionalContainers.Single(c => c.Name == "hot").IsSelected = true;
+
+        Assert.Equal(2, vm.ContainersToRead.Count);
+        Assert.True(vm.ReadsSeveralContainers);
+        Assert.Equal(["archive", "hot"], vm.ContainersToRead.Select(c => c.Name));
+    }
+
+    /// <summary>
+    /// The primary stays first however the extras are ticked. Everything anchored to one container
+    /// - the credential panel, the script header, a copied path - reads that first entry.
+    /// </summary>
+    [Fact]
+    public void ThePrimaryStaysFirst()
+    {
+        var vm = Restore(out _);
+        vm.AdditionalContainers.Single(c => c.Name == "hot").IsSelected = true;
+
+        Assert.Equal(vm.SelectedContainer?.Id, vm.ContainersToRead[0].Id);
+    }
+
+    /// <summary>
+    /// What is on screen came from the previous set of containers. Leaving a chain there while the
+    /// sources under it changed is the mistake that let Execute stay armed against URLs that were
+    /// no longer being read.
+    /// </summary>
+    [Fact]
+    public void TickingAContainerClearsWhatWasLoaded()
+    {
+        var vm = Restore(out _);
+        vm.Inventory.BackupsLoaded = true;
+
+        vm.AdditionalContainers.Single(c => c.Name == "hot").IsSelected = true;
+
+        Assert.False(vm.Inventory.BackupsLoaded);
+    }
+
+    // ── the mode gate ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Pro only. It answers a question somebody has to know to ask - that a chain CAN be split
+    /// across containers - which is the test every other Pro-only feature had to pass.
+    /// </summary>
+    [Theory]
+    [InlineData(AppMode.Basic, false)]
+    [InlineData(AppMode.Standard, false)]
+    [InlineData(AppMode.Pro, true)]
+    public void OnlyTheWidestModeOffersIt(AppMode mode, bool offered)
+    {
+        var vm = Restore(out _);
+        vm.Mode = mode;
+
+        Assert.Equal(offered, vm.ShowMultipleContainers);
+    }
+
+    /// <summary>A tick list with nothing in it is worse than no tick list.</summary>
+    [Fact]
+    public void WithOnlyOneContainerThereIsNothingToOffer()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(Container("c1", "archive"));
+
+        var vm = Restore(store);
+        vm.Mode = AppMode.Pro;
+
+        Assert.Empty(vm.AdditionalContainers);
+        Assert.False(vm.ShowMultipleContainers);
+    }
+
+    private static RestoreViewModel Restore(out FakeCredentialStore store)
+    {
+        store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(Container("c1", "archive"));
+        store.Config.BlobContainers.Add(Container("c2", "hot"));
+
+        return Restore(store);
+    }
+
+    private static RestoreViewModel Restore(FakeCredentialStore store)
+    {
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(),
+            new FakeRestoreHistoryStore(), TestAuditStores.Temp())
+        {
+            Mode = AppMode.Pro
+        };
+
+        vm.RefreshContainers();
+        return vm;
+    }
+}

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -171,6 +171,19 @@ public class BackupFileInfo
 
     /// <summary>True when this is a file on a path rather than a blob.</summary>
     public bool IsOnDisk => !string.IsNullOrWhiteSpace(LocalPath);
+
+    /// <summary>
+    /// Which container this was listed from (#32).
+    ///
+    /// Carried on the FILE rather than on the working set as a whole, because a chain can span
+    /// containers - and each container means a separate credential on the instance and a separate
+    /// URL prefix. Without it, a restore reaching across two containers has no way to say which
+    /// container a missing credential is about.
+    ///
+    /// Null for anything read from an instance's msdb, which has no container.
+    /// </summary>
+    public string? ContainerId { get; set; }
+
     public BackupType Type { get; set; } = BackupType.Unknown;
     public long SizeBytes { get; set; }
     public DateTimeOffset LastModified { get; set; }

--- a/src/NineLives/Models/BackupLocation.cs
+++ b/src/NineLives/Models/BackupLocation.cs
@@ -40,8 +40,22 @@ public sealed record BackupLocation
 
     // ── blob ────────────────────────────────────────────────────────────────────
 
-    /// <summary>The container to list. Set when <see cref="Medium"/> is AzureBlob.</summary>
-    public BlobContainerConfig? Container { get; init; }
+    /// <summary>
+    /// The containers to list, in order. Set when <see cref="Medium"/> is AzureBlob.
+    ///
+    /// Plural because a chain can span containers (#32) - the layout this exists for is full
+    /// backups archived to cool storage while the logs stay hot, so the full and the logs that
+    /// carry it forward are in different places.
+    ///
+    /// A LIST rather than a set, because the first is the primary: it is what the credential panel
+    /// points at, what the script header names, and what a copied path is relative to. The rest are
+    /// also read. That asymmetry is real rather than an implementation detail - there is a
+    /// container somebody is working in, and others that happen to hold parts of the chain.
+    /// </summary>
+    public IReadOnlyList<BlobContainerConfig> Containers { get; init; } = [];
+
+    /// <summary>The primary container - the one everything anchored to a single container uses.</summary>
+    public BlobContainerConfig? Container => Containers.Count > 0 ? Containers[0] : null;
 
     // ── shared path ─────────────────────────────────────────────────────────────
 
@@ -62,7 +76,11 @@ public sealed record BackupLocation
     public BackupPathMapping Mapping { get; init; } = BackupPathMapping.None;
 
     public static BackupLocation Blob(BlobContainerConfig container) =>
-        new() { Medium = BackupMedium.AzureBlob, Container = container };
+        new() { Medium = BackupMedium.AzureBlob, Containers = [container] };
+
+    /// <summary>Several containers, the first of which is the primary.</summary>
+    public static BackupLocation Blob(IReadOnlyList<BlobContainerConfig> containers) =>
+        new() { Medium = BackupMedium.AzureBlob, Containers = containers };
 
     public static BackupLocation Shared(ServerConnection sourceServer, BackupPathMapping? mapping = null) =>
         new()
@@ -78,7 +96,12 @@ public sealed record BackupLocation
     /// <summary>What this location is, for a status line or a history entry.</summary>
     public string Describe() => Medium switch
     {
-        BackupMedium.AzureBlob => Container?.Name ?? "a container",
+        BackupMedium.AzureBlob => Containers.Count switch
+        {
+            0 => "a container",
+            1 => Containers[0].Name,
+            _ => $"{Containers[0].Name} and {Containers.Count - 1} other container(s)"
+        },
         BackupMedium.SharedPath => SourceServer == null
             ? "a shared path"
             : $"{SourceServer.ServerName}'s backup history",
@@ -95,7 +118,11 @@ public sealed record BackupLocation
 
         return Medium switch
         {
-            BackupMedium.AzureBlob => Container?.Id == other.Container?.Id,
+            // Every container, in order. A chain built while a second container was also being read
+            // is not a chain from the primary alone, and treating them as the same place is exactly
+            // the assumption #112 was.
+            BackupMedium.AzureBlob =>
+                Containers.Select(c => c.Id).SequenceEqual(other.Containers.Select(c => c.Id)),
 
             // The mapping is part of the identity, not decoration: the same instance's history read
             // with a different substitution names different files, and a chain from one is not a

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -590,7 +590,10 @@ public partial class BackupInventoryViewModel : ViewModelBase
     private List<BackupSet> RegroupPerContainer(List<BackupFileInfo> files, BackupLocation? location = null)
     {
         var from = location ?? LoadedFrom;
-        var zones = from?.Containers.ToDictionary(c => c.Id, c => c.BackupServerTimeZoneId)
+        // Keyed on the same "" fallback the grouping below uses, because a container's Id is
+        // nullable and a null key would throw rather than simply not match.
+        var zones = from?.Containers
+                        .ToDictionary(c => c.Id ?? string.Empty, c => c.BackupServerTimeZoneId)
                     ?? [];
 
         // One container is the overwhelmingly common case and groups exactly as it always did.

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -355,8 +355,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
 
             // Regroup: what the headers said changes which set a file belongs to, and a set is
             // keyed on the database and type that have just been corrected.
-            _allSets = _blob.GroupIntoBackupSets(
-                _allBackups, LoadedFrom?.Container?.BackupServerTimeZoneId);
+            _allSets = RegroupPerContainer(_allBackups);
 
             ApplyCachedAudit();
 
@@ -488,7 +487,6 @@ public partial class BackupInventoryViewModel : ViewModelBase
                 return;
             }
 
-            var container = location.Container!;
             // If a database is already chosen - a reload after taking a fresh backup, say - push
             // that down to Azure as a prefix instead of walking the whole container and discarding
             // most of it. Measured on a real 4,440-blob container: about 1,075 ms unscoped versus
@@ -497,13 +495,28 @@ public partial class BackupInventoryViewModel : ViewModelBase
             // The FIRST load has no selection yet and stays a full scan, which it has to be: the
             // server and database lists are built from what it finds.
             var scope = BuildListingScope();
-            var progress = new Progress<int>(n => LoadProgressText = $"Scanned {n:N0} blobs...");
 
-            var files = await _blob.ListBackupFilesAsync(container, scope, progress, ct);
-            var sets = _blob.GroupIntoBackupSets(files, container.BackupServerTimeZoneId);
+            var files = new List<BackupFileInfo>();
+
+            // One container at a time (#32).
+            foreach (var container in location.Containers)
+            {
+                var scanning = container;
+                var progress = new Progress<int>(n => LoadProgressText = location.Containers.Count > 1
+                    ? $"Scanned {n:N0} blobs in {scanning.Name}..."
+                    : $"Scanned {n:N0} blobs...");
+
+                var found = await _blob.ListBackupFilesAsync(container, scope, progress, ct);
+
+                // Stamped here, the only point that knows. Everything downstream that has to tell
+                // one container from another - the credential check above all - reads this.
+                foreach (var file in found) file.ContainerId = container.Id;
+
+                files.AddRange(found);
+            }
 
             _allBackups = files;
-            _allSets = sets;
+            _allSets = RegroupPerContainer(files, location);
 
             // Stated, not assumed: everything derived from here belongs to THIS location.
             LoadedFrom = location;
@@ -524,8 +537,16 @@ public partial class BackupInventoryViewModel : ViewModelBase
             // valid restore points found", and painting a success line over that left an empty
             // timeline with the status bar cheerfully reporting how many files had loaded.
             if (!HasError)
-                SetStatus($"Loaded {files.Count} files in {sets.Count} backup set(s) across " +
+            {
+                // Names the containers when there is more than one, because "loaded 900 files" from
+                // an unstated number of places is not something anybody can check.
+                var across = location.Containers.Count > 1
+                    ? $" from {location.Containers.Count} containers"
+                    : string.Empty;
+
+                SetStatus($"Loaded {files.Count} files in {_allSets.Count} backup set(s){across} across " +
                           $"{DiscoveredDatabases.Count} database(s).");
+            }
         }
         catch (OperationCanceledException)
         {
@@ -555,6 +576,35 @@ public partial class BackupInventoryViewModel : ViewModelBase
     /// connections, for the same reason the container path derives them from what it found: what
     /// matters is what can actually be restored, not what somebody once configured.
     /// </summary>
+    /// <summary>
+    /// Groups files into sets, one container at a time (#32).
+    ///
+    /// Per container rather than over everything at once, because the backup-server time zone is a
+    /// property OF a container - it is how a set whose filename carried no timestamp gets a time at
+    /// all - and a single grouping could only ever apply one container's zone to every set.
+    ///
+    /// It also states what is true anyway: a backup SET is one operation and does not span
+    /// containers. A CHAIN does, which is the whole point here - a full archived to cool storage
+    /// with the logs that carry it forward still in the hot one.
+    /// </summary>
+    private List<BackupSet> RegroupPerContainer(List<BackupFileInfo> files, BackupLocation? location = null)
+    {
+        var from = location ?? LoadedFrom;
+        var zones = from?.Containers.ToDictionary(c => c.Id, c => c.BackupServerTimeZoneId)
+                    ?? [];
+
+        // One container is the overwhelmingly common case and groups exactly as it always did.
+        if (zones.Count <= 1)
+            return _blob.GroupIntoBackupSets(files, from?.Container?.BackupServerTimeZoneId);
+
+        return files
+            .GroupBy(f => f.ContainerId ?? string.Empty)
+            .SelectMany(g => _blob.GroupIntoBackupSets(
+                [.. g],
+                zones.TryGetValue(g.Key, out var zone) ? zone : null))
+            .ToList();
+    }
+
     private async Task LoadFromHistoryAsync(BackupLocation location, CancellationToken ct)
     {
         var source = location.SourceServer!;

--- a/src/NineLives/ViewModels/ContainerChoice.cs
+++ b/src/NineLives/ViewModels/ContainerChoice.cs
@@ -1,0 +1,27 @@
+using Blackcat.NineLives.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// A container offered as an extra place to read, with a tick (#32).
+///
+/// A wrapper rather than a flag on <see cref="BlobContainerConfig"/> itself: the config is what
+/// gets written to config.json, and "is this one currently ticked on the restore screen" is a
+/// property of the screen rather than of the container. Putting it on the model would persist a
+/// transient choice and leak it into every other screen that shows the same containers.
+/// </summary>
+public partial class ContainerChoice(BlobContainerConfig container, Action onToggled) : ObservableObject
+{
+    public BlobContainerConfig Container { get; } = container;
+
+    public string Name => Container.Name;
+
+    /// <summary>The tags, so "which of these is production" is answerable here too (#117 item 8).</summary>
+    public IEnumerable<TagChip> TagChips => Container.TagChips;
+
+    [ObservableProperty]
+    private bool _isSelected;
+
+    partial void OnIsSelectedChanged(bool value) => onToggled();
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -310,8 +310,96 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private string _restoreSummaryText = string.Empty;
 
+    /// <summary>
+    /// Other containers to read as well as the selected one (#32).
+    ///
+    /// The layout this exists for is asymmetric, and the model follows it: full backups archived to
+    /// cool storage while the logs that carry them forward stay hot. There is a container somebody
+    /// is working in - the credential panel points at it, the script header names it, a copied path
+    /// is relative to it - and others that happen to hold parts of the chain.
+    ///
+    /// Peers would have been the tidier model and the wrong one: it would have made every one of
+    /// those anchored things ask "which container?" and have no answer.
+    /// </summary>
+    public ObservableCollection<ContainerChoice> AdditionalContainers { get; } = [];
+
+    /// <summary>Every container a load will read, primary first.</summary>
+    public IReadOnlyList<BlobContainerConfig> ContainersToRead
+    {
+        get
+        {
+            if (SelectedContainer == null) return [];
+
+            return
+            [
+                SelectedContainer,
+                .. AdditionalContainers
+                    .Where(c => c.IsSelected && c.Container.Id != SelectedContainer.Id)
+                    .Select(c => c.Container)
+            ];
+        }
+    }
+
+    /// <summary>Whether more than one container is being read, for the screen to say so.</summary>
+    public bool ReadsSeveralContainers => ContainersToRead.Count > 1;
+
+    public string ContainersToReadSummary => ContainersToRead.Count switch
+    {
+        0 or 1 => string.Empty,
+        var n => $"Reading {n} containers. A chain may span them."
+    };
+
+    /// <summary>
+    /// Called by each tick. The list rebuilds rather than the choice being observable itself,
+    /// because what changed is what a LOAD would read - and that is a property of the whole set.
+    /// </summary>
+    private void OnAdditionalContainerToggled()
+    {
+        // What is on screen came from the previous set of containers.
+        ClearLoadedBackups();
+
+        OnPropertyChanged(nameof(ContainersToRead));
+        OnPropertyChanged(nameof(ReadsSeveralContainers));
+        OnPropertyChanged(nameof(ContainersToReadSummary));
+        OnPropertyChanged(nameof(CurrentLocation));
+        RefreshSteps();
+    }
+
+    /// <summary>
+    /// Rebuilds the additional list to be everything EXCEPT the primary.
+    ///
+    /// Offering the primary again would be a tick that either does nothing or, read literally, asks
+    /// to list the same container twice.
+    /// </summary>
+    private void RefreshAdditionalContainers()
+    {
+        var ticked = AdditionalContainers
+            .Where(c => c.IsSelected)
+            .Select(c => c.Container.Id)
+            .ToHashSet();
+
+        AdditionalContainers.Clear();
+
+        foreach (var container in Containers)
+        {
+            if (SelectedContainer != null && container.Id == SelectedContainer.Id) continue;
+
+            AdditionalContainers.Add(new ContainerChoice(container, OnAdditionalContainerToggled)
+            {
+                IsSelected = ticked.Contains(container.Id)
+            });
+        }
+
+        OnPropertyChanged(nameof(ContainersToRead));
+        OnPropertyChanged(nameof(ReadsSeveralContainers));
+        OnPropertyChanged(nameof(ContainersToReadSummary));
+        OnPropertyChanged(nameof(ShowMultipleContainers));
+    }
+
     partial void OnSelectedContainerChanged(BlobContainerConfig? value)
     {
+        RefreshAdditionalContainers();
+
         // Everything on screen below this point came from the PREVIOUS container. Leaving it there
         // meant the credential panel and Create credential targeted the new container while the
         // script still restored from the old one's URLs - so Execute stayed armed and enabled, and
@@ -357,6 +445,16 @@ public partial class RestoreViewModel : ViewModelBase
     public bool ShowAgentJob => AppModeCapabilities.CanScriptAsAgentJob(Mode);
     public bool ShowAdvancedOptions => AppModeCapabilities.CanUseAdvancedRestoreOptions(Mode);
 
+    /// <summary>
+    /// Whether to offer reading more than one container (#32).
+    ///
+    /// Pro, and only when there is more than one container to offer. It answers a question somebody
+    /// has to know to ask - that a chain CAN be split across containers - and a tick list with
+    /// nothing in it is worse than no tick list.
+    /// </summary>
+    public bool ShowMultipleContainers =>
+        AppModeCapabilities.CanUseAdvancedRestoreOptions(Mode) && AdditionalContainers.Count > 0;
+
     partial void OnModeChanged(AppMode value)
     {
         OnPropertyChanged(nameof(ShowMediumChoice));
@@ -366,7 +464,8 @@ public partial class RestoreViewModel : ViewModelBase
         OnPropertyChanged(nameof(ShowAuditPanel));
         OnPropertyChanged(nameof(ShowCredentialPanel));
         OnPropertyChanged(nameof(ShowAgentJob));
-        OnPropertyChanged(nameof(ShowAdvancedOptions));
+        OnPropertyChanged(nameof(ShowAdvancedOptions));
+        OnPropertyChanged(nameof(ShowMultipleContainers));
 
         // A medium that is no longer offered must not stay selected underneath a hidden control -
         // the screen would be restoring FROM DISK with nothing on screen saying so.
@@ -434,7 +533,7 @@ public partial class RestoreViewModel : ViewModelBase
     public BackupLocation? CurrentLocation => SelectedMedium switch
     {
         BackupMedium.AzureBlob =>
-            SelectedContainer == null ? null : BackupLocation.Blob(SelectedContainer),
+            SelectedContainer == null ? null : BackupLocation.Blob(ContainersToRead),
 
         BackupMedium.SharedPath =>
             SourceServer == null
@@ -734,6 +833,9 @@ public partial class RestoreViewModel : ViewModelBase
             SelectedContainer = Containers.FirstOrDefault(c => c.Name == previous);
         if (SelectedContainer == null && Containers.Count > 0)
             SelectedContainer = Containers[0];
+
+        // After the primary is settled, so the list it excludes is the right one.
+        RefreshAdditionalContainers();
     }
 
 
@@ -1946,7 +2048,75 @@ public partial class RestoreViewModel : ViewModelBase
         if (MediumIsSharedPath)
             return await CheckTargetCanReadFilesAsync(server, appendLog);
 
-        return await Credential.PrepareForRestoreAsync(server, appendLog);
+        var primary = await Credential.PrepareForRestoreAsync(server, appendLog);
+        if (!primary.CanProceed) return primary;
+
+        return await CheckOtherContainersHaveCredentialsAsync(server, appendLog);
+    }
+
+    /// <summary>
+    /// The containers this chain's files actually came from (#32).
+    ///
+    /// From the FILES rather than from what is ticked on screen: a container that was read but
+    /// contributed nothing to this chain needs no credential for this restore, and saying it does
+    /// would be a refusal nobody can act on sensibly.
+    /// </summary>
+    private IReadOnlyList<BlobContainerConfig> ChainContainers()
+    {
+        var ids = RestoreChain?.AllFiles
+            .Select(f => f.ContainerId)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Distinct()
+            .ToHashSet() ?? [];
+
+        return [.. ContainersToRead.Where(c => ids.Contains(c.Id))];
+    }
+
+    /// <summary>
+    /// Every container beyond the primary needs its own credential on the target (#32).
+    ///
+    /// <c>RESTORE ... FROM URL</c> matches a credential by URL prefix, so a chain whose full is in
+    /// one container and whose logs are in another needs a credential for BOTH - and the panel only
+    /// ever points at the primary. Without this the restore starts, reads the full, and fails on
+    /// the first log with "Cannot open backup device" - after WITH REPLACE has already dropped the
+    /// database being restored over.
+    ///
+    /// Checked, not created. Creating one needs a stored SAS this app may not have, and writing
+    /// server-side credentials nobody asked for is what #145 and #10 are both about. Refusing
+    /// before anything is touched leaves nothing to unwind.
+    /// </summary>
+    private async Task<CredentialPreflight> CheckOtherContainersHaveCredentialsAsync(
+        ServerConnection server, Action<string> appendLog)
+    {
+        var others = ChainContainers()
+            .Where(c => c.Id != SelectedContainer?.Id)
+            .ToList();
+
+        if (others.Count == 0) return CredentialPreflight.Proceed;
+
+        appendLog($"This chain spans {others.Count + 1} containers. "
+                  + $"Checking the others have credentials on {server.ServerName}...");
+
+        var missing = new List<string>();
+
+        foreach (var container in others)
+        {
+            var status = await _sqlService.CredentialExistsAsync(server, container.ContainerUrl);
+
+            if (status.CanRestoreFromUrl)
+                appendLog($"  {container.Name}: credential present.");
+            else
+                missing.Add(container.Name);
+        }
+
+        if (missing.Count == 0) return CredentialPreflight.Proceed;
+
+        return CredentialPreflight.Stop(
+            $"This restore also reads from {string.Join(" and ", missing)}, and {server.ServerName} "
+            + $"has no credential for {(missing.Count == 1 ? "it" : "them")}. RESTORE FROM URL "
+            + "matches a credential by container URL, so every container in the chain needs one. "
+            + "Select each as the container above and use Create credential, then come back - "
+            + "nothing has been changed on the server or the database.");
     }
 
     /// <summary>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -154,6 +154,46 @@
                                 VerticalAlignment="Bottom" />
                     </Grid>
 
+                    <!-- Other containers to read as well (#32).
+                         The layout this exists for is asymmetric - fulls archived to cool storage
+                         while the logs that carry them forward stay hot - so these are additions to
+                         the container above rather than peers of it. Collapsed by default, because
+                         one container is what almost everybody has. -->
+                    <Expander Header="Also read other containers"
+                              Margin="0,12,0,0"
+                              Foreground="{DynamicResource SecondaryTextBrush}"
+                              Visibility="{Binding ShowMultipleContainers, Converter={StaticResource BoolToVis}}">
+                        <StackPanel Margin="0,10,0,0">
+                            <TextBlock Style="{StaticResource SecondaryText}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,8"
+                                       Text="For a chain split across containers - a full archived to cool storage with its logs still in the hot one. Each container in the chain needs its own credential on the target, which is checked before a restore runs." />
+
+                            <ItemsControl ItemsSource="{Binding AdditionalContainers}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                                            <CheckBox IsChecked="{Binding IsSelected}"
+                                                      Content="{Binding Name}"
+                                                      Style="{StaticResource DarkCheckBox}"
+                                                      VerticalAlignment="Center" />
+                                            <ItemsControl ItemsSource="{Binding TagChips}"
+                                                          Style="{StaticResource TagChipList}"
+                                                          Margin="8,0,0,0"
+                                                          VerticalAlignment="Center" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <TextBlock Text="{Binding ContainersToReadSummary}"
+                                       Style="{StaticResource BodyText}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,8,0,0"
+                                       Visibility="{Binding ReadsSeveralContainers, Converter={StaticResource BoolToVis}}" />
+                        </StackPanel>
+                    </Expander>
+
                     <!-- Shared path: whose history, and how the target reaches the files.
 
                          A share cannot be listed the way a container can - a directory of .bak


### PR DESCRIPTION
The last unticked box on #32, and the one I argued against scheduling — so here is what changed my approach to it.

## Primary plus additional, not a set of peers

The layout this exists for is asymmetric: full backups archived to cool storage while the logs that carry them forward stay hot. The model follows that. The selected container stays **the primary** — what the credential panel points at, what the script header names, what a copied path is relative to — and others are ticked alongside it.

Peers would have been tidier and wrong: it would have made every one of those anchored things ask "which container?" and have no answer, in a workflow that took #110, #45 and #44 to get right.

## Grouped per container

Files are grouped into sets one container at a time. That is what lets each container's own backup-server time zone apply to its own sets — the zone is a property *of* a container, and a single grouping could only ever use one of them.

It also states what is true anyway: a backup **set** is one operation and does not span containers. A **chain** does, which is the point.

## The risk, which is entirely the credential

The restore itself needed no change — `RESTORE ... FROM URL` matches its credential by URL prefix and `BlobUrl` is already absolute. But a chain whose full is in one container and whose logs are in another needs a credential for **both**, and the panel only ever points at the primary.

Without a check, the restore starts, reads the full, and fails on the first log — *after* `WITH REPLACE` has already dropped the database being restored over. So every container the chain **actually uses** (from the files, not from what is ticked) is checked before anything is touched, and a missing one refuses by name with nothing to unwind.

Checked, not created: creating one needs a stored SAS this app may not have, and writing server-side credentials nobody asked for is what #145 and #10 are both about.

## Scope

Pro only, and only when there is more than one container to offer — a tick list with nothing in it is worse than no tick list. Collapsed by default, because one container is what almost everybody has.

14 new tests, 1,368 pass. Rendered expanded and collapsed.