### PR TITLE
Open on the mode cards rather than the container list (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ built for.
 
 ### Changed
 
+- **The app opens on the mode cards** rather than the container list. The first thing on screen
+  says what shape the app is in and offers to change it, instead of the app simply being that shape
+  with nothing saying why. Only a question the first time - after that the current mode is marked
+  and "Keep what I have" carries straight on (#200)
 - **A restore chain can span containers** - a full archived to cool storage with the logs that
   carry it forward still in the hot one. Additional containers are ticked alongside the selected
   one, which stays the primary: it is what the credential panel points at and the script header

--- a/src/NineLives.Tests/AppModeTests.cs
+++ b/src/NineLives.Tests/AppModeTests.cs
@@ -114,17 +114,41 @@ public class AppModeTests
         Assert.Same(main.ModeSelection, main.CurrentView);
     }
 
+    /// <summary>
+    /// The cards are the landing screen, not a first-run gate (#200).
+    ///
+    /// It reads better than opening on the container list: the first thing on screen says what
+    /// shape the app is in and offers to change it. It stays a QUESTION only the first time - after
+    /// that the current mode is marked and there is a way straight past it.
+    /// </summary>
     [Fact]
-    public void OnceChosenTheCardsDoNotComeBack()
+    public void TheCardsAreTheLandingScreenEveryLaunch()
     {
-        var store = new FakeCredentialStore();
-        store.Config.Mode = AppMode.Basic;
+        var main = Chosen(AppMode.Basic);
 
-        var main = new MainViewModel(store);
+        Assert.True(main.IsChoosingMode);
+        Assert.Same(main.ModeSelection, main.CurrentView);
+        Assert.Equal(AppMode.Basic, main.Mode);
+
+        // Not a question this time: it says which one you are on, and lets you carry on.
+        Assert.True(main.ModeSelection.CanCancel);
+        Assert.Equal(AppMode.Basic, main.ModeSelection.Cards.Single(c => c.IsCurrent).Mode);
+    }
+
+    /// <summary>
+    /// Carrying on from the landing screen goes INTO the app, not to the settings page. Somebody
+    /// who has just started it was not heading for Settings.
+    /// </summary>
+    [Fact]
+    public void CarryingOnFromTheLandingScreenGoesIntoTheApp()
+    {
+        var main = Chosen(AppMode.Pro);
+
+        main.ModeSelection.CancelCommand.Execute(null);
 
         Assert.False(main.IsChoosingMode);
-        Assert.Equal(AppMode.Basic, main.Mode);
         Assert.NotSame(main.ModeSelection, main.CurrentView);
+        Assert.NotSame(main.Settings, main.CurrentView);
     }
 
     /// <summary>The choice is remembered, or it would be asked again next time.</summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -80,17 +80,29 @@ public partial class MainViewModel : ViewModelBase
     /// They used to be shown once and then reduced to a drop-down of three names, which is the part
     /// of them worth the least - what each mode turns ON is written on the cards.
     /// </summary>
-    private void ShowModeCards()
+    private void ShowModeCards() => ShowModeCards(Nav.Settings);
+
+    private void ShowModeCards(string returnTo)
     {
+        _modeCardsReturnTo = returnTo;
         ModeSelection.ShowCurrent(Mode);
         IsChoosingMode = true;
         CurrentView = ModeSelection;
     }
 
+    /// <summary>
+    /// Where "Keep what I have" goes back to.
+    ///
+    /// Depends on why the cards are up: from Settings, back to Settings; from a launch, on into the
+    /// app. Sending somebody who has just started the app to the settings page would be a stranger
+    /// place to land than the one they were heading for.
+    /// </summary>
+    private string _modeCardsReturnTo = Nav.BlobStorage;
+
     private void OnModeCardsCancelled()
     {
         IsChoosingMode = false;
-        NavigateTo(Nav.Settings);
+        NavigateTo(_modeCardsReturnTo);
     }
 
     /// <summary>Whether a sidebar entry is offered in the current mode.</summary>
@@ -206,8 +218,7 @@ public partial class MainViewModel : ViewModelBase
         // view, and the Restore screen's own status line is below the fold most of the time (#128).
         WatchForBusy(BlobConfig, ServerManager, BlobBrowser, Backup, Restore, CopyDatabase);
 
-        // How much of the app to show (#176). Unknown means nobody has chosen yet, which is what
-        // makes the cards a first-run screen rather than a gate on every launch.
+        // How much of the app to show (#176).
         //
         // An unreadable or unrecognised value lands on Pro rather than Basic: hiding features from
         // somebody whose config got mangled is a worse failure than showing too many, because the
@@ -218,13 +229,21 @@ public partial class MainViewModel : ViewModelBase
         if (savedMode == null)
         {
             // First run. Nothing else is shown until the question is answered - a sidebar behind a
-            // choice about what the sidebar contains would be answering it twice.
+            // choice about what the sidebar contains would be answering it twice - and there is no
+            // way past it, because leaving would mean an app that has not been told how much of
+            // itself to show.
             IsChoosingMode = true;
             CurrentView = ModeSelection;
         }
         else
         {
-            CurrentView = BlobConfig;
+            // The cards are the landing screen, not a first-run gate (#200).
+            //
+            // It reads better than opening on the container list: the first thing on screen says
+            // what shape the app is in and offers to change it, rather than the app simply being
+            // that shape with no indication why. It is only a question the first time - after that
+            // the current mode is marked and "Keep what I have" carries straight on.
+            ShowModeCards(Nav.BlobStorage);
         }
 
         // Fire and forget - startup must not wait on the network.


### PR DESCRIPTION
The first thing on screen now says what shape the app is in and offers to change it, instead of the app simply *being* that shape with nothing saying why — which is the same reason the cards exist at all.

Only a question the first time. After that the current mode carries its **CURRENT** pill and **Keep what I have** goes straight on, so it costs one click.

That button now returns to wherever the cards were opened *from*:

- from **Settings** → back to Settings
- from a **launch** → into the app, because somebody who has just started it was not heading for the settings page
- on **first run** → no way past at all, since leaving would mean an app that has not been told how much of itself to show

1,369 tests pass. Rendered.