### PR TITLE
Land on Restore after "Keep what I have" (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ built for.
 
 ### Fixed
 
+- "Keep what I have" on the launch cards landed on the container list - the exact landing the
+  cards exist to avoid. It now lands on Restore, the same place choosing a mode lands (#209)
 - The widest mode drew an empty bordered box under the source picker. The audit card's border was
   gated on the mode while its contents waited on the backups, so between "this mode can audit" and
   "there is something to audit" the chrome outlived its own contents (#195)

--- a/src/NineLives.Tests/AppModeTests.cs
+++ b/src/NineLives.Tests/AppModeTests.cs
@@ -147,8 +147,11 @@ public class AppModeTests
         main.ModeSelection.CancelCommand.Execute(null);
 
         Assert.False(main.IsChoosingMode);
-        Assert.NotSame(main.ModeSelection, main.CurrentView);
-        Assert.NotSame(main.Settings, main.CurrentView);
+
+        // Restore, specifically - the same place choosing a mode lands. "Not the settings page"
+        // was too weak a pin: it let the container list through, which is the landing the cards
+        // exist to get away from (#209).
+        Assert.Same(main.Restore, main.CurrentView);
     }
 
     /// <summary>The choice is remembered, or it would be asked again next time.</summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -97,7 +97,7 @@ public partial class MainViewModel : ViewModelBase
     /// app. Sending somebody who has just started the app to the settings page would be a stranger
     /// place to land than the one they were heading for.
     /// </summary>
-    private string _modeCardsReturnTo = Nav.BlobStorage;
+    private string _modeCardsReturnTo = Nav.Restore;
 
     private void OnModeCardsCancelled()
     {
@@ -243,7 +243,11 @@ public partial class MainViewModel : ViewModelBase
             // what shape the app is in and offers to change it, rather than the app simply being
             // that shape with no indication why. It is only a question the first time - after that
             // the current mode is marked and "Keep what I have" carries straight on.
-            ShowModeCards(Nav.BlobStorage);
+            //
+            // Straight on TO RESTORE (#209): the same place choosing a mode lands, because carrying
+            // on and choosing-the-same-thing are the same decision - and the container list is the
+            // landing #200 existed to get away from.
+            ShowModeCards(Nav.Restore);
         }
 
         // Fire and forget - startup must not wait on the network.


### PR DESCRIPTION
Carrying on and choosing-the-same-thing are the same decision, so they now land in the same place: Restore. The container list — where this went — is the landing #200 existed to get away from, reached through the new front door.

The test pin was too weak to catch it: "not the settings page" let the container list through. It now names Restore.

Found in my own #201 during the review. 1,369 tests pass.