### PR TITLE
Finish the job after a successful restore (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ built for.
 
 ### Changed
 
+- **A successful restore now ends with the job's remainder on screen**, in the same read-then-run
+  shape as the recovery panel: DBCC CHECKDB offered on every success - the restore is the cheapest
+  moment to find corruption, and it proves the backup rather than just the copy - plus an automatic
+  scan for orphaned SQL-auth users, the single most common post-restore fault. Fixable orphans get
+  the ALTER USER ... WITH LOGIN statement; one with no matching login gets guidance that copies but
+  never runs, because inventing a statement means inventing a password. The database's compat
+  level, recovery model and owner are stated, not altered (#205)
 - **A backup file nobody's msdb knows can now be restored** - the vendor .bak, the file that
   outlived its server. A third source on the restore screen takes pasted paths, asks a server to
   read each file's own headers, and hands the result to the same chain, options and script

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -245,6 +245,30 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Set to make asking about volumes fail - which must not become a warning (#32).</summary>
     public Exception? VolumeCheckThrows { get; set; }
 
+    /// <summary>What GetDatabaseOverviewAsync answers (#205).</summary>
+    public DatabaseOverview? DatabaseOverview { get; set; } = new(150, "FULL", "sa");
+
+    public Exception? OverviewThrows { get; set; }
+
+    public Task<DatabaseOverview?> GetDatabaseOverviewAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+    {
+        if (OverviewThrows != null) throw OverviewThrows;
+        return Task.FromResult(DatabaseOverview);
+    }
+
+    /// <summary>What FindOrphanedUsersAsync answers (#205).</summary>
+    public List<OrphanedUser> OrphanedUsers { get; set; } = [];
+
+    public Exception? OrphanScanThrows { get; set; }
+
+    public Task<List<OrphanedUser>> FindOrphanedUsersAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+    {
+        if (OrphanScanThrows != null) throw OrphanScanThrows;
+        return Task.FromResult(OrphanedUsers.ToList());
+    }
+
     public Task<Dictionary<string, long>> GetVolumeFreeSpaceAsync(
         ServerConnection server, CancellationToken ct = default)
     {

--- a/src/NineLives.Tests/PostRestoreTests.cs
+++ b/src/NineLives.Tests/PostRestoreTests.cs
@@ -1,0 +1,183 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// What finishes a restore (#205).
+///
+/// The recovery panel (#14) handles databases left in a bad state. This is its counterpart for
+/// the restore that WORKED, because "restored" is not the end of the job: nobody has verified the
+/// data, and on a different server every SQL-auth user is orphaned - login succeeds, database
+/// access fails, and nothing on screen says why.
+/// </summary>
+public class PostRestoreTests
+{
+    // ── the advice itself ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void CheckDbNamesTheDatabaseAndHoldsNoSurprises()
+    {
+        var action = PostRestoreAdvice.CheckDb("MyDb");
+
+        Assert.Equal("DBCC CHECKDB ([MyDb]) WITH NO_INFOMSGS", action.Sql);
+        Assert.Contains("Duration", action.Caution);
+    }
+
+    /// <summary>Quoting goes through TSql, so a bracket in a name cannot break out.</summary>
+    [Fact]
+    public void CheckDbQuotesAwkwardNames()
+    {
+        var action = PostRestoreAdvice.CheckDb("My]Db");
+
+        Assert.Contains("[My]]Db]", action.Sql);
+    }
+
+    [Fact]
+    public void AFixableOrphanRemapsTheSid()
+    {
+        var action = PostRestoreAdvice.FixOrphan("MyDb", new OrphanedUser("app_user", true));
+
+        Assert.Contains("ALTER USER [app_user] WITH LOGIN = [app_user]", action.Sql);
+        Assert.Contains("USE [MyDb]", action.Sql);
+    }
+
+    /// <summary>
+    /// No login to map onto means no runnable statement is invented - inventing one means
+    /// inventing a password. The CREATE LOGIN line appears only as commented guidance.
+    /// </summary>
+    [Fact]
+    public void AnUnmappableOrphanGetsGuidanceNotAStatement()
+    {
+        var action = PostRestoreAdvice.ExplainUnmappableOrphan("MyDb", new OrphanedUser("ghost", false));
+
+        Assert.Contains("-- CREATE LOGIN [ghost]", action.Sql);
+        Assert.Contains("no login of that name", action.Caution);
+    }
+
+    /// <summary>Guidance is not a statement: the unmappable card copies but never runs.</summary>
+    [Fact]
+    public void GuidanceIsNotRunnable()
+    {
+        Assert.False(PostRestoreAdvice.ExplainUnmappableOrphan("MyDb", new OrphanedUser("ghost", false)).Runnable);
+        Assert.True(PostRestoreAdvice.FixOrphan("MyDb", new OrphanedUser("a", true)).Runnable);
+        Assert.True(PostRestoreAdvice.CheckDb("MyDb").Runnable);
+    }
+
+    [Fact]
+    public void TheOrphanVerdictCountsHonestly()
+    {
+        Assert.Contains("No orphaned users", PostRestoreAdvice.DescribeOrphans([]));
+        Assert.Contains("1 database user is orphaned",
+            PostRestoreAdvice.DescribeOrphans([new OrphanedUser("a", true)]));
+        Assert.Contains("2 database users are orphaned",
+            PostRestoreAdvice.DescribeOrphans([new OrphanedUser("a", true), new OrphanedUser("b", false)]));
+    }
+
+    [Fact]
+    public void TheOverviewStatesWhatArrived()
+    {
+        var overview = new DatabaseOverview(150, "FULL", "sa");
+
+        var line = overview.Describe("MyDb");
+
+        Assert.Contains("compatibility level 150", line);
+        Assert.Contains("recovery model FULL", line);
+        Assert.Contains("sa", line);
+    }
+
+    // ── the execution surface ───────────────────────────────────────────────────
+
+    private static (RestoreExecutionViewModel vm, FakeSqlServerService sql) New()
+    {
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreExecutionViewModel(
+            sql, new FakeRestoreHistoryStore(), TestLogs.Temp(), new OperationCancellation());
+        return (vm, sql);
+    }
+
+    private static RestoreRun Run() => new(
+        Server: new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" },
+        Script: "RESTORE DATABASE [MyDb] FROM DISK = N'D:\\b.bak' WITH REPLACE, RECOVERY;",
+        TargetDatabase: "MyDb",
+        SourceDatabase: null,
+        ContainerName: null,
+        ChainSummary: "1 full",
+        RestorePointTimestamp: null,
+        OptionsForLog: "WITH REPLACE, RECOVERY");
+
+    /// <summary>Success now ends with the job's remainder on screen, CHECKDB always first.</summary>
+    [Fact]
+    public async Task ASuccessfulRestoreOffersCheckDb()
+    {
+        var (vm, sql) = New();
+        sql.DatabaseOverview = new DatabaseOverview(160, "FULL", "sa");
+
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.True(vm.HasPostRestoreActions);
+        Assert.Contains(vm.PostRestoreActions, a => a.Sql.Contains("DBCC CHECKDB"));
+        Assert.Contains("compatibility level 160", vm.PostRestoreMessage);
+    }
+
+    [Fact]
+    public async Task OrphanedUsersAreFoundAndOfferedFixes()
+    {
+        var (vm, sql) = New();
+        sql.OrphanedUsers = [new OrphanedUser("app_user", true), new OrphanedUser("ghost", false)];
+
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.Contains("2 database users are orphaned", vm.PostRestoreMessage);
+        Assert.Contains(vm.PostRestoreActions, a => a.Sql.Contains("ALTER USER [app_user]"));
+        Assert.Contains(vm.PostRestoreActions, a => a.Title.Contains("ghost"));
+    }
+
+    /// <summary>A failed restore gets the recovery panel, not this one.</summary>
+    [Fact]
+    public async Task AFailedRestoreOffersNoPostRestoreActions()
+    {
+        var (vm, sql) = New();
+        sql.ExecuteThrows = new InvalidOperationException("Msg 3201: Cannot open backup device");
+
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.False(vm.HasPostRestoreActions);
+        Assert.Empty(vm.PostRestoreActions);
+    }
+
+    /// <summary>
+    /// A restore that succeeded must never LOOK failed because the follow-up queries could not
+    /// run - the panel still appears, with CHECKDB, and the failure goes to the log.
+    /// </summary>
+    [Fact]
+    public async Task FollowUpQueryFailuresDoNotDressSuccessAsFailure()
+    {
+        var (vm, sql) = New();
+        sql.OverviewThrows = new InvalidOperationException("VIEW DATABASE STATE denied");
+
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.True(vm.ExecutionSuccess);
+        Assert.True(vm.HasPostRestoreActions);
+        Assert.Contains(vm.PostRestoreActions, a => a.Sql.Contains("DBCC CHECKDB"));
+        Assert.False(vm.HasError);
+    }
+
+    /// <summary>The next run starts clean - last run's advice is not this run's.</summary>
+    [Fact]
+    public async Task ANewRunClearsTheLastRunsAdvice()
+    {
+        var (vm, sql) = New();
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+        Assert.True(vm.HasPostRestoreActions);
+
+        sql.ExecuteThrows = new InvalidOperationException("boom");
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.False(vm.HasPostRestoreActions);
+        Assert.Empty(vm.PostRestoreActions);
+    }
+}

--- a/src/NineLives/Services/DatabaseRecoveryState.cs
+++ b/src/NineLives/Services/DatabaseRecoveryState.cs
@@ -107,4 +107,9 @@ public sealed record DatabaseRecoveryState(
 /// <param name="Title">Short label for the button.</param>
 /// <param name="Sql">The exact statement - shown before it is run, never hidden.</param>
 /// <param name="Caution">What running it commits them to.</param>
-public sealed record RecoveryAction(string Title, string Sql, string Caution);
+/// <param name="Runnable">
+/// False when the Sql is guidance rather than a statement to execute - a commented template that
+/// needs a human decision (a password, a name) before it means anything. Copy still applies; Run
+/// would only ever produce a confusing error.
+/// </param>
+public sealed record RecoveryAction(string Title, string Sql, string Caution, bool Runnable = true);

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -36,6 +36,17 @@ public interface ISqlServerService
     Task<List<FileMoveOption>> GetDatabaseFilesAsync(
         ServerConnection server, string database, CancellationToken ct = default);
 
+    /// <summary>What the restored database looks like now - compat level, recovery model, owner (#205).</summary>
+    Task<DatabaseOverview?> GetDatabaseOverviewAsync(
+        ServerConnection server, string database, CancellationToken ct = default);
+
+    /// <summary>
+    /// Database users whose SIDs match no login on this server (#205). SQL-auth users only -
+    /// Windows and Entra principals resolve by directory identity, not by per-server SID.
+    /// </summary>
+    Task<List<OrphanedUser>> FindOrphanedUsersAsync(
+        ServerConnection server, string database, CancellationToken ct = default);
+
     Task<Dictionary<string, long>> GetVolumeFreeSpaceAsync(
         ServerConnection server, CancellationToken ct = default);
 

--- a/src/NineLives/Services/PostRestoreAdvice.cs
+++ b/src/NineLives/Services/PostRestoreAdvice.cs
@@ -1,0 +1,90 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>What a restored database looks like, read back from sys.databases (#205).</summary>
+/// <param name="CompatibilityLevel">e.g. 150. Travels with the backup, not the target.</param>
+/// <param name="RecoveryModelDesc">FULL, SIMPLE or BULK_LOGGED, as the restore left it.</param>
+/// <param name="Owner">Who owns it now - the login that ran the restore, not the original owner.</param>
+public sealed record DatabaseOverview(int CompatibilityLevel, string RecoveryModelDesc, string? Owner)
+{
+    /// <summary>
+    /// One sentence stating what arrived. Stated, not altered - none of these are wrong, they are
+    /// simply facts about the source that people forget travel with a backup.
+    /// </summary>
+    public string Describe(string database) =>
+        $"[{database}] arrived with compatibility level {CompatibilityLevel}, " +
+        $"recovery model {RecoveryModelDesc}" +
+        (Owner == null ? "." : $", owned by {Owner}.");
+}
+
+/// <summary>
+/// A database user whose SID matches no login on this server (#205).
+///
+/// The single most common post-restore fault. SQL-auth users carry their SID inside the database,
+/// and on a different server the same-named login has a different SID - so the app connects, the
+/// login succeeds, and access to the database fails with "The server principal is not able to
+/// access the database under the current security context."
+/// </summary>
+/// <param name="Name">The user, as named inside the database.</param>
+/// <param name="HasSameNamedLogin">Whether a login of the same name exists to map onto.</param>
+public sealed record OrphanedUser(string Name, bool HasSameNamedLogin);
+
+/// <summary>
+/// What finishes a restore, offered rather than performed (#205).
+///
+/// The recovery panel (#14) handles databases left in a BAD state. This is its counterpart for the
+/// database that restored fine, because "restored" is not the end of the job: nobody has verified
+/// the data, and on a different server every SQL-auth user is orphaned. Same shape as recovery -
+/// the statement shown in full, run or copy, caution text - because that shape is the whole
+/// contract: nothing runs that was not read first.
+/// </summary>
+public static class PostRestoreAdvice
+{
+    /// <summary>
+    /// The verification everyone means to run and defers. Offered on every success, because the
+    /// restore is the cheapest moment to find corruption - it proves the backup, not just the copy.
+    /// </summary>
+    public static RecoveryAction CheckDb(string database) => new(
+        "Check the restored database (DBCC CHECKDB)",
+        $"DBCC CHECKDB ({TSql.QuoteName(database)}) WITH NO_INFOMSGS",
+        "Reads every allocation and page. Duration scales with the size of the database - minutes " +
+        "on most, longer on very large ones - and it holds schema locks briefly as it goes. " +
+        "No output means it found nothing wrong: the backup is proven, not just restored.");
+
+    /// <summary>
+    /// The fix for an orphaned user with a same-named login: remap the SID. This is the modern
+    /// form of sp_change_users_login, which is deprecated and SQL-auth only.
+    /// </summary>
+    public static RecoveryAction FixOrphan(string database, OrphanedUser user) => new(
+        $"Re-attach user {user.Name} to the login of the same name",
+        $"USE {TSql.QuoteName(database)}; " +
+        $"ALTER USER {TSql.QuoteName(user.Name)} WITH LOGIN = {TSql.QuoteName(user.Name)}",
+        "Points the database user at this server's login by rewriting its SID. The user keeps " +
+        "every permission it had inside the database.");
+
+    /// <summary>
+    /// An orphan with nothing to map onto. No statement is offered, because inventing one means
+    /// inventing a password - said plainly instead, with the statement to run once a login exists.
+    /// </summary>
+    public static RecoveryAction ExplainUnmappableOrphan(string database, OrphanedUser user) => new(
+        $"User {user.Name} has no matching login on this server",
+        $"-- After creating the login:\n" +
+        $"-- CREATE LOGIN {TSql.QuoteName(user.Name)} WITH PASSWORD = '...';\n" +
+        $"USE {TSql.QuoteName(database)}; " +
+        $"ALTER USER {TSql.QuoteName(user.Name)} WITH LOGIN = {TSql.QuoteName(user.Name)}",
+        "This server has no login of that name, so there is nothing to re-attach the user to. " +
+        "Create the login first - with a password set by whoever owns that account, not invented " +
+        "here - then the ALTER USER line maps the user onto it.",
+        Runnable: false);
+
+    /// <summary>What the orphan scan concluded, in one line.</summary>
+    public static string DescribeOrphans(IReadOnlyList<OrphanedUser> orphans) => orphans.Count switch
+    {
+        0 => "No orphaned users - every database user maps to a login on this server.",
+        1 => "1 database user is orphaned - its SID matches no login on this server. " +
+             "It will fail to access the database until it is re-attached.",
+        var n => $"{n} database users are orphaned - their SIDs match no login on this server. " +
+                 "They will fail to access the database until they are re-attached."
+    };
+}

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1193,6 +1193,71 @@ public class SqlServerService : ISqlServerService
         return files;
     }
 
+    public async Task<DatabaseOverview?> GetDatabaseOverviewAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+
+        cmd.CommandText = @"
+            SELECT d.compatibility_level,
+                   d.recovery_model_desc,
+                   SUSER_SNAME(d.owner_sid) AS OwnerName
+            FROM sys.databases AS d
+            WHERE d.name = @database";
+        cmd.Parameters.AddWithValue("@database", database);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        if (!await reader.ReadAsync(ct)) return null;
+
+        return new DatabaseOverview(
+            Convert.ToInt32(reader["compatibility_level"]),
+            reader["recovery_model_desc"]?.ToString() ?? "UNKNOWN",
+            reader["OwnerName"] as string);
+    }
+
+    public async Task<List<OrphanedUser>> FindOrphanedUsersAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+    {
+        var orphans = new List<OrphanedUser>();
+
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+
+        // Three-part naming rather than USE, so the connection state never changes. The database
+        // name is our own restore target and is quoted, not parameterised - object names cannot
+        // be parameters.
+        //
+        // SQL-auth users only (authentication_type 1): a Windows or Entra principal resolves by
+        // directory identity, so a SID mismatch there is not the orphaning this looks for.
+        // principal_id > 4 skips dbo, guest, sys and INFORMATION_SCHEMA.
+        cmd.CommandText = $@"
+            SELECT dp.name AS UserName,
+                   CASE WHEN same_named.name IS NOT NULL THEN 1 ELSE 0 END AS HasSameNamedLogin
+            FROM {TSql.QuoteName(database)}.sys.database_principals AS dp
+            LEFT JOIN sys.server_principals AS by_sid
+                   ON by_sid.sid = dp.sid
+            LEFT JOIN sys.server_principals AS same_named
+                   ON same_named.name = dp.name AND same_named.type = 'S'
+            WHERE dp.type = 'S'
+              AND dp.authentication_type = 1
+              AND dp.principal_id > 4
+              AND by_sid.sid IS NULL
+            ORDER BY dp.name";
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            orphans.Add(new OrphanedUser(
+                reader["UserName"]?.ToString() ?? string.Empty,
+                Convert.ToInt32(reader["HasSameNamedLogin"]) == 1));
+        }
+
+        return orphans;
+    }
+
     public async Task<Dictionary<string, long>> GetVolumeFreeSpaceAsync(
         ServerConnection server, CancellationToken ct = default)
     {

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -198,6 +198,9 @@ public partial class RestoreExecutionViewModel : ViewModelBase
         Console.Clear();
         RecoveryActions = [];
         HasRecoveryActions = false;
+        PostRestoreActions = [];
+        HasPostRestoreActions = false;
+        PostRestoreMessage = string.Empty;
         RaiseCancelStateChanged();
 
         try
@@ -222,13 +225,26 @@ public partial class RestoreExecutionViewModel : ViewModelBase
                 // Server sends an info message, and a synchronous Invoke BLOCKS that thread until
                 // the UI has finished handling it. With the UI busy re-rendering, progress backed
                 // up and then arrived in bursts - which is precisely what "not live" looked like.
-                msg => Application.Current.Dispatcher.InvokeAsync(() => AppendLog(msg)),
+                msg =>
+                {
+                    // InvokeAsync when a dispatcher exists and this is not its thread - see the
+                    // note above. Null when there is no Application at all (headless: the tests),
+                    // where appending directly is both safe and the only option.
+                    var dispatcher = Application.Current?.Dispatcher;
+                    if (dispatcher == null || dispatcher.CheckAccess()) AppendLog(msg);
+                    else dispatcher.InvokeAsync(() => AppendLog(msg));
+                },
                 executeToken);
 
             ExecutionSuccess = true;
             outcome = RestoreOutcome.Succeeded;
             AppendLog("\nRestore completed successfully!");
             SetStatus("Restore execution completed successfully.");
+
+            // The restore is not the end of the job (#205): nobody has verified the data yet, and
+            // on a different server every SQL-auth user is orphaned. Reported while the outcome is
+            // on screen, in the same shape as the recovery panel - read, then run.
+            await ReportPostRestoreAsync(run.Server, run.TargetDatabase);
         }
         catch (OperationCanceledException)
         {
@@ -336,6 +352,69 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     /// SQL error, when the app is still holding the connection that could tell them, is the wrong
     /// place to stop.
     /// </summary>
+    // ── after a SUCCESSFUL restore (#205) ───────────────────────────────────────
+
+    /// <summary>What finishing the job involves, shown under the success banner.</summary>
+    [ObservableProperty]
+    private ObservableCollection<RecoveryAction> _postRestoreActions = [];
+
+    [ObservableProperty]
+    private bool _hasPostRestoreActions;
+
+    /// <summary>The overview and the orphan verdict, as one readable paragraph.</summary>
+    [ObservableProperty]
+    private string _postRestoreMessage = string.Empty;
+
+    /// <summary>
+    /// The counterpart of <see cref="ReportRecoveryStateAsync"/> for the restore that WORKED.
+    ///
+    /// CHECKDB is offered on every success - the restore is the cheapest moment to find corruption,
+    /// and it proves the backup rather than just the copy. The orphan scan runs automatically
+    /// because it is one cheap query, and its findings are the single most common post-restore
+    /// fault: login succeeds, database access fails, and nothing on screen says why.
+    ///
+    /// Best effort throughout. A restore that succeeded must never LOOK failed because the
+    /// follow-up queries could not run.
+    /// </summary>
+    private async Task ReportPostRestoreAsync(ServerConnection server, string targetDatabase)
+    {
+        var actions = new List<RecoveryAction> { PostRestoreAdvice.CheckDb(targetDatabase) };
+        var message = new List<string>();
+
+        try
+        {
+            var overview = await _sql.GetDatabaseOverviewAsync(server, targetDatabase);
+            if (overview != null) message.Add(overview.Describe(targetDatabase));
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"\nCould not read [{targetDatabase}]'s properties: {ex.Message}");
+        }
+
+        try
+        {
+            var orphans = await _sql.FindOrphanedUsersAsync(server, targetDatabase);
+            message.Add(PostRestoreAdvice.DescribeOrphans(orphans));
+
+            foreach (var orphan in orphans)
+            {
+                actions.Add(orphan.HasSameNamedLogin
+                    ? PostRestoreAdvice.FixOrphan(targetDatabase, orphan)
+                    : PostRestoreAdvice.ExplainUnmappableOrphan(targetDatabase, orphan));
+            }
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"\nCould not check [{targetDatabase}] for orphaned users: {ex.Message}");
+        }
+
+        PostRestoreMessage = string.Join(" ", message);
+        PostRestoreActions = new ObservableCollection<RecoveryAction>(actions);
+        HasPostRestoreActions = true;
+
+        AppendLog($"\n{PostRestoreMessage}");
+    }
+
     private async Task ReportRecoveryStateAsync(ServerConnection server, string targetDatabase)
     {
         RecoveryActions = [];

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -140,6 +140,60 @@
                 </ItemsControl>
             </StackPanel>
         </Border>
+        <!-- What finishes the restore that WORKED (#205): the recovery panel's counterpart.
+             CHECKDB proves the backup rather than just the copy, and the orphan scan names the
+             single most common post-restore fault before anybody hits it. -->
+        <Border Grid.Row="2" CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                BorderBrush="{DynamicResource SuccessBrush}"
+                BorderThickness="1"
+                Visibility="{Binding Execution.HasPostRestoreActions, Converter={StaticResource BoolToVis}}">
+            <StackPanel>
+                <TextBlock Text="FINISHING THE JOB"
+                           Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                <TextBlock Text="{Binding Execution.PostRestoreMessage}"
+                           Style="{StaticResource BodyText}"
+                           TextWrapping="Wrap" Margin="0,0,0,10" />
+                <ItemsControl ItemsSource="{Binding Execution.PostRestoreActions}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
+                                    CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource PrimaryTextBrush}"
+                                               TextWrapping="Wrap" />
+                                    <TextBox Text="{Binding Sql, Mode=OneWay}"
+                                             Style="{StaticResource DarkTextBox}"
+                                             IsReadOnly="True" TextWrapping="Wrap"
+                                             FontFamily="{StaticResource ConsoleFont}"
+                                             FontSize="12" Margin="0,6,0,6" />
+                                    <TextBlock Text="{Binding Caution}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap" Margin="0,0,0,8" />
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Content="Run this"
+                                                Visibility="{Binding Runnable, Converter={StaticResource BoolToVis}}"
+                                                Command="{Binding DataContext.Execution.RunRecoveryActionCommand,
+                                                          RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="10,6" Margin="0,0,8,0" />
+                                        <Button Content="Copy"
+                                                Command="{Binding DataContext.Execution.CopyRecoveryActionCommand,
+                                                          RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="10,6" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
+
 
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
             <Button Content="Stop restore"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -2150,6 +2150,60 @@
                             </ItemsControl>
                         </StackPanel>
                     </Border>
+        <!-- What finishes the restore that WORKED (#205): the recovery panel's counterpart.
+             CHECKDB proves the backup rather than just the copy, and the orphan scan names the
+             single most common post-restore fault before anybody hits it. -->
+        <Border CornerRadius="4" Padding="12" Margin="0,12,0,0"
+                Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                BorderBrush="{DynamicResource SuccessBrush}"
+                BorderThickness="1"
+                Visibility="{Binding Execution.HasPostRestoreActions, Converter={StaticResource BoolToVis}}">
+            <StackPanel>
+                <TextBlock Text="FINISHING THE JOB"
+                           Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                <TextBlock Text="{Binding Execution.PostRestoreMessage}"
+                           Style="{StaticResource BodyText}"
+                           TextWrapping="Wrap" Margin="0,0,0,10" />
+                <ItemsControl ItemsSource="{Binding Execution.PostRestoreActions}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Background="{DynamicResource InputBackgroundBrush}"
+                                    CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource PrimaryTextBrush}"
+                                               TextWrapping="Wrap" />
+                                    <TextBox Text="{Binding Sql, Mode=OneWay}"
+                                             Style="{StaticResource DarkTextBox}"
+                                             IsReadOnly="True" TextWrapping="Wrap"
+                                             FontFamily="{StaticResource ConsoleFont}"
+                                             FontSize="12" Margin="0,6,0,6" />
+                                    <TextBlock Text="{Binding Caution}"
+                                               Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap" Margin="0,0,0,8" />
+                                    <StackPanel Orientation="Horizontal">
+                                        <Button Content="Run this"
+                                                Visibility="{Binding Runnable, Converter={StaticResource BoolToVis}}"
+                                                Command="{Binding DataContext.Execution.RunRecoveryActionCommand,
+                                                          RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="10,6" Margin="0,0,8,0" />
+                                        <Button Content="Copy"
+                                                Command="{Binding DataContext.Execution.CopyRecoveryActionCommand,
+                                                          RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="10,6" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </Border>
+
                     </StackPanel>
                 </StackPanel>
             </Border>


### PR DESCRIPTION
The recovery panel (#14) handles databases left in a bad state. This is its counterpart for the restore that **worked**, because "restored" is not the end of the job: nobody has verified the data, and on a different server every SQL-auth user is orphaned — login succeeds, database access fails, and nothing on screen says why.

Same shape as recovery — statement shown in full, run or copy, caution text — because that shape is the whole contract: nothing runs that was not read first.

## What it offers

- **DBCC CHECKDB, on every success.** The restore is the cheapest moment to find corruption, and it proves the backup rather than just the copy.
- **An automatic orphan scan** (one cheap query, SQL-auth users only — Windows/Entra principals resolve by directory identity). A fixable orphan gets `ALTER USER ... WITH LOGIN` — the modern form of the deprecated `sp_change_users_login`. One with **no** matching login gets guidance that copies but never runs: inventing a runnable statement would mean inventing a password. `RecoveryAction` grew a `Runnable` flag and the Run button follows it.
- **The overview, stated not altered**: compatibility level, recovery model, owner — facts about the source that people forget travel with a backup.

Best effort throughout: a restore that succeeded must never *look* failed because the follow-up queries could not run.

## One product fix underneath

The execution callback dereferenced `Application.Current` unconditionally, so the whole RunAsync path was untestable headless — and the first two tests only passed when WPF tests happened to be running alongside. It now marshals via the dispatcher when one exists and appends directly when none does.

Rendered in its populated state — CHECKDB card, a fixable orphan, and an unmappable one showing commented guidance with no Run button. 12 new tests, 1,398 pass.