### PR TITLE
Move the configuration between machines, secrets stay behind (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ built for.
 
 ### Changed
 
+- **The configuration can move to another machine without moving a single secret** - export
+  writes containers, servers and settings to a file that is safe on a share or in a ticket (SAS
+  tokens and SQL passwords stay in Windows Credential Manager; a SAS pasted into a container URL
+  is stripped on the way out), and import adds and updates but never deletes. Each connection
+  asks for its credential again on the new machine (#213)
 - **Several databases can be backed up in one run** - tick them (or "All user databases"), one
   BACKUP per database sharing the same options, run database-at-a-time so a failure on the sixth
   names the sixth and the rest still run. The verify offer afterwards covers exactly what

--- a/src/NineLives.Tests/ConfigPortabilityTests.cs
+++ b/src/NineLives.Tests/ConfigPortabilityTests.cs
@@ -1,0 +1,166 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Moving the configuration between machines without moving a single secret (#213).
+///
+/// The boundary IS the feature: the exported file holds shapes - containers, servers, settings -
+/// and is safe on a share or in a ticket, because SAS tokens and SQL passwords live in Windows
+/// Credential Manager and never leave the machine.
+/// </summary>
+public class ConfigPortabilityTests
+{
+    private static AppConfig Config()
+    {
+        var config = new AppConfig { Mode = AppMode.Pro };
+
+        config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        config.Servers.Add(new ServerConnection
+        {
+            Id = "s1",
+            Name = "SRV01",
+            ServerName = "SRV01",
+            AuthMode = AuthMode.SqlAuth,
+            Username = "restore_svc",
+            UnsavedPassword = "NEVER-THIS"
+        });
+
+        return config;
+    }
+
+    // ── what leaves the machine ─────────────────────────────────────────────────
+
+    /// <summary>The one plain-sight secret: a SAS pasted into the container URL.</summary>
+    [Fact]
+    public void ASasPastedIntoTheUrlIsStrippedOnExport()
+    {
+        var config = Config();
+        config.BlobContainers[0].ContainerUrl =
+            "https://acct.blob.core.windows.net/backups?sv=2024&sig=SECRETSIGNATURE";
+
+        var json = ConfigPortability.Export(config);
+
+        Assert.DoesNotContain("SECRETSIGNATURE", json);
+        Assert.Contains("https://acct.blob.core.windows.net/backups", json);
+    }
+
+    /// <summary>An unsaved password in memory at export time does not travel.</summary>
+    [Fact]
+    public void AnUnsavedPasswordNeverReachesTheFile()
+    {
+        var json = ConfigPortability.Export(Config());
+
+        Assert.DoesNotContain("NEVER-THIS", json);
+        Assert.Contains("restore_svc", json); // the username is a shape, not a secret
+    }
+
+    /// <summary>Local-machine state stays local - the file describes the estate, not this desk.</summary>
+    [Fact]
+    public void WindowGeometryAndLastScreenStayLocal()
+    {
+        var config = Config();
+        config.Window = new WindowGeometry { Left = 100, Top = 100, Width = 1200, Height = 800 };
+        config.LastScreen = "History";
+
+        var json = ConfigPortability.Export(config);
+
+        Assert.DoesNotContain("LastScreen", json);
+        Assert.DoesNotContain("\"Window\"", json);
+    }
+
+    // ── the round trip ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AnExportReadsBackWhole()
+    {
+        var read = ConfigPortability.Read(ConfigPortability.Export(Config()));
+
+        Assert.NotNull(read);
+        Assert.Single(read!.BlobContainers);
+        Assert.Single(read.Servers);
+        Assert.Equal("SRV01", read.Servers[0].Name);
+        Assert.Equal(AppMode.Pro, read.Mode);
+    }
+
+    [Fact]
+    public void GarbageIsRefusedNotThrown()
+    {
+        Assert.Null(ConfigPortability.Read("this is not json"));
+    }
+
+    // ── the merge ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void NewEntriesAreAddedAndCountedAndCredentialNeedsNamed()
+    {
+        var local = new AppConfig { Mode = AppMode.Basic };
+        var imported = ConfigPortability.Read(ConfigPortability.Export(Config()))!;
+
+        var summary = ConfigPortability.Merge(local, imported);
+
+        Assert.Equal(1, summary.ContainersAdded);
+        Assert.Equal(1, summary.ServersAdded);
+        Assert.Single(local.BlobContainers);
+        Assert.Single(local.Servers);
+        Assert.Contains(summary.NeedCredentials, n => n.Contains("backups"));
+        Assert.Contains(summary.NeedCredentials, n => n.Contains("SRV01"));
+        Assert.Contains("Credentials do not travel", summary.Describe());
+    }
+
+    [Fact]
+    public void AMatchingIdUpdatesInPlace()
+    {
+        var local = Config();
+        var incoming = Config();
+        incoming.Servers[0].ServerName = "SRV01.internal.example";
+
+        var summary = ConfigPortability.Merge(local, ConfigPortability.Read(ConfigPortability.Export(incoming))!);
+
+        Assert.Equal(1, summary.ServersUpdated);
+        Assert.Single(local.Servers);
+        Assert.Equal("SRV01.internal.example", local.Servers[0].ServerName);
+    }
+
+    /// <summary>
+    /// Never deletes: a stale file taken last month must not silently remove this month's
+    /// containers. An import is additive or it is a trap.
+    /// </summary>
+    [Fact]
+    public void WhatTheFileDoesNotMentionSurvives()
+    {
+        var local = Config();
+        local.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c2",
+            Name = "newer-container",
+            ContainerUrl = "https://acct.blob.core.windows.net/newer"
+        });
+
+        var oldFile = ConfigPortability.Read(ConfigPortability.Export(Config()))!;
+        ConfigPortability.Merge(local, oldFile);
+
+        Assert.Contains(local.BlobContainers, c => c.Id == "c2");
+    }
+
+    /// <summary>A machine that chose its mode keeps it; one that never chose inherits the file's.</summary>
+    [Fact]
+    public void TheLocalModeIsNotOverwritten()
+    {
+        var chosen = new AppConfig { Mode = AppMode.Basic };
+        ConfigPortability.Merge(chosen, ConfigPortability.Read(ConfigPortability.Export(Config()))!);
+        Assert.Equal(AppMode.Basic, chosen.Mode);
+
+        var fresh = new AppConfig();
+        ConfigPortability.Merge(fresh, ConfigPortability.Read(ConfigPortability.Export(Config()))!);
+        Assert.Equal(AppMode.Pro, fresh.Mode);
+    }
+}

--- a/src/NineLives/Services/ConfigPortability.cs
+++ b/src/NineLives/Services/ConfigPortability.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// What an exported configuration file holds (#213). An explicit shape, not a dump of AppConfig,
+/// so what travels is decided here and secrets are impossible by construction rather than by
+/// remembering to exclude them.
+/// </summary>
+public sealed class ExportedConfig
+{
+    /// <summary>Format version, for reading files from newer or older builds politely.</summary>
+    public int FormatVersion { get; set; } = 1;
+
+    public string? ExportedBy { get; set; }
+    public DateTime ExportedAt { get; set; }
+
+    public List<BlobContainerConfig> BlobContainers { get; set; } = [];
+    public List<ServerConnection> Servers { get; set; } = [];
+
+    public AppMode? Mode { get; set; }
+    public AppTheme Theme { get; set; }
+    public bool CheckForUpdates { get; set; } = true;
+    public int LogRetentionDays { get; set; }
+}
+
+/// <summary>What an import did, in words somebody can check against what they expected.</summary>
+public sealed record ImportSummary(
+    int ContainersAdded, int ContainersUpdated,
+    int ServersAdded, int ServersUpdated,
+    IReadOnlyList<string> NeedCredentials)
+{
+    public string Describe()
+    {
+        var parts = new List<string>();
+
+        if (ContainersAdded > 0) parts.Add($"{ContainersAdded} container(s) added");
+        if (ContainersUpdated > 0) parts.Add($"{ContainersUpdated} container(s) updated");
+        if (ServersAdded > 0) parts.Add($"{ServersAdded} server(s) added");
+        if (ServersUpdated > 0) parts.Add($"{ServersUpdated} server(s) updated");
+        if (parts.Count == 0) parts.Add("Nothing new - everything in the file was already here");
+
+        var summary = string.Join(", ", parts) + ".";
+
+        if (NeedCredentials.Count > 0)
+            summary += " Credentials do not travel: " + string.Join(", ", NeedCredentials) +
+                       " will ask for theirs on first use.";
+
+        return summary;
+    }
+}
+
+/// <summary>
+/// Moves the configuration between machines without moving a single secret (#213).
+///
+/// The boundary IS the feature: SAS tokens and SQL passwords live in Windows Credential Manager
+/// and stay there, so the exported file holds shapes rather than secrets and is safe to put on a
+/// share or in a ticket. The one place a secret could hide in plain sight - a SAS pasted into a
+/// container URL - is stripped on export.
+/// </summary>
+public static class ConfigPortability
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static string Export(AppConfig config)
+    {
+        var exported = new ExportedConfig
+        {
+            ExportedBy = $"Nine Lives {AppVersion.Display}",
+            ExportedAt = DateTime.Now,
+            BlobContainers = config.BlobContainers.Select(Sanitise).ToList(),
+            Servers = config.Servers.Select(Clone).ToList(),
+            Mode = config.Mode,
+            Theme = config.Theme,
+            CheckForUpdates = config.CheckForUpdates,
+            LogRetentionDays = config.LogRetentionDays
+        };
+
+        return JsonSerializer.Serialize(exported, Options);
+    }
+
+    /// <summary>Null when the file is not an exported configuration at all.</summary>
+    public static ExportedConfig? Read(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<ExportedConfig>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Folds an exported file into the local configuration: adds what is new, updates what
+    /// matches by id, never deletes. Deleting on import would let a stale file taken last month
+    /// silently remove this month's containers - an import is additive or it is a trap.
+    /// </summary>
+    public static ImportSummary Merge(AppConfig target, ExportedConfig imported)
+    {
+        int containersAdded = 0, containersUpdated = 0, serversAdded = 0, serversUpdated = 0;
+        var needCredentials = new List<string>();
+
+        foreach (var incoming in imported.BlobContainers)
+        {
+            var clean = Sanitise(incoming);
+            var existing = target.BlobContainers.FirstOrDefault(c => c.Id == clean.Id);
+
+            if (existing == null)
+            {
+                target.BlobContainers.Add(clean);
+                containersAdded++;
+
+                if (clean.AuthMode == BlobAuthMode.SasToken)
+                    needCredentials.Add($"container {clean.Name}");
+            }
+            else
+            {
+                var index = target.BlobContainers.IndexOf(existing);
+                target.BlobContainers[index] = clean;
+                containersUpdated++;
+            }
+        }
+
+        foreach (var incoming in imported.Servers)
+        {
+            var clone = Clone(incoming);
+            var existing = target.Servers.FirstOrDefault(s => s.Id == clone.Id);
+
+            if (existing == null)
+            {
+                target.Servers.Add(clone);
+                serversAdded++;
+
+                if (clone.AuthMode.NeedsStoredPassword())
+                    needCredentials.Add($"server {clone.Name}");
+            }
+            else
+            {
+                var index = target.Servers.IndexOf(existing);
+                target.Servers[index] = clone;
+                serversUpdated++;
+            }
+        }
+
+        // Preferences travel only where the local machine has not said otherwise: mode and theme
+        // are taken from the file ONLY on a machine that never chose one. A jump box inheriting
+        // the exporting DBA's dark theme is fine; overwriting a choice this machine made is not.
+        target.Mode ??= imported.Mode;
+
+        return new ImportSummary(
+            containersAdded, containersUpdated, serversAdded, serversUpdated, needCredentials);
+    }
+
+    /// <summary>
+    /// A copy with the one plain-sight secret removed: a SAS pasted into the container URL. The
+    /// query string is not part of a container's identity, so nothing of value is lost.
+    /// </summary>
+    internal static BlobContainerConfig Sanitise(BlobContainerConfig source)
+    {
+        var clone = CloneViaJson(source);
+
+        var url = clone.ContainerUrl;
+        var query = url.IndexOf('?');
+        if (query >= 0) clone.ContainerUrl = url[..query];
+
+        return clone;
+    }
+
+    private static ServerConnection Clone(ServerConnection source) => CloneViaJson(source);
+
+    /// <summary>
+    /// Serialize-deserialize cloning, deliberately: it applies every [JsonIgnore] in the models,
+    /// so anything those marked as not-for-disk - unsaved passwords, unsaved SAS tokens - cannot
+    /// survive into the export even if a future field forgets this class exists.
+    /// </summary>
+    private static T CloneViaJson<T>(T source) =>
+        JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(source))!;
+}

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -24,6 +24,84 @@ public partial class SettingsViewModel : ViewModelBase
     private readonly ICredentialStore _credentialStore;
     private readonly OperationLog _log;
 
+    // ── moving machines (#213) ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Writes the configuration to a file that holds shapes rather than secrets - SAS tokens and
+    /// SQL passwords live in Windows Credential Manager and stay there, and a SAS pasted into a
+    /// container URL is stripped on the way out.
+    /// </summary>
+    [RelayCommand]
+    private void ExportConfig()
+    {
+        try
+        {
+            var dialog = new Microsoft.Win32.SaveFileDialog
+            {
+                Title = "Export configuration (no secrets)",
+                FileName = $"NineLives-config-{DateTime.Now:yyyyMMdd}.json",
+                Filter = "JSON configuration|*.json",
+                DefaultExt = ".json"
+            };
+
+            if (dialog.ShowDialog() != true) return;
+
+            var config = _credentialStore.LoadConfig();
+            System.IO.File.WriteAllText(dialog.FileName, ConfigPortability.Export(config));
+
+            SetStatus($"Exported to {dialog.FileName}. The file holds no secrets - credentials " +
+                      "are re-entered on the importing machine.");
+            _log.Info($"[config] exported to {dialog.FileName}");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Export failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Folds an exported file in: adds what is new, updates what matches, never deletes -
+    /// an import is additive or it is a trap.
+    /// </summary>
+    [RelayCommand]
+    private void ImportConfig()
+    {
+        try
+        {
+            var dialog = new Microsoft.Win32.OpenFileDialog
+            {
+                Title = "Import configuration",
+                Filter = "JSON configuration|*.json|All files|*.*"
+            };
+
+            if (dialog.ShowDialog() != true) return;
+
+            var imported = ConfigPortability.Read(System.IO.File.ReadAllText(dialog.FileName));
+            if (imported == null)
+            {
+                SetError("That file is not a Nine Lives configuration export.");
+                return;
+            }
+
+            var config = _credentialStore.LoadConfig();
+            if (config.LoadError != null)
+            {
+                SetError($"The local configuration could not be read, so nothing was imported: {config.LoadError}");
+                return;
+            }
+
+            var summary = ConfigPortability.Merge(config, imported);
+            _credentialStore.SaveConfig(config);
+
+            SetStatus(summary.Describe() + " Restart screens that list servers or containers to see them.");
+            _log.Info($"[config] imported from {dialog.FileName}: {summary.Describe()}");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Import failed: {ex.Message}");
+        }
+    }
+
     /// <summary>True while the constructor is filling the properties from config.</summary>
     private readonly bool _loading;
 

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -105,6 +105,28 @@
                 </StackPanel>
             </Border>
 
+            <!-- Moving machines (#213). The boundary is the feature: the file holds shapes,
+                 never secrets. -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,16,0,0">
+                <StackPanel>
+                    <TextBlock Text="Moving to another machine" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,10"
+                               Text="Export writes the containers, servers and settings to a file that holds NO secrets - SAS tokens and SQL passwords stay in this machine's Windows Credential Manager, and each connection asks for its credential again on the new machine. Import adds and updates; it never deletes." />
+                    <StackPanel Orientation="Horizontal">
+                        <Button Content="Export configuration..."
+                                Command="{Binding ExportConfigCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="14,7" Margin="0,0,8,0" />
+                        <Button Content="Import configuration..."
+                                Command="{Binding ImportConfigCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="14,7" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
         </StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
The jump-box problem: the app is a portable exe, but its configuration had to be rebuilt by hand on every machine. The obvious fix ships the config; the trap in the obvious fix is that a config file carrying credentials is a credential leak with a `.json` extension.

## The boundary is the feature

- **An explicit export shape, not a dump of AppConfig** — what travels is decided in one place, and secrets are impossible by construction. Cloning goes through the JSON serializer, so every `[JsonIgnore]` the models already carry (unsaved passwords, unsaved SAS tokens) is applied automatically — even for fields added later by someone who has never heard of this class.
- **The one plain-sight secret is stripped**: a SAS pasted into a container URL loses its query string on export. The query is not part of a container's identity.
- **Local state stays local** — window geometry, last screen. The file describes the estate, not the desk.

## Import is additive or it is a trap

Adds what is new, updates what matches by id, **never deletes** — a stale file from last month must not silently remove this month's containers. The summary names every connection that will ask for its credential on first use ("Credentials do not travel: container backups, server SRV01 will ask for theirs on first use"), because that is the part of the contract somebody could mistake in either direction. A machine that chose its mode keeps it.

Settings gains a "Moving to another machine" card with the boundary stated in plain text.

9 new tests, 1,479 pass.