### PR TITLE
Refuse a newer version's backup before anything is touched (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ built for.
 
 ### Changed
 
+- **A newer version's backup aimed at an older server refuses before anything runs**, naming both
+  versions and the way out - SQL Server can never restore in that direction (error 3169), and
+  without the check it failed mid-restore, after WITH REPLACE had dropped the target. The legal
+  upgrade direction proceeds with a note about the one-way door. One HEADERONLY on the target,
+  device-aware, so blob, shared-path and ad-hoc chains all get the same check (#210)
 - **A running restore shows its progress as a bar**, built from the server's own STATS lines -
   per statement across the chain, mirrored to the Windows taskbar so the app conveys progress
   while minimised. Failure turns the taskbar red and stays red until the next run; finishing

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -245,6 +245,12 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Set to make asking about volumes fail - which must not become a warning (#32).</summary>
     public Exception? VolumeCheckThrows { get; set; }
 
+    /// <summary>What GetProductMajorVersionAsync answers - 16 is SQL Server 2022 (#210).</summary>
+    public int? ProductMajorVersion { get; set; } = 16;
+
+    public Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult(ProductMajorVersion);
+
     /// <summary>What GetDatabaseOverviewAsync answers (#205).</summary>
     public DatabaseOverview? DatabaseOverview { get; set; } = new(150, "FULL", "sa");
 
@@ -367,7 +373,8 @@ public sealed class FakeSqlServerService : ISqlServerService
         FirstLsn = source.FirstLsn,
         LastLsn = source.LastLsn,
         CheckpointLsn = source.CheckpointLsn,
-        DatabaseBackupLsn = source.DatabaseBackupLsn
+        DatabaseBackupLsn = source.DatabaseBackupLsn,
+        SoftwareVersionMajor = source.SoftwareVersionMajor
     };
 
     /// <summary>Called with the token the viewmodel supplied, so a test can see it was cancellable.</summary>

--- a/src/NineLives.Tests/VersionPreflightTests.cs
+++ b/src/NineLives.Tests/VersionPreflightTests.cs
@@ -1,0 +1,187 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The one-directional law of RESTORE (#210): a backup taken on a newer major version can never be
+/// restored onto an older one - error 3169, no exceptions, not even between adjacent releases.
+/// Without a preflight it arrives from the server mid-restore, after WITH REPLACE has already
+/// dropped the database being restored over.
+/// </summary>
+public class VersionPreflightTests
+{
+    // ── the law itself ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(17, 16, VersionVerdict.Refuse)]
+    [InlineData(16, 15, VersionVerdict.Refuse)]
+    [InlineData(16, 16, VersionVerdict.Same)]
+    [InlineData(15, 16, VersionVerdict.UpgradeInPassing)]
+    [InlineData(11, 16, VersionVerdict.UpgradeInPassing)]
+    public void TheVerdictFollowsTheDirection(int backup, int target, VersionVerdict expected)
+    {
+        Assert.Equal(expected, VersionCompatibility.Check(backup, target));
+    }
+
+    /// <summary>
+    /// No verdict from silence. A header that did not say, or an edition that does not report, is
+    /// not evidence of a mismatch - refusing on a guess would block legal restores.
+    /// </summary>
+    [Theory]
+    [InlineData(null, 16)]
+    [InlineData(17, null)]
+    [InlineData(null, null)]
+    public void SilenceEarnsNoVerdict(int? backup, int? target)
+    {
+        Assert.Equal(VersionVerdict.Unknown, VersionCompatibility.Check(backup, target));
+    }
+
+    /// <summary>Named in years people recognise, with the way out stated.</summary>
+    [Fact]
+    public void TheRefusalNamesBothSidesAndTheWayOut()
+    {
+        var text = VersionCompatibility.ExplainRefusal(17, 16, "SRV01");
+
+        Assert.Contains("SQL Server 2025 (17.x)", text);
+        Assert.Contains("SQL Server 2022 (16.x)", text);
+        Assert.Contains("SRV01", text);
+        Assert.Contains("error 3169", text);
+        Assert.Contains("Nothing has been changed", text);
+    }
+
+    [Fact]
+    public void TheUpgradeNoteWarnsAboutTheOneWayDoor()
+    {
+        var text = VersionCompatibility.ExplainUpgrade(15, 16);
+
+        Assert.Contains("SQL Server 2019 (15.x)", text);
+        Assert.Contains("never go back", text);
+        Assert.Contains("compatibility level", text);
+    }
+
+    // ── the preflight on the restore screen ─────────────────────────────────────
+
+    private static readonly DateTime T0 = new(2026, 8, 7, 22, 0, 0);
+
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    /// <summary>A restore screen with a loaded ad-hoc chain whose header reports a version.</summary>
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> LoadedAsync(int backupMajor)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server());
+
+        var sql = new FakeSqlServerService
+        {
+            FileHeaders =
+            {
+                [@"D:\drop\VendorDb.bak"] =
+                [
+                    new BackupHistoryEntry
+                    {
+                        DatabaseName = "VendorDb",
+                        Type = BackupType.Full,
+                        StartedAt = T0,
+                        FinishedAt = T0.AddMinutes(1),
+                        CheckpointLsn = 100m,
+                        Position = 1,
+                        Files = [@"D:\drop\VendorDb.bak"]
+                    }
+                ]
+            },
+            // Header, not HeaderForUrls: the preflight goes through RestoreHeaderOnlyMultiAsync,
+            // and the fake routes that through the single Header property.
+            Header = new BackupFileInfo
+            {
+                DatabaseName = "VendorDb",
+                Type = BackupType.Full,
+                BackupTypeCode = 1,
+                SoftwareVersionMajor = backupMajor
+            }
+        };
+
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), sql, new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(),
+            new FakeRestoreHistoryStore(), TestAuditStores.Temp())
+        {
+            Mode = AppMode.Pro
+        };
+        vm.RefreshContainers();
+
+        vm.SelectedMedium = BackupMedium.AdHocFile;
+        vm.SourceServer = vm.SourceServers[0];
+        vm.AdHocPathsText = @"D:\drop\VendorDb.bak";
+        await vm.Inventory.LoadAsync(vm.CurrentLocation!);
+        vm.Inventory.SelectedDatabaseName = "VendorDb";
+
+        // The preflight reads the CHAIN's full set, and a chain exists once a restore point is
+        // chosen - which is the only state Execute can run from anyway.
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Last();
+        Assert.NotNull(vm.RestoreChain);
+
+        return (vm, sql);
+    }
+
+    /// <summary>
+    /// The one this exists for: a 2025 backup aimed at a 2022 server refuses BEFORE anything runs,
+    /// naming both versions.
+    /// </summary>
+    [Fact]
+    public async Task ANewerBackupOntoAnOlderTargetRefusesByName()
+    {
+        var (vm, sql) = await LoadedAsync(backupMajor: 17);
+        sql.ProductMajorVersion = 16;
+
+        var log = new List<string>();
+        var result = await vm.PreflightAsync(Server(), log.Add);
+
+        Assert.False(result.CanProceed);
+        Assert.Contains("SQL Server 2025 (17.x)", result.Refusal);
+        Assert.Contains("SQL Server 2022 (16.x)", result.Refusal);
+    }
+
+    /// <summary>The legal direction proceeds, with the one-way door said out loud.</summary>
+    [Fact]
+    public async Task AnOlderBackupOntoANewerTargetProceedsWithANote()
+    {
+        var (vm, sql) = await LoadedAsync(backupMajor: 15);
+        sql.ProductMajorVersion = 16;
+
+        var log = new List<string>();
+        var result = await vm.PreflightAsync(Server(), log.Add);
+
+        Assert.True(result.CanProceed);
+        Assert.Contains(log, l => l.Contains("never go back"));
+    }
+
+    [Fact]
+    public async Task MatchingVersionsProceedQuietly()
+    {
+        var (vm, sql) = await LoadedAsync(backupMajor: 16);
+        sql.ProductMajorVersion = 16;
+
+        var result = await vm.PreflightAsync(Server(), _ => { });
+
+        Assert.True(result.CanProceed);
+    }
+
+    /// <summary>
+    /// A version check that cannot run does not block the restore - the restore reads the same
+    /// header in a moment and reports its own, better error if something is genuinely wrong.
+    /// </summary>
+    [Fact]
+    public async Task ACheckThatCannotRunDoesNotBlock()
+    {
+        var (vm, sql) = await LoadedAsync(backupMajor: 17);
+        sql.ProductMajorVersion = null;
+
+        var result = await vm.PreflightAsync(Server(), _ => { });
+
+        Assert.True(result.CanProceed);
+    }
+}

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -214,6 +214,15 @@ public class BackupFileInfo
     public DateTime? BackupStartDate { get; set; }
     public DateTime? BackupFinishDate { get; set; }
     public int? BackupTypeCode { get; set; }
+
+    /// <summary>
+    /// The major version of the SQL Server that TOOK this backup, from HEADERONLY (#210).
+    ///
+    /// The one-directional law of RESTORE hangs on it: a backup from a newer major can never be
+    /// restored onto an older one, and without reading this the refusal arrives from the server
+    /// mid-restore - after WITH REPLACE has dropped the target.
+    /// </summary>
+    public int? SoftwareVersionMajor { get; set; }
     public decimal? FirstLsn { get; set; }
     public decimal? LastLsn { get; set; }
 

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -36,6 +36,9 @@ public interface ISqlServerService
     Task<List<FileMoveOption>> GetDatabaseFilesAsync(
         ServerConnection server, string database, CancellationToken ct = default);
 
+    /// <summary>SERVERPROPERTY('ProductMajorVersion') - 16 is SQL Server 2022 - or null if it did not say (#210).</summary>
+    Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default);
+
     /// <summary>What the restored database looks like now - compat level, recovery model, owner (#205).</summary>
     Task<DatabaseOverview?> GetDatabaseOverviewAsync(
         ServerConnection server, string database, CancellationToken ct = default);

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -689,7 +689,8 @@ public class SqlServerService : ISqlServerService
             FirstLsn = GetDecimalFromReader(reader, "FirstLSN"),
             LastLsn = GetDecimalFromReader(reader, "LastLSN"),
             DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN"),
-            CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN")
+            CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN"),
+            SoftwareVersionMajor = GetIntFromReader(reader, "SoftwareVersionMajor")
         };
         }, ct, "Reading the backup header");
     }
@@ -1191,6 +1192,18 @@ public class SqlServerService : ISqlServerService
         }
 
         return files;
+    }
+
+    public async Task<int?> GetProductMajorVersionAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT CONVERT(int, SERVERPROPERTY('ProductMajorVersion'))";
+
+        var result = await cmd.ExecuteScalarAsync(ct);
+        return result is int major ? major : null;
     }
 
     public async Task<DatabaseOverview?> GetDatabaseOverviewAsync(

--- a/src/NineLives/Services/VersionCompatibility.cs
+++ b/src/NineLives/Services/VersionCompatibility.cs
@@ -1,0 +1,76 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>How a backup's version relates to the target's (#210).</summary>
+public enum VersionVerdict
+{
+    /// <summary>One side or the other did not say. No verdict, no warning - evidence only.</summary>
+    Unknown,
+
+    /// <summary>Same major version. Nothing to say.</summary>
+    Same,
+
+    /// <summary>
+    /// Older backup onto a newer target - legal, and the database is upgraded on the way through.
+    /// Worth a sentence, not a stop.
+    /// </summary>
+    UpgradeInPassing,
+
+    /// <summary>
+    /// Newer backup onto an older target. SQL Server can never do this - error 3169, no
+    /// exceptions - so the restore must not start.
+    /// </summary>
+    Refuse
+}
+
+/// <summary>
+/// The one-directional law of RESTORE (#210): a backup taken on a newer major version can never be
+/// restored onto an older one. Not with compatibility levels, not between adjacent releases, not
+/// ever - error 3169. And without this check it arrives from the server mid-restore, after WITH
+/// REPLACE has already dropped the database being restored over.
+///
+/// Same failure shape as the credential preflight (#32), the readability preflight (#149) and the
+/// disk-space check (#182), and the cheapest of the lot: the header carries the version, and the
+/// target's is one SERVERPROPERTY away.
+/// </summary>
+public static class VersionCompatibility
+{
+    /// <summary>Major version to marketing year, for messages people can act on.</summary>
+    public static string Describe(int major) => major switch
+    {
+        17 => "SQL Server 2025 (17.x)",
+        16 => "SQL Server 2022 (16.x)",
+        15 => "SQL Server 2019 (15.x)",
+        14 => "SQL Server 2017 (14.x)",
+        13 => "SQL Server 2016 (13.x)",
+        12 => "SQL Server 2014 (12.x)",
+        11 => "SQL Server 2012 (11.x)",
+        10 => "SQL Server 2008 (10.x)",
+        9 => "SQL Server 2005 (9.x)",
+        _ => $"SQL Server (major version {major})"
+    };
+
+    public static VersionVerdict Check(int? backupMajor, int? targetMajor)
+    {
+        // No verdict from silence. A header that did not say, or an edition that does not report,
+        // is not evidence of a mismatch - and refusing on a guess would block legal restores.
+        if (backupMajor is not int backup || targetMajor is not int target) return VersionVerdict.Unknown;
+        if (backup == target) return VersionVerdict.Same;
+
+        return backup < target ? VersionVerdict.UpgradeInPassing : VersionVerdict.Refuse;
+    }
+
+    /// <summary>The refusal, naming both sides and the way out.</summary>
+    public static string ExplainRefusal(int backupMajor, int targetMajor, string targetName) =>
+        $"This backup was taken on {Describe(backupMajor)}. {targetName} is " +
+        $"{Describe(targetMajor)}, and SQL Server can never restore a newer version's backup " +
+        "onto an older one - error 3169, with no exceptions. Restore it onto a " +
+        $"{Describe(backupMajor)} or later instance instead. Nothing has been changed on the " +
+        "server or the database.";
+
+    /// <summary>The upgrade note - one sentence, because the restore is legal and will work.</summary>
+    public static string ExplainUpgrade(int backupMajor, int targetMajor) =>
+        $"This backup was taken on {Describe(backupMajor)} and is being restored onto " +
+        $"{Describe(targetMajor)}. That is fine - the database is upgraded as it is restored - " +
+        "but it can never go back to the older version afterwards, and its compatibility level " +
+        "will stay at the source's until raised.";
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2102,12 +2102,78 @@ public partial class RestoreViewModel : ViewModelBase
         // Both non-blob media end in FROM DISK on the target, so both need the same answer: can
         // the instance that will run the RESTORE actually read these files (#203).
         if (MediumIsSharedPath || MediumIsAdHocFile)
-            return await CheckTargetCanReadFilesAsync(server, appendLog);
+        {
+            var readable = await CheckTargetCanReadFilesAsync(server, appendLog);
+            if (!readable.CanProceed) return readable;
+
+            return await CheckVersionCompatibilityAsync(server, appendLog);
+        }
 
         var primary = await Credential.PrepareForRestoreAsync(server, appendLog);
         if (!primary.CanProceed) return primary;
 
-        return await CheckOtherContainersHaveCredentialsAsync(server, appendLog);
+        var containers = await CheckOtherContainersHaveCredentialsAsync(server, appendLog);
+        if (!containers.CanProceed) return containers;
+
+        return await CheckVersionCompatibilityAsync(server, appendLog);
+    }
+
+    /// <summary>
+    /// Refuses a newer version's backup before anything is touched (#210).
+    ///
+    /// The one-directional law of RESTORE: a backup taken on a newer major version can never be
+    /// restored onto an older one - error 3169, no exceptions, not even between adjacent releases.
+    /// Without this it arrives from the server mid-restore, after WITH REPLACE has already dropped
+    /// the database being restored over. Same failure shape as every other preflight here, and the
+    /// cheapest: the header carries the version, and the target's is one SERVERPROPERTY away.
+    ///
+    /// One HEADERONLY on the full set, on the target, device-aware since #203 - so this one path
+    /// serves blob, shared path and ad-hoc alike. Best effort throughout: no verdict from silence,
+    /// because refusing on a guess would block legal restores.
+    /// </summary>
+    private async Task<CredentialPreflight> CheckVersionCompatibilityAsync(
+        ServerConnection server, Action<string> appendLog)
+    {
+        var files = RestoreChain?.FullSet.Files;
+        if (files == null || files.Count == 0) return CredentialPreflight.Proceed;
+
+        try
+        {
+            appendLog("Comparing the backup's SQL Server version with the target's...");
+
+            var devices = files
+                .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+                .ToList();
+
+            var header = await _sqlService.RestoreHeaderOnlyMultiAsync(server, devices);
+            var targetMajor = await _sqlService.GetProductMajorVersionAsync(server);
+
+            switch (VersionCompatibility.Check(header?.SoftwareVersionMajor, targetMajor))
+            {
+                case VersionVerdict.Refuse:
+                    return CredentialPreflight.Stop(
+                        VersionCompatibility.ExplainRefusal(
+                            header!.SoftwareVersionMajor!.Value, targetMajor!.Value, server.ServerName));
+
+                case VersionVerdict.UpgradeInPassing:
+                    appendLog(VersionCompatibility.ExplainUpgrade(
+                        header!.SoftwareVersionMajor!.Value, targetMajor!.Value));
+                    break;
+
+                default:
+                    appendLog("Versions are compatible.");
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            // The check could not run, which is not the same as the check failing. The restore
+            // itself will read the same header in a moment and report its own, better error if
+            // something is genuinely wrong with the file.
+            appendLog($"Could not compare versions: {ex.Message}");
+        }
+
+        return CredentialPreflight.Proceed;
     }
 
     /// <summary>


### PR DESCRIPTION
The one-directional law of RESTORE: a backup taken on a newer major version can never be restored onto an older one — error 3169, no exceptions, not even between adjacent releases. Without this the refusal arrived from the server mid-restore, *after* `WITH REPLACE` had already dropped the database being restored over.

Same failure shape as the credential preflight (#32), the readability preflight (#149) and the disk-space check (#182) — and the cheapest of the lot: the header carries `SoftwareVersionMajor` (now actually read), and the target's version is one SERVERPROPERTY away.

## One check, three sources

One HEADERONLY on the chain's full set, on the target — device-aware since #203 — so blob, shared-path and ad-hoc chains all pass through the same code path.

- **Refusal names both sides in years people recognise**: "This backup was taken on SQL Server 2025 (17.x). SRV01 is SQL Server 2022 (16.x)…" — with the way out stated, and nothing touched.
- **The legal direction proceeds with a sentence about the one-way door**: the database upgrades on the way through, can never go back, and its compat level stays at the source's — which is exactly what the post-restore panel (#205) then states after the run.
- **No verdict from silence**: a header that did not say, or an edition that does not report, is not evidence of a mismatch — refusing on a guess would block legal restores. A check that cannot run does not block; the restore reads the same header moments later and reports its own, better error if the file is genuinely wrong.

14 new tests, 1,422 pass.