### PR TITLE
Ask the certificate question before the restore, not after (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ built for.
 
 ### Changed
 
+- **TDE and encrypted backups are checked before the restore, not discovered by error 33111.**
+  The preflight reads both certificate thumbprints from the header it already fetches; a missing
+  certificate refuses by thumbprint - and by certificate NAME when the source instance can be
+  asked - with the BACKUP CERTIFICATE / CREATE CERTIFICATE route spelled out and passwords left
+  to whoever owns them. Copy Database warns before the backup half if the source database is TDE
+  and the target lacks its certificate (#222)
 - **Browse Backups hands over to Restore in one move** - a button once a database is chosen, and
   "Restore this database" on every row. The restore screen arrives with the same source selected,
   the backups loaded and the database landed, so the only thing left is choosing the restore

--- a/src/NineLives.Tests/EncryptionPreflightTests.cs
+++ b/src/NineLives.Tests/EncryptionPreflightTests.cs
@@ -1,0 +1,263 @@
+using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The certificate question, asked before the restore instead of answered by error 33111 (#222).
+///
+/// A TDE database's backups are encrypted with a key protected by a certificate in the SOURCE
+/// server's master; a backup taken WITH ENCRYPTION is protected by one directly. Either way,
+/// restoring on a server without that certificate fails - and without a preflight it fails
+/// mid-DR, staring at a thumbprint, with the source server possibly gone.
+/// </summary>
+public class EncryptionPreflightTests
+{
+    private static readonly byte[] Thumbprint = Convert.FromHexString("AABBCCDD");
+    private static readonly DateTime T0 = new(2026, 8, 7, 22, 0, 0);
+
+    // ── the guidance ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheRefusalNamesTheThumbprintTheErrorAndTheRoute()
+    {
+        var text = EncryptionGuidance.ExplainMissingCertificate(
+            isTde: true, Thumbprint, "SRV02", certificateNameOnSource: null, sourceServerName: null);
+
+        Assert.Contains("0xAABBCCDD", text);
+        Assert.Contains("33111", text);
+        Assert.Contains("BACKUP CERTIFICATE", text);
+        Assert.Contains("Nothing has been changed", text);
+    }
+
+    /// <summary>
+    /// When the source instance could be asked, the refusal names the certificate - BACKUP
+    /// CERTIFICATE takes a name, not a thumbprint, and mid-incident is the wrong time to go
+    /// looking for which one.
+    /// </summary>
+    [Fact]
+    public void KnowingTheSourceNamesTheCertificateAndBothServers()
+    {
+        var text = EncryptionGuidance.ExplainMissingCertificate(
+            isTde: true, Thumbprint, "SRV02", "TDE_Cert_2026", "SRV01");
+
+        Assert.Contains("[TDE_Cert_2026]", text);
+        Assert.Contains("On SRV01", text);
+        Assert.Contains("On SRV02, in master", text);
+        // The password is whoever-runs-it's to choose, never invented here.
+        Assert.DoesNotContain("PASSWORD = 'P", text);
+    }
+
+    [Fact]
+    public void ProtectionIsDescribedForWhatTheHeaderActuallySaid()
+    {
+        Assert.Empty(EncryptionGuidance.DescribeProtection(null, null));
+        Assert.Contains("TDE-encrypted database", EncryptionGuidance.DescribeProtection(Thumbprint, null));
+        Assert.Contains("file is encrypted", EncryptionGuidance.DescribeProtection(null, Thumbprint));
+
+        var both = EncryptionGuidance.DescribeProtection(Thumbprint, Thumbprint);
+        Assert.Contains("TDE", both);
+        Assert.Contains("encrypted", both);
+    }
+
+    // ── the restore preflight ───────────────────────────────────────────────────
+
+    private static ServerConnection Server(string name = "SRV02") =>
+        new() { Id = ServerConnection.NewId(), Name = name, ServerName = name };
+
+    /// <summary>A loaded ad-hoc chain whose header carries the given thumbprints.</summary>
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql, ServerConnection target)>
+        LoadedAsync(byte[]? tde = null, byte[]? encryptor = null)
+    {
+        var target = Server();
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(target);
+
+        var sql = new FakeSqlServerService
+        {
+            FileHeaders =
+            {
+                [@"D:\drop\MyDb.bak"] =
+                [
+                    new BackupHistoryEntry
+                    {
+                        DatabaseName = "MyDb",
+                        Type = BackupType.Full,
+                        StartedAt = T0,
+                        FinishedAt = T0.AddMinutes(1),
+                        CheckpointLsn = 100m,
+                        Position = 1,
+                        Files = [@"D:\drop\MyDb.bak"]
+                    }
+                ]
+            },
+            Header = new BackupFileInfo
+            {
+                DatabaseName = "MyDb",
+                Type = BackupType.Full,
+                BackupTypeCode = 1,
+                SoftwareVersionMajor = 16,
+                TdeThumbprint = tde,
+                EncryptorThumbprint = encryptor
+            },
+            ProductMajorVersion = 16
+        };
+
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), sql, new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(),
+            new FakeRestoreHistoryStore(), TestAuditStores.Temp())
+        {
+            Mode = AppMode.Pro
+        };
+        vm.RefreshContainers();
+
+        vm.SelectedMedium = BackupMedium.AdHocFile;
+        vm.SourceServer = vm.SourceServers[0];
+        vm.AdHocPathsText = @"D:\drop\MyDb.bak";
+        await vm.Inventory.LoadAsync(vm.CurrentLocation!);
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Last();
+
+        return (vm, sql, target);
+    }
+
+    /// <summary>The one this exists for: TDE backup, no certificate on the target, refused by name.</summary>
+    [Fact]
+    public async Task ATdeBackupWithoutTheCertificateRefusesBeforeAnythingRuns()
+    {
+        var (vm, _, target) = await LoadedAsync(tde: Thumbprint);
+
+        var result = await vm.PreflightAsync(target, _ => { });
+
+        Assert.False(result.CanProceed);
+        Assert.Contains("0xAABBCCDD", result.Refusal);
+        Assert.Contains("33111", result.Refusal);
+    }
+
+    [Fact]
+    public async Task ATdeBackupWithTheCertificatePresentProceedsAndSaysSo()
+    {
+        var (vm, sql, target) = await LoadedAsync(tde: Thumbprint);
+        sql.CertificatesByThumbprint["SRV02"] = new() { ["AABBCCDD"] = "TDE_Cert_2026" };
+
+        var log = new List<string>();
+        var result = await vm.PreflightAsync(target, log.Add);
+
+        Assert.True(result.CanProceed);
+        Assert.Contains(log, l => l.Contains("[TDE_Cert_2026]"));
+    }
+
+    /// <summary>An encrypted backup file follows the same rule via its own thumbprint.</summary>
+    [Fact]
+    public async Task AnEncryptedBackupFileIsCheckedTheSameWay()
+    {
+        var (vm, _, target) = await LoadedAsync(encryptor: Thumbprint);
+
+        var result = await vm.PreflightAsync(target, _ => { });
+
+        Assert.False(result.CanProceed);
+        Assert.Contains("backup file is encrypted", result.Refusal);
+    }
+
+    [Fact]
+    public async Task AnUnprotectedBackupIsNotSlowedDown()
+    {
+        var (vm, sql, target) = await LoadedAsync();
+
+        var result = await vm.PreflightAsync(target, _ => { });
+
+        Assert.True(result.CanProceed);
+        // No certificate question was ever asked of the target.
+        Assert.Empty(sql.CertificatesByThumbprint);
+    }
+
+    // ── the copy screen's early warning ─────────────────────────────────────────
+
+    private static (CopyDatabaseViewModel vm, FakeSqlServerService sql) Copy()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server("SRV01"));
+        store.Config.Servers.Add(Server("SRV02"));
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService
+        {
+            DatabaseFiles =
+            [
+                new FileMoveOption
+                {
+                    LogicalName = "MyDb",
+                    PhysicalName = @"D:\SQL\MyDb.mdf",
+                    NewPhysicalName = @"D:\SQL\MyDb.mdf",
+                    SizeBytes = 1024
+                }
+            ],
+            VolumeFreeSpace = new Dictionary<string, long> { [@"D:\"] = long.MaxValue / 2 }
+        };
+
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp());
+        vm.SourceServer = vm.Servers[0];
+        vm.TargetServer = vm.Servers[1];
+        vm.SourceDatabases = new ObservableCollection<string>(["MyDb"]);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetDatabaseName = "MyDb";
+        vm.Container = vm.Containers[0];
+
+        return (vm, sql);
+    }
+
+    /// <summary>
+    /// Known before the backup half runs: a backup the target can never read should not be taken
+    /// on the strength of this screen.
+    /// </summary>
+    [Fact]
+    public async Task CopyingATdeDatabaseWarnsWhenTheTargetLacksTheCertificate()
+    {
+        var (vm, sql) = Copy();
+        sql.TdeByDatabase["MyDb"] = (true, "TDE_Cert_2026");
+        sql.CertificatesByThumbprint["SRV01"] = new() { ["AABBCCDD"] = "TDE_Cert_2026" };
+        // SRV02 has nothing.
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.True(vm.HasEncryptionWarning);
+        Assert.Contains("TDE", vm.EncryptionWarning);
+        Assert.Contains("[TDE_Cert_2026]", vm.EncryptionWarning);
+        Assert.Contains("33111", vm.EncryptionWarning);
+    }
+
+    [Fact]
+    public async Task CopyingATdeDatabaseStaysQuietWhenTheTargetHoldsTheCertificate()
+    {
+        var (vm, sql) = Copy();
+        sql.TdeByDatabase["MyDb"] = (true, "TDE_Cert_2026");
+        sql.CertificatesByThumbprint["SRV01"] = new() { ["AABBCCDD"] = "TDE_Cert_2026" };
+        sql.CertificatesByThumbprint["SRV02"] = new() { ["AABBCCDD"] = "TDE_Cert_2026" };
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.False(vm.HasEncryptionWarning);
+    }
+
+    [Fact]
+    public async Task CopyingAPlainDatabaseAsksNoCertificateQuestions()
+    {
+        var (vm, _) = Copy();
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.False(vm.HasEncryptionWarning);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -245,6 +245,40 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Set to make asking about volumes fail - which must not become a warning (#32).</summary>
     public Exception? VolumeCheckThrows { get; set; }
 
+    /// <summary>Certificates on each server, keyed by server name then hex thumbprint (#222).</summary>
+    public Dictionary<string, Dictionary<string, string>> CertificatesByThumbprint { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public Task<string?> FindCertificateByThumbprintAsync(
+        ServerConnection server, byte[] thumbprint, CancellationToken ct = default)
+    {
+        var hex = Convert.ToHexString(thumbprint);
+        return Task.FromResult(
+            CertificatesByThumbprint.TryGetValue(server.ServerName, out var certs) &&
+            certs.TryGetValue(hex, out var name)
+                ? name
+                : (string?)null);
+    }
+
+    public Task<byte[]?> GetCertificateThumbprintAsync(
+        ServerConnection server, string certificateName, CancellationToken ct = default)
+    {
+        if (CertificatesByThumbprint.TryGetValue(server.ServerName, out var certs))
+            foreach (var (hex, name) in certs)
+                if (string.Equals(name, certificateName, StringComparison.OrdinalIgnoreCase))
+                    return Task.FromResult<byte[]?>(Convert.FromHexString(hex));
+
+        return Task.FromResult<byte[]?>(null);
+    }
+
+    /// <summary>TDE state per database name (#222).</summary>
+    public Dictionary<string, (bool IsEncrypted, string? CertificateName)> TdeByDatabase { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public Task<(bool IsEncrypted, string? CertificateName)> GetDatabaseTdeInfoAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+        => Task.FromResult(TdeByDatabase.TryGetValue(database, out var info) ? info : (false, null));
+
     /// <summary>What GetProductMajorVersionAsync answers - 16 is SQL Server 2022 (#210).</summary>
     public int? ProductMajorVersion { get; set; } = 16;
 
@@ -374,7 +408,9 @@ public sealed class FakeSqlServerService : ISqlServerService
         LastLsn = source.LastLsn,
         CheckpointLsn = source.CheckpointLsn,
         DatabaseBackupLsn = source.DatabaseBackupLsn,
-        SoftwareVersionMajor = source.SoftwareVersionMajor
+        SoftwareVersionMajor = source.SoftwareVersionMajor,
+        TdeThumbprint = source.TdeThumbprint,
+        EncryptorThumbprint = source.EncryptorThumbprint
     };
 
     /// <summary>Called with the token the viewmodel supplied, so a test can see it was cancellable.</summary>

--- a/src/NineLives/Models/BackupFileInfo.cs
+++ b/src/NineLives/Models/BackupFileInfo.cs
@@ -216,6 +216,19 @@ public class BackupFileInfo
     public int? BackupTypeCode { get; set; }
 
     /// <summary>
+    /// The TDE certificate's thumbprint when the backed-up database is TDE-encrypted, from
+    /// HEADERONLY (#222). The target must hold a certificate with this thumbprint or the restore
+    /// fails with error 33111 - the failure people discover mid-DR.
+    /// </summary>
+    public byte[]? TdeThumbprint { get; set; }
+
+    /// <summary>
+    /// The encrypting certificate's thumbprint when the backup FILE was taken WITH ENCRYPTION,
+    /// from HEADERONLY (#222). Same rule, same error number, different certificate.
+    /// </summary>
+    public byte[]? EncryptorThumbprint { get; set; }
+
+    /// <summary>
     /// The major version of the SQL Server that TOOK this backup, from HEADERONLY (#210).
     ///
     /// The one-directional law of RESTORE hangs on it: a backup from a newer major can never be

--- a/src/NineLives/Services/EncryptionGuidance.cs
+++ b/src/NineLives/Services/EncryptionGuidance.cs
@@ -1,0 +1,122 @@
+using System.Text;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// The certificate question, asked before the restore instead of answered by error 33111 (#222).
+///
+/// Two kinds of protection put a certificate between a backup and its restore:
+///
+///  - TDE: the database's own encryption rides along inside every backup, protected by a
+///    certificate in the SOURCE server's master. The header says so via TDEThumbprint.
+///  - Encrypted backups (WITH ENCRYPTION): the backup file itself is encrypted against a server
+///    certificate. The header says so via EncryptorThumbprint.
+///
+/// Either way the rule is the same: the TARGET must hold a certificate with that thumbprint, or
+/// the restore fails - and without a preflight it fails mid-DR, staring at a thumbprint, with the
+/// source server possibly gone. The thumbprint is in the header the preflight already reads
+/// (#210), and the certificate question is one query against master.sys.certificates.
+/// </summary>
+public static class EncryptionGuidance
+{
+    /// <summary>0x-prefixed uppercase hex, the way SQL Server prints thumbprints in error 33111.</summary>
+    public static string Hex(byte[] thumbprint) =>
+        "0x" + Convert.ToHexString(thumbprint);
+
+    /// <summary>What the header says the backup is protected by, for logs and metadata.</summary>
+    public static string DescribeProtection(byte[]? tdeThumbprint, byte[]? encryptorThumbprint) =>
+        (tdeThumbprint, encryptorThumbprint) switch
+        {
+            (null, null) => string.Empty,
+            (not null, null) => $"This backup is of a TDE-encrypted database (certificate thumbprint {Hex(tdeThumbprint!)}).",
+            (null, not null) => $"This backup file is encrypted (certificate thumbprint {Hex(encryptorThumbprint!)}).",
+            _ => $"This backup file is encrypted (thumbprint {Hex(encryptorThumbprint!)}) and the database " +
+                 $"inside it is TDE-encrypted (thumbprint {Hex(tdeThumbprint!)})."
+        };
+
+    /// <summary>
+    /// The refusal, with the whole way out spelled from the source side to the target side.
+    ///
+    /// The certificate name is included when the source instance could be asked for it, because
+    /// "back up certificate 0x9A3F..." is not something anybody can type - BACKUP CERTIFICATE
+    /// takes a name, and mid-incident is the wrong time to go looking for which one.
+    ///
+    /// The password and the file paths stay placeholders, never invented (#205's rule): the
+    /// private-key password protects the key material itself, and it belongs to whoever runs the
+    /// source server.
+    /// </summary>
+    public static string ExplainMissingCertificate(
+        bool isTde,
+        byte[] thumbprint,
+        string targetName,
+        string? certificateNameOnSource,
+        string? sourceServerName)
+    {
+        var sb = new StringBuilder();
+
+        sb.Append(isTde
+            ? "This backup is of a TDE-encrypted database, and its certificate is not on " +
+              $"{targetName}. The restore would fail with error 33111 - Cannot find server " +
+              $"certificate with thumbprint '{Hex(thumbprint)}'."
+            : "This backup file is encrypted, and the certificate it is encrypted against is not " +
+              $"on {targetName}. The restore would fail with error 33111 - Cannot find server " +
+              $"certificate with thumbprint '{Hex(thumbprint)}'.");
+
+        sb.Append(' ');
+
+        if (certificateNameOnSource != null && sourceServerName != null)
+        {
+            sb.Append($"On {sourceServerName} that thumbprint is certificate " +
+                      $"[{certificateNameOnSource}]. Export it there and create it here:\n\n" +
+                      $"-- On {sourceServerName}:\n" +
+                      $"BACKUP CERTIFICATE [{certificateNameOnSource}] " +
+                      "TO FILE = '<path>.cer' " +
+                      "WITH PRIVATE KEY (FILE = '<path>.pvk', " +
+                      "ENCRYPTION BY PASSWORD = '<a password whoever runs it chooses>');\n\n" +
+                      $"-- On {targetName}, in master:\n" +
+                      $"CREATE CERTIFICATE [{certificateNameOnSource}] " +
+                      "FROM FILE = '<path>.cer' " +
+                      "WITH PRIVATE KEY (FILE = '<path>.pvk', " +
+                      "DECRYPTION BY PASSWORD = '<the same password>');");
+        }
+        else
+        {
+            sb.Append("The certificate lives in the master database of the server that took the " +
+                      "backup. Find it by thumbprint there - SELECT name FROM sys.certificates " +
+                      $"WHERE thumbprint = {Hex(thumbprint)} - then BACKUP CERTIFICATE it to files " +
+                      $"and CREATE CERTIFICATE from those files in {targetName}'s master.");
+        }
+
+        sb.Append(isTde
+            ? "\n\nNothing has been changed on the server or the database. TDE certificates " +
+              "protect the key that decrypts the data itself - restoring this backup anywhere " +
+              "will always need that certificate first."
+            : "\n\nNothing has been changed on the server or the database.");
+
+        return sb.ToString();
+    }
+
+    /// <summary>The all-clear, said out loud because silence would look like the check never ran.</summary>
+    public static string ExplainPresent(bool isTde, string certificateName, string targetName) =>
+        isTde
+            ? $"{targetName} holds certificate [{certificateName}] matching this backup's TDE thumbprint."
+            : $"{targetName} holds certificate [{certificateName}] matching this backup's encryption thumbprint.";
+
+    /// <summary>
+    /// The copy screen's early warning: the source database is TDE and the target lacks the
+    /// certificate, known BEFORE the backup half runs - a backup the target can never read should
+    /// not be taken on the strength of this screen.
+    /// </summary>
+    public static string ExplainCopyOfTdeDatabase(
+        string database, string targetName, string? certificateNameOnSource)
+    {
+        var cert = certificateNameOnSource == null
+            ? "its TDE certificate"
+            : $"its TDE certificate [{certificateNameOnSource}]";
+
+        return $"[{database}] is TDE-encrypted, and {targetName} does not hold {cert}. The backup " +
+               "half of this copy would succeed and the restore half would fail with error 33111. " +
+               $"Create the certificate on {targetName} first - export it from the source's master " +
+               "with BACKUP CERTIFICATE, then CREATE CERTIFICATE FROM FILE on the target.";
+    }
+}

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -36,6 +36,24 @@ public interface ISqlServerService
     Task<List<FileMoveOption>> GetDatabaseFilesAsync(
         ServerConnection server, string database, CancellationToken ct = default);
 
+    /// <summary>
+    /// The name of the certificate in this instance's master with the given thumbprint, or null
+    /// when there is none (#222). The question error 33111 answers too late.
+    /// </summary>
+    Task<string?> FindCertificateByThumbprintAsync(
+        ServerConnection server, byte[] thumbprint, CancellationToken ct = default);
+
+    /// <summary>The thumbprint of a named certificate in this instance's master, or null (#222).</summary>
+    Task<byte[]?> GetCertificateThumbprintAsync(
+        ServerConnection server, string certificateName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Whether a database on this instance is TDE-encrypted, and by which certificate (#222).
+    /// The certificate name is best effort - it needs VIEW SERVER STATE - and null when unknown.
+    /// </summary>
+    Task<(bool IsEncrypted, string? CertificateName)> GetDatabaseTdeInfoAsync(
+        ServerConnection server, string database, CancellationToken ct = default);
+
     /// <summary>SERVERPROPERTY('ProductMajorVersion') - 16 is SQL Server 2022 - or null if it did not say (#210).</summary>
     Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default);
 

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -690,7 +690,9 @@ public class SqlServerService : ISqlServerService
             LastLsn = GetDecimalFromReader(reader, "LastLSN"),
             DatabaseBackupLsn = GetDecimalFromReader(reader, "DatabaseBackupLSN"),
             CheckpointLsn = GetDecimalFromReader(reader, "CheckpointLSN"),
-            SoftwareVersionMajor = GetIntFromReader(reader, "SoftwareVersionMajor")
+            SoftwareVersionMajor = GetIntFromReader(reader, "SoftwareVersionMajor"),
+            TdeThumbprint = GetBytesFromReader(reader, "TDEThumbprint"),
+            EncryptorThumbprint = GetBytesFromReader(reader, "EncryptorThumbprint")
         };
         }, ct, "Reading the backup header");
     }
@@ -894,6 +896,27 @@ public class SqlServerService : ISqlServerService
             double db => (long)db,
             _ => null
         };
+    }
+
+    /// <summary>
+    /// A varbinary column, or null when it is NULL, empty, or absent - the encryption columns
+    /// arrived over several SQL Server versions, and a header from an old instance simply does
+    /// not have them (#222).
+    /// </summary>
+    private static byte[]? GetBytesFromReader(SqlDataReader reader, string columnName)
+    {
+        try
+        {
+            var ordinal = reader.GetOrdinal(columnName);
+            if (reader.IsDBNull(ordinal)) return null;
+
+            var value = reader.GetValue(ordinal) as byte[];
+            return value is { Length: > 0 } ? value : null;
+        }
+        catch (IndexOutOfRangeException)
+        {
+            return null;
+        }
     }
 
     private static int? GetIntFromReader(SqlDataReader reader, string columnName)
@@ -1192,6 +1215,66 @@ public class SqlServerService : ISqlServerService
         }
 
         return files;
+    }
+
+    public async Task<string?> FindCertificateByThumbprintAsync(
+        ServerConnection server, byte[] thumbprint, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+
+        cmd.CommandText = "SELECT name FROM master.sys.certificates WHERE thumbprint = @thumbprint";
+        cmd.Parameters.AddWithValue("@thumbprint", thumbprint);
+
+        return await cmd.ExecuteScalarAsync(ct) as string;
+    }
+
+    public async Task<byte[]?> GetCertificateThumbprintAsync(
+        ServerConnection server, string certificateName, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+
+        cmd.CommandText = "SELECT thumbprint FROM master.sys.certificates WHERE name = @name";
+        cmd.Parameters.AddWithValue("@name", certificateName);
+
+        return await cmd.ExecuteScalarAsync(ct) as byte[];
+    }
+
+    public async Task<(bool IsEncrypted, string? CertificateName)> GetDatabaseTdeInfoAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = "SELECT is_encrypted FROM sys.databases WHERE name = @database";
+            cmd.Parameters.AddWithValue("@database", database);
+
+            if (await cmd.ExecuteScalarAsync(ct) is not true) return (false, null);
+        }
+
+        // Which certificate, best effort: dm_database_encryption_keys needs VIEW SERVER STATE,
+        // and "TDE, certificate unknown" is still worth warning about.
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+                SELECT c.name
+                FROM sys.dm_database_encryption_keys AS dek
+                JOIN master.sys.certificates AS c ON c.thumbprint = dek.encryptor_thumbprint
+                WHERE dek.database_id = DB_ID(@database)";
+            cmd.Parameters.AddWithValue("@database", database);
+
+            return (true, await cmd.ExecuteScalarAsync(ct) as string);
+        }
+        catch
+        {
+            return (true, null);
+        }
     }
 
     public async Task<int?> GetProductMajorVersionAsync(

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -324,10 +324,74 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
         SetStatus("Scripts generated.");
 
-        // Fire and forget: the scripts are usable immediately, and the space answer arrives when
-        // the two instances have answered. A generation that had to wait on both would make the
-        // whole screen feel slower for a check that usually says "fine".
+        // Fire and forget: the scripts are usable immediately, and the answers arrive when the
+        // two instances have answered. A generation that had to wait on them would make the whole
+        // screen feel slower for checks that usually say "fine".
         _ = CheckSpaceAsync();
+        _ = CheckEncryptionAsync();
+    }
+
+    // ── will the target be able to READ it (#222) ───────────────────────────────
+
+    [ObservableProperty]
+    private string _encryptionWarning = string.Empty;
+
+    public bool HasEncryptionWarning => EncryptionWarning.Length > 0;
+
+    partial void OnEncryptionWarningChanged(string value) => OnPropertyChanged(nameof(HasEncryptionWarning));
+
+    /// <summary>
+    /// Whether the source database's TDE certificate exists on the target, asked BEFORE the
+    /// backup half runs (#222).
+    ///
+    /// TDE rides along inside every backup of an encrypted database, so a copy of one is only as
+    /// good as the target's ability to decrypt it - and without this check that is discovered by
+    /// the restore half, with the backup already taken and error 33111 on screen. The copy knows
+    /// its source, so sys.databases answers in one column.
+    ///
+    /// A warning rather than a block, same stance as the space check: certificates can be created
+    /// between generating and running, and this app is not the authority on somebody else's
+    /// security estate. Failing to answer raises nothing - warn on evidence, not on silence.
+    /// </summary>
+    private async Task CheckEncryptionAsync()
+    {
+        EncryptionWarning = string.Empty;
+
+        if (SourceServer == null || TargetServer == null || string.IsNullOrWhiteSpace(SourceDatabase))
+            return;
+
+        try
+        {
+            var (isEncrypted, certName) = await _sql.GetDatabaseTdeInfoAsync(SourceServer, SourceDatabase!);
+            if (!isEncrypted) return;
+
+            // The certificate itself, by thumbprint, when the source will say which it is - the
+            // name alone cannot be checked on the target, because names are not identity.
+            if (certName != null)
+            {
+                try
+                {
+                    var thumbprint = await _sql.GetCertificateThumbprintAsync(SourceServer, certName);
+                    if (thumbprint != null &&
+                        await _sql.FindCertificateByThumbprintAsync(TargetServer, thumbprint) != null)
+                        return;
+                }
+                catch
+                {
+                    // Fall through to the warning - TDE is confirmed even when the certificate
+                    // comparison could not be completed.
+                }
+            }
+
+            EncryptionWarning = EncryptionGuidance.ExplainCopyOfTdeDatabase(
+                SourceDatabase!, TargetServer.ServerName, certName);
+
+            _log.Warn($"[tde] copy: {EncryptionWarning}");
+        }
+        catch
+        {
+            // An instance that will not say has not said the database is encrypted.
+        }
     }
 
     // ── will it fit (#206) ──────────────────────────────────────────────────────

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2156,6 +2156,65 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Refuses a restore whose certificate is missing from the target (#222).
+    ///
+    /// Two thumbprints can appear in a header, and both mean the same thing: TDEThumbprint says
+    /// the database inside the backup is TDE-encrypted, EncryptorThumbprint says the backup file
+    /// itself was taken WITH ENCRYPTION. Either way the target must hold a certificate with that
+    /// thumbprint in master, or the restore fails with error 33111.
+    ///
+    /// When the source instance is known (the shared path knows it), the refusal also NAMES the
+    /// certificate there - BACKUP CERTIFICATE takes a name, not a thumbprint, and mid-incident is
+    /// the wrong time to go looking for which one. Null return means no objection.
+    /// </summary>
+    private async Task<CredentialPreflight?> CheckCertificatesAsync(
+        ServerConnection server, BackupFileInfo? header, Action<string> appendLog)
+    {
+        if (header == null) return null;
+
+        foreach (var (thumbprint, isTde) in new[]
+                 {
+                     (header.TdeThumbprint, true),
+                     (header.EncryptorThumbprint, false)
+                 })
+        {
+            if (thumbprint == null) continue;
+
+            appendLog(EncryptionGuidance.DescribeProtection(
+                isTde ? thumbprint : null, isTde ? null : thumbprint));
+
+            var onTarget = await _sqlService.FindCertificateByThumbprintAsync(server, thumbprint);
+            if (onTarget != null)
+            {
+                appendLog(EncryptionGuidance.ExplainPresent(isTde, onTarget, server.ServerName));
+                continue;
+            }
+
+            // Name the certificate on the source when an instance is there to ask - best effort,
+            // and only meaningful for media that HAVE a source instance.
+            string? sourceCertName = null;
+            var sourceServer = MediumIsBlob ? null : SourceServer;
+            if (sourceServer != null && sourceServer.Id != server.Id)
+            {
+                try
+                {
+                    sourceCertName =
+                        await _sqlService.FindCertificateByThumbprintAsync(sourceServer, thumbprint);
+                }
+                catch
+                {
+                    // The refusal stands on the thumbprint alone.
+                }
+            }
+
+            return CredentialPreflight.Stop(EncryptionGuidance.ExplainMissingCertificate(
+                isTde, thumbprint, server.ServerName, sourceCertName, sourceServer?.ServerName));
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Refuses a newer version's backup before anything is touched (#210).
     ///
     /// The one-directional law of RESTORE: a backup taken on a newer major version can never be
@@ -2201,6 +2260,11 @@ public partial class RestoreViewModel : ViewModelBase
                     appendLog("Versions are compatible.");
                     break;
             }
+
+            // The same header answers the certificate question (#222) - the failure that
+            // otherwise arrives as error 33111, mid-DR, with the source server possibly gone.
+            var certVerdict = await CheckCertificatesAsync(server, header, appendLog);
+            if (certVerdict is { } certificateStop) return certificateStop;
         }
         catch (Exception ex)
         {

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -198,6 +198,19 @@
                 <StackPanel>
                     <TextBlock Text="4. Run it" Style="{StaticResource SubHeaderText}" />
 
+                    <!-- Will the target be able to READ it (#222). TDE rides along inside every
+                         backup, and a copy of an encrypted database is only as good as the
+                         target's certificate - warned here, before the backup half runs. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,10,0,0"
+                            Background="{DynamicResource DangerPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource ErrorBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding HasEncryptionWarning, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding EncryptionWarning}"
+                                   TextWrapping="Wrap"
+                                   Style="{StaticResource BodyText}" />
+                    </Border>
+
                     <!-- Will it fit (#206). Same check and stance as the restore screen: a warning,
                          not a block - this app is not the authority on somebody else's storage. -->
                     <Border CornerRadius="4" Padding="10,8" Margin="0,10,0,0"


### PR DESCRIPTION
Parts 1+2 of #222. A TDE database's backups are encrypted with a key protected by a certificate in the **source** server's master; a backup taken `WITH ENCRYPTION` is protected by one directly. Either way the restore needs that certificate on the target, and without a preflight the answer arrives as **error 33111 — mid-DR, staring at a thumbprint, with the source server possibly gone.**

Every piece needed to prevent it was already in hand: the preflight reads the header (#210), and the header carries both thumbprints (`TDEThumbprint`, `EncryptorThumbprint` — now read, version-tolerantly, since the columns arrived over several SQL Server releases).

## The refusal is actionable, not just early

- Names the thumbprint the way SQL Server prints it (`0x…`), and the error number.
- **When the source instance is there to ask, names the certificate** — `BACKUP CERTIFICATE` takes a name, not a thumbprint, and mid-incident is the wrong time to go looking for which one. The full export/import route is spelled out for both servers.
- Paths and the private-key password stay placeholders, never invented — the password belongs to whoever runs the source server (#205's rule).
- The all-clear is said out loud too ("SRV02 holds certificate [TDE_Cert_2026] matching this backup's TDE thumbprint") — silence would look like the check never ran.

## Copy Database warns before the backup half

The copy knows its source: `sys.databases.is_encrypted` answers in one column at script generation, the certificate is compared **by thumbprint** (names are not identity), and the warning lands before a backup the target can never read gets taken. Warning rather than block — certificates can be created between generating and running.

No verdict from silence throughout, and an unprotected backup asks no certificate questions at all.

Part 3 (taking backups `WITH ENCRYPTION`) follows separately.

10 new tests, 1,438 pass.