### PR TITLE
Run the disk-space check on Copy Database too (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ built for.
 
 ### Fixed
 
+- Copy Database never ran the disk-space check the restore screen has had since #182, so the
+  screen where a copy fails after the target is already dropped was the one that never warned. It
+  now checks the source's live file sizes against the target's volumes when the scripts are
+  generated - including a drive the target does not have at all, which without MOVE clauses is
+  exactly where the restore would aim (#206)
 - "Keep what I have" on the launch cards landed on the container list - the exact landing the
   cards exist to avoid. It now lands on Restore, the same place choosing a mode lands (#209)
 - The widest mode drew an empty bordered box under the source picker. The audit card's border was

--- a/src/NineLives.Tests/CopySpaceCheckTests.cs
+++ b/src/NineLives.Tests/CopySpaceCheckTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The disk-space check on the copy screen (#206).
+///
+/// The restore screen has warned since #182; the copy - which ends in exactly the same RESTORE on
+/// the target - did not. So the screen where somebody pays the least attention was the one that
+/// never warned, and a copy without room fails in the restore half: source backup already taken,
+/// target database already dropped by WITH REPLACE.
+///
+/// A copy has no backup to FILELISTONLY when the check should run, and needs none - the database is
+/// live on the source, so its own catalog answers up front. And because the copy's restore carries
+/// no MOVE clauses, the files land at the paths the source recorded, which is what makes the
+/// source's own drive letters the right volumes to ask the target about.
+/// </summary>
+public class CopySpaceCheckTests
+{
+    private const long GB = 1024L * 1024 * 1024;
+
+    private static ServerConnection Server(string name) =>
+        new() { Id = ServerConnection.NewId(), Name = name, ServerName = name };
+
+    private static FileMoveOption File_(string logical, string path, long size) => new()
+    {
+        LogicalName = logical,
+        PhysicalName = path,
+        NewPhysicalName = path,
+        SizeBytes = size
+    };
+
+    private static (CopyDatabaseViewModel vm, FakeSqlServerService sql) New()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server("SRV01"));
+        store.Config.Servers.Add(Server("SRV02"));
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService
+        {
+            DatabaseFiles =
+            [
+                File_("MyDb", @"D:\SQL\Data\MyDb.mdf", 40 * GB),
+                File_("MyDb_log", @"L:\SQL\Log\MyDb_log.ldf", 10 * GB)
+            ],
+            VolumeFreeSpace = new Dictionary<string, long>
+            {
+                [@"D:\"] = 100 * GB,
+                [@"L:\"] = 50 * GB
+            }
+        };
+
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp());
+        vm.SourceServer = vm.Servers[0];
+        vm.TargetServer = vm.Servers[1];
+        vm.SourceDatabases = new ObservableCollection<string>(["MyDb"]);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetDatabaseName = "MyDb";
+        vm.Container = vm.Containers[0];
+
+        return (vm, sql);
+    }
+
+    /// <summary>Generating the scripts asks the question; room enough reports without alarm.</summary>
+    [Fact]
+    public async Task GeneratingReportsTheVolumesWhenEverythingFits()
+    {
+        var (vm, _) = New();
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.Equal(2, vm.VolumeSpace.Count);
+        Assert.All(vm.VolumeSpace, v => Assert.True(v.Fits));
+        Assert.False(vm.HasSpaceWarning);
+    }
+
+    /// <summary>The one this exists for: the target has less room than the copy needs.</summary>
+    [Fact]
+    public async Task ATargetWithoutRoomWarnsBeforeAnythingRuns()
+    {
+        var (vm, sql) = New();
+        sql.VolumeFreeSpace[@"D:\"] = 10 * GB;
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.True(vm.HasSpaceWarning);
+        Assert.Contains(@"D:\", vm.SpaceWarning);
+    }
+
+    /// <summary>
+    /// The volumes checked are the SOURCE's paths against the TARGET's free space - the copy's
+    /// restore carries no MOVE clauses, so that is where the files will actually land.
+    /// </summary>
+    [Fact]
+    public async Task TheVolumesCheckedAreWhereTheFilesWillLand()
+    {
+        var (vm, _) = New();
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.Contains(vm.VolumeSpace, v => v.Volume.StartsWith(@"D:\", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(vm.VolumeSpace, v => v.Volume.StartsWith(@"L:\", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Failing to answer is not a warning. An instance that will not report files or volumes has
+    /// said nothing, and silence must not read as "the copy will fail".
+    /// </summary>
+    [Fact]
+    public async Task AnInstanceThatWillNotAnswerRaisesNoAlarm()
+    {
+        var (vm, sql) = New();
+        sql.DatabaseFilesThrows = new InvalidOperationException("VIEW SERVER STATE denied");
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.False(vm.HasSpaceWarning);
+        Assert.Empty(vm.VolumeSpace);
+        Assert.False(vm.HasError);
+    }
+
+    /// <summary>
+    /// A drive the target never reports warns rather than passing - dm_os_volume_stats only
+    /// describes volumes that host database files, so "not reported" routinely means "the target
+    /// has no such drive". For a copy that is the classic layout mismatch: the source keeps logs
+    /// on L:\ and the target has no L:\ at all, and without MOVE clauses the restore aims at it.
+    /// </summary>
+    [Fact]
+    public async Task ADriveTheTargetDoesNotHaveWarns()
+    {
+        var (vm, sql) = New();
+        sql.VolumeFreeSpace.Remove(@"L:\");
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.True(vm.HasSpaceWarning);
+        Assert.Contains(@"L:\", vm.SpaceWarning);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -229,6 +229,19 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>What the fake instance says it has free, by mount point.</summary>
     public Dictionary<string, long> VolumeFreeSpace { get; set; } = [];
 
+    /// <summary>What GetDatabaseFilesAsync answers - the live files of whatever database is asked about.</summary>
+    public List<FileMoveOption> DatabaseFiles { get; set; } = [];
+
+    /// <summary>Set to make the file listing fail, standing in for a permissions refusal.</summary>
+    public Exception? DatabaseFilesThrows { get; set; }
+
+    public Task<List<FileMoveOption>> GetDatabaseFilesAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+    {
+        if (DatabaseFilesThrows != null) throw DatabaseFilesThrows;
+        return Task.FromResult(DatabaseFiles.ToList());
+    }
+
     /// <summary>Set to make asking about volumes fail - which must not become a warning (#32).</summary>
     public Exception? VolumeCheckThrows { get; set; }
 

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -26,6 +26,16 @@ public interface ISqlServerService
     /// Asked of the SERVER rather than measured from here: this app's process may not see those
     /// volumes at all, and where it can, what it sees is not what the service account writes to.
     /// </summary>
+    /// <summary>
+    /// The files of a database that exists on this instance now - name, path and current size.
+    ///
+    /// For the copy screen's disk-space check (#206): a copy has no backup to FILELISTONLY until
+    /// the source half has already run, but the database being copied is live on the source, so
+    /// its own catalog answers the same question up front.
+    /// </summary>
+    Task<List<FileMoveOption>> GetDatabaseFilesAsync(
+        ServerConnection server, string database, CancellationToken ct = default);
+
     Task<Dictionary<string, long>> GetVolumeFreeSpaceAsync(
         ServerConnection server, CancellationToken ct = default);
 

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1081,6 +1081,50 @@ public class SqlServerService : ISqlServerService
     /// limitation of this approach - a brand-new drive with nothing on it does not appear, and a
     /// restore aimed there is simply not covered rather than being reported as full.
     /// </summary>
+    public async Task<List<FileMoveOption>> GetDatabaseFilesAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+    {
+        var files = new List<FileMoveOption>();
+
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+
+        // size is in 8 KB pages. master_files rather than the database's own sys.database_files,
+        // so this works without access to the database itself - backing up only needs the server
+        // role, and the check should not demand more than the operation does.
+        cmd.CommandText = @"
+            SELECT mf.name          AS LogicalName,
+                   mf.physical_name AS PhysicalName,
+                   mf.type_desc     AS TypeDesc,
+                   CAST(mf.size AS bigint) * 8192 AS SizeBytes
+            FROM sys.master_files AS mf
+            WHERE mf.database_id = DB_ID(@database)";
+        cmd.Parameters.AddWithValue("@database", database);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var physical = reader["PhysicalName"]?.ToString() ?? string.Empty;
+
+            files.Add(new FileMoveOption
+            {
+                LogicalName = reader["LogicalName"]?.ToString() ?? string.Empty,
+                PhysicalName = physical,
+
+                // The copy's restore carries no MOVE clauses, so each file lands at the path the
+                // backup recorded - this one - on the TARGET. Filling NewPhysicalName in is what
+                // lets RestoreSpaceCheck ask about the right volumes.
+                NewPhysicalName = physical,
+
+                Type = reader["TypeDesc"]?.ToString() ?? string.Empty,
+                SizeBytes = reader["SizeBytes"] as long? ?? 0
+            });
+        }
+
+        return files;
+    }
+
     public async Task<Dictionary<string, long>> GetVolumeFreeSpaceAsync(
         ServerConnection server, CancellationToken ct = default)
     {

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -323,6 +323,65 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             });
 
         SetStatus("Scripts generated.");
+
+        // Fire and forget: the scripts are usable immediately, and the space answer arrives when
+        // the two instances have answered. A generation that had to wait on both would make the
+        // whole screen feel slower for a check that usually says "fine".
+        _ = CheckSpaceAsync();
+    }
+
+    // ── will it fit (#206) ──────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private ObservableCollection<VolumeSpace> _volumeSpace = [];
+
+    [ObservableProperty]
+    private string _spaceWarning = string.Empty;
+
+    public bool HasSpaceWarning => SpaceWarning.Length > 0;
+
+    partial void OnSpaceWarningChanged(string value) => OnPropertyChanged(nameof(HasSpaceWarning));
+
+    /// <summary>
+    /// Whether the restore half can physically fit on the target, asked BEFORE the copy starts.
+    ///
+    /// The restore screen has had this since #182; the copy - which ends in exactly the same
+    /// RESTORE - did not, so the screen where somebody pays the least attention was the one that
+    /// never warned. A copy that runs out of disk fails in the restore half, with the source's
+    /// backup already taken and the target's database already dropped by WITH REPLACE.
+    ///
+    /// There is no backup to FILELISTONLY yet, and no need: the database is live on the source, so
+    /// its catalog gives the same sizes up front. The copy's restore carries no MOVE clauses, so
+    /// the files land at the paths the source recorded - meaning the volumes to check on the
+    /// target are the source's own drive letters.
+    ///
+    /// Failing to answer is not a warning, same stance as the restore screen: this is a courtesy
+    /// check over somebody else's storage.
+    /// </summary>
+    private async Task CheckSpaceAsync()
+    {
+        VolumeSpace = [];
+        SpaceWarning = string.Empty;
+
+        if (SourceServer == null || TargetServer == null || string.IsNullOrWhiteSpace(SourceDatabase))
+            return;
+
+        try
+        {
+            var files = await _sql.GetDatabaseFilesAsync(SourceServer, SourceDatabase!);
+            var free = await _sql.GetVolumeFreeSpaceAsync(TargetServer);
+            var volumes = RestoreSpaceCheck.Check(files, free);
+
+            VolumeSpace = new ObservableCollection<VolumeSpace>(volumes);
+            SpaceWarning = RestoreSpaceCheck.Warn(volumes);
+
+            if (HasSpaceWarning) _log.Warn($"[space] copy: {SpaceWarning}");
+        }
+        catch
+        {
+            // An instance that will not report its files or volumes has not said the copy will
+            // fail - it has said nothing. Warn on evidence, not on silence.
+        }
     }
 
     /// <summary>

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -197,6 +197,39 @@
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
                 <StackPanel>
                     <TextBlock Text="4. Run it" Style="{StaticResource SubHeaderText}" />
+
+                    <!-- Will it fit (#206). Same check and stance as the restore screen: a warning,
+                         not a block - this app is not the authority on somebody else's storage. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,10,0,0"
+                            Background="{DynamicResource DangerPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource ErrorBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding HasSpaceWarning, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding SpaceWarning}"
+                                   TextWrapping="Wrap"
+                                   Style="{StaticResource BodyText}" />
+                    </Border>
+
+                    <ItemsControl ItemsSource="{Binding VolumeSpace}" Margin="0,8,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Describe}"
+                                           TextWrapping="Wrap"
+                                           FontSize="11"
+                                           Margin="0,0,0,2">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Fits}" Value="False">
+                                                    <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,4,0,12"
                                Text="Both statements are shown together, because what happens to each server is one decision - reading them one at a time is how somebody approves the half they were looking at." />
 


### PR DESCRIPTION
The restore screen has warned since #182; the copy — which ends in exactly the same RESTORE on the target — did not. So the screen where somebody pays the least attention was the one that never warned, and a copy without room fails in the restore half: source backup already taken, target database already dropped by `WITH REPLACE`.

## No backup to FILELISTONLY, and none needed

The check runs when the scripts are generated, before anything has been written. The database is live on the source, so `sys.master_files` answers the same question up front — via the server catalog rather than the database itself, so the check demands no more access than the operation does.

## The volumes checked are the source's own drive letters

The copy's restore carries no MOVE clauses, so each file lands at the path the backup recorded. That is what makes the check honest about the classic layout mismatch: logs on `L:` at the source, no `L:` drive on the target — `dm_os_volume_stats` never reports it, the check treats unreported as empty (the existing #182 rule: not knowing is not the same as fitting), and the warning names the drive before the run instead of error 3634 after the drop.

Same stance as the restore screen throughout: a warning, not a block, and an instance that will not answer raises nothing — warn on evidence, not on silence.

Rendered in its firing state — red box above the run buttons, short volume in red, fitting one in grey. 5 new tests, 1,374 pass.