### PR TITLE
Read the log inside the app that wrote it (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ built for.
 
 ### Changed
 
+- **The operation log is readable inside the app that wrote it** - today's file with a filter,
+  copy and refresh, from Settings. The support conversation is "what does the log say about X?",
+  not "navigate to this folder" (#214)
 - **The configuration can move to another machine without moving a single secret** - export
   writes containers, servers and settings to a file that is safe on a share or in a ticket (SAS
   tokens and SQL passwords stay in Windows Credential Manager; a SAS pasted into a container URL

--- a/src/NineLives.Tests/LogViewerTests.cs
+++ b/src/NineLives.Tests/LogViewerTests.cs
@@ -1,0 +1,91 @@
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The operation log, readable inside the app that wrote it (#214). A reader, not a log
+/// framework: today's file, a filter, a refresh - the shape of the actual support conversation,
+/// which is "what does the log say about X?".
+/// </summary>
+public class LogViewerTests
+{
+    private static (LogViewerViewModel vm, OperationLog log) New()
+    {
+        var log = TestLogs.Temp();
+        log.Info("connected to SRV01");
+        log.Warn("[space] restore may not fit");
+        log.Info("restore finished");
+
+        return (new LogViewerViewModel(log), log);
+    }
+
+    [Fact]
+    public void TodayFileIsShownWhole()
+    {
+        var (vm, log) = New();
+
+        Assert.Equal(log.CurrentFile, vm.CurrentFile);
+        Assert.Contains("connected to SRV01", vm.VisibleText);
+        Assert.Contains("restore finished", vm.VisibleText);
+        Assert.Contains("3 lines", vm.LineSummary);
+    }
+
+    [Fact]
+    public void TheFilterNarrowsAndCountsHonestly()
+    {
+        var (vm, _) = New();
+
+        vm.FilterText = "space";
+
+        Assert.Contains("may not fit", vm.VisibleText);
+        Assert.DoesNotContain("connected", vm.VisibleText);
+        Assert.Contains("1 of 3 lines match", vm.LineSummary);
+    }
+
+    [Fact]
+    public void TheFilterIsCaseInsensitive()
+    {
+        var (vm, _) = New();
+
+        vm.FilterText = "SRV01";
+        var upper = vm.VisibleText;
+        vm.FilterText = "srv01";
+
+        Assert.Equal(upper, vm.VisibleText);
+    }
+
+    /// <summary>New lines written after opening appear on refresh - the file is read shared.</summary>
+    [Fact]
+    public void RefreshPicksUpWhatWasWrittenSinceOpening()
+    {
+        var (vm, log) = New();
+
+        log.Info("a later line");
+        Assert.DoesNotContain("a later line", vm.VisibleText);
+
+        vm.RefreshCommand.Execute(null);
+
+        Assert.Contains("a later line", vm.VisibleText);
+    }
+
+    [Fact]
+    public void AnEmptyDaySaysSoInsteadOfShowingNothing()
+    {
+        var vm = new LogViewerViewModel(TestLogs.Temp());
+
+        Assert.Contains("Nothing logged today", vm.VisibleText);
+    }
+
+    [Fact]
+    public void ClearingTheFilterBringsEverythingBack()
+    {
+        var (vm, _) = New();
+        vm.FilterText = "space";
+        vm.FilterText = "";
+
+        Assert.Contains("connected to SRV01", vm.VisibleText);
+        Assert.Contains("3 lines", vm.LineSummary);
+    }
+}

--- a/src/NineLives/ViewModels/LogViewerViewModel.cs
+++ b/src/NineLives/ViewModels/LogViewerViewModel.cs
@@ -1,0 +1,124 @@
+using System.IO;
+using System.Text;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The operation log, readable inside the app that wrote it (#214).
+///
+/// The log is the app's own evidence trail - per-run records, header timings, credential
+/// decisions - and the app is the only tool guaranteed to be present when that trail is needed.
+/// "Open the log folder" hands somebody a directory of dated files and leaves them to it; this
+/// shows today's file, filtered, with a refresh - which covers the actual support conversation:
+/// "what does the log say about X?".
+///
+/// Deliberately not a log framework. A read of the current file with a filter over the lines
+/// covers the need; the file is opened shared so the app's own appends never fight the viewer.
+/// </summary>
+public partial class LogViewerViewModel : ViewModelBase
+{
+    private readonly OperationLog _log;
+
+    private List<string> _allLines = [];
+
+    public LogViewerViewModel(OperationLog? log = null)
+    {
+        _log = log ?? App.Log;
+        Refresh();
+    }
+
+    /// <summary>Which file is on screen, so what is being read is never a mystery.</summary>
+    [ObservableProperty]
+    private string _currentFile = string.Empty;
+
+    /// <summary>The lines after the filter, newest last - the shape the file has.</summary>
+    [ObservableProperty]
+    private string _visibleText = string.Empty;
+
+    [ObservableProperty]
+    private string _lineSummary = string.Empty;
+
+    /// <summary>Case-insensitive substring over whole lines. Empty shows everything.</summary>
+    [ObservableProperty]
+    private string _filterText = string.Empty;
+
+    partial void OnFilterTextChanged(string value) => ApplyFilter();
+
+    /// <summary>
+    /// Re-reads the file. A button rather than a timer: the log grows in bursts around
+    /// operations, and a viewer that re-reads on a schedule is churn for a file that is usually
+    /// not changing.
+    /// </summary>
+    [RelayCommand]
+    public void Refresh()
+    {
+        try
+        {
+            CurrentFile = _log.CurrentFile;
+
+            if (!File.Exists(CurrentFile))
+            {
+                _allLines = [];
+                VisibleText = "Nothing logged today yet.";
+                LineSummary = "0 lines";
+                return;
+            }
+
+            // FileShare.ReadWrite, because the app appends to this exact file while it is open
+            // here - the viewer must never make the log un-writable.
+            using var stream = new FileStream(
+                CurrentFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream, Encoding.UTF8);
+
+            var lines = new List<string>();
+            while (reader.ReadLine() is { } line) lines.Add(line);
+
+            _allLines = lines;
+            ApplyFilter();
+        }
+        catch (Exception ex)
+        {
+            VisibleText = $"The log could not be read: {ex.Message}";
+            LineSummary = string.Empty;
+        }
+    }
+
+    private void ApplyFilter()
+    {
+        var filter = FilterText.Trim();
+
+        var visible = filter.Length == 0
+            ? _allLines
+            : _allLines.Where(l => l.Contains(filter, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        VisibleText = string.Join(Environment.NewLine, visible);
+
+        LineSummary = filter.Length == 0
+            ? $"{_allLines.Count:N0} lines"
+            : $"{visible.Count:N0} of {_allLines.Count:N0} lines match";
+    }
+
+    [RelayCommand]
+    private void CopyVisible() =>
+        TryCopyToClipboard(VisibleText, "Log lines copied to clipboard.");
+
+    [RelayCommand]
+    private void OpenLogFolder()
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = _log.Directory,
+                UseShellExecute = true
+            });
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not open the log folder: {ex.Message}");
+        }
+    }
+}

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -231,6 +231,20 @@ public partial class SettingsViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Today's log, inside the app that wrote it (#214) - the support conversation is "what does
+    /// the log say about X?", not "navigate to this folder".
+    /// </summary>
+    [RelayCommand]
+    private void ViewLog()
+    {
+        var window = new Views.LogViewerWindow(new LogViewerViewModel(_log))
+        {
+            Owner = System.Windows.Application.Current?.MainWindow
+        };
+        window.Show();
+    }
+
+    /// <summary>
     /// Opens the log folder in Explorer. The logs are what someone attaches to a bug report, so
     /// there needs to be a way to find them that is not "know where LocalAppData is" (#40).
     /// </summary>

--- a/src/NineLives/Views/LogViewerWindow.xaml
+++ b/src/NineLives/Views/LogViewerWindow.xaml
@@ -1,0 +1,75 @@
+<Window x:Class="Blackcat.NineLives.Views.LogViewerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Operation Log - Nine Lives"
+        Width="1000" Height="700"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}">
+
+    <!-- The operation log, readable inside the app that wrote it (#214). A reader, not a log
+         framework: today's file, a filter, copy, refresh. -->
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Text="{Binding CurrentFile}"
+                   Style="{StaticResource SecondaryText}"
+                   FontFamily="Consolas"
+                   TextTrimming="CharacterEllipsis"
+                   Margin="0,0,0,10" />
+
+        <Grid Grid.Row="1" Margin="0,0,0,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBox Grid.Column="0"
+                     Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}"
+                     Style="{StaticResource DarkTextBox}"
+                     VerticalContentAlignment="Center"
+                     ToolTip="Show only lines containing this text. Case does not matter." />
+
+            <Button Grid.Column="1" Content="Refresh"
+                    Command="{Binding RefreshCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Padding="12,6" Margin="8,0,0,0" />
+            <Button Grid.Column="2" Content="Copy shown lines"
+                    Command="{Binding CopyVisibleCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Padding="12,6" Margin="8,0,0,0" />
+            <Button Grid.Column="3" Content="Open folder"
+                    Command="{Binding OpenLogFolderCommand}"
+                    Style="{StaticResource SecondaryButton}"
+                    Padding="12,6" Margin="8,0,0,0"
+                    ToolTip="Older days live here as dated files." />
+        </Grid>
+
+        <Border Grid.Row="2"
+                Background="{DynamicResource InputBackgroundBrush}"
+                BorderBrush="{DynamicResource BorderBrush}"
+                BorderThickness="1" CornerRadius="4">
+            <TextBox Text="{Binding VisibleText, Mode=OneWay}"
+                     IsReadOnly="True"
+                     FontFamily="Consolas" FontSize="12"
+                     Background="Transparent"
+                     Foreground="{DynamicResource PrimaryTextBrush}"
+                     BorderThickness="0"
+                     Padding="10"
+                     VerticalScrollBarVisibility="Auto"
+                     HorizontalScrollBarVisibility="Auto" />
+        </Border>
+
+        <TextBlock Grid.Row="3"
+                   Text="{Binding LineSummary}"
+                   Style="{StaticResource SecondaryText}"
+                   Margin="0,8,0,0" />
+    </Grid>
+</Window>

--- a/src/NineLives/Views/LogViewerWindow.xaml.cs
+++ b/src/NineLives/Views/LogViewerWindow.xaml.cs
@@ -1,0 +1,13 @@
+using System.Windows;
+using Blackcat.NineLives.ViewModels;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class LogViewerWindow : Window
+{
+    public LogViewerWindow(LogViewerViewModel viewModel)
+    {
+        InitializeComponent();
+        DataContext = viewModel;
+    }
+}

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -84,6 +84,11 @@
 
                     <!-- The logs are what someone attaches to a bug report, so there has to be a
                          way to find them that is not "know where LocalAppData lives" (#40). -->
+                    <Button Content="View the log"
+                            Command="{Binding ViewLogCommand}"
+                            Style="{StaticResource SecondaryButton}"
+                            Padding="14,7" Margin="0,0,8,0"
+                            ToolTip="Today's operation log, inside the app - filter, copy, refresh." />
                     <Button Content="Open log folder"
                             Command="{Binding OpenLogFolderCommand}"
                             Style="{StaticResource SecondaryButton}"


### PR DESCRIPTION
The operation log is the app's own evidence trail — per-run records, header timings, credential decisions — and the app is the only tool guaranteed to be present when that trail is needed. "Open log folder" hands somebody a directory of dated files and leaves them to it.

A window off Settings: today's file, a case-insensitive filter with honest counts ("1 of 3 lines match"), copy-shown-lines, refresh, and the folder button still there for older days. Deliberately a reader, not a log framework — `FileShare.ReadWrite` so the app's own appends never fight the viewer, and refresh is a button rather than a timer because the log grows in bursts around operations.

6 new tests, 1,485 pass.