### PR TITLE
Release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- A drive the target does not have was described as having "0.0 B free". Absent is now said as
+  absent, with the actual fix named: relocate the files (MOVE) or pick a different target -
+  freeing space on a drive that does not exist was never the answer (#233)
 - **Copy Database crashed mid-run** - "An ItemsControl is inconsistent with its items source" -
   when SQL Server's progress messages, which arrive on the connection's worker thread, were added
   to the bound console straight from that thread. The copy and backup screens now marshal the way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Fixed
+
+- **Copy Database crashed mid-run** - "An ItemsControl is inconsistent with its items source" -
+  when SQL Server's progress messages, which arrive on the connection's worker thread, were added
+  to the bound console straight from that thread. The copy and backup screens now marshal the way
+  the restore screen always has, and the batching console buffer owns its thread-affinity outright
+  so no future screen can reintroduce the race (#233)
+
 ## [1.4.0] - 2026-08-09
 
 Nine Lives stops being a blob restore tool. It backs up and restores, to and from Azure Blob

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
-## [Unreleased]
+## [1.4.1] - 2026-08-09
 
 ### Fixed
 

--- a/src/NineLives.Tests/ConsoleBufferThreadingTests.cs
+++ b/src/NineLives.Tests/ConsoleBufferThreadingTests.cs
@@ -1,0 +1,116 @@
+using System.Windows.Threading;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The console fed from the connection's thread (#233).
+///
+/// SQL Server's progress callbacks fire on the connection's worker thread, and the copy screen
+/// handed them straight to a bound collection - two seconds into a real copy the ItemsControl
+/// tore: "An ItemsControl is inconsistent with its items source", run dead. The buffer now owns
+/// its thread-affinity, so every caller is safe by construction.
+///
+/// The deterministic trick throughout: GATE the dispatcher with a blocking job, act from the
+/// foreign thread, and only then release - so "nothing happened yet" and "everything arrived
+/// after" are facts, not races.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class ConsoleBufferThreadingTests
+{
+    private readonly WpfFixture _wpf;
+
+    public ConsoleBufferThreadingTests(WpfFixture wpf) => _wpf = wpf;
+
+    private ConsoleBuffer OnFixtureThread()
+    {
+        ConsoleBuffer buffer = null!;
+        _wpf.Invoke(() => buffer = new ConsoleBuffer());
+        return buffer;
+    }
+
+    /// <summary>Waits until everything queued at Normal and below has run.</summary>
+    private void Drain() =>
+        _wpf.Dispatcher.Invoke(() => { }, DispatcherPriority.ContextIdle);
+
+    /// <summary>
+    /// The pin for the crash: an append from a foreign thread must not touch the buffer's state
+    /// on that thread. With the dispatcher gated, nothing can have processed the append - so any
+    /// pending line now was put there by the CALLING thread, which is the #233 race itself.
+    /// </summary>
+    [Fact]
+    public void AnAppendFromAForeignThreadDoesNotTouchTheBufferThere()
+    {
+        var buffer = OnFixtureThread();
+
+        using var gate = new ManualResetEventSlim(false);
+        _wpf.Dispatcher.InvokeAsync(() => gate.Wait());
+
+        try
+        {
+            buffer.Append("10 percent processed.");
+
+            Assert.False(buffer.HasPending,
+                "the append mutated the buffer on the calling thread - the #233 race");
+        }
+        finally
+        {
+            gate.Set();
+        }
+
+        Drain();
+        _wpf.Invoke(() => buffer.Flush());
+        Assert.Contains("10 percent processed", buffer.Text);
+    }
+
+    /// <summary>
+    /// A foreign flush returns with the flush DONE, including appends queued before it - its
+    /// contract is "flush, then read Text", and both overtaking (Send priority) and an async hop
+    /// would hand back text from before the run's tail.
+    /// </summary>
+    [Fact]
+    public void AForeignFlushIsCompleteWhenItReturnsAndDoesNotOvertakeAppends()
+    {
+        var buffer = OnFixtureThread();
+
+        buffer.Append("the last line of the run");
+        buffer.Flush();
+
+        Assert.Contains("the last line of the run", buffer.Text);
+    }
+
+    /// <summary>Order survives the queue - progress lines out of order would misreport the run.</summary>
+    [Fact]
+    public void ArrivalOrderIsPreserved()
+    {
+        var buffer = OnFixtureThread();
+
+        for (var i = 1; i <= 5; i++)
+            buffer.Append($"line {i}");
+
+        buffer.Flush();
+
+        var text = buffer.Text;
+        for (var i = 1; i < 5; i++)
+            Assert.True(
+                text.IndexOf($"line {i}", StringComparison.Ordinal) <
+                text.IndexOf($"line {i + 1}", StringComparison.Ordinal),
+                text);
+    }
+
+    /// <summary>A foreign Clear empties everything that was queued before it, not a snapshot.</summary>
+    [Fact]
+    public void AForeignClearSweepsWhatWasQueuedBeforeIt()
+    {
+        var buffer = OnFixtureThread();
+
+        buffer.Append("stale line from the previous run");
+        buffer.Clear();
+
+        Drain();
+        _wpf.Invoke(() => buffer.Flush());
+
+        Assert.DoesNotContain("stale", buffer.Text);
+    }
+}

--- a/src/NineLives.Tests/CopySpaceCheckTests.cs
+++ b/src/NineLives.Tests/CopySpaceCheckTests.cs
@@ -150,5 +150,10 @@ public class CopySpaceCheckTests
 
         Assert.True(vm.HasSpaceWarning);
         Assert.Contains(@"L:\", vm.SpaceWarning);
+
+        // Absent is said as absent - "0.0 B free" was the wrong sentence, because the fix is a
+        // MOVE clause or a different target, not freeing space.
+        Assert.Contains(@"no L:\ volume", vm.SpaceWarning);
+        Assert.Contains("MOVE", vm.SpaceWarning);
     }
 }

--- a/src/NineLives.Tests/WpfFixture.cs
+++ b/src/NineLives.Tests/WpfFixture.cs
@@ -60,6 +60,9 @@ public sealed class WpfFixture : IDisposable
         ready.Wait(TimeSpan.FromSeconds(30));
     }
 
+    /// <summary>The fixture's dispatcher, for tests that gate or queue against it directly.</summary>
+    public Dispatcher Dispatcher => _dispatcher;
+
     /// <summary>Runs on the UI thread and rethrows anything it threw, with its stack intact.</summary>
     public void Invoke(Action action)
     {

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/Services/RestoreSpaceCheck.cs
+++ b/src/NineLives/Services/RestoreSpaceCheck.cs
@@ -6,9 +6,15 @@ namespace Blackcat.NineLives.Services;
 /// <param name="Volume">The mount point as SQL Server reports it, e.g. <c>D:\</c>.</param>
 /// <param name="RequiredBytes">The size of the database files landing there.</param>
 /// <param name="FreeBytes">What the volume has left, as the SQL Server service account sees it.</param>
-public sealed record VolumeSpace(string Volume, long RequiredBytes, long FreeBytes)
+/// <param name="WasReported">
+/// Whether the target reported this volume at all. dm_os_volume_stats only describes volumes that
+/// host database files, so "not reported" routinely means the drive does not exist there - and
+/// "has only 0.0 B free" was the wrong sentence for that, because the fix is not freeing space,
+/// it is a MOVE clause or a different target (#233's screenshot).
+/// </param>
+public sealed record VolumeSpace(string Volume, long RequiredBytes, long FreeBytes, bool WasReported = true)
 {
-    public bool Fits => FreeBytes >= RequiredBytes;
+    public bool Fits => WasReported && FreeBytes >= RequiredBytes;
 
     public long ShortfallBytes => Math.Max(0, RequiredBytes - FreeBytes);
 
@@ -17,10 +23,14 @@ public sealed record VolumeSpace(string Volume, long RequiredBytes, long FreeByt
     /// nothing when asked to - which shipped as an empty panel once already this week (#130).
     /// </summary>
     public string Describe =>
-        Fits
-            ? $"{Volume} needs {ByteSize.Format(RequiredBytes)} and has {ByteSize.Format(FreeBytes)} free."
-            : $"{Volume} needs {ByteSize.Format(RequiredBytes)} and has only " +
-              $"{ByteSize.Format(FreeBytes)} free - short by {ByteSize.Format(ShortfallBytes)}.";
+        !WasReported
+            ? $"{Volume} needs {ByteSize.Format(RequiredBytes)}, and the target reported no " +
+              $"{Volume} volume at all - it may not have that drive. Relocate the files (MOVE) " +
+              "or they will be written to a path that does not exist."
+            : Fits
+                ? $"{Volume} needs {ByteSize.Format(RequiredBytes)} and has {ByteSize.Format(FreeBytes)} free."
+                : $"{Volume} needs {ByteSize.Format(RequiredBytes)} and has only " +
+                  $"{ByteSize.Format(FreeBytes)} free - short by {ByteSize.Format(ShortfallBytes)}.";
 }
 
 /// <summary>
@@ -64,12 +74,14 @@ public static class RestoreSpaceCheck
         }
 
         return required
-            .Select(pair => new VolumeSpace(
-                pair.Key,
-                pair.Value,
-                // A volume the target did not report on is treated as having nothing, so it is
-                // reported rather than silently passing. Not knowing is not the same as fitting.
-                MatchVolume(freeByVolume, pair.Key)))
+            .Select(pair =>
+            {
+                // A volume the target did not report on is surfaced rather than silently passing
+                // - not knowing is not the same as fitting - and it is surfaced as ABSENT, not as
+                // full, because those have different fixes.
+                var free = MatchVolume(freeByVolume, pair.Key);
+                return new VolumeSpace(pair.Key, pair.Value, free ?? 0, free != null);
+            })
             .OrderBy(v => v.Volume, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
@@ -90,7 +102,7 @@ public static class RestoreSpaceCheck
         return path[..2].ToUpperInvariant() + @"\";
     }
 
-    private static long MatchVolume(IReadOnlyDictionary<string, long> freeByVolume, string volume)
+    private static long? MatchVolume(IReadOnlyDictionary<string, long> freeByVolume, string volume)
     {
         if (freeByVolume.TryGetValue(volume, out var free)) return free;
 
@@ -102,7 +114,9 @@ public static class RestoreSpaceCheck
             if (string.Equals(key.TrimEnd('\\'), trimmed, StringComparison.OrdinalIgnoreCase))
                 return value;
 
-        return 0;
+        // Genuinely absent, and said as such - null is "no such volume", which has a different
+        // fix from "a volume with nothing free".
+        return null;
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -664,5 +664,25 @@ public partial class BackupViewModel : ViewModelBase
         }
     }
 
-    private void Append(string line) => Console.Add(line);
+    /// <summary>
+    /// The dispatcher of whatever thread constructed this screen - the UI thread in the app,
+    /// nothing in a test. Captured at construction, the same rule ConsoleBuffer documents: the
+    /// console belongs to the thread that made it. NOT Application.Current, which is process-wide
+    /// state another component (the WPF test fixture, a future second window) can own.
+    /// </summary>
+    private readonly System.Windows.Threading.Dispatcher? _consoleDispatcher =
+        System.Windows.Threading.Dispatcher.FromThread(Thread.CurrentThread);
+
+    /// <summary>
+    /// The console is bound to the UI, and lines arrive off it: SQL Server's progress callbacks
+    /// fire on the connection's worker thread, and adding to a bound collection there tore the
+    /// ItemsControl two seconds into a real copy (#233). The restore screen has carried this rule
+    /// since its console was built; this screen now carries it too. InvokeAsync, not Invoke - a
+    /// blocked connection thread is how "live" output arrives in bursts.
+    /// </summary>
+    private void Append(string line)
+    {
+        if (_consoleDispatcher == null || _consoleDispatcher.CheckAccess()) Console.Add(line);
+        else _consoleDispatcher.InvokeAsync(() => Console.Add(line));
+    }
 }

--- a/src/NineLives/ViewModels/ConsoleBuffer.cs
+++ b/src/NineLives/ViewModels/ConsoleBuffer.cs
@@ -87,6 +87,19 @@ public partial class ConsoleBuffer : ObservableObject
     /// </summary>
     public void Append(string message)
     {
+        // The buffer belongs to one thread, and messages do not arrive on it: SQL Server's
+        // progress callbacks fire on the connection's worker thread, and feeding _pending and the
+        // blank-line logic (which reads Lines) from there while the flush timer drains on the UI
+        // thread tore the ItemsControl mid-copy (#233). Queued rather than locked - InvokeAsync
+        // keeps the connection thread unblocked (the restore screen's old rule, now enforced
+        // where it cannot be forgotten) and the dispatcher queue preserves arrival order.
+        // Headless there is no dispatcher and no other thread to race.
+        if (_dispatcher != null && !_dispatcher.CheckAccess())
+        {
+            _dispatcher.InvokeAsync(() => Append(message));
+            return;
+        }
+
         foreach (var raw in message.Split('\n'))
         {
             var line = raw.TrimEnd('\r');
@@ -109,6 +122,16 @@ public partial class ConsoleBuffer : ObservableObject
     /// <summary>Moves everything buffered onto the bound collection now.</summary>
     public void Flush()
     {
+        // Synchronous marshalling, unlike Append: callers flush in order to READ - "flush, then
+        // record Console.Text" - and an async hop would hand them the text from before the flush.
+        if (_dispatcher != null && !_dispatcher.CheckAccess())
+        {
+            // Background, not the default Send: Send jumps the dispatcher queue, and a flush that
+            // overtakes the appends queued before it would hand the caller text from before them.
+            _dispatcher.Invoke(Flush, System.Windows.Threading.DispatcherPriority.Background);
+            return;
+        }
+
         if (_pending.Count == 0)
         {
             // Nothing arriving and nothing running - stop ticking rather than spin forever.
@@ -128,6 +151,12 @@ public partial class ConsoleBuffer : ObservableObject
     /// <summary>Empties the console, for the start of a run.</summary>
     public void Clear()
     {
+        if (_dispatcher != null && !_dispatcher.CheckAccess())
+        {
+            _dispatcher.Invoke(Clear, System.Windows.Threading.DispatcherPriority.Background);
+            return;
+        }
+
         _pending.Clear();
         Lines.Clear();
         HasOutput = false;

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -696,5 +696,25 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         SetStatus("Stopping...");
     }
 
-    private void Append(string line) => Console.Add(line);
+    /// <summary>
+    /// The dispatcher of whatever thread constructed this screen - the UI thread in the app,
+    /// nothing in a test. Captured at construction, the same rule ConsoleBuffer documents: the
+    /// console belongs to the thread that made it. NOT Application.Current, which is process-wide
+    /// state another component (the WPF test fixture, a future second window) can own.
+    /// </summary>
+    private readonly System.Windows.Threading.Dispatcher? _consoleDispatcher =
+        System.Windows.Threading.Dispatcher.FromThread(Thread.CurrentThread);
+
+    /// <summary>
+    /// The console is bound to the UI, and lines arrive off it: SQL Server's progress callbacks
+    /// fire on the connection's worker thread, and adding to a bound collection there tore the
+    /// ItemsControl two seconds into a real copy (#233). The restore screen has carried this rule
+    /// since its console was built; this screen now carries it too. InvokeAsync, not Invoke - a
+    /// blocked connection thread is how "live" output arrives in bursts.
+    /// </summary>
+    private void Append(string line)
+    {
+        if (_consoleDispatcher == null || _consoleDispatcher.CheckAccess()) Console.Add(line);
+        else _consoleDispatcher.InvokeAsync(() => Console.Add(line));
+    }
 }


### PR DESCRIPTION
Point release: the #233 crash fix (copy console tearing the ItemsControl when progress messages arrive on the connection's thread — hit in the field two hours after v1.4.0) plus the absent-drive wording fix from the same report.
