### PR TITLE
Come back where the app was left (#211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ built for.
 
 ### Changed
 
+- **The app comes back where it was left**: window size, position and maximised state, and the
+  screen that was in use - carrying on from the launch cards lands there rather than starting
+  again. Geometry is applied only when it still puts a grabbable title bar on a screen, so a
+  monitor unplugged since cannot swallow the window (#211)
 - **The end of a backup stops being a dead end**: a successful run offers "Verify what was
   written" - RESTORE VERIFYONLY over the exact devices the statement wrote - and the backup
   screen gains the same "Copy as Agent job" handover the restore screen has, because backups are

--- a/src/NineLives.Tests/RememberedWindowTests.cs
+++ b/src/NineLives.Tests/RememberedWindowTests.cs
@@ -59,7 +59,7 @@ public class RememberedWindowTests
 
     // ── the landing screen ──────────────────────────────────────────────────────
 
-    private static MainViewModel Main(AppMode mode = AppMode.Pro, string? lastScreen = null)
+    private static MainViewModel Shell(AppMode mode = AppMode.Pro, string? lastScreen = null)
     {
         var store = new FakeCredentialStore();
         store.Config.Mode = mode;
@@ -71,7 +71,7 @@ public class RememberedWindowTests
     [Fact]
     public void CarryingOnLandsOnTheLastScreen()
     {
-        var main = Main(lastScreen: MainViewModel.Nav.History);
+        var main = Shell(lastScreen: MainViewModel.Nav.History);
 
         main.ModeSelection.CancelCommand.Execute(null);
 
@@ -82,7 +82,7 @@ public class RememberedWindowTests
     [Fact]
     public void NothingRecordedLandsOnRestore()
     {
-        var main = Main();
+        var main = Shell();
 
         main.ModeSelection.CancelCommand.Execute(null);
 
@@ -96,7 +96,7 @@ public class RememberedWindowTests
     [Fact]
     public void AScreenTheModeDoesNotOfferFallsBackToRestore()
     {
-        var main = Main(AppMode.Basic, MainViewModel.Nav.CopyDatabase);
+        var main = Shell(AppMode.Basic, MainViewModel.Nav.CopyDatabase);
 
         main.ModeSelection.CancelCommand.Execute(null);
 
@@ -106,7 +106,7 @@ public class RememberedWindowTests
     [Fact]
     public void GarbageInTheConfigFallsBackToRestore()
     {
-        Assert.Equal(MainViewModel.Nav.Restore, Main().LandingScreen("No Such Screen"));
+        Assert.Equal(MainViewModel.Nav.Restore, Shell().LandingScreen("No Such Screen"));
     }
 
     // ── saving at shutdown ──────────────────────────────────────────────────────

--- a/src/NineLives.Tests/RememberedWindowTests.cs
+++ b/src/NineLives.Tests/RememberedWindowTests.cs
@@ -1,0 +1,162 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The app comes back where it was left (#211): window geometry, and the screen in use.
+///
+/// The small daily tax everyone pays without mentioning - resize, reposition, renavigate, every
+/// launch. The geometry is applied only when it still puts a grabbable title bar on a screen,
+/// because a monitor unplugged since must not swallow the window.
+/// </summary>
+public class RememberedWindowTests
+{
+    // ── the geometry guard ──────────────────────────────────────────────────────
+
+    private static WindowGeometry At(double left, double top, double w = 1200, double h = 800) =>
+        new() { Left = left, Top = top, Width = w, Height = h };
+
+    /// <summary>A single 1920x1080 screen, for the cases below.</summary>
+    private static bool Usable(WindowGeometry g) => g.IsUsableOn(0, 0, 1920, 1080);
+
+    [Fact]
+    public void APositionOnTheScreenIsUsable()
+    {
+        Assert.True(Usable(At(100, 100)));
+    }
+
+    /// <summary>People park windows half-off deliberately - partly off is fine.</summary>
+    [Fact]
+    public void PartlyOffTheEdgeIsStillUsable()
+    {
+        Assert.True(Usable(At(-400, 50)));
+        Assert.True(Usable(At(1700, 50, w: 800)));
+    }
+
+    /// <summary>The unplugged-monitor case: fully off the virtual screen, nothing to grab.</summary>
+    [Fact]
+    public void AWindowOnAMonitorThatIsGoneIsNotUsable()
+    {
+        Assert.False(Usable(At(-2500, 200)));   // was on a screen to the left
+        Assert.False(Usable(At(2500, 200)));    // was on a screen to the right
+        Assert.False(Usable(At(100, 1200)));    // title bar below the bottom
+    }
+
+    /// <summary>A maximised window sits a few pixels above zero - that is not "off screen".</summary>
+    [Fact]
+    public void TheMaximisedOffsetIsTolerated()
+    {
+        Assert.True(Usable(At(-8, -8)));
+    }
+
+    [Fact]
+    public void NonsenseSizesAreNotUsable()
+    {
+        Assert.False(Usable(At(100, 100, w: 50, h: 40)));
+    }
+
+    // ── the landing screen ──────────────────────────────────────────────────────
+
+    private static MainViewModel Main(AppMode mode = AppMode.Pro, string? lastScreen = null)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = mode;
+        store.Config.LastScreen = lastScreen;
+        return new MainViewModel(store);
+    }
+
+    /// <summary>Carrying on means carrying ON - the last screen, not a fixed one.</summary>
+    [Fact]
+    public void CarryingOnLandsOnTheLastScreen()
+    {
+        var main = Main(lastScreen: MainViewModel.Nav.History);
+
+        main.ModeSelection.CancelCommand.Execute(null);
+
+        Assert.Same(main.History, main.CurrentView);
+    }
+
+    /// <summary>Nothing recorded still lands on Restore, the app's centre (#209).</summary>
+    [Fact]
+    public void NothingRecordedLandsOnRestore()
+    {
+        var main = Main();
+
+        main.ModeSelection.CancelCommand.Execute(null);
+
+        Assert.Same(main.Restore, main.CurrentView);
+    }
+
+    /// <summary>
+    /// A screen the current mode no longer offers falls back to Restore - a guess at the nearest
+    /// cousin would be worse than the app's centre.
+    /// </summary>
+    [Fact]
+    public void AScreenTheModeDoesNotOfferFallsBackToRestore()
+    {
+        var main = Main(AppMode.Basic, MainViewModel.Nav.CopyDatabase);
+
+        main.ModeSelection.CancelCommand.Execute(null);
+
+        Assert.Same(main.Restore, main.CurrentView);
+    }
+
+    [Fact]
+    public void GarbageInTheConfigFallsBackToRestore()
+    {
+        Assert.Equal(MainViewModel.Nav.Restore, Main().LandingScreen("No Such Screen"));
+    }
+
+    // ── saving at shutdown ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ShutdownFilesGeometryAndScreen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Pro;
+
+        var main = new MainViewModel(store);
+        main.ModeSelection.CancelCommand.Execute(null);
+        main.NavigateToCommand.Execute(MainViewModel.Nav.History);
+
+        main.SaveShutdownState(At(120, 80));
+
+        Assert.Equal(MainViewModel.Nav.History, store.Config.LastScreen);
+        Assert.Equal(120, store.Config.Window?.Left);
+    }
+
+    /// <summary>
+    /// Closing from the launch cards records no screen - the cards are a question, not a place,
+    /// and recording them would land the next session on a screen that is not one.
+    /// </summary>
+    [Fact]
+    public void ClosingFromTheCardsRecordsNoScreen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Pro;
+        store.Config.LastScreen = MainViewModel.Nav.History;
+
+        var main = new MainViewModel(store);
+        // Still on the cards - never carried on.
+
+        main.SaveShutdownState(At(0, 0));
+
+        Assert.Null(store.Config.LastScreen);
+    }
+
+    /// <summary>A config that would not load is not written back (#7's rule, respected here too).</summary>
+    [Fact]
+    public void ABrokenConfigIsNotOverwrittenAtShutdown()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Pro;
+        store.Config.LoadError = "unreadable";
+
+        var main = new MainViewModel(store);
+        main.SaveShutdownState(At(0, 0));
+
+        Assert.Equal(0, store.SaveConfigCalls);
+    }
+}

--- a/src/NineLives/MainWindow.xaml.cs
+++ b/src/NineLives/MainWindow.xaml.cs
@@ -25,5 +25,47 @@ public partial class MainWindow : Window
         {
             // Icon load failure is non-fatal
         }
+
+        // Where the window was last time (#211): applied before first paint, and only when the
+        // position still puts a grabbable title bar on a screen - a monitor that was unplugged
+        // since must not swallow the window.
+        SourceInitialized += (_, _) =>
+        {
+            var saved = viewModel.SavedGeometry;
+            if (saved == null) return;
+
+            if (saved.IsUsableOn(
+                    SystemParameters.VirtualScreenLeft, SystemParameters.VirtualScreenTop,
+                    SystemParameters.VirtualScreenWidth, SystemParameters.VirtualScreenHeight))
+            {
+                Left = saved.Left;
+                Top = saved.Top;
+                Width = saved.Width;
+                Height = saved.Height;
+            }
+
+            // Maximised is remembered even when the position was not usable - it lands maximised
+            // on whichever screen Windows chose, which is what anyone means by "it was maximised".
+            if (saved.IsMaximized) WindowState = WindowState.Maximized;
+        };
+
+        Closing += (_, _) =>
+        {
+            // RestoreBounds, not Left/Top: a maximised window's own coordinates describe the
+            // maximised rectangle, and restoring those on next launch would recreate a
+            // maximised-sized window that is not actually maximised.
+            var bounds = WindowState == WindowState.Normal
+                ? new Rect(Left, Top, Width, Height)
+                : RestoreBounds;
+
+            viewModel.SaveShutdownState(new Models.WindowGeometry
+            {
+                Left = bounds.Left,
+                Top = bounds.Top,
+                Width = bounds.Width,
+                Height = bounds.Height,
+                IsMaximized = WindowState == WindowState.Maximized
+            });
+        };
     }
 }

--- a/src/NineLives/Models/WindowGeometry.cs
+++ b/src/NineLives/Models/WindowGeometry.cs
@@ -1,0 +1,47 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>
+/// Where the window was, so it comes back there (#211).
+///
+/// The app forgot its size, position and screen on every launch - the small daily tax everyone
+/// pays without mentioning. Captured on close, applied before first paint, and never trusted
+/// blindly: a position saved on a monitor that has since been unplugged would put the window
+/// somewhere nobody can click.
+/// </summary>
+public sealed class WindowGeometry
+{
+    public double Left { get; set; }
+    public double Top { get; set; }
+    public double Width { get; set; }
+    public double Height { get; set; }
+    public bool IsMaximized { get; set; }
+
+    /// <summary>
+    /// Whether this position still puts something clickable on a screen.
+    ///
+    /// The test is the title bar: at least a hand's width of the window's top edge must lie
+    /// within the virtual screen, because the title bar is how a window in the wrong place gets
+    /// dragged to the right one. A window that is merely partly off-screen is fine - people park
+    /// windows half-off deliberately.
+    /// </summary>
+    public bool IsUsableOn(double virtualLeft, double virtualTop, double virtualWidth, double virtualHeight)
+    {
+        if (Width < 200 || Height < 200) return false;
+
+        const double grabbable = 100;
+
+        var virtualRight = virtualLeft + virtualWidth;
+        var virtualBottom = virtualTop + virtualHeight;
+
+        // Some slice of the top edge, at least `grabbable` wide, inside the virtual bounds.
+        var overlapLeft = Math.Max(Left, virtualLeft);
+        var overlapRight = Math.Min(Left + Width, virtualRight);
+
+        var titleBarVisible =
+            overlapRight - overlapLeft >= grabbable &&
+            Top >= virtualTop - 8 &&          // -8: maximised windows sit slightly above 0
+            Top <= virtualBottom - grabbable; // and the bar itself must not be below the bottom
+
+        return titleBarVisible;
+    }
+}

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -311,6 +311,16 @@ public class AppConfig
     /// </summary>
     public AppMode? Mode { get; set; }
 
+    /// <summary>Where the window was when the app closed, or null before the first close (#211).</summary>
+    public WindowGeometry? Window { get; set; }
+
+    /// <summary>
+    /// The screen in use when the app closed (#211). Carrying on from the launch cards lands here
+    /// - carrying on means carrying ON, not starting again - falling back to Restore when the
+    /// screen is unknown or the current mode no longer offers it.
+    /// </summary>
+    public string? LastScreen { get; set; }
+
     /// <summary>Check GitHub for a newer release at startup. Turn off for offline installs.</summary>
     public bool CheckForUpdates { get; set; } = true;
 

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -106,6 +106,44 @@ public partial class MainViewModel : ViewModelBase
         NavigateTo(_modeCardsReturnTo);
     }
 
+    /// <summary>
+    /// Where carrying on from the launch cards lands (#211): the last session's screen when it is
+    /// still a screen this mode offers, Restore otherwise. Restore rather than the recorded
+    /// screen's nearest cousin, because a guess about intent is worse than the app's centre.
+    /// </summary>
+    internal string LandingScreen(string? lastScreen) =>
+        lastScreen != null && Nav.Views.Contains(lastScreen) && IsViewAvailable(lastScreen)
+            ? lastScreen
+            : Nav.Restore;
+
+    /// <summary>
+    /// Files everything the next launch wants back: where the window was, and which screen was in
+    /// use (#211). Called once, at close - geometry changes are not worth a disk write each.
+    ///
+    /// Silent on failure, deliberately: the app is shutting down, and there is nobody left to act
+    /// on an error about remembering window positions. The store itself refuses to save over a
+    /// config that failed to load (#7), and that refusal is respected here too.
+    /// </summary>
+    public void SaveShutdownState(WindowGeometry geometry)
+    {
+        try
+        {
+            var config = _credentialStore.LoadConfig();
+            if (config.LoadError != null) return;
+
+            config.Window = geometry;
+            config.LastScreen = IsChoosingMode ? null : CurrentViewName;
+            _credentialStore.SaveConfig(config);
+        }
+        catch
+        {
+            // Shutdown. Nothing useful can be done with a failure here.
+        }
+    }
+
+    /// <summary>The geometry the last session saved, for the window to apply before first paint.</summary>
+    public WindowGeometry? SavedGeometry { get; private set; }
+
     /// <summary>Whether a sidebar entry is offered in the current mode.</summary>
     public bool IsViewAvailable(string viewName) => viewName switch
     {
@@ -232,8 +270,13 @@ public partial class MainViewModel : ViewModelBase
         // An unreadable or unrecognised value lands on Pro rather than Basic: hiding features from
         // somebody whose config got mangled is a worse failure than showing too many, because the
         // second is untidy and the first looks like the app has lost a capability.
-        var savedMode = _credentialStore.LoadConfig().Mode;
+        var config = _credentialStore.LoadConfig();
+        var savedMode = config.Mode;
         Mode = savedMode ?? AppMode.Pro;
+
+        // The window applies this before first paint (#211) - read here so the window never
+        // touches the store itself.
+        SavedGeometry = config.Window;
 
         if (savedMode == null)
         {
@@ -253,10 +296,10 @@ public partial class MainViewModel : ViewModelBase
             // that shape with no indication why. It is only a question the first time - after that
             // the current mode is marked and "Keep what I have" carries straight on.
             //
-            // Straight on TO RESTORE (#209): the same place choosing a mode lands, because carrying
-            // on and choosing-the-same-thing are the same decision - and the container list is the
-            // landing #200 existed to get away from.
-            ShowModeCards(Nav.Restore);
+            // Straight on to where the last session WAS (#211), or to Restore - the same place
+            // choosing a mode lands (#209) - when nothing is recorded or the mode no longer
+            // offers it. Carrying on means carrying on.
+            ShowModeCards(LandingScreen(config.LastScreen));
         }
 
         // Fire and forget - startup must not wait on the network.


### PR DESCRIPTION
Window size, position and maximised state, and the screen that was in use — the small daily tax everyone paid without mentioning: resize, reposition, renavigate, every launch.

## The geometry

- **Captured once at close** — from `RestoreBounds` when maximised, because a maximised window's own coordinates describe the maximised rectangle, and restoring those would recreate a maximised-*sized* window that isn't actually maximised.
- **Applied before first paint, and only when usable**: the saved position must still put a hand's width of title bar inside the virtual screen — the title bar is how a window in the wrong place gets dragged to the right one, and a monitor unplugged since must not swallow the window. Partly off-screen stays honoured (people park windows half-off deliberately); the maximised −8px offset is tolerated.

## The screen

Carrying on from the launch cards lands on the **last session's screen** — which is what carrying on means — falling back to Restore (#209's landing) when nothing is recorded or the mode no longer offers it. Closing from the cards records no screen: the cards are a question, not a place.

\#7's rule (never save over a config that failed to load) is respected at shutdown too, and a shutdown save failure is silent — there is nobody left to act on it.

12 new tests, 1,463 pass.