### PR TITLE
Take backups WITH ENCRYPTION (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ built for.
 
 ### Changed
 
+- **Backups can be taken WITH ENCRYPTION** - AES-256 against a server certificate picked from
+  the source's own list (only certificates whose private key the backup can actually use are
+  offered). The caution is stated where the choice is made: every future restore target needs
+  that certificate first, so export it and keep it with the DR kit (#222)
 - **TDE and encrypted backups are checked before the restore, not discovered by error 33111.**
   The preflight reads both certificate thumbprints from the header it already fetches; a missing
   certificate refuses by thumbprint - and by certificate NAME when the source instance can be

--- a/src/NineLives.Tests/EncryptedBackupTests.cs
+++ b/src/NineLives.Tests/EncryptedBackupTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Taking backups WITH ENCRYPTION (#222, part 3).
+///
+/// An encrypted backup can only be restored where its certificate exists - which is the point,
+/// and also the trap. The UI states the caution; these pin that the statement is right and that
+/// encryption asked-for is never quietly dropped.
+/// </summary>
+public class EncryptedBackupTests
+{
+    // ── the statement ───────────────────────────────────────────────────────────
+
+    private static BackupOptions Options(string? certificate) => new()
+    {
+        DatabaseName = "MyDb",
+        Medium = BackupMedium.SharedPath,
+        Destinations = [@"\\nas01\backups\MyDb.bak"],
+        EncryptionCertificate = certificate
+    };
+
+    [Fact]
+    public void TheClauseNamesAes256AndTheCertificate()
+    {
+        var script = new BackupScriptGenerator().Generate(Options("BackupCert2026"));
+
+        Assert.Contains("ENCRYPTION (ALGORITHM = AES_256, SERVER CERTIFICATE = [BackupCert2026])", script);
+    }
+
+    [Fact]
+    public void NoCertificateMeansNoClause()
+    {
+        var script = new BackupScriptGenerator().Generate(Options(null));
+
+        Assert.DoesNotContain("ENCRYPTION", script);
+    }
+
+    /// <summary>Quoting goes through TSql - a bracket in a certificate name cannot break out.</summary>
+    [Fact]
+    public void TheCertificateNameIsQuoted()
+    {
+        var script = new BackupScriptGenerator().Generate(Options("Odd]Name"));
+
+        Assert.Contains("SERVER CERTIFICATE = [Odd]]Name]", script);
+    }
+
+    // ── the screen ──────────────────────────────────────────────────────────────
+
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    private static (BackupViewModel vm, FakeSqlServerService sql) New()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server());
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService
+        {
+            DatabaseList = ["MyDb"],
+            BackupCertificates = ["BackupCert2026"]
+        };
+
+        var vm = new BackupViewModel(store, sql, TestLogs.Temp());
+        vm.Server = vm.Servers[0];
+        vm.Container = vm.Containers[0];
+
+        return (vm, sql);
+    }
+
+    /// <summary>The certificates ride along with the database list - same instance, same moment.</summary>
+    [Fact]
+    public async Task CertificatesLoadWithTheDatabases()
+    {
+        var (vm, _) = New();
+
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+
+        Assert.Equal(["BackupCert2026"], vm.EncryptionCertificates);
+    }
+
+    [Fact]
+    public async Task TheOnlyCertificateIsChosenWhenEncryptionIsTicked()
+    {
+        var (vm, _) = New();
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.SelectedDatabase = "MyDb";
+        vm.GenerateCommand.Execute(null);
+
+        vm.Encrypt = true;
+
+        Assert.Equal("BackupCert2026", vm.SelectedEncryptionCertificate);
+        Assert.Contains("ENCRYPTION (ALGORITHM = AES_256", vm.GeneratedScript);
+    }
+
+    /// <summary>
+    /// Encryption asked for with no certificate chosen generates nothing - a statement without the
+    /// clause is not a weaker statement, it is a different one.
+    /// </summary>
+    [Fact]
+    public async Task EncryptionWithoutACertificateRefusesToGenerate()
+    {
+        var (vm, sql) = New();
+        sql.BackupCertificates = [];
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.SelectedDatabase = "MyDb";
+
+        vm.Encrypt = true;
+
+        Assert.False(vm.CanGenerate);
+        Assert.True(vm.EncryptWantedButNoCertificate);
+    }
+
+    [Fact]
+    public async Task UntickingEncryptionDropsTheClause()
+    {
+        var (vm, _) = New();
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.SelectedDatabase = "MyDb";
+        vm.GenerateCommand.Execute(null);
+        vm.Encrypt = true;
+        Assert.Contains("ENCRYPTION", vm.GeneratedScript);
+
+        vm.Encrypt = false;
+
+        Assert.DoesNotContain("ENCRYPTION", vm.GeneratedScript);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -271,6 +271,13 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.FromResult<byte[]?>(null);
     }
 
+    /// <summary>What ListBackupCertificatesAsync answers (#222).</summary>
+    public List<string> BackupCertificates { get; set; } = [];
+
+    public Task<List<string>> ListBackupCertificatesAsync(
+        ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult(BackupCertificates.ToList());
+
     /// <summary>TDE state per database name (#222).</summary>
     public Dictionary<string, (bool IsEncrypted, string? CertificateName)> TdeByDatabase { get; } =
         new(StringComparer.OrdinalIgnoreCase);

--- a/src/NineLives/Models/BackupOptions.cs
+++ b/src/NineLives/Models/BackupOptions.cs
@@ -26,6 +26,17 @@ public class BackupOptions
     public List<string> Destinations { get; set; } = [];
 
     /// <summary>
+    /// The server certificate to encrypt the backup with, or null for none (#222).
+    ///
+    /// Always AES_256 when set - offering the weaker algorithms SQL Server still accepts would
+    /// be a menu of mistakes. An encrypted backup can only be restored where this certificate
+    /// exists, which is the point, and also the caution the UI states: a TDE database's backups
+    /// are already encrypted regardless, so this is for everything else - the plain database
+    /// whose stolen blob would otherwise be restorable by whoever holds the SAS.
+    /// </summary>
+    public string? EncryptionCertificate { get; set; }
+
+    /// <summary>
     /// COPY_ONLY, and on by default.
     ///
     /// A plain full backup resets the differential base on the source. Doing that to a production

--- a/src/NineLives/Services/BackupScriptGenerator.cs
+++ b/src/NineLives/Services/BackupScriptGenerator.cs
@@ -90,6 +90,10 @@ public class BackupScriptGenerator
         if (options.Compression) with.Add("COMPRESSION");
         if (options.Checksum) with.Add("CHECKSUM");
 
+        if (!string.IsNullOrWhiteSpace(options.EncryptionCertificate))
+            with.Add("ENCRYPTION (ALGORITHM = AES_256, " +
+                     $"SERVER CERTIFICATE = {TSql.QuoteName(options.EncryptionCertificate)})");
+
         // FORMAT implies INIT, and naming both is noise at best. FORMAT also discards whatever the
         // media set already held, so it is never inferred - only ever asked for.
         if (options.Format) with.Add("FORMAT");

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -43,6 +43,13 @@ public interface ISqlServerService
     Task<string?> FindCertificateByThumbprintAsync(
         ServerConnection server, byte[] thumbprint, CancellationToken ct = default);
 
+    /// <summary>
+    /// Certificates in this instance's master that can encrypt a backup (#222): private key held
+    /// and protected by the database master key. System certificates (##...##) are not offered.
+    /// </summary>
+    Task<List<string>> ListBackupCertificatesAsync(
+        ServerConnection server, CancellationToken ct = default);
+
     /// <summary>The thumbprint of a named certificate in this instance's master, or null (#222).</summary>
     Task<byte[]?> GetCertificateThumbprintAsync(
         ServerConnection server, string certificateName, CancellationToken ct = default);

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1230,6 +1230,35 @@ public class SqlServerService : ISqlServerService
         return await cmd.ExecuteScalarAsync(ct) as string;
     }
 
+    public async Task<List<string>> ListBackupCertificatesAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        var names = new List<string>();
+
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+
+        // BACKUP ... WITH ENCRYPTION needs the certificate's private key, protected by the
+        // database master key - a certificate without one (or with a password-protected key)
+        // fails at backup time, so it is not offered at all.
+        cmd.CommandText = @"
+            SELECT name
+            FROM master.sys.certificates
+            WHERE pvt_key_encryption_type = 'MK'
+              AND name NOT LIKE '##%'
+            ORDER BY name";
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var name = reader["name"]?.ToString();
+            if (!string.IsNullOrEmpty(name)) names.Add(name);
+        }
+
+        return names;
+    }
+
     public async Task<byte[]?> GetCertificateThumbprintAsync(
         ServerConnection server, string certificateName, CancellationToken ct = default)
     {

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -94,6 +94,19 @@ public partial class BackupViewModel : ViewModelBase
 
             Databases = new ObservableCollection<string>(names);
 
+            // The certificates ride along with the database list - same instance, same moment.
+            // Best effort: an instance that will not list them still backs up unencrypted.
+            try
+            {
+                EncryptionCertificates = new ObservableCollection<string>(
+                    await _sql.ListBackupCertificatesAsync(Server, ct));
+            }
+            catch
+            {
+                EncryptionCertificates = [];
+            }
+            OnPropertyChanged(nameof(EncryptWantedButNoCertificate));
+
             // Nothing is chosen for the user, the same rule the Restore screen learned - and here
             // the wrong choice means a production database read at full speed for several minutes.
             SelectedDatabase = null;
@@ -190,6 +203,38 @@ public partial class BackupViewModel : ViewModelBase
     [ObservableProperty]
     private string _description = string.Empty;
 
+    // ── encryption (#222) ───────────────────────────────────────────────────────
+
+    /// <summary>Whether to take the backup WITH ENCRYPTION. Off by default - it is a real choice.</summary>
+    [ObservableProperty]
+    private bool _encrypt;
+
+    /// <summary>Certificates on the source that can encrypt a backup, loaded with the databases.</summary>
+    [ObservableProperty]
+    private ObservableCollection<string> _encryptionCertificates = [];
+
+    [ObservableProperty]
+    private string? _selectedEncryptionCertificate;
+
+    /// <summary>
+    /// Encryption asked for on a server that offered no usable certificate - the checkbox is
+    /// honest about why the script is not appearing.
+    /// </summary>
+    public bool EncryptWantedButNoCertificate =>
+        Encrypt && EncryptionCertificates.Count == 0;
+
+    partial void OnEncryptChanged(bool value)
+    {
+        // The obvious default when there is exactly one thing to choose.
+        if (value && SelectedEncryptionCertificate == null && EncryptionCertificates.Count == 1)
+            SelectedEncryptionCertificate = EncryptionCertificates[0];
+
+        OnPropertyChanged(nameof(EncryptWantedButNoCertificate));
+        Invalidate();
+    }
+
+    partial void OnSelectedEncryptionCertificateChanged(string? value) => Invalidate();
+
     partial void OnCopyOnlyChanged(bool value) => Invalidate();
     partial void OnCompressionChanged(bool value) => Invalidate();
     partial void OnChecksumChanged(bool value) => Invalidate();
@@ -219,7 +264,10 @@ public partial class BackupViewModel : ViewModelBase
     public bool CanGenerate =>
         Server != null &&
         !string.IsNullOrWhiteSpace(SelectedDatabase) &&
-        (MediumIsBlob ? Container != null : !string.IsNullOrWhiteSpace(SharedPathRoot));
+        (MediumIsBlob ? Container != null : !string.IsNullOrWhiteSpace(SharedPathRoot)) &&
+        // Encryption asked for needs a certificate chosen - a statement without one is not a
+        // weaker statement, it is a different one.
+        (!Encrypt || !string.IsNullOrWhiteSpace(SelectedEncryptionCertificate));
 
     /// <summary>
     /// Rebuilds the script from the current options, or clears it.
@@ -263,6 +311,7 @@ public partial class BackupViewModel : ViewModelBase
             CopyOnly = CopyOnly,
             Compression = Compression,
             Checksum = Checksum,
+            EncryptionCertificate = Encrypt ? SelectedEncryptionCertificate : null,
             Description = string.IsNullOrWhiteSpace(Description) ? null : Description
         });
 

--- a/src/NineLives/Views/BackupView.xaml
+++ b/src/NineLives/Views/BackupView.xaml
@@ -157,6 +157,34 @@
                                       IsChecked="{Binding Checksum}"
                                       Style="{StaticResource DarkCheckBox}"
                                       ToolTip="What makes a later RESTORE VERIFYONLY mean anything. Without it, verifying can only confirm the file is readable." />
+
+                            <!-- WITH ENCRYPTION (#222). AES_256 always - the weaker algorithms
+                                 SQL Server still accepts would be a menu of mistakes. -->
+                            <CheckBox Content="ENCRYPTION (AES-256, server certificate)"
+                                      IsChecked="{Binding Encrypt}"
+                                      Style="{StaticResource DarkCheckBox}"
+                                      Margin="0,8,0,0"
+                                      ToolTip="Encrypts the backup itself. It can then only be restored on a server holding this certificate - which is the point. A TDE database's backups are already encrypted regardless; this is for everything else." />
+
+                            <StackPanel Visibility="{Binding Encrypt, Converter={StaticResource BoolToVis}}"
+                                        Margin="24,6,0,0">
+                                <TextBlock Text="CERTIFICATE" Style="{StaticResource LabelText}" />
+                                <ComboBox ItemsSource="{Binding EncryptionCertificates}"
+                                          SelectedItem="{Binding SelectedEncryptionCertificate}"
+                                          Style="{StaticResource DarkComboBox}" />
+                                <TextBlock Style="{StaticResource SecondaryText}"
+                                           TextWrapping="Wrap"
+                                           FontSize="11"
+                                           Margin="0,4,0,0"
+                                           Text="Every future restore target needs this certificate in its master first - export it with BACKUP CERTIFICATE and keep the files with your DR kit, or the backup is only as recoverable as this one server." />
+                                <TextBlock Style="{StaticResource SecondaryText}"
+                                           Foreground="{DynamicResource WarningBrush}"
+                                           TextWrapping="Wrap"
+                                           FontSize="11"
+                                           Margin="0,4,0,0"
+                                           Visibility="{Binding EncryptWantedButNoCertificate, Converter={StaticResource BoolToVis}}"
+                                           Text="This server offered no usable certificate - one whose private key is protected by the database master key. Create one in master, or untick encryption." />
+                            </StackPanel>
                         </StackPanel>
 
                         <StackPanel Grid.Column="2">


### PR DESCRIPTION
Part 3 of #222 — the other direction. Parts 1+2 (#223) stopped encrypted backups failing to restore; this lets the app produce them, because an unencrypted backup of a plain database is how a stolen blob gets restored by whoever holds the SAS.

- **AES-256 always.** SQL Server still accepts weaker algorithms; offering them would be a menu of mistakes.
- **Only certificates that can actually do the job are offered** — private key held and protected by the database master key, system `##…##` certificates excluded. One that would fail at backup time never appears.
- **Asking for encryption with no usable certificate says so in words** rather than greying a button, and generates nothing — a statement without the clause is not a weaker statement, it is a different one.
- **The caution lives where the choice is made**: every future restore target needs the certificate first — export it and keep it with the DR kit, or the backup is only as recoverable as the one server that took it. The parts-1+2 preflight is what then catches the day that advice wasn't followed, before error 33111 does.

Rendered — checkbox, picker with the only certificate auto-chosen, and the generated script carrying the clause. 8 new tests, 1,445 pass.