### PR TITLE
Restore a backup file nobody's msdb knows (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ built for.
 
 ### Changed
 
+- **A backup file nobody's msdb knows can now be restored** - the vendor .bak, the file that
+  outlived its server. A third source on the restore screen takes pasted paths, asks a server to
+  read each file's own headers, and hands the result to the same chain, options and script
+  machinery as every other source. A file holding several appended backups yields one restore
+  point per position and the script says WITH FILE = n; a single stripe of a striped set is
+  refused by name, because its header happily describes media it cannot deliver (#203)
+- HEADERONLY, FILELISTONLY and VERIFYONLY statements now name DISK or URL by what each file
+  actually is, instead of assuming blob - which also makes the header audit meaningful for
+  backups discovered through msdb (#203)
 - **The app opens on the mode cards** rather than the container list. The first thing on screen
   says what shape the app is in and offers to change it, instead of the app simply being that shape
   with nothing saying why. Only a question the first time - after that the current mode is marked

--- a/src/NineLives.Tests/AdHocFileRestoreTests.cs
+++ b/src/NineLives.Tests/AdHocFileRestoreTests.cs
@@ -1,0 +1,307 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Restoring a backup file that no configured instance's msdb knows (#203).
+///
+/// The classic case in the job: a vendor sends a .bak, or the file outlived the server that took
+/// it. Until this, neither medium could reach it - blob obviously not, and the shared path reads a
+/// source instance's history, which by definition does not contain a backup nobody here took.
+///
+/// The file's own headers are the only account of what it holds, and they carry the same fields
+/// msdb records - database, type, LSNs, position. So the reader maps headers onto the same
+/// BackupHistoryEntry the shared path uses, and everything downstream is shared machinery: ToSets,
+/// the LSN chain, FROM DISK, the target-side readability preflight.
+/// </summary>
+public class AdHocFileRestoreTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 7, 22, 0, 0);
+
+    private static ServerConnection Server(string name = "SRV01") =>
+        new() { Id = ServerConnection.NewId(), Name = name, ServerName = name };
+
+    private static BackupHistoryEntry Header(
+        string file, BackupType type, int position = 1, int familyCount = 1,
+        decimal? firstLsn = null, decimal? lastLsn = null,
+        decimal? checkpointLsn = null, decimal? databaseBackupLsn = null,
+        string database = "VendorDb", int minutesAfterT0 = 0) => new()
+    {
+        DatabaseName = database,
+        ServerName = "THEIR-SERVER",
+        Type = type,
+        StartedAt = T0.AddMinutes(minutesAfterT0),
+        FinishedAt = T0.AddMinutes(minutesAfterT0 + 1),
+        FirstLsn = firstLsn,
+        LastLsn = lastLsn,
+        CheckpointLsn = checkpointLsn,
+        DatabaseBackupLsn = databaseBackupLsn,
+        Position = position,
+        FamilyCount = familyCount,
+        Files = [file]
+    };
+
+    private static (BackupInventoryViewModel vm, FakeSqlServerService sql) New()
+    {
+        var sql = new FakeSqlServerService();
+        var vm = new BackupInventoryViewModel(
+            new FakeBlobStorageService(), sql, TestLogs.Temp(), TestAuditStores.Temp());
+        return (vm, sql);
+    }
+
+    // ── reading a file ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AFileIsReadByItsOwnHeaders()
+    {
+        var (vm, sql) = New();
+        sql.FileHeaders[@"\\share\drop\VendorDb.bak"] =
+            [Header(@"\\share\drop\VendorDb.bak", BackupType.Full, checkpointLsn: 100m)];
+
+        await vm.LoadAsync(BackupLocation.AdHoc(Server(), [@"\\share\drop\VendorDb.bak"]));
+
+        Assert.True(vm.BackupsLoaded);
+        var set = Assert.Single(vm.AllSets);
+        Assert.Equal("VendorDb", set.DatabaseName);
+        Assert.Equal(BackupType.Full, set.Type);
+
+        // FROM DISK, because the file model says where it lives - not a flag elsewhere.
+        var file = Assert.Single(set.Files);
+        Assert.True(file.IsOnDisk);
+        Assert.Equal(@"\\share\drop\VendorDb.bak", file.RestoreDevice);
+    }
+
+    /// <summary>
+    /// A full and the logs that follow it, listed together, chain by their own LSNs - the file
+    /// names say nothing and are not consulted.
+    /// </summary>
+    [Fact]
+    public async Task AFullAndItsLogsChainByLsn()
+    {
+        var (vm, sql) = New();
+        sql.FileHeaders[@"D:\drop\full.bak"] =
+            [Header(@"D:\drop\full.bak", BackupType.Full,
+                    firstLsn: 100m, lastLsn: 150m, checkpointLsn: 120m)];
+        sql.FileHeaders[@"D:\drop\log1.trn"] =
+            [Header(@"D:\drop\log1.trn", BackupType.TransactionLog,
+                    firstLsn: 150m, lastLsn: 200m, databaseBackupLsn: 120m, minutesAfterT0: 30)];
+
+        await vm.LoadAsync(BackupLocation.AdHoc(Server(), [@"D:\drop\full.bak", @"D:\drop\log1.trn"]));
+
+        Assert.Equal(2, vm.AllSets.Count);
+        Assert.Contains(vm.AllSets, s => s.Type == BackupType.Full);
+        Assert.Contains(vm.AllSets, s => s.Type == BackupType.TransactionLog);
+    }
+
+    /// <summary>
+    /// A file holds several backups whenever NOINIT appended to it, and each is its own restore
+    /// point carrying its position - restoring "the file" without saying which would silently
+    /// mean the oldest.
+    /// </summary>
+    [Fact]
+    public async Task AMultiBackupFileYieldsOneSetPerPosition()
+    {
+        var (vm, sql) = New();
+        sql.FileHeaders[@"D:\drop\appended.bak"] =
+        [
+            Header(@"D:\drop\appended.bak", BackupType.Full, position: 1, checkpointLsn: 100m),
+            Header(@"D:\drop\appended.bak", BackupType.Full, position: 2, checkpointLsn: 200m, minutesAfterT0: 60)
+        ];
+
+        await vm.LoadAsync(BackupLocation.AdHoc(Server(), [@"D:\drop\appended.bak"]));
+
+        Assert.Equal(2, vm.AllSets.Count);
+        Assert.Equal([1, 2], vm.AllSets.Select(s => s.Position ?? 0).OrderBy(p => p));
+    }
+
+    /// <summary>The generated RESTORE says WITH FILE = n, or SQL Server quietly restores position 1.</summary>
+    [Fact]
+    public void TheScriptNamesThePosition()
+    {
+        var generator = new RestoreScriptGenerator();
+        var chain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                SetId = "VendorDb_p2",
+                DatabaseName = "VendorDb",
+                Type = BackupType.Full,
+                Position = 2,
+                Timestamp = T0,
+                Files =
+                [
+                    new BackupFileInfo
+                    {
+                        BlobName = "appended.bak",
+                        LocalPath = @"D:\drop\appended.bak",
+                        Type = BackupType.Full
+                    }
+                ]
+            }
+        };
+
+        var script = generator.Generate(chain, new RestoreOptions { TargetDatabaseName = "VendorDb" });
+
+        Assert.Contains(@"FROM DISK = N'D:\drop\appended.bak'", script);
+        Assert.Contains("FILE = 2,", script);
+    }
+
+    /// <summary>A chain with no position says nothing about FILE - existing scripts do not change.</summary>
+    [Fact]
+    public void NoPositionMeansNoFileClause()
+    {
+        var generator = new RestoreScriptGenerator();
+        var chain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                SetId = "MyDb",
+                DatabaseName = "MyDb",
+                Type = BackupType.Full,
+                Timestamp = T0,
+                Files =
+                [
+                    new BackupFileInfo
+                    {
+                        BlobName = "MyDb.bak",
+                        BlobUrl = "https://acct.blob.core.windows.net/backups/MyDb.bak",
+                        Type = BackupType.Full
+                    }
+                ]
+            }
+        };
+
+        var script = generator.Generate(chain, new RestoreOptions { TargetDatabaseName = "MyDb" });
+
+        Assert.DoesNotContain("FILE =", script);
+    }
+
+    // ── refusals, by name ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A stripe cannot be restored alone, and HEADERONLY on one member happily describes the whole
+    /// set - FamilyCount is the only tell, so it refuses loudly rather than offering a restore the
+    /// media cannot deliver.
+    /// </summary>
+    [Fact]
+    public async Task AStripeMemberIsRefusedWithAnExplanation()
+    {
+        var (vm, sql) = New();
+        sql.FileHeaders[@"D:\drop\stripe1of3.bak"] =
+            [Header(@"D:\drop\stripe1of3.bak", BackupType.Full, familyCount: 3)];
+
+        await vm.LoadAsync(BackupLocation.AdHoc(Server(), [@"D:\drop\stripe1of3.bak"]));
+
+        Assert.False(vm.BackupsLoaded);
+        Assert.True(vm.HasError);
+        Assert.Contains("stripe", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("3", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// One unreadable file fails the whole load, by name. Reading three files and quietly showing
+    /// two is how somebody restores "everything" minus the log that carried the chain to the
+    /// point they wanted.
+    /// </summary>
+    [Fact]
+    public async Task OneUnreadableFileFailsTheLoadByName()
+    {
+        var (vm, sql) = New();
+        sql.FileHeaders[@"D:\drop\full.bak"] =
+            [Header(@"D:\drop\full.bak", BackupType.Full)];
+        // log1.trn deliberately not present in the fake.
+
+        await vm.LoadAsync(BackupLocation.AdHoc(Server(), [@"D:\drop\full.bak", @"D:\drop\log1.trn"]));
+
+        Assert.False(vm.BackupsLoaded);
+        Assert.True(vm.HasError);
+        Assert.Contains("log1.trn", vm.StatusMessage);
+    }
+
+    // ── the location itself ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheSameFilesReadViaADifferentServerAreADifferentPlace()
+    {
+        var srv1 = Server("SRV01");
+        var srv2 = Server("SRV02");
+
+        var viaOne = BackupLocation.AdHoc(srv1, [@"D:\drop\full.bak"]);
+        var viaTwo = BackupLocation.AdHoc(srv2, [@"D:\drop\full.bak"]);
+
+        // A local drive letter names a different disk on every machine.
+        Assert.False(viaOne.SamePlaceAs(viaTwo));
+        Assert.True(viaOne.SamePlaceAs(BackupLocation.AdHoc(srv1, [@"D:\drop\full.bak"])));
+    }
+
+    [Fact]
+    public void ALocationNamesItsFile()
+    {
+        var one = BackupLocation.AdHoc(Server(), [@"D:\drop\VendorDb.bak"]);
+        var several = BackupLocation.AdHoc(Server(), [@"D:\a.bak", @"D:\b.trn", @"D:\c.trn"]);
+
+        Assert.Equal("VendorDb.bak", one.Describe());
+        Assert.Equal("3 backup files", several.Describe());
+    }
+
+    // ── the restore screen ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ThePathsBoxFeedsTheLocation()
+    {
+        var vm = Restore();
+        vm.SelectedMedium = BackupMedium.AdHocFile;
+        vm.SourceServer = vm.SourceServers[0];
+        vm.AdHocPathsText = "D:\\drop\\full.bak\r\n\r\n  D:\\drop\\log1.trn  \r\n";
+
+        var location = vm.CurrentLocation;
+
+        Assert.NotNull(location);
+        Assert.True(location!.IsAdHocFile);
+        Assert.Equal([@"D:\drop\full.bak", @"D:\drop\log1.trn"], location.FilePaths);
+    }
+
+    [Fact]
+    public void WithNoPathsThereIsNothingToLoad()
+    {
+        var vm = Restore();
+        vm.SelectedMedium = BackupMedium.AdHocFile;
+        vm.SourceServer = vm.SourceServers[0];
+        vm.AdHocPathsText = "   ";
+
+        Assert.Null(vm.CurrentLocation);
+    }
+
+    /// <summary>Same mode gate as the shared path: both are FROM DISK with an instance asked.</summary>
+    [Fact]
+    public void EditingThePathsClearsWhatWasLoaded()
+    {
+        var vm = Restore();
+        vm.SelectedMedium = BackupMedium.AdHocFile;
+        vm.Inventory.BackupsLoaded = true;
+
+        vm.AdHocPathsText = @"D:\drop\other.bak";
+
+        Assert.False(vm.Inventory.BackupsLoaded);
+    }
+
+    private static RestoreViewModel Restore()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server());
+
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(),
+            new FakeRestoreHistoryStore(), TestAuditStores.Temp())
+        {
+            Mode = AppMode.Pro
+        };
+
+        vm.RefreshContainers();
+        return vm;
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -418,6 +418,25 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Paths the fake target refuses, and why. Anything not listed is readable.</summary>
     public Dictionary<string, BackupFileProblem> UnreadablePaths { get; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>What each ad-hoc file's headers say, keyed by path (#203).</summary>
+    public Dictionary<string, List<BackupHistoryEntry>> FileHeaders { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Every path whose headers were read, in order.</summary>
+    public List<string> HeaderReadPaths { get; } = [];
+
+    public Task<List<BackupHistoryEntry>> ReadBackupFileHeadersAsync(
+        ServerConnection server, string path, CancellationToken ct = default)
+    {
+        HeaderReadPaths.Add(path);
+
+        if (!FileHeaders.TryGetValue(path, out var entries))
+            throw new InvalidOperationException(
+                $"Cannot open backup device '{path}'. Operating system error 2(The system cannot find the file specified.).");
+
+        return Task.FromResult(entries.ToList());
+    }
+
     public Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
         ServerConnection server, string? databaseName = null, CancellationToken ct = default)
         => Task.FromResult(databaseName == null

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -277,6 +277,18 @@ public class BackupFileInfo
 public class BackupSet
 {
     public string SetId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Where this backup sits within its file, when it was read from one (#203).
+    ///
+    /// Drives WITH FILE = n in the generated script. A backup file holds several backup sets
+    /// whenever BACKUP ... NOINIT appended to it, and a restore that does not say which one it
+    /// means silently gets position 1 - the OLDEST backup in the file, presented as a success.
+    ///
+    /// Null everywhere except sets read directly from a file, which is the only source where a
+    /// file position is in play.
+    /// </summary>
+    public int? Position { get; set; }
     public BackupType Type { get; set; }
     public List<BackupFileInfo> Files { get; set; } = [];
     /// <summary>

--- a/src/NineLives/Models/BackupHistoryEntry.cs
+++ b/src/NineLives/Models/BackupHistoryEntry.cs
@@ -62,6 +62,28 @@ public sealed class BackupHistoryEntry
     public string? ServerName { get; init; }
 
     /// <summary>
+    /// Where this backup sits within its file, when it was read from one (#203).
+    ///
+    /// A backup FILE can hold several backup SETS - every BACKUP ... NOINIT appends another - and
+    /// HEADERONLY reports one row per set with its Position. A restore that wants any but the
+    /// first must say WITH FILE = n, or SQL Server silently restores position 1: the oldest
+    /// backup in the file, presented as a success.
+    ///
+    /// Null for anything read from msdb, where each history row is its own backup and the file
+    /// position is not in play.
+    /// </summary>
+    public int? Position { get; init; }
+
+    /// <summary>
+    /// How many files make up the media set this backup was written across (#203).
+    ///
+    /// More than one means this file is one stripe of a striped set, and restoring needs every
+    /// member. HEADERONLY on a single member happily describes the set, which is exactly why this
+    /// has to be carried and checked - the header looks complete when the media is not.
+    /// </summary>
+    public int FamilyCount { get; init; } = 1;
+
+    /// <summary>
     /// A record with no files cannot be restored from, whatever else it says.
     ///
     /// msdb keeps history for backups whose files have since been deleted, archived or pruned by a

--- a/src/NineLives/Models/BackupLocation.cs
+++ b/src/NineLives/Models/BackupLocation.cs
@@ -18,7 +18,17 @@ public enum BackupMedium
     /// A path both instances can see - SMB, NFS, a mount. <c>RESTORE ... FROM DISK</c>, and no
     /// credential at all, because SQL Server reaches it as its own service account.
     /// </summary>
-    SharedPath
+    SharedPath,
+
+    /// <summary>
+    /// A backup file named directly, that no configured instance's msdb knows (#203).
+    ///
+    /// The classic case: a vendor sends a .bak, or the file outlived the server that took it. The
+    /// file's own headers are the only account of what it holds, so that is what gets read -
+    /// HEADERONLY on an instance that can see the path. Restores <c>FROM DISK</c>, no credential,
+    /// same as a shared path.
+    /// </summary>
+    AdHocFile
 }
 
 /// <summary>
@@ -82,6 +92,25 @@ public sealed record BackupLocation
     public static BackupLocation Blob(IReadOnlyList<BlobContainerConfig> containers) =>
         new() { Medium = BackupMedium.AzureBlob, Containers = containers };
 
+    /// <summary>
+    /// The files to read directly, when the medium is AdHocFile (#203).
+    ///
+    /// Each entry is one complete backup file. NOT stripe members of one set - a striped set's
+    /// header says FamilyCount > 1 and is refused with an explanation, because HEADERONLY on a
+    /// single stripe happily describes a set the media cannot deliver.
+    /// </summary>
+    public IReadOnlyList<string> FilePaths { get; init; } = [];
+
+    public static BackupLocation AdHoc(ServerConnection readVia, IReadOnlyList<string> paths) =>
+        new()
+        {
+            Medium = BackupMedium.AdHocFile,
+            // The instance ASKED, not the instance that took the backups - nothing that took them
+            // is known here. It has to be able to read the path, which usually means the target.
+            SourceServer = readVia,
+            FilePaths = paths
+        };
+
     public static BackupLocation Shared(ServerConnection sourceServer, BackupPathMapping? mapping = null) =>
         new()
         {
@@ -92,6 +121,7 @@ public sealed record BackupLocation
 
     public bool IsBlob => Medium == BackupMedium.AzureBlob;
     public bool IsSharedPath => Medium == BackupMedium.SharedPath;
+    public bool IsAdHocFile => Medium == BackupMedium.AdHocFile;
 
     /// <summary>What this location is, for a status line or a history entry.</summary>
     public string Describe() => Medium switch
@@ -105,6 +135,13 @@ public sealed record BackupLocation
         BackupMedium.SharedPath => SourceServer == null
             ? "a shared path"
             : $"{SourceServer.ServerName}'s backup history",
+
+        BackupMedium.AdHocFile => FilePaths.Count switch
+        {
+            0 => "a backup file",
+            1 => System.IO.Path.GetFileName(FilePaths[0]),
+            var n => $"{n} backup files"
+        },
         _ => "an unknown location"
     };
 
@@ -129,6 +166,13 @@ public sealed record BackupLocation
             // chain from the other.
             BackupMedium.SharedPath =>
                 SourceServer?.Id == other.SourceServer?.Id && Mapping == other.Mapping,
+
+            // The reader AND the exact files, in order. The same paths read via a different
+            // instance can resolve to different files - a local drive letter names a different
+            // disk on every machine.
+            BackupMedium.AdHocFile =>
+                SourceServer?.Id == other.SourceServer?.Id
+                && FilePaths.SequenceEqual(other.FilePaths, StringComparer.OrdinalIgnoreCase),
 
             _ => false
         };

--- a/src/NineLives/Services/BackupHistoryInventory.cs
+++ b/src/NineLives/Services/BackupHistoryInventory.cs
@@ -59,7 +59,12 @@ public static class BackupHistoryInventory
         {
             // msdb has no notion of the set ids this app derives from blob names, so the identity
             // is what a person would recognise it by: what it is and when it ran.
-            SetId = $"{entry.DatabaseName}_{entry.StartedAt:yyyyMMdd_HHmmss}",
+            // The position suffix keeps two backups of one database that share a second - which a
+            // multi-backup FILE can genuinely hold - from collapsing into one set.
+            SetId = entry.Position is int p
+                ? $"{entry.DatabaseName}_{entry.StartedAt:yyyyMMdd_HHmmss}_p{p}"
+                : $"{entry.DatabaseName}_{entry.StartedAt:yyyyMMdd_HHmmss}",
+            Position = entry.Position,
             DatabaseName = entry.DatabaseName,
             ServerName = host,
             InstanceName = instance,

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -50,6 +50,18 @@ public interface ISqlServerService
     Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
         ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default);
 
+    /// <summary>
+    /// Everything one backup FILE says about itself: one entry per backup set it holds (#203).
+    ///
+    /// For the backup nobody's msdb knows - a vendor's .bak, a file off a decommissioned server.
+    /// HEADERONLY is asked on <paramref name="server"/>, which must be able to read the path; the
+    /// entries carry Position (a file holds several sets whenever NOINIT appended) and FamilyCount
+    /// (more than one means the file is a single stripe of a striped set, and cannot be restored
+    /// alone).
+    /// </summary>
+    Task<List<BackupHistoryEntry>> ReadBackupFileHeadersAsync(
+        ServerConnection server, string path, CancellationToken ct = default);
+
     Task<BackupFileInfo?> RestoreHeaderOnlyMultiAsync(
         ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default);
 

--- a/src/NineLives/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives/Services/RestoreScriptGenerator.cs
@@ -170,6 +170,13 @@ public class RestoreScriptGenerator
         }
 
         sb.AppendLine("    WITH");
+
+        // Which backup within the file (#203). Stated whenever it is known, not only when it is
+        // not 1: the default IS 1, but a file that holds several backups is exactly the situation
+        // where the script should say which one it means rather than relying on a default the
+        // reader may not know exists.
+        if (set.Position is int position)
+            sb.AppendLine($"         FILE = {position},");
     }
 
     private static void AppendFileMoves(StringBuilder sb, RestoreOptions options)

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -387,6 +387,25 @@ public class SqlServerService : ISqlServerService
     // keyed off the identity type that CredentialExistsAsync already reports - not off a flag.
 
     /// <summary>RESTORE FILELISTONLY across the files of one backup set, striped or not.</summary>
+    /// <summary>
+    /// The device clause for one backup device - <c>DISK = N'...'</c> for a path,
+    /// <c>URL = N'...'</c> for anything else (#203).
+    ///
+    /// The same rule <see cref="BackupFileInfo.IsOnDisk"/> applies, expressed over the raw string:
+    /// a drive letter or a UNC prefix is a path. These statements were built with URL hardcoded,
+    /// which quietly limited HEADERONLY, FILELISTONLY and VERIFYONLY to blob - the restore itself
+    /// has been device-aware since #149, and the inspection statements should match it.
+    /// </summary>
+    private static string DeviceClause(string device)
+    {
+        var isPath = device.StartsWith(@"\\", StringComparison.Ordinal)
+                     || (device.Length >= 2 && device[1] == ':');
+
+        return isPath
+            ? $"DISK = N'{TSql.EscapeLiteral(device)}'"
+            : $"URL = N'{TSql.EscapeLiteral(device)}'";
+    }
+
     public async Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
         ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)
     {
@@ -397,8 +416,8 @@ public class SqlServerService : ISqlServerService
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
 
-        var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
-        cmd.CommandText = $"RESTORE FILELISTONLY FROM {urlClauses}";
+        var deviceClauses = string.Join(", ", blobUrls.Select(DeviceClause));
+        cmd.CommandText = $"RESTORE FILELISTONLY FROM {deviceClauses}";
 
         return await CancellableAsync(async () =>
         {
@@ -491,6 +510,55 @@ public class SqlServerService : ISqlServerService
         }
 
         return results;
+    }
+
+    public async Task<List<BackupHistoryEntry>> ReadBackupFileHeadersAsync(
+        ServerConnection server, string path, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandTimeout = 120;
+        cmd.CommandText = $"RESTORE HEADERONLY FROM {DeviceClause(path)}";
+
+        return await CancellableAsync(async () =>
+        {
+            var entries = new List<BackupHistoryEntry>();
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+            // Every row, not the first. Each row is one backup set in the file, and reading only
+            // the first is how a multi-backup file would quietly present its oldest content as
+            // the whole story.
+            while (await reader.ReadAsync(ct))
+            {
+                var typeCode = GetIntFromReader(reader, "BackupType");
+
+                entries.Add(new BackupHistoryEntry
+                {
+                    DatabaseName = GetStringFromReader(reader, "DatabaseName") ?? string.Empty,
+                    ServerName = GetStringFromReader(reader, "ServerName"),
+                    Type = (typeCode ?? 0) switch
+                    {
+                        1 => BackupType.Full,
+                        5 => BackupType.Differential,
+                        2 => BackupType.TransactionLog,
+                        _ => BackupType.Unknown
+                    },
+                    StartedAt = GetDateTimeFromReader(reader, "BackupStartDate") ?? DateTime.MinValue,
+                    FinishedAt = GetDateTimeFromReader(reader, "BackupFinishDate") ?? DateTime.MinValue,
+                    IsCopyOnly = GetIntFromReader(reader, "IsCopyOnly") == 1,
+                    FirstLsn = GetDecimalFromReader(reader, "FirstLSN"),
+                    LastLsn = GetDecimalFromReader(reader, "LastLSN"),
+                    CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN"),
+                    DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN"),
+                    Position = GetIntFromReader(reader, "Position"),
+                    FamilyCount = GetIntFromReader(reader, "FamilyCount") ?? 1,
+                    Files = [path]
+                });
+            }
+
+            return entries;
+        }, ct, "Reading the backup file's headers");
     }
 
     public async Task<BackupFileInfo?> RestoreHeaderOnlyMultiAsync(
@@ -596,8 +664,8 @@ public class SqlServerService : ISqlServerService
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 120;
 
-        var urlClauses = string.Join(", ", blobUrls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
-        cmd.CommandText = $"RESTORE HEADERONLY FROM {urlClauses}";
+        var deviceClauses = string.Join(", ", blobUrls.Select(DeviceClause));
+        cmd.CommandText = $"RESTORE HEADERONLY FROM {deviceClauses}";
 
         return await CancellableAsync<BackupFileInfo?>(async () =>
         {

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -487,6 +487,12 @@ public partial class BackupInventoryViewModel : ViewModelBase
                 return;
             }
 
+            if (location.IsAdHocFile)
+            {
+                await LoadFromFileAsync(location, ct);
+                return;
+            }
+
             // If a database is already chosen - a reload after taking a fresh backup, say - push
             // that down to Azure as a prefix instead of walking the whole container and discarding
             // most of it. Measured on a real 4,440-blob container: about 1,075 ms unscoped versus
@@ -606,6 +612,101 @@ public partial class BackupInventoryViewModel : ViewModelBase
                 [.. g],
                 zones.TryGetValue(g.Key, out var zone) ? zone : null))
             .ToList();
+    }
+
+    /// <summary>
+    /// Reads what the files themselves say they hold (#203).
+    ///
+    /// For the backup nobody's msdb knows: a vendor's .bak, a file that outlived its server. The
+    /// headers carry the same fields msdb records - database, type, LSNs, position - so everything
+    /// downstream of here is the shared-path path: ToSets, the LSN chain, FROM DISK.
+    ///
+    /// One failure fails the LOAD, by name. Reading three files and quietly showing two is how
+    /// somebody restores "everything" minus the log that carried the chain to the point they
+    /// wanted.
+    /// </summary>
+    private async Task LoadFromFileAsync(BackupLocation location, CancellationToken ct)
+    {
+        var reader = location.SourceServer!;
+        var entries = new List<BackupHistoryEntry>();
+
+        foreach (var path in location.FilePaths)
+        {
+            ct.ThrowIfCancellationRequested();
+            LoadProgressText = $"Reading {System.IO.Path.GetFileName(path)}...";
+
+            List<BackupHistoryEntry> read;
+            try
+            {
+                read = await _sql.ReadBackupFileHeadersAsync(reader, path, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                SetError($"{reader.ServerName} could not read {path}: {ex.Message} " +
+                         "The path must be one the SQL Server service account can open - " +
+                         "it is read on the server, not from this machine.");
+                BackupsLoaded = false;
+                return;
+            }
+
+            if (read.Count == 0)
+            {
+                SetError($"{path} contains no backups. RESTORE HEADERONLY read it and found nothing.");
+                BackupsLoaded = false;
+                return;
+            }
+
+            // A stripe cannot be restored alone, and its header does not say so loudly - HEADERONLY
+            // on one member happily describes the whole set. FamilyCount is the tell.
+            var striped = read.FirstOrDefault(e => e.FamilyCount > 1);
+            if (striped != null)
+            {
+                SetError($"{path} is one stripe of a {striped.FamilyCount}-file striped set. " +
+                         "Restoring needs every member, and reading a striped set here is not " +
+                         "supported yet - restore it from the server's own backup history instead, " +
+                         "which knows all the members.");
+                BackupsLoaded = false;
+                return;
+            }
+
+            entries.AddRange(read);
+        }
+
+        var sets = BackupHistoryInventory.ToSets(entries, BackupPathMapping.None);
+
+        _allBackups = sets.SelectMany(s => s.Files).ToList();
+        _allSets = sets;
+        LoadedFrom = location;
+
+        ApplyCachedAudit();
+
+        DiscoveredServers = new ObservableCollection<string>(
+            sets.Select(s => s.ServerDisplay)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)!);
+
+        DiscoveredDatabases = new ObservableCollection<string>(
+            sets.Select(s => s.DatabaseName)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)!);
+
+        BackupsLoaded = sets.Count > 0;
+
+        // Nothing read from a header arrives unplaced - the header is the authority the
+        // unclassified count exists to flag the absence of.
+        UnclassifiedCount = 0;
+
+        RebuildWorkingSet();
+
+        if (!HasError)
+            SetStatus($"Read {sets.Count} backup(s) from {location.FilePaths.Count} file(s). " +
+                      $"Every detail comes from the files' own headers.");
     }
 
     private async Task LoadFromHistoryAsync(BackupLocation location, CancellationToken ct)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -475,6 +475,30 @@ public partial class RestoreViewModel : ViewModelBase
 
     public bool MediumIsBlob => SelectedMedium == BackupMedium.AzureBlob;
     public bool MediumIsSharedPath => SelectedMedium == BackupMedium.SharedPath;
+    public bool MediumIsAdHocFile => SelectedMedium == BackupMedium.AdHocFile;
+
+    /// <summary>
+    /// The pasted paths, one complete backup file per line (#203).
+    ///
+    /// As the READING server sees them, not this machine - the same trust rule as the shared path,
+    /// and the readability preflight enforces it on the target before anything runs.
+    /// </summary>
+    [ObservableProperty]
+    private string _adHocPathsText = string.Empty;
+
+    partial void OnAdHocPathsTextChanged(string value)
+    {
+        // What is loaded came from the PREVIOUS files.
+        ClearLoadedBackups();
+        OnPropertyChanged(nameof(CurrentLocation));
+    }
+
+    /// <summary>One path per non-empty line, in the order given.</summary>
+    public IReadOnlyList<string> AdHocPaths =>
+        AdHocPathsText
+            .Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
     /// <summary>
     /// Whether the server-side credential means anything here.
@@ -489,6 +513,7 @@ public partial class RestoreViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(MediumIsBlob));
         OnPropertyChanged(nameof(MediumIsSharedPath));
+        OnPropertyChanged(nameof(MediumIsAdHocFile));
         OnPropertyChanged(nameof(CredentialApplies));
         OnPropertyChanged(nameof(ShowCredentialPanel));
 
@@ -539,6 +564,13 @@ public partial class RestoreViewModel : ViewModelBase
             SourceServer == null
                 ? null
                 : BackupLocation.Shared(SourceServer, new BackupPathMapping(SourcePathPrefix, TargetPathPrefix)),
+
+        // The same server picker as the shared path, deliberately: both media mean "an instance I
+        // ask about backups", and for a file the natural reader is the target itself.
+        BackupMedium.AdHocFile =>
+            SourceServer == null || AdHocPaths.Count == 0
+                ? null
+                : BackupLocation.AdHoc(SourceServer, AdHocPaths),
 
         _ => null
     };
@@ -912,7 +944,9 @@ public partial class RestoreViewModel : ViewModelBase
         var location = CurrentLocation;
         if (location == null)
         {
-            SetError(MediumIsSharedPath
+            SetError(MediumIsAdHocFile
+                ? "Enter at least one backup file path, and choose a server that can read it."
+                : MediumIsSharedPath
                 ? "Choose the server the backups were taken on first."
                 : "Please select a container first.");
             return;
@@ -1311,7 +1345,7 @@ public partial class RestoreViewModel : ViewModelBase
             // A null result is an unreadable member rather than a failure of the whole validation:
             // the validator reports it and carries on with the rest.
             var requests = RestoreChain.AllSets
-                .Select(s => (IReadOnlyList<string>)s.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList())
+                .Select(s => (IReadOnlyList<string>)s.Files.Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl)).ToList())
                 .ToList();
 
             var read = await _sqlService.RestoreHeaderOnlyBatchAsync(
@@ -1395,7 +1429,7 @@ public partial class RestoreViewModel : ViewModelBase
                 var set = sets[i];
                 SetStatus($"Verifying {i + 1} of {sets.Count}: {set.TypeDisplay} {set.SetId}...");
 
-                var urls = set.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+                var urls = set.Files.Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
                 var result = await _sqlService.RestoreVerifyOnlyAsync(
                     ConnectedServer, urls, Options.WithChecksum, fileMoves, ct);
 
@@ -1808,7 +1842,8 @@ public partial class RestoreViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(CanFetchLogicalNames))]
     private async Task FetchLogicalNamesAsync()
     {
-        if (RestoreChain == null || ConnectedServer == null || SelectedContainer == null) return;
+        if (RestoreChain == null || ConnectedServer == null) return;
+        if (SelectedContainer == null && !RestoreChain.FullSet.Files.All(f => f.IsOnDisk)) return;
 
         var ct = _queryCancellation.Begin();
         IsBusy = true;
@@ -1819,7 +1854,11 @@ public partial class RestoreViewModel : ViewModelBase
         // catch below would itself throw, replacing the error explaining why FILELISTONLY failed
         // with a bare "Nine Lives hit an unexpected error".
         // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
-        var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+        // By the device a RESTORE would name it: an encoded URL for blob, the raw path for
+        // disk - a path is not a URI, and percent-encoding one breaks it (#203).
+        var urls = RestoreChain.FullSet.Files
+            .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+            .ToList();
 
         try
         {
@@ -1864,7 +1903,10 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     private bool CanFetchLogicalNames() =>
-        IsConnectedToServer && RestoreChain != null && SelectedContainer != null && RestoreChain.FullSet.Files.Count > 0;
+        IsConnectedToServer && RestoreChain != null && RestoreChain.FullSet.Files.Count > 0
+        // A container for blob URLs; a chain on disk needs none - FILELISTONLY reads the path
+        // directly, and demanding a container here kept MOVE defaults blob-only (#203).
+        && (SelectedContainer != null || RestoreChain.FullSet.Files.All(f => f.IsOnDisk));
 
     [RelayCommand(CanExecute = nameof(CanInspectMetadata))]
     private async Task InspectBackupMetadataAsync()
@@ -1876,7 +1918,11 @@ public partial class RestoreViewModel : ViewModelBase
         RefreshCancelState();
         // Captured before the await - see the note on FetchLogicalNamesAsync.
         // Use URL without SAS and omit WITH CREDENTIAL. Encode path so spaces/special chars (e.g. in folder names) are valid.
-        var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+        // By the device a RESTORE would name it: an encoded URL for blob, the raw path for
+        // disk - a path is not a URI, and percent-encoding one breaks it (#203).
+        var urls = RestoreChain.FullSet.Files
+            .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+            .ToList();
 
         try
         {
@@ -1922,7 +1968,11 @@ public partial class RestoreViewModel : ViewModelBase
     private void CopyFileListOnlyCommand()
     {
         if (RestoreChain == null || RestoreChain.FullSet.Files.Count == 0) return;
-        var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+        // By the device a RESTORE would name it: an encoded URL for blob, the raw path for
+        // disk - a path is not a URI, and percent-encoding one breaks it (#203).
+        var urls = RestoreChain.FullSet.Files
+            .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+            .ToList();
         var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var sql = $"RESTORE FILELISTONLY FROM {urlClauses}";
         TryCopyToClipboard(sql, "RESTORE FILELISTONLY command copied to clipboard. Paste into SSMS to run.");
@@ -1933,7 +1983,11 @@ public partial class RestoreViewModel : ViewModelBase
     private void CopyHeaderOnlyCommand()
     {
         if (RestoreChain == null || RestoreChain.FullSet.Files.Count == 0) return;
-        var urls = RestoreChain.FullSet.Files.Select(f => BlobUrlEncoder.Encode(f.BlobUrl)).ToList();
+        // By the device a RESTORE would name it: an encoded URL for blob, the raw path for
+        // disk - a path is not a URI, and percent-encoding one breaks it (#203).
+        var urls = RestoreChain.FullSet.Files
+            .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+            .ToList();
         var urlClauses = string.Join(", ", urls.Select(u => $"URL = N'{TSql.EscapeLiteral(u)}'"));
         var sql = $"RESTORE HEADERONLY FROM {urlClauses}";
         TryCopyToClipboard(sql, "RESTORE HEADERONLY command copied to clipboard. Paste into SSMS to run.");
@@ -2045,7 +2099,9 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     internal async Task<CredentialPreflight> PreflightAsync(ServerConnection server, Action<string> appendLog)
     {
-        if (MediumIsSharedPath)
+        // Both non-blob media end in FROM DISK on the target, so both need the same answer: can
+        // the instance that will run the RESTORE actually read these files (#203).
+        if (MediumIsSharedPath || MediumIsAdHocFile)
             return await CheckTargetCanReadFilesAsync(server, appendLog);
 
         var primary = await Credential.PrepareForRestoreAsync(server, appendLog);

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -113,6 +113,15 @@
                                          Style="{StaticResource DarkRadioButton}"
                                          IsChecked="{Binding SelectedMedium, Converter={StaticResource EnumToBool}, ConverterParameter=SharedPath}"
                                          ToolTip="RESTORE FROM DISK against a file share. No credential, no egress, and no waiting on an upload - but both instances have to reach it." />
+
+                            <!-- The backup nobody's msdb knows: a vendor's .bak, a file that
+                                 outlived its server (#203). -->
+                            <RadioButton Content="A backup file I have"
+                                         GroupName="BackupMedium"
+                                         Style="{StaticResource DarkRadioButton}"
+                                         Margin="20,0,0,0"
+                                         IsChecked="{Binding SelectedMedium, Converter={StaticResource EnumToBool}, ConverterParameter=AdHocFile}"
+                                         ToolTip="RESTORE FROM DISK, identified by its own headers. For a file no configured server took - a vendor's backup, or one that outlived its server." />
                         </StackPanel>
                     </StackPanel>
 
@@ -269,6 +278,57 @@
                                        Foreground="{DynamicResource WarningBrush}"
                                        TextWrapping="Wrap" />
                         </Border>
+                    </StackPanel>
+
+                    <!-- Ad-hoc file: paths and a reader (#203).
+
+                         The file's own headers are the only account of what it holds, so an
+                         instance that can see the path is asked to read them. Usually that is the
+                         target itself - which also has to read the file to restore it. -->
+                    <StackPanel Visibility="{Binding MediumIsAdHocFile, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="BACKUP FILE(S), AS THE SERVER SEES THEM" Style="{StaticResource LabelText}" />
+                        <TextBox Text="{Binding AdHocPathsText, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource DarkTextBox}"
+                                 AcceptsReturn="True"
+                                 TextWrapping="NoWrap"
+                                 VerticalScrollBarVisibility="Auto"
+                                 MinHeight="52"
+                                 MaxHeight="110"
+                                 FontFamily="Consolas"
+                                 ToolTip="One complete backup file per line - a .bak, .trn or .dif. The path is opened by the SQL Server service account on the server, not by this app, so it must be a path that account can reach." />
+
+                        <TextBlock Style="{StaticResource SecondaryText}"
+                                   TextWrapping="Wrap"
+                                   FontSize="11"
+                                   Margin="0,4,0,0"
+                                   Text="One complete backup file per line. A full plus the logs that follow it can be listed together - the chain is assembled from the files' own LSNs. Striped sets are not supported here; restore those from the server's own backup history." />
+
+                        <Grid Margin="0,10,0,0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <StackPanel Grid.Column="0" Margin="0,0,12,0">
+                                <TextBlock Text="ASK THIS SERVER TO READ THEM" Style="{StaticResource LabelText}" />
+                                <ComboBox ItemsSource="{Binding SourceServers}"
+                                          SelectedItem="{Binding SourceServer}"
+                                          Style="{StaticResource DarkComboBox}"
+                                          ToolTip="RESTORE HEADERONLY runs here, so this instance must be able to open the path. Usually the server the restore will run on.">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Name}" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                            </StackPanel>
+
+                            <Button Grid.Column="1"
+                                    Content="Read the files"
+                                    Style="{StaticResource PrimaryButton}"
+                                    Command="{Binding LoadBackupsCommand}"
+                                    VerticalAlignment="Bottom" />
+                        </Grid>
                     </StackPanel>
 
                     <!-- Server + Database selectors -->


### PR DESCRIPTION
The classic case in the job: a vendor sends a `.bak`, or the file outlived the server that took it. Until now neither medium could reach it — blob obviously not, and the shared path reads a source instance's msdb, which by definition does not contain a backup nobody here took.

## A third source: "A backup file I have"

Paste the paths, one complete backup file per line, pick a server that can read them — usually the target, which has to read them to restore anyway. `RESTORE HEADERONLY` is asked per file, and **every row is taken**: a file holds several backups whenever `NOINIT` appended to it, and reading only the first is how a multi-backup file quietly presents its oldest content as the whole story. Each position becomes its own restore point, and the script says `WITH FILE = n` — stated whenever known, because the default *is* 1 and a multi-backup file is exactly where the script should say which one it means.

The headers carry the same fields msdb records — database, type, LSNs, position — so they map onto the same `BackupHistoryEntry` the shared path uses, and everything downstream is shared machinery: `ToSets`, the LSN chain, `FROM DISK`, the target-side readability preflight. A full plus its logs pasted together chain by their own LSNs.

## Refusals, loud and by name

- **A single stripe of a striped set is refused** — HEADERONLY on one member happily describes media it cannot deliver, and `FamilyCount` is the only tell.
- **One unreadable file fails the whole load, naming the file** — reading three files and quietly showing two is how somebody restores "everything" minus the log that carried the chain to the point they wanted.

## The inspection statements stop assuming blob

HEADERONLY, FILELISTONLY and VERIFYONLY were all built with `URL =` hardcoded, quietly limiting them to blob while the restore itself has been device-aware since #149. One clause helper now names `DISK` or `URL` by what each file is. That also unblocks MOVE defaults for on-disk chains (FILELISTONLY without a container), and makes the header audit meaningful for msdb-discovered backups rather than broken-if-attempted.

12 new tests, 1,386 pass. Rendered.