### PR TITLE
Halve the download: compress the single-file bundle (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ built for.
 
 ### Changed
 
+- **The download is 55% smaller** - 71 MB instead of 157 MB - by compressing the single-file
+  bundle. Measured before enabling: time-to-first-window is unchanged, hidden entirely inside the
+  splash dwell (#212)
 - **The app comes back where it was left**: window size, position and maximised state, and the
   screen that was in use - carrying on from the launch cards lands there rather than starting
   again. Geometry is applied only when it still puts a grabbable title bar on a screen, so a

--- a/src/NineLives/Properties/PublishProfiles/SingleFileExe.pubxml
+++ b/src/NineLives/Properties/PublishProfiles/SingleFileExe.pubxml
@@ -40,6 +40,18 @@
       starts to matter.
     -->
     <PublishReadyToRun>false</PublishReadyToRun>
+
+    <!--
+      On, and measured the same way ReadyToRun was measured off (#212):
+
+        uncompressed   156.8 MB   time-to-first-window 3.3-4.5s
+        compressed      71.0 MB   time-to-first-window 3.4-4.4s
+
+      55% smaller, and the decompression cost is invisible inside the startup noise - both
+      builds are dominated by the deliberate splash dwell. For an unsigned portable exe fetched
+      from a Releases page (#33), half the download is the difference that matters.
+    -->
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <!-- Same reasoning as Directory.Build.props: a single-file publish restore drags in an
          SDK-versioned tool pack, so it must not rewrite the committed lock file. Repeated
          here because a publish profile is imported after Directory.Build.props, too late


### PR DESCRIPTION
Measured the same way ReadyToRun was measured off (#39), recorded in the profile the same way:

| build | size | time-to-first-window |
|---|---|---|
| uncompressed | 156.8 MB | 3.3–4.5s |
| compressed | **71.0 MB** | 3.4–4.4s |

55% smaller; the decompression cost is invisible inside the startup noise — both builds are dominated by the splash dwell. For an unsigned portable exe fetched from a Releases page (#33), half the download is the difference that matters.

One property plus the measurement comment. The next `publish/` refresh ships compressed.