### PR TITLE
Hand the browser's answer straight to the restore screen (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ built for.
 
 ### Changed
 
+- **Browse Backups hands over to Restore in one move** - a button once a database is chosen, and
+  "Restore this database" on every row. The restore screen arrives with the same source selected,
+  the backups loaded and the database landed, so the only thing left is choosing the restore
+  point. Works from either browsing source, container or server history (#202)
 - **A newer version's backup aimed at an older server refuses before anything runs**, naming both
   versions and the way out - SQL Server can never restore in that direction (error 3169), and
   without the check it failed mid-restore, after WITH REPLACE had dropped the target. The legal

--- a/src/NineLives.Tests/BrowseToRestoreHandoffTests.cs
+++ b/src/NineLives.Tests/BrowseToRestoreHandoffTests.cs
@@ -1,0 +1,191 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// From looking to restoring in one move (#202).
+///
+/// The browser answers "what do I actually have?", and until now it stopped there: having found
+/// the exact backup that matters, the only way to restore it was the restore screen and the whole
+/// selection again by hand - same source, same server, same database. That is the app repeating a
+/// question it already asked.
+/// </summary>
+public class BrowseToRestoreHandoffTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 7, 22, 0, 0);
+
+    private static ServerConnection Server(string name = "SRV01") =>
+        new() { Id = ServerConnection.NewId(), Name = name, ServerName = name };
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = "c1",
+        Name = "backups",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups"
+    };
+
+    private static BackupFileInfo File_(string database, string name) => new()
+    {
+        BlobName = $"FULL/SRV01/{database}/{name}",
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/FULL/SRV01/{database}/{name}",
+        Type = BackupType.Full,
+        InferredDatabaseName = database,
+        InferredServerName = "SRV01",
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    // ── what the browser hands over ─────────────────────────────────────────────
+
+    /// <summary>The browser on a container hands over the container and the database.</summary>
+    [Fact]
+    public async Task ABlobBrowseHandsOverItsContainerAndDatabase()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(Container());
+
+        var blob = new FakeBlobStorageService { Files = [File_("Sales", "Sales_20260807_220000.bak")] };
+        var vm = new BlobBrowserViewModel(blob, new FakeSqlServerService(), store);
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.SelectedDatabase = "Sales";
+
+        BrowseHandoff? handoff = null;
+        vm.RestoreRequested += h => handoff = h;
+
+        vm.RestoreFromHereCommand.Execute(null);
+
+        Assert.NotNull(handoff);
+        Assert.Equal(BackupMedium.AzureBlob, handoff!.Medium);
+        Assert.Equal("c1", handoff.Container?.Id);
+        Assert.Equal("Sales", handoff.Database);
+    }
+
+    /// <summary>A row's context menu names its own database, whatever the filter says.</summary>
+    [Fact]
+    public async Task ARowHandsOverItsOwnDatabase()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(Container());
+
+        var blob = new FakeBlobStorageService
+        {
+            Files = [File_("Sales", "a.bak"), File_("Payroll", "b.bak")]
+        };
+        var vm = new BlobBrowserViewModel(blob, new FakeSqlServerService(), store);
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        BrowseHandoff? handoff = null;
+        vm.RestoreRequested += h => handoff = h;
+
+        vm.RestoreFromHereCommand.Execute("Payroll");
+
+        Assert.Equal("Payroll", handoff?.Database);
+    }
+
+    /// <summary>With nothing chosen there is nothing to hand over, and nothing fires.</summary>
+    [Fact]
+    public void NothingChosenMeansNothingFires()
+    {
+        var store = new FakeCredentialStore();
+        var vm = new BlobBrowserViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), store);
+
+        var fired = false;
+        vm.RestoreRequested += _ => fired = true;
+
+        vm.RestoreFromHereCommand.Execute(null);
+
+        Assert.False(fired);
+        Assert.False(vm.CanRestoreFromHere);
+    }
+
+    // ── what the restore screen does with it ────────────────────────────────────
+
+    private static RestoreViewModel Restore(FakeCredentialStore store, FakeBlobStorageService blob)
+    {
+        var vm = new RestoreViewModel(
+            blob, new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(),
+            new FakeRestoreHistoryStore(), TestAuditStores.Temp())
+        {
+            Mode = AppMode.Pro
+        };
+        vm.RefreshContainers();
+        return vm;
+    }
+
+    /// <summary>
+    /// The whole point: source selected, backups loaded, database landed - the only thing left is
+    /// the restore point.
+    /// </summary>
+    [Fact]
+    public async Task TheRestoreScreenArrivesLoadedAndPointedAtTheDatabase()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(Container());
+
+        var blob = new FakeBlobStorageService
+        {
+            Files = [File_("Sales", "Sales_20260807_220000.bak"), File_("Payroll", "b.bak")]
+        };
+        var vm = Restore(store, blob);
+
+        await vm.AcceptHandoffAsync(new BrowseHandoff(
+            BackupMedium.AzureBlob, Container(), null, "SRV01", "Sales"));
+
+        Assert.Equal(BackupMedium.AzureBlob, vm.SelectedMedium);
+        Assert.Equal("c1", vm.SelectedContainer?.Id);
+        Assert.True(vm.Inventory.BackupsLoaded);
+        Assert.Equal("Sales", vm.Inventory.SelectedDatabaseName);
+    }
+
+    /// <summary>
+    /// A database the load did not find is not selected - forcing it would put the working set
+    /// into a state the screen cannot reach by hand.
+    /// </summary>
+    [Fact]
+    public async Task ADatabaseTheLoadDidNotFindIsNotForced()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(Container());
+
+        var blob = new FakeBlobStorageService { Files = [File_("Sales", "a.bak")] };
+        var vm = Restore(store, blob);
+
+        await vm.AcceptHandoffAsync(new BrowseHandoff(
+            BackupMedium.AzureBlob, Container(), null, null, "Ghost"));
+
+        Assert.True(vm.Inventory.BackupsLoaded);
+        Assert.Null(vm.Inventory.SelectedDatabaseName);
+    }
+
+    /// <summary>
+    /// The shell's half of the contract: the browser's command lands the app on the restore
+    /// screen with the handoff's source selected. The load itself fails against the fake
+    /// container's URL, which is fine - navigation and selection are what the shell owes.
+    /// </summary>
+    [Fact]
+    public void TheShellLandsOnTheRestoreScreenWithTheSourceSelected()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Pro;
+        store.Config.BlobContainers.Add(Container());
+
+        var main = new MainViewModel(store);
+        main.ModeSelection.CancelCommand.Execute(null);
+        main.NavigateToCommand.Execute(MainViewModel.Nav.BrowseBackups);
+
+        // The browser's state is the command's input, and both pieces are settable.
+        main.BlobBrowser.HasFiles = true;
+        main.BlobBrowser.SelectedDatabase = "Sales";
+
+        main.BlobBrowser.RestoreFromHereCommand.Execute(null);
+
+        Assert.Same(main.Restore, main.CurrentView);
+        Assert.Equal("c1", main.Restore.SelectedContainer?.Id);
+        Assert.Equal(BackupMedium.AzureBlob, main.Restore.SelectedMedium);
+    }
+}

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -7,6 +7,25 @@ using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.ViewModels;
 
+/// <summary>
+/// Everything the restore screen needs to pick up where the browser left off (#202).
+///
+/// The browser answers "what do I actually have?", and once it has answered, making somebody
+/// re-select the same source, server and database by hand on the restore screen is the app
+/// repeating a question it already asked.
+/// </summary>
+/// <param name="Medium">Which source the browser was looking at.</param>
+/// <param name="Container">The container, when the medium is blob.</param>
+/// <param name="SourceServer">The instance whose history was read, when it is not.</param>
+/// <param name="ServerFilter">The server/instance filter in force, if any.</param>
+/// <param name="Database">The database to land on.</param>
+public sealed record BrowseHandoff(
+    BackupMedium Medium,
+    BlobContainerConfig? Container,
+    ServerConnection? SourceServer,
+    string? ServerFilter,
+    string? Database);
+
 public partial class BlobBrowserViewModel : ViewModelBase
 {
     private readonly IBlobStorageService _blobService;
@@ -182,6 +201,7 @@ public partial class BlobBrowserViewModel : ViewModelBase
     {
         ApplyFilter();
         UpdateFilteredSummary();
+        OnPropertyChanged(nameof(CanRestoreFromHere));
     }
 
     [RelayCommand]
@@ -413,6 +433,36 @@ public partial class BlobBrowserViewModel : ViewModelBase
     [RelayCommand]
     private void CopyPathContainer(BackupFileInfo? file)
         => CopyBlobContainerPath(file ?? SelectedFile, SelectedContainer);
+
+    // ── from looking to restoring (#202) ────────────────────────────────────────
+
+    /// <summary>Raised when somebody wants to restore what they found. The shell wires it.</summary>
+    public event Action<BrowseHandoff>? RestoreRequested;
+
+    /// <summary>
+    /// Jumps to the restore screen with everything already answered (#202).
+    ///
+    /// The parameter is a database name when it came from a row's context menu; null means "use
+    /// the database filter in force", which is what the button under the summary does.
+    /// </summary>
+    [RelayCommand]
+    private void RestoreFromHere(string? database)
+    {
+        var target = string.IsNullOrWhiteSpace(database) ? SelectedDatabase : database;
+        if (string.IsNullOrWhiteSpace(target)) return;
+
+        RestoreRequested?.Invoke(new BrowseHandoff(
+            SelectedMedium,
+            MediumIsBlob ? SelectedContainer : null,
+            MediumIsSharedPath ? SourceServer : null,
+            SelectedServer,
+            target));
+    }
+
+    /// <summary>Whether there is anything to hand over - a database chosen, from a loaded source.</summary>
+    public bool CanRestoreFromHere => HasFiles && !string.IsNullOrWhiteSpace(SelectedDatabase);
+
+    partial void OnHasFilesChanged(bool value) => OnPropertyChanged(nameof(CanRestoreFromHere));
 
     /// <summary>
     /// The path a file on disk actually has (#197).

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -208,6 +208,14 @@ public partial class MainViewModel : ViewModelBase
 
         ServerManager.ConnectionChanged += OnSqlConnectionChanged;
 
+        // From looking to restoring in one move (#202). Navigation first, so the load's progress
+        // happens on the screen the user is now watching rather than behind the one they left.
+        BlobBrowser.RestoreRequested += handoff =>
+        {
+            NavigateTo(Nav.Restore);
+            _ = Restore.AcceptHandoffAsync(handoff);
+        };
+
         // Changing the mode from Settings has to move the app immediately - a sidebar that still
         // offers a screen the new mode hides, or a screen left on display underneath one that no
         // longer lists it, is worse than not offering the setting (#176).

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -523,6 +523,43 @@ public partial class RestoreViewModel : ViewModelBase
         ClearLoadedBackups();
     }
 
+    /// <summary>
+    /// Picks up where the browser left off (#202): same source, same server, same database,
+    /// backups loaded - so the only thing left to do here is choose the restore point.
+    /// </summary>
+    public async Task AcceptHandoffAsync(BrowseHandoff handoff)
+    {
+        SelectedMedium = handoff.Medium == BackupMedium.SharedPath
+            ? BackupMedium.SharedPath
+            : BackupMedium.AzureBlob;
+
+        if (handoff.Medium == BackupMedium.SharedPath)
+        {
+            // By id against OUR list, because the browser's instance and this screen's are
+            // separate objects loaded from the same config.
+            SourceServer = SourceServers.FirstOrDefault(s => s.Id == handoff.SourceServer?.Id)
+                           ?? handoff.SourceServer;
+        }
+        else if (handoff.Container != null)
+        {
+            SelectedContainer = Containers.FirstOrDefault(c => c.Id == handoff.Container.Id)
+                                ?? handoff.Container;
+        }
+
+        await LoadBackupsCommand.ExecuteAsync(null);
+
+        // The filters land only when the load found them - a database the load did not see would
+        // put the working set into a state the screen cannot have reached by hand.
+        if (handoff.ServerFilter != null && Inventory.DiscoveredServers.Contains(handoff.ServerFilter))
+            Inventory.SelectedServerName = handoff.ServerFilter;
+
+        if (handoff.Database != null &&
+            Inventory.DiscoveredDatabases.Contains(handoff.Database, StringComparer.OrdinalIgnoreCase))
+            Inventory.SelectedDatabaseName =
+                Inventory.DiscoveredDatabases.First(d =>
+                    string.Equals(d, handoff.Database, StringComparison.OrdinalIgnoreCase));
+    }
+
     /// <summary>The saved connections, for choosing whose backup history to read.</summary>
     [ObservableProperty]
     private ObservableCollection<ServerConnection> _sourceServers = [];

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -129,6 +129,17 @@
                         <TextBlock Text="{Binding DbSummaryText}"
                                    Style="{StaticResource SecondaryText}"
                                    Margin="0,0,0,8" />
+
+                        <!-- From looking to restoring in one move (#202). The browser has already
+                             answered which source, server and database - making somebody re-answer
+                             all three on the restore screen was the app repeating itself. -->
+                        <Button Content="Restore this database"
+                                Command="{Binding RestoreFromHereCommand}"
+                                Style="{StaticResource PrimaryButton}"
+                                HorizontalAlignment="Left"
+                                Padding="14,7"
+                                Margin="0,0,0,8"
+                                Visibility="{Binding CanRestoreFromHere, Converter={StaticResource BoolToVis}}" />
                     </StackPanel>
                 </Grid>
             </StackPanel>
@@ -264,6 +275,10 @@
                                       Command="{Binding CopyLocalPathCommand}"
                                       CommandParameter="{Binding SelectedFile}"
                                       Visibility="{Binding MediumIsSharedPath, Converter={StaticResource BoolToVis}}" />
+                            <Separator />
+                            <MenuItem Header="Restore this database"
+                                      Command="{Binding RestoreFromHereCommand}"
+                                      CommandParameter="{Binding SelectedFile.InferredDatabaseName}" />
                         </ContextMenu>
                     </DataGrid.ContextMenu>
                     <DataGrid.Columns>


### PR DESCRIPTION
The browser answers "what do I actually have?", and until now it stopped there: having found the exact backup that matters, the only way to restore it was the restore screen and the whole selection again by hand — same source, same server, same database. The app repeating a question it already asked.

## Two ways in

- **A button under the summary** once a database is chosen — the case where somebody filtered their way to an answer.
- **"Restore this database" on every row** — the row hands over its *own* database, whatever the filter says.

## What the handoff carries

Source (container **or** server history — both browsing sources work), the server filter, and the database. The restore screen selects the same source by id against its own list, loads, and lands the filters **only when the load actually found them** — a database the load did not see would put the working set into a state the screen cannot reach by hand.

Navigation happens before the load, so the progress shows on the screen the user is now watching rather than behind the one they left.

6 new tests, 1,428 pass. Rendered — the button sits beside the summary.