### PR TITLE
Show a running restore's progress, on screen and on the taskbar (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ built for.
 
 ### Changed
 
+- **A running restore shows its progress as a bar**, built from the server's own STATS lines -
+  per statement across the chain, mirrored to the Windows taskbar so the app conveys progress
+  while minimised. Failure turns the taskbar red and stays red until the next run; finishing
+  behind another window flashes the taskbar button, the polite signal that stops the moment the
+  app is clicked (#204)
 - **A successful restore now ends with the job's remainder on screen**, in the same read-then-run
   shape as the recovery panel: DBCC CHECKDB offered on every success - the restore is the cheapest
   moment to find corruption, and it proves the backup rather than just the copy - plus an automatic

--- a/src/NineLives.Tests/RestoreProgressTests.cs
+++ b/src/NineLives.Tests/RestoreProgressTests.cs
@@ -1,0 +1,181 @@
+using System.Windows.Shell;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The server's progress prose, turned back into a number (#204).
+///
+/// The scripts run WITH STATS = 10 and the "10 percent processed." lines were scrolling past as
+/// console text - a 40-minute restore looked identical at 5% and 95% unless somebody read the
+/// log. The number was always there; these pin that it survives the trip.
+/// </summary>
+public class RestoreProgressTests
+{
+    private const string ChainScript = @"
+RESTORE DATABASE [MyDb] FROM DISK = N'D:\full.bak' WITH NORECOVERY, STATS = 10;
+GO
+RESTORE LOG [MyDb] FROM DISK = N'D:\log1.trn' WITH NORECOVERY, STATS = 10;
+GO
+RESTORE LOG [MyDb] FROM DISK = N'D:\log2.trn' WITH RECOVERY, STATS = 10;";
+
+    // ── counting the denominator ────────────────────────────────────────────────
+
+    /// <summary>From the script itself, so it can never disagree with what runs.</summary>
+    [Fact]
+    public void StatementsAreCountedFromTheScript()
+    {
+        Assert.Equal(3, RestoreProgress.CountStatements(ChainScript));
+    }
+
+    /// <summary>VERIFYONLY and friends report no STATS and must not dilute the total.</summary>
+    [Fact]
+    public void InspectionStatementsDoNotCount()
+    {
+        var script = @"
+RESTORE VERIFYONLY FROM DISK = N'D:\full.bak';
+RESTORE HEADERONLY FROM DISK = N'D:\full.bak';
+RESTORE DATABASE [MyDb] FROM DISK = N'D:\full.bak' WITH RECOVERY;";
+
+        Assert.Equal(1, RestoreProgress.CountStatements(script));
+    }
+
+    // ── the trajectory ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PercentLinesMoveTheBar()
+    {
+        var progress = new RestoreProgress(1);
+
+        Assert.True(progress.Feed("10 percent processed."));
+        Assert.Equal(10, progress.OverallPercent, 1);
+
+        Assert.True(progress.Feed("90 percent processed."));
+        Assert.Equal(90, progress.OverallPercent, 1);
+    }
+
+    /// <summary>
+    /// Across a chain, a finished statement is worth its whole share - and the server does not
+    /// always say "100 percent" before the completion line, so completion IS the 100.
+    /// </summary>
+    [Fact]
+    public void AChainAdvancesByStatement()
+    {
+        var progress = new RestoreProgress(3);
+
+        progress.Feed("50 percent processed.");
+        Assert.Equal(100.0 / 3 / 2, progress.OverallPercent, 1);
+        Assert.Equal("Statement 1 of 3 - 50%", progress.Describe());
+
+        progress.Feed("RESTORE DATABASE successfully processed 823 pages in 0.208 seconds (30.9 MB/sec).");
+        Assert.Equal(100.0 / 3, progress.OverallPercent, 1);
+
+        progress.Feed("30 percent processed.");
+        Assert.Equal("Statement 2 of 3 - 30%", progress.Describe());
+
+        progress.Feed("RESTORE LOG successfully processed 12 pages in 0.011 seconds (8.1 MB/sec).");
+        progress.Feed("RESTORE LOG successfully processed 9 pages in 0.009 seconds (7.4 MB/sec).");
+
+        Assert.Equal(100, progress.OverallPercent, 1);
+        Assert.Equal("All 3 statements complete", progress.Describe());
+    }
+
+    /// <summary>Ordinary output moves nothing, and says so - the caller skips re-rendering.</summary>
+    [Fact]
+    public void OrdinaryLinesAreIgnored()
+    {
+        var progress = new RestoreProgress(1);
+
+        Assert.False(progress.Feed("Processed 823 pages for database 'MyDb', file 'MyDb' on file 1."));
+        Assert.False(progress.Feed("Beginning restore execution..."));
+        Assert.Equal(0, progress.OverallPercent, 1);
+    }
+
+    /// <summary>"1 of 1" is noise wearing a number - one statement shows the bare percent.</summary>
+    [Fact]
+    public void OneStatementSpeaksPlainly()
+    {
+        var progress = new RestoreProgress(1);
+        progress.Feed("40 percent processed.");
+
+        Assert.Equal("40%", progress.Describe());
+    }
+
+    /// <summary>More completions than statements cannot push past 100.</summary>
+    [Fact]
+    public void ProgressNeverExceedsTheWhole()
+    {
+        var progress = new RestoreProgress(1);
+        progress.Feed("RESTORE DATABASE successfully processed 1 pages in 0.001 seconds (1.0 MB/sec).");
+        progress.Feed("RESTORE DATABASE successfully processed 1 pages in 0.001 seconds (1.0 MB/sec).");
+
+        Assert.Equal(100, progress.OverallPercent, 1);
+    }
+
+    // ── the execution surface and the taskbar ───────────────────────────────────
+
+    private static (RestoreExecutionViewModel vm, FakeSqlServerService sql) New()
+    {
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreExecutionViewModel(
+            sql, new FakeRestoreHistoryStore(), TestLogs.Temp(), new OperationCancellation());
+        return (vm, sql);
+    }
+
+    private static RestoreRun Run() => new(
+        Server: new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" },
+        Script: "RESTORE DATABASE [MyDb] FROM DISK = N'D:\\b.bak' WITH REPLACE, RECOVERY;",
+        TargetDatabase: "MyDb",
+        SourceDatabase: null,
+        ContainerName: null,
+        ChainSummary: "1 full",
+        RestorePointTimestamp: null,
+        OptionsForLog: "WITH REPLACE, RECOVERY");
+
+    /// <summary>A finished run reads 100 even when the last STATS line never said so.</summary>
+    [Fact]
+    public async Task SuccessEndsAtOneHundred()
+    {
+        var (vm, _) = New();
+
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.Equal(100, vm.ProgressValue, 1);
+        Assert.Equal(1.0, vm.TaskbarValue, 2);
+        Assert.Equal(TaskbarItemProgressState.None, vm.TaskbarState);
+    }
+
+    /// <summary>
+    /// Failure stays red on the taskbar until the next run - it is the signal somebody who
+    /// alt-tabbed away most needs to see.
+    /// </summary>
+    [Fact]
+    public async Task FailureStaysRedOnTheTaskbar()
+    {
+        var (vm, sql) = New();
+        sql.ExecuteThrows = new InvalidOperationException("Msg 3201");
+
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.Equal(TaskbarItemProgressState.Error, vm.TaskbarState);
+        Assert.Equal(1.0, vm.TaskbarValue, 2);
+    }
+
+    [Fact]
+    public async Task TheNextRunResetsTheBar()
+    {
+        var (vm, sql) = New();
+        sql.ExecuteThrows = new InvalidOperationException("boom");
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+        Assert.Equal(TaskbarItemProgressState.Error, vm.TaskbarState);
+
+        sql.ExecuteThrows = null;
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.Equal(TaskbarItemProgressState.None, vm.TaskbarState);
+        Assert.Equal(100, vm.ProgressValue, 1);
+    }
+}

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -10,6 +10,15 @@
         WindowStartupLocation="CenterScreen"
         Background="{DynamicResource WindowBackgroundBrush}">
 
+    <!-- The taskbar carries the restore's progress, so the app conveys it while minimised (#204).
+         Red on failure and it stays red until the next run - the signal somebody who alt-tabbed
+         away most needs. -->
+    <Window.TaskbarItemInfo>
+        <TaskbarItemInfo ProgressState="{Binding Restore.Execution.TaskbarState}"
+                         ProgressValue="{Binding Restore.Execution.TaskbarValue}" />
+    </Window.TaskbarItemInfo>
+
+
     <!-- DataContext is set in the constructor, not here. Declaring it in XAML meant every
          construction of this window - including a test that only wanted to check the markup -
          built a MainViewModel against the real %LOCALAPPDATA% config and ran the secret-key

--- a/src/NineLives/Services/RestoreProgress.cs
+++ b/src/NineLives/Services/RestoreProgress.cs
@@ -1,0 +1,97 @@
+using System.Text.RegularExpressions;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Turns SQL Server's own progress prose into a number (#204).
+///
+/// The scripts run WITH STATS = 10, so the server reports "10 percent processed." as each
+/// statement advances, and "RESTORE DATABASE successfully processed ..." as each one finishes.
+/// Those lines were scrolling into the console as text and nothing more - a 40-minute restore
+/// looked identical at 5% and at 95% unless somebody read the log. The number was always there;
+/// this makes it a number again.
+///
+/// A chain is several statements, so overall progress is statements-completed plus the current
+/// statement's fraction, over the total. Weighting by statement rather than by bytes is knowingly
+/// approximate - a 200 GB full and a 2 MB log weigh the same - but honest per-statement text
+/// ("statement 2 of 5") keeps the bar from promising precision it does not have.
+/// </summary>
+public sealed partial class RestoreProgress
+{
+    [GeneratedRegex(@"^\s*(\d{1,3})\s+percent\s+processed\.?\s*$", RegexOptions.IgnoreCase)]
+    private static partial Regex PercentLine();
+
+    [GeneratedRegex(@"RESTORE\s+(DATABASE|LOG)\s+successfully\s+processed", RegexOptions.IgnoreCase)]
+    private static partial Regex CompletionLine();
+
+    [GeneratedRegex(@"^\s*RESTORE\s+(DATABASE|LOG)\s", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    private static partial Regex RestoreStatement();
+
+    /// <summary>
+    /// How many RESTORE statements the script will run - the denominator.
+    ///
+    /// Counted from the script itself rather than passed in, so the number can never disagree
+    /// with what actually executes. VERIFYONLY, HEADERONLY and FILELISTONLY do not match: they
+    /// report no STATS and would dilute the total with statements that finish in one line.
+    /// </summary>
+    public static int CountStatements(string script) => RestoreStatement().Matches(script).Count;
+
+    public RestoreProgress(int totalStatements)
+    {
+        TotalStatements = Math.Max(1, totalStatements);
+    }
+
+    public int TotalStatements { get; }
+
+    public int StatementsCompleted { get; private set; }
+
+    /// <summary>The current statement's own percent, 0-100, as the server last reported it.</summary>
+    public int CurrentStatementPercent { get; private set; }
+
+    /// <summary>
+    /// Feeds one console line. Returns true when it changed anything, so the caller can skip
+    /// re-rendering for the vast majority of lines, which are ordinary output.
+    /// </summary>
+    public bool Feed(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line)) return false;
+
+        var percent = PercentLine().Match(line);
+        if (percent.Success && int.TryParse(percent.Groups[1].Value, out var value))
+        {
+            CurrentStatementPercent = Math.Clamp(value, 0, 100);
+            return true;
+        }
+
+        if (CompletionLine().IsMatch(line))
+        {
+            // The server does not always say "100 percent" before the completion line - a small
+            // statement can finish without ever reporting - so completion IS the 100.
+            StatementsCompleted = Math.Min(TotalStatements, StatementsCompleted + 1);
+            CurrentStatementPercent = 0;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Overall progress, 0-100, across the whole chain.</summary>
+    public double OverallPercent =>
+        Math.Min(100.0,
+            (StatementsCompleted + CurrentStatementPercent / 100.0) / TotalStatements * 100.0);
+
+    /// <summary>
+    /// What to print next to the bar. Statement-aware only when there are several, because
+    /// "statement 1 of 1" is noise wearing a number.
+    /// </summary>
+    public string Describe()
+    {
+        var current = Math.Min(TotalStatements, StatementsCompleted + 1);
+
+        return TotalStatements == 1
+            ? $"{CurrentStatementPercent}%"
+            : StatementsCompleted >= TotalStatements
+                ? $"All {TotalStatements} statements complete"
+                : $"Statement {current} of {TotalStatements} - {CurrentStatementPercent}%";
+    }
+}

--- a/src/NineLives/Services/WindowAttention.cs
+++ b/src/NineLives/Services/WindowAttention.cs
@@ -1,0 +1,63 @@
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Flashes the taskbar button when a long operation finishes behind another window (#204).
+///
+/// The polite form of a completion signal: no toast, no sound, no window stealing focus - the
+/// same amber flash Windows itself uses, which stops the moment the window is clicked. Anybody
+/// who alt-tabbed away from a 40-minute restore gets told it finished without being interrupted
+/// in whatever they moved on to.
+/// </summary>
+public static class WindowAttention
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FLASHWINFO
+    {
+        public uint cbSize;
+        public IntPtr hwnd;
+        public uint dwFlags;
+        public uint uCount;
+        public uint dwTimeout;
+    }
+
+    private const uint FLASHW_TRAY = 0x00000002;
+    private const uint FLASHW_TIMERNOFG = 0x0000000C;
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool FlashWindowEx(ref FLASHWINFO pwfi);
+
+    /// <summary>
+    /// Flashes the app's taskbar button if no window of ours is foreground. A no-op when the user
+    /// is already looking at the app - flashing at somebody mid-click is noise - and headless,
+    /// where there is nothing to flash.
+    /// </summary>
+    public static void FlashIfInBackground()
+    {
+        var window = Application.Current?.MainWindow;
+        if (window == null) return;
+
+        // Any of our windows being active counts as "watching" - the execution window is its own
+        // top-level window and is exactly where somebody would be looking.
+        foreach (Window w in Application.Current!.Windows)
+            if (w.IsActive) return;
+
+        var handle = new WindowInteropHelper(window).Handle;
+        if (handle == IntPtr.Zero) return;
+
+        var info = new FLASHWINFO
+        {
+            cbSize = (uint)Marshal.SizeOf<FLASHWINFO>(),
+            hwnd = handle,
+            dwFlags = FLASHW_TRAY | FLASHW_TIMERNOFG,
+            uCount = uint.MaxValue,
+            dwTimeout = 0
+        };
+
+        FlashWindowEx(ref info);
+    }
+}

--- a/src/NineLives/Services/WindowAttention.cs
+++ b/src/NineLives/Services/WindowAttention.cs
@@ -38,26 +38,43 @@ public static class WindowAttention
     /// </summary>
     public static void FlashIfInBackground()
     {
-        var window = Application.Current?.MainWindow;
-        if (window == null) return;
+        // The Windows collection and IsActive are thread-affine, and this is called from the
+        // execution's finally - a worker thread. Marshalled rather than touched directly, and
+        // fire-and-forget: a completion signal must never be able to fail the run it signals.
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null) return;
 
-        // Any of our windows being active counts as "watching" - the execution window is its own
-        // top-level window and is exactly where somebody would be looking.
-        foreach (Window w in Application.Current!.Windows)
-            if (w.IsActive) return;
-
-        var handle = new WindowInteropHelper(window).Handle;
-        if (handle == IntPtr.Zero) return;
-
-        var info = new FLASHWINFO
+        dispatcher.InvokeAsync(() =>
         {
-            cbSize = (uint)Marshal.SizeOf<FLASHWINFO>(),
-            hwnd = handle,
-            dwFlags = FLASHW_TRAY | FLASHW_TIMERNOFG,
-            uCount = uint.MaxValue,
-            dwTimeout = 0
-        };
+            try
+            {
+                var app = Application.Current;
+                var window = app?.MainWindow;
+                if (app == null || window == null) return;
 
-        FlashWindowEx(ref info);
+                // Any of our windows being active counts as "watching" - the execution window is
+                // its own top-level window and is exactly where somebody would be looking.
+                foreach (Window w in app.Windows)
+                    if (w.IsActive) return;
+
+                var handle = new WindowInteropHelper(window).Handle;
+                if (handle == IntPtr.Zero) return;
+
+                var info = new FLASHWINFO
+                {
+                    cbSize = (uint)Marshal.SizeOf<FLASHWINFO>(),
+                    hwnd = handle,
+                    dwFlags = FLASHW_TRAY | FLASHW_TIMERNOFG,
+                    uCount = uint.MaxValue,
+                    dwTimeout = 0
+                };
+
+                FlashWindowEx(ref info);
+            }
+            catch
+            {
+                // Nothing about a missed flash is worth surfacing.
+            }
+        });
     }
 }

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -201,6 +201,14 @@ public partial class RestoreExecutionViewModel : ViewModelBase
         PostRestoreActions = [];
         HasPostRestoreActions = false;
         PostRestoreMessage = string.Empty;
+
+        // The denominator comes from the script itself, so it can never disagree with what runs.
+        _progress = new RestoreProgress(RestoreProgress.CountStatements(run.Script));
+        ProgressValue = 0;
+        ProgressText = string.Empty;
+        TaskbarValue = 0;
+        TaskbarState = System.Windows.Shell.TaskbarItemProgressState.Normal;
+
         RaiseCancelStateChanged();
 
         try
@@ -227,6 +235,10 @@ public partial class RestoreExecutionViewModel : ViewModelBase
                 // up and then arrived in bursts - which is precisely what "not live" looked like.
                 msg =>
                 {
+                    // The progress model reads every line on this thread - it is cheap and its
+                    // outputs are scalars, which WPF marshals itself (#204).
+                    TrackProgress(msg);
+
                     // InvokeAsync when a dispatcher exists and this is not its thread - see the
                     // note above. Null when there is no Application at all (headless: the tests),
                     // where appending directly is both safe and the only option.
@@ -238,6 +250,15 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             ExecutionSuccess = true;
             outcome = RestoreOutcome.Succeeded;
+
+            // The run IS over, whatever the last STATS line said - a small final statement often
+            // finishes without reporting 100.
+            ProgressValue = 100;
+            ProgressText = _progress is { TotalStatements: > 1 }
+                ? $"All {_progress.TotalStatements} statements complete"
+                : "Complete";
+            TaskbarValue = 1;
+
             AppendLog("\nRestore completed successfully!");
             SetStatus("Restore execution completed successfully.");
 
@@ -280,6 +301,18 @@ public partial class RestoreExecutionViewModel : ViewModelBase
         }
         finally
         {
+            // Error stays red on the taskbar until the next run - it is the signal somebody who
+            // alt-tabbed away most needs to see. Success clears: a full green bar that never
+            // leaves reads as "still running" from the taskbar alone.
+            TaskbarState = ExecutionSuccess
+                ? System.Windows.Shell.TaskbarItemProgressState.None
+                : System.Windows.Shell.TaskbarItemProgressState.Error;
+            if (!ExecutionSuccess) TaskbarValue = 1;
+
+            // Told, not interrupted: the amber taskbar flash, only when none of our windows is
+            // foreground, and stops the moment the app is clicked.
+            WindowAttention.FlashIfInBackground();
+
             _executeCancellation.End();
             IsExecuting = false;
             Console.IsRunning = false;
@@ -352,6 +385,43 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     /// SQL error, when the app is still holding the connection that could tell them, is the wrong
     /// place to stop.
     /// </summary>
+    // ── progress, as a number again (#204) ──────────────────────────────────────
+
+    /// <summary>Overall progress across the chain, 0-100, from the server's own STATS lines.</summary>
+    [ObservableProperty]
+    private double _progressValue;
+
+    /// <summary>"Statement 2 of 5 - 60%", or just the percent for a one-statement run.</summary>
+    [ObservableProperty]
+    private string _progressText = string.Empty;
+
+    /// <summary>
+    /// The taskbar mirror, so the app conveys progress while minimised. 0-1 because that is the
+    /// scale TaskbarItemInfo speaks.
+    /// </summary>
+    [ObservableProperty]
+    private double _taskbarValue;
+
+    [ObservableProperty]
+    private System.Windows.Shell.TaskbarItemProgressState _taskbarState =
+        System.Windows.Shell.TaskbarItemProgressState.None;
+
+    private RestoreProgress? _progress;
+
+    /// <summary>
+    /// Feeds one console line into the progress model and mirrors the result. Runs on the
+    /// connection's message thread; the scalar properties are safe to set there - WPF marshals
+    /// scalar INPC to the UI thread itself.
+    /// </summary>
+    private void TrackProgress(string message)
+    {
+        if (_progress == null || !_progress.Feed(message)) return;
+
+        ProgressValue = _progress.OverallPercent;
+        ProgressText = _progress.Describe();
+        TaskbarValue = _progress.OverallPercent / 100.0;
+    }
+
     // ── after a SUCCESSFUL restore (#205) ───────────────────────────────────────
 
     /// <summary>What finishing the job involves, shown under the success banner.</summary>

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -10,6 +10,12 @@
         Background="{DynamicResource WindowBackgroundBrush}"
         Closing="OnClosing">
 
+    <Window.TaskbarItemInfo>
+        <TaskbarItemInfo ProgressState="{Binding Execution.TaskbarState}"
+                         ProgressValue="{Binding Execution.TaskbarValue}" />
+    </Window.TaskbarItemInfo>
+
+
     <Window.Resources>
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
     </Window.Resources>
@@ -93,6 +99,19 @@
         </Border>
 
         <!-- What a failed or cancelled restore left behind (#14). -->
+        
+        <!-- The chain's own progress, from the server's STATS lines (#204). Indeterminate until
+             the first percent arrives would be a lie in the other direction - the bar simply sits
+             at zero until the server has said something. -->
+        <StackPanel Grid.Row="2" Margin="0,10,0,0"
+                    Visibility="{Binding Execution.IsExecuting, Converter={StaticResource BoolToVis}}">
+            <ProgressBar Value="{Binding Execution.ProgressValue, Mode=OneWay}"
+                         Maximum="100" Height="8"
+                         Style="{StaticResource DarkProgressBar}" />
+            <TextBlock Text="{Binding Execution.ProgressText}"
+                       Style="{StaticResource SecondaryText}"
+                       Margin="0,4,0,0" />
+        </StackPanel>
         <Border Grid.Row="2" CornerRadius="4" Padding="12" Margin="0,12,0,0"
                 Background="{DynamicResource DangerPanelBackgroundBrush}" BorderBrush="{DynamicResource DangerPanelBorderBrush}" BorderThickness="1"
                 Visibility="{Binding Execution.HasRecoveryActions, Converter={StaticResource BoolToVis}}">

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -2082,6 +2082,18 @@
                         </Grid>
                     </Border>
 
+                    <!-- The chain's own progress, from the server's STATS lines (#204). -->
+                    <StackPanel Margin="0,8,0,0"
+                                Visibility="{Binding Execution.IsExecuting, Converter={StaticResource BoolToVis}}">
+                        <ProgressBar Value="{Binding Execution.ProgressValue, Mode=OneWay}"
+                                     Maximum="100" Height="8"
+                                     Style="{StaticResource DarkProgressBar}" />
+                        <TextBlock Text="{Binding Execution.ProgressText}"
+                                   Style="{StaticResource SecondaryText}"
+                                   Margin="0,4,0,0" />
+                    </StackPanel>
+
+
                     <!-- What a failed restore left behind, and how to undo it (#14). A chain that
                          stops part-way leaves the target in RESTORING, and in SINGLE_USER too if
                          Disconnect sessions was on. Both block other connections, and this is the


### PR DESCRIPTION
The scripts run `WITH STATS = 10`, so the server was already reporting progress — "10 percent processed." — and it scrolled into the console as prose. A 40-minute restore looked identical at 5% and at 95% unless somebody read the log. The number was always there; this makes it a number again.

## The parser

A small class fed by the execution callback, fully unit-tested:

- **The denominator comes from the script itself** — counting `RESTORE DATABASE/LOG` statements — so it can never disagree with what runs. VERIFYONLY/HEADERONLY/FILELISTONLY don't match: they report no STATS and would dilute the total.
- **Completion *is* the 100.** The server doesn't always say "100 percent" before "RESTORE LOG successfully processed…", so the completion line closes the statement.
- Weighting by statement rather than bytes is knowingly approximate — the text says "Statement 2 of 5 — 60%" precisely so the bar doesn't promise precision it doesn't have. One statement shows a bare percent, because "1 of 1" is noise wearing a number.

## The taskbar half

Mirrored to `TaskbarItemInfo` on both the main window and the execution window — this is the half that matters to anybody who alt-tabbed away, which is everybody on a long restore.

- **Failure turns the taskbar red and stays red until the next run** — the signal that person most needs.
- **Success clears** — a full green bar that never leaves reads as still-running from the taskbar alone.
- **Finishing in the background flashes the taskbar button** (`FlashWindowEx`, `FLASHW_TIMERNOFG`) — the same amber flash Windows itself uses, only when none of our windows is foreground, stopping the moment the app is clicked. Told, not interrupted. No toast, no sound, no stolen focus.

10 new tests, 1,408 pass.