### PR TITLE
Stop the copy console tearing the ItemsControl mid-run (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Fixed
+
+- **Copy Database crashed mid-run** - "An ItemsControl is inconsistent with its items source" -
+  when SQL Server's progress messages, which arrive on the connection's worker thread, were added
+  to the bound console straight from that thread. The copy and backup screens now marshal the way
+  the restore screen always has, and the batching console buffer owns its thread-affinity outright
+  so no future screen can reintroduce the race (#233)
+
 ## [1.4.0] - 2026-08-09
 
 Nine Lives stops being a blob restore tool. It backs up and restores, to and from Azure Blob

--- a/src/NineLives.Tests/ConsoleBufferThreadingTests.cs
+++ b/src/NineLives.Tests/ConsoleBufferThreadingTests.cs
@@ -1,0 +1,116 @@
+using System.Windows.Threading;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The console fed from the connection's thread (#233).
+///
+/// SQL Server's progress callbacks fire on the connection's worker thread, and the copy screen
+/// handed them straight to a bound collection - two seconds into a real copy the ItemsControl
+/// tore: "An ItemsControl is inconsistent with its items source", run dead. The buffer now owns
+/// its thread-affinity, so every caller is safe by construction.
+///
+/// The deterministic trick throughout: GATE the dispatcher with a blocking job, act from the
+/// foreign thread, and only then release - so "nothing happened yet" and "everything arrived
+/// after" are facts, not races.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class ConsoleBufferThreadingTests
+{
+    private readonly WpfFixture _wpf;
+
+    public ConsoleBufferThreadingTests(WpfFixture wpf) => _wpf = wpf;
+
+    private ConsoleBuffer OnFixtureThread()
+    {
+        ConsoleBuffer buffer = null!;
+        _wpf.Invoke(() => buffer = new ConsoleBuffer());
+        return buffer;
+    }
+
+    /// <summary>Waits until everything queued at Normal and below has run.</summary>
+    private void Drain() =>
+        _wpf.Dispatcher.Invoke(() => { }, DispatcherPriority.ContextIdle);
+
+    /// <summary>
+    /// The pin for the crash: an append from a foreign thread must not touch the buffer's state
+    /// on that thread. With the dispatcher gated, nothing can have processed the append - so any
+    /// pending line now was put there by the CALLING thread, which is the #233 race itself.
+    /// </summary>
+    [Fact]
+    public void AnAppendFromAForeignThreadDoesNotTouchTheBufferThere()
+    {
+        var buffer = OnFixtureThread();
+
+        using var gate = new ManualResetEventSlim(false);
+        _wpf.Dispatcher.InvokeAsync(() => gate.Wait());
+
+        try
+        {
+            buffer.Append("10 percent processed.");
+
+            Assert.False(buffer.HasPending,
+                "the append mutated the buffer on the calling thread - the #233 race");
+        }
+        finally
+        {
+            gate.Set();
+        }
+
+        Drain();
+        _wpf.Invoke(() => buffer.Flush());
+        Assert.Contains("10 percent processed", buffer.Text);
+    }
+
+    /// <summary>
+    /// A foreign flush returns with the flush DONE, including appends queued before it - its
+    /// contract is "flush, then read Text", and both overtaking (Send priority) and an async hop
+    /// would hand back text from before the run's tail.
+    /// </summary>
+    [Fact]
+    public void AForeignFlushIsCompleteWhenItReturnsAndDoesNotOvertakeAppends()
+    {
+        var buffer = OnFixtureThread();
+
+        buffer.Append("the last line of the run");
+        buffer.Flush();
+
+        Assert.Contains("the last line of the run", buffer.Text);
+    }
+
+    /// <summary>Order survives the queue - progress lines out of order would misreport the run.</summary>
+    [Fact]
+    public void ArrivalOrderIsPreserved()
+    {
+        var buffer = OnFixtureThread();
+
+        for (var i = 1; i <= 5; i++)
+            buffer.Append($"line {i}");
+
+        buffer.Flush();
+
+        var text = buffer.Text;
+        for (var i = 1; i < 5; i++)
+            Assert.True(
+                text.IndexOf($"line {i}", StringComparison.Ordinal) <
+                text.IndexOf($"line {i + 1}", StringComparison.Ordinal),
+                text);
+    }
+
+    /// <summary>A foreign Clear empties everything that was queued before it, not a snapshot.</summary>
+    [Fact]
+    public void AForeignClearSweepsWhatWasQueuedBeforeIt()
+    {
+        var buffer = OnFixtureThread();
+
+        buffer.Append("stale line from the previous run");
+        buffer.Clear();
+
+        Drain();
+        _wpf.Invoke(() => buffer.Flush());
+
+        Assert.DoesNotContain("stale", buffer.Text);
+    }
+}

--- a/src/NineLives.Tests/WpfFixture.cs
+++ b/src/NineLives.Tests/WpfFixture.cs
@@ -60,6 +60,9 @@ public sealed class WpfFixture : IDisposable
         ready.Wait(TimeSpan.FromSeconds(30));
     }
 
+    /// <summary>The fixture's dispatcher, for tests that gate or queue against it directly.</summary>
+    public Dispatcher Dispatcher => _dispatcher;
+
     /// <summary>Runs on the UI thread and rethrows anything it threw, with its stack intact.</summary>
     public void Invoke(Action action)
     {

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -664,5 +664,17 @@ public partial class BackupViewModel : ViewModelBase
         }
     }
 
-    private void Append(string line) => Console.Add(line);
+    /// <summary>
+    /// The console is bound to the UI, and lines arrive off it: SQL Server's progress callbacks
+    /// fire on the connection's worker thread, and adding to a bound collection there tore the
+    /// ItemsControl two seconds into a real copy (#233). The restore screen has carried this rule
+    /// since its console was built; this screen now carries it too. InvokeAsync, not Invoke - a
+    /// blocked connection thread is how "live" output arrives in bursts.
+    /// </summary>
+    private void Append(string line)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess()) Console.Add(line);
+        else dispatcher.InvokeAsync(() => Console.Add(line));
+    }
 }

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -665,6 +665,15 @@ public partial class BackupViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// The dispatcher of whatever thread constructed this screen - the UI thread in the app,
+    /// nothing in a test. Captured at construction, the same rule ConsoleBuffer documents: the
+    /// console belongs to the thread that made it. NOT Application.Current, which is process-wide
+    /// state another component (the WPF test fixture, a future second window) can own.
+    /// </summary>
+    private readonly System.Windows.Threading.Dispatcher? _consoleDispatcher =
+        System.Windows.Threading.Dispatcher.FromThread(Thread.CurrentThread);
+
+    /// <summary>
     /// The console is bound to the UI, and lines arrive off it: SQL Server's progress callbacks
     /// fire on the connection's worker thread, and adding to a bound collection there tore the
     /// ItemsControl two seconds into a real copy (#233). The restore screen has carried this rule
@@ -673,8 +682,7 @@ public partial class BackupViewModel : ViewModelBase
     /// </summary>
     private void Append(string line)
     {
-        var dispatcher = System.Windows.Application.Current?.Dispatcher;
-        if (dispatcher == null || dispatcher.CheckAccess()) Console.Add(line);
-        else dispatcher.InvokeAsync(() => Console.Add(line));
+        if (_consoleDispatcher == null || _consoleDispatcher.CheckAccess()) Console.Add(line);
+        else _consoleDispatcher.InvokeAsync(() => Console.Add(line));
     }
 }

--- a/src/NineLives/ViewModels/ConsoleBuffer.cs
+++ b/src/NineLives/ViewModels/ConsoleBuffer.cs
@@ -87,6 +87,19 @@ public partial class ConsoleBuffer : ObservableObject
     /// </summary>
     public void Append(string message)
     {
+        // The buffer belongs to one thread, and messages do not arrive on it: SQL Server's
+        // progress callbacks fire on the connection's worker thread, and feeding _pending and the
+        // blank-line logic (which reads Lines) from there while the flush timer drains on the UI
+        // thread tore the ItemsControl mid-copy (#233). Queued rather than locked - InvokeAsync
+        // keeps the connection thread unblocked (the restore screen's old rule, now enforced
+        // where it cannot be forgotten) and the dispatcher queue preserves arrival order.
+        // Headless there is no dispatcher and no other thread to race.
+        if (_dispatcher != null && !_dispatcher.CheckAccess())
+        {
+            _dispatcher.InvokeAsync(() => Append(message));
+            return;
+        }
+
         foreach (var raw in message.Split('\n'))
         {
             var line = raw.TrimEnd('\r');
@@ -109,6 +122,16 @@ public partial class ConsoleBuffer : ObservableObject
     /// <summary>Moves everything buffered onto the bound collection now.</summary>
     public void Flush()
     {
+        // Synchronous marshalling, unlike Append: callers flush in order to READ - "flush, then
+        // record Console.Text" - and an async hop would hand them the text from before the flush.
+        if (_dispatcher != null && !_dispatcher.CheckAccess())
+        {
+            // Background, not the default Send: Send jumps the dispatcher queue, and a flush that
+            // overtakes the appends queued before it would hand the caller text from before them.
+            _dispatcher.Invoke(Flush, System.Windows.Threading.DispatcherPriority.Background);
+            return;
+        }
+
         if (_pending.Count == 0)
         {
             // Nothing arriving and nothing running - stop ticking rather than spin forever.
@@ -128,6 +151,12 @@ public partial class ConsoleBuffer : ObservableObject
     /// <summary>Empties the console, for the start of a run.</summary>
     public void Clear()
     {
+        if (_dispatcher != null && !_dispatcher.CheckAccess())
+        {
+            _dispatcher.Invoke(Clear, System.Windows.Threading.DispatcherPriority.Background);
+            return;
+        }
+
         _pending.Clear();
         Lines.Clear();
         HasOutput = false;

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -696,5 +696,17 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         SetStatus("Stopping...");
     }
 
-    private void Append(string line) => Console.Add(line);
+    /// <summary>
+    /// The console is bound to the UI, and lines arrive off it: SQL Server's progress callbacks
+    /// fire on the connection's worker thread, and adding to a bound collection there tore the
+    /// ItemsControl two seconds into a real copy (#233). The restore screen has carried this rule
+    /// since its console was built; this screen now carries it too. InvokeAsync, not Invoke - a
+    /// blocked connection thread is how "live" output arrives in bursts.
+    /// </summary>
+    private void Append(string line)
+    {
+        var dispatcher = System.Windows.Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess()) Console.Add(line);
+        else dispatcher.InvokeAsync(() => Console.Add(line));
+    }
 }

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -697,6 +697,15 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// The dispatcher of whatever thread constructed this screen - the UI thread in the app,
+    /// nothing in a test. Captured at construction, the same rule ConsoleBuffer documents: the
+    /// console belongs to the thread that made it. NOT Application.Current, which is process-wide
+    /// state another component (the WPF test fixture, a future second window) can own.
+    /// </summary>
+    private readonly System.Windows.Threading.Dispatcher? _consoleDispatcher =
+        System.Windows.Threading.Dispatcher.FromThread(Thread.CurrentThread);
+
+    /// <summary>
     /// The console is bound to the UI, and lines arrive off it: SQL Server's progress callbacks
     /// fire on the connection's worker thread, and adding to a bound collection there tore the
     /// ItemsControl two seconds into a real copy (#233). The restore screen has carried this rule
@@ -705,8 +714,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// </summary>
     private void Append(string line)
     {
-        var dispatcher = System.Windows.Application.Current?.Dispatcher;
-        if (dispatcher == null || dispatcher.CheckAccess()) Console.Add(line);
-        else dispatcher.InvokeAsync(() => Console.Add(line));
+        if (_consoleDispatcher == null || _consoleDispatcher.CheckAccess()) Console.Add(line);
+        else _consoleDispatcher.InvokeAsync(() => Console.Add(line));
     }
 }


### PR DESCRIPTION
Hit for real, 2.2 seconds into a copy — the moment the backup half's first STATS messages arrived:

```
19:51:30.595 INFO  Copy started: MyDb from SRV01 to localhost\SQLEXPRESS as BACKUPRESTORETEST
19:51:32.781 ERROR Unhandled exception on the UI thread | InvalidOperationException: An ItemsControl is inconsistent with its items source.
```

`ExecuteWithProgressAsync` raises its callback on the connection's worker thread; the copy screen's `Append` handed that straight to a bound `ObservableCollection<string>`. The backup screen carried the identical latent bug. The restore screen alone had the marshalling rule — as a note at one callsite.

## Two layers, so the rule cannot be forgotten again

- **The copy and backup screens marshal in their `Append` helpers** — `InvokeAsync`, not `Invoke`, because a blocked connection thread is how "live" output arrives in bursts. Headless they add inline, so the whole test suite runs unchanged.
- **`ConsoleBuffer` owns its thread-affinity outright**: a foreign-thread append queues itself onto the buffer's dispatcher; a foreign flush or clear marshals at **Background** priority — below the queued appends — because `Invoke`'s default (Send) jumps the dispatcher queue, and a flush that overtook the appends before it would hand back text from before the run's tail.

## Deterministic tests, not racy ones

The threading tests **gate the dispatcher with a blocking job**, act from the foreign thread, and only then release — so "nothing happened yet" and "everything arrived after" are facts. The crash's own pin (append from a foreign thread must not touch the buffer on that thread) fails red without the fix.

4 new tests, 1,489 pass.