### PR TITLE
Push run notifications to Teams, Slack and generic webhooks (#242)

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -187,6 +187,14 @@ public sealed class FakeRestoreHistoryStore : IRestoreHistoryStore
 /// <summary>
 /// A SQL Server that records what it was asked to do. Nothing opens a connection.
 /// </summary>
+/// <summary>Records every notification a screen fires (#242), in order.</summary>
+public sealed class FakeRunNotifier : IRunNotifier
+{
+    public List<RunNotification> Sent { get; } = [];
+
+    public void Notify(RunNotification notification) => Sent.Add(notification);
+}
+
 public sealed class FakeSqlServerService : ISqlServerService
 {
     /// <summary>Every server instance handed to an execute call, in order.</summary>

--- a/src/NineLives.Tests/WebhookNotificationTests.cs
+++ b/src/NineLives.Tests/WebhookNotificationTests.cs
@@ -1,0 +1,274 @@
+using System.Collections.ObjectModel;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Run notifications to Teams, Slack and generic endpoints (#242).
+///
+/// For everyone whose focus is rightly NOT on the application while a long run executes: a
+/// message when it starts, when it finishes, and - most importantly - when there is a problem.
+/// The payload shapes follow the PerformanceMonitor webhooks, already proven against real Teams
+/// and Slack channels.
+/// </summary>
+public class WebhookNotificationTests
+{
+    private static readonly RunNotification Restore =
+        new(RunPhase.Succeeded, "Restore", "MyDb", "SRV01", "1 full + 2 logs", TimeSpan.FromMinutes(40));
+
+    // ── the payloads ────────────────────────────────────────────────────────────
+
+    /// <summary>Teams gets a MessageCard - the shape both connectors and Power Automate accept.</summary>
+    [Fact]
+    public void TeamsGetsAMessageCard()
+    {
+        var json = WebhookNotifier.BuildTeamsPayload(Restore);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.Equal("MessageCard", doc.RootElement.GetProperty("@type").GetString());
+        Assert.Equal("107C10", doc.RootElement.GetProperty("themeColor").GetString());
+        Assert.Contains("COMPLETED", doc.RootElement.GetProperty("summary").GetString());
+
+        var section = doc.RootElement.GetProperty("sections")[0];
+        Assert.Contains("Restore MyDb", section.GetProperty("activityTitle").GetString());
+
+        var facts = section.GetProperty("facts").EnumerateArray()
+            .Select(f => (f.GetProperty("name").GetString(), f.GetProperty("value").GetString()))
+            .ToList();
+        Assert.Contains(facts, f => f.Item1 == "Server" && f.Item2 == "SRV01");
+        Assert.Contains(facts, f => f.Item1 == "Duration" && f.Item2 == "40m 00s");
+    }
+
+    [Fact]
+    public void SlackGetsBlocks()
+    {
+        var json = WebhookNotifier.BuildSlackPayload(
+            Restore with { Phase = RunPhase.Problem, Detail = "Msg 3201: Cannot open backup device" });
+        using var doc = JsonDocument.Parse(json);
+
+        var blocks = doc.RootElement.GetProperty("blocks");
+        Assert.Equal("header", blocks[0].GetProperty("type").GetString());
+        Assert.Contains("PROBLEM", blocks[0].GetProperty("text").GetProperty("text").GetString());
+
+        // The failure line rides in its own section - the sofa reader needs the WHY.
+        var all = json;
+        Assert.Contains("Msg 3201", all);
+    }
+
+    /// <summary>The generic payload is fields, not display text - nothing needs parsing back out.</summary>
+    [Fact]
+    public void GenericGetsPlainFields()
+    {
+        var json = WebhookNotifier.BuildGenericPayload(Restore);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.Equal("NineLives", doc.RootElement.GetProperty("app").GetString());
+        Assert.Equal("Succeeded", doc.RootElement.GetProperty("phase").GetString());
+        Assert.Equal("MyDb", doc.RootElement.GetProperty("subject").GetString());
+        Assert.Equal(2400, doc.RootElement.GetProperty("durationSeconds").GetDouble(), 1);
+    }
+
+    [Theory]
+    [InlineData(RunPhase.Started, "0078D7")]
+    [InlineData(RunPhase.Succeeded, "107C10")]
+    [InlineData(RunPhase.Problem, "D13438")]
+    public void EachPhaseHasItsColour(RunPhase phase, string colour)
+    {
+        Assert.Equal(colour, WebhookNotifier.Look(phase).ThemeColor);
+    }
+
+    // ── routing ─────────────────────────────────────────────────────────────────
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public List<(string Url, string Body)> Posts { get; } = [];
+        public HttpStatusCode Respond { get; set; } = HttpStatusCode.OK;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            Posts.Add((request.RequestUri!.ToString(), await request.Content!.ReadAsStringAsync(ct)));
+            return new HttpResponseMessage(Respond) { Content = new StringContent("") };
+        }
+    }
+
+    private static WebhookEndpoint Endpoint(
+        string name = "chan", WebhookFormat format = WebhookFormat.Teams,
+        bool started = true, bool finished = true, bool problems = true) => new()
+    {
+        Name = name,
+        Url = "https://example.test/hook",
+        Format = format,
+        NotifyStarted = started,
+        NotifyFinished = finished,
+        NotifyProblems = problems
+    };
+
+    /// <summary>An endpoint hears only about the phases it asked for.</summary>
+    [Fact]
+    public async Task TogglesDecideWhatEachEndpointHears()
+    {
+        var handler = new RecordingHandler();
+        var notifier = new WebhookNotifier(handler);
+        var quietStart = Endpoint(started: false);
+
+        await notifier.NotifyAsync([quietStart], Restore with { Phase = RunPhase.Started });
+        Assert.Empty(handler.Posts);
+
+        await notifier.NotifyAsync([quietStart], Restore);
+        Assert.Single(handler.Posts);
+    }
+
+    [Fact]
+    public async Task EveryConfiguredEndpointIsPosted()
+    {
+        var handler = new RecordingHandler();
+        var notifier = new WebhookNotifier(handler);
+
+        await notifier.NotifyAsync(
+            [Endpoint("teams"), Endpoint("slack", WebhookFormat.Slack)], Restore);
+
+        Assert.Equal(2, handler.Posts.Count);
+        Assert.Contains("MessageCard", handler.Posts[0].Body);
+        Assert.Contains("blocks", handler.Posts[1].Body);
+    }
+
+    /// <summary>A dead endpoint is a log line, never an exception - the run must not notice.</summary>
+    [Fact]
+    public async Task AFailingEndpointOnlyLogs()
+    {
+        var handler = new RecordingHandler { Respond = HttpStatusCode.NotFound };
+        var notifier = new WebhookNotifier(handler);
+        var log = new List<string>();
+
+        await notifier.NotifyAsync([Endpoint()], Restore, log.Add);
+
+        Assert.Contains(log, l => l.Contains("FAILED") && l.Contains("404"));
+    }
+
+    [Fact]
+    public async Task TheTestSendReportsSuccessAndFailureHonestly()
+    {
+        var ok = new WebhookNotifier(new RecordingHandler());
+        Assert.Null(await ok.SendTestAsync(Endpoint()));
+
+        var dead = new WebhookNotifier(new RecordingHandler { Respond = HttpStatusCode.Unauthorized });
+        Assert.Contains("401", await dead.SendTestAsync(Endpoint()));
+
+        Assert.Contains("empty", (await ok.SendTestAsync(new WebhookEndpoint()))!);
+    }
+
+    // ── the screens fire the right events ───────────────────────────────────────
+
+    private static ServerConnection Server(string name = "SRV01") =>
+        new() { Id = ServerConnection.NewId(), Name = name, ServerName = name };
+
+    private static RestoreRun Run() => new(
+        Server: Server(),
+        Script: "RESTORE DATABASE [MyDb] FROM DISK = N'D:\\b.bak' WITH REPLACE, RECOVERY;",
+        TargetDatabase: "MyDb",
+        SourceDatabase: null,
+        ContainerName: null,
+        ChainSummary: "1 full",
+        RestorePointTimestamp: null,
+        OptionsForLog: "WITH REPLACE, RECOVERY");
+
+    [Fact]
+    public async Task ARestoreAnnouncesStartAndSuccess()
+    {
+        var notifier = new FakeRunNotifier();
+        var vm = new RestoreExecutionViewModel(
+            new FakeSqlServerService(), new FakeRestoreHistoryStore(), TestLogs.Temp(),
+            new OperationCancellation(), notifier);
+
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.Equal([RunPhase.Started, RunPhase.Succeeded], notifier.Sent.Select(n => n.Phase));
+        Assert.All(notifier.Sent, n => Assert.Equal("MyDb", n.Subject));
+        Assert.NotNull(notifier.Sent[1].Duration);
+    }
+
+    [Fact]
+    public async Task AFailedRestoreAnnouncesTheProblemWithTheReason()
+    {
+        var notifier = new FakeRunNotifier();
+        var sql = new FakeSqlServerService { ExecuteThrows = new InvalidOperationException("Msg 3201") };
+        var vm = new RestoreExecutionViewModel(
+            sql, new FakeRestoreHistoryStore(), TestLogs.Temp(), new OperationCancellation(), notifier);
+
+        await vm.RunAsync(Run(), _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.Equal([RunPhase.Started, RunPhase.Problem], notifier.Sent.Select(n => n.Phase));
+        Assert.Contains("Msg 3201", notifier.Sent[1].Detail);
+    }
+
+    /// <summary>
+    /// A multi-database backup announces each problem AT the problem - the run continues, and
+    /// whoever is elsewhere decides now whether it changes their evening - then closes the run.
+    /// </summary>
+    [Fact]
+    public async Task AMultiDatabaseBackupAnnouncesProblemsAsTheyHappen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server());
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["Archive", "Payroll", "Sales"] };
+        var notifier = new FakeRunNotifier();
+        var vm = new BackupViewModel(store, sql, TestLogs.Temp(), notifier);
+        vm.Server = vm.Servers[0];
+        vm.Container = vm.Containers[0];
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.MultiSelect = true;
+        vm.PickAllCommand.Execute(null);
+        vm.GenerateCommand.Execute(null);
+        sql.FailOnExecuteNumber = 2;
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        Assert.Equal(
+            [RunPhase.Started, RunPhase.Problem, RunPhase.Problem],
+            notifier.Sent.Select(n => n.Phase));
+        Assert.Equal("Payroll", notifier.Sent[1].Subject);         // the problem, as it happened
+        Assert.Contains("1 of 3", notifier.Sent[2].Detail);        // the close of the run
+    }
+
+    // ── the export boundary ─────────────────────────────────────────────────────
+
+    /// <summary>A webhook URL is a bearer secret; the entry travels, the secret stays (#213).</summary>
+    [Fact]
+    public void WebhookUrlsNeverLeaveInAnExport()
+    {
+        var config = new AppConfig();
+        config.Webhooks.Add(new WebhookEndpoint
+        {
+            Name = "DBA Teams",
+            Url = "https://prod.powerautomate.example/workflows/abc/triggers/manual/paths/invoke?sig=SECRETSIG"
+        });
+
+        var json = ConfigPortability.Export(config);
+
+        Assert.DoesNotContain("SECRETSIG", json);
+        Assert.Contains("DBA Teams", json);
+
+        // And an import over a machine that HAS the URL keeps it.
+        var local = new AppConfig();
+        local.Webhooks.Add(new WebhookEndpoint { Id = config.Webhooks[0].Id, Name = "old", Url = "https://kept" });
+        ConfigPortability.Merge(local, ConfigPortability.Read(json)!);
+
+        Assert.Equal("https://kept", local.Webhooks.Single().Url);
+        Assert.Equal("DBA Teams", local.Webhooks.Single().Name);
+    }
+}

--- a/src/NineLives/Models/WebhookEndpoint.cs
+++ b/src/NineLives/Models/WebhookEndpoint.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+
+namespace Blackcat.NineLives.Models;
+
+/// <summary>Which shape of payload an endpoint expects (#242).</summary>
+public enum WebhookFormat
+{
+    /// <summary>
+    /// A MessageCard. Understood by both the legacy Teams incoming-webhook connectors and the
+    /// Power Automate "when a Teams webhook request is received" flows that replaced them - the
+    /// same dual audience the PerformanceMonitor implementation serves with this format.
+    /// </summary>
+    Teams = 0,
+
+    /// <summary>Slack Block Kit - a header block and mrkdwn section fields.</summary>
+    Slack = 1,
+
+    /// <summary>Plain JSON, for Power Automate HTTP triggers, Zapier, n8n, or anything home-made.</summary>
+    Generic = 2
+}
+
+/// <summary>
+/// One place notifications go (#242): a Teams channel, a Slack channel, or any endpoint that
+/// accepts JSON. A list of these, because "Teams for the team, Slack for the on-call bridge, and
+/// the generic one into the ticket system" is an ordinary arrangement, not an edge case.
+/// </summary>
+public class WebhookEndpoint
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>What it is called in Settings and in the log - "DBA Teams channel".</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The webhook URL. A SECRET in all but name: a Teams or Slack webhook URL carries its
+    /// signature in the path, and anyone holding it can post as the integration. It therefore
+    /// never leaves this machine in a config export (#213's rule).
+    /// </summary>
+    public string Url { get; set; } = string.Empty;
+
+    public WebhookFormat Format { get; set; } = WebhookFormat.Teams;
+
+    // ── which moments are worth a message ───────────────────────────────────────
+    //
+    // All three on by default: the whole point (#242) is knowing what the app is doing when focus
+    // is NOT on the application, and a problem nobody hears about is the worst of the three.
+
+    /// <summary>A backup, restore or copy has started.</summary>
+    public bool NotifyStarted { get; set; } = true;
+
+    /// <summary>It finished successfully.</summary>
+    public bool NotifyFinished { get; set; } = true;
+
+    /// <summary>It failed, was cancelled, or hit a problem mid-run.</summary>
+    public bool NotifyProblems { get; set; } = true;
+
+    [JsonIgnore]
+    public bool IsUsable => !string.IsNullOrWhiteSpace(Url);
+}

--- a/src/NineLives/Services/ConfigPortability.cs
+++ b/src/NineLives/Services/ConfigPortability.cs
@@ -20,6 +20,9 @@ public sealed class ExportedConfig
     public List<BlobContainerConfig> BlobContainers { get; set; } = [];
     public List<ServerConnection> Servers { get; set; } = [];
 
+    /// <summary>Endpoints travel as shapes - name, format, toggles - with their URLs stripped.</summary>
+    public List<WebhookEndpoint> Webhooks { get; set; } = [];
+
     public AppMode? Mode { get; set; }
     public AppTheme Theme { get; set; }
     public bool CheckForUpdates { get; set; } = true;
@@ -76,6 +79,12 @@ public static class ConfigPortability
             ExportedAt = DateTime.Now,
             BlobContainers = config.BlobContainers.Select(Sanitise).ToList(),
             Servers = config.Servers.Select(Clone).ToList(),
+
+            // A Teams or Slack webhook URL carries its signature in the path - anyone holding it
+            // can post as the integration. The entry travels; the secret stays.
+            Webhooks = config.Webhooks
+                .Select(w => { var c = CloneViaJson(w); c.Url = string.Empty; return c; })
+                .ToList(),
             Mode = config.Mode,
             Theme = config.Theme,
             CheckForUpdates = config.CheckForUpdates,
@@ -147,6 +156,24 @@ public static class ConfigPortability
                 var index = target.Servers.IndexOf(existing);
                 target.Servers[index] = clone;
                 serversUpdated++;
+            }
+        }
+
+        foreach (var incoming in imported.Webhooks)
+        {
+            var clone = CloneViaJson(incoming);
+            var existing = target.Webhooks.FirstOrDefault(w => w.Id == clone.Id);
+
+            if (existing == null)
+            {
+                target.Webhooks.Add(clone);
+                if (!clone.IsUsable) needCredentials.Add($"webhook {clone.Name}");
+            }
+            else
+            {
+                // The URL never travels, so an update must not blank the one this machine holds.
+                clone.Url = existing.Url;
+                target.Webhooks[target.Webhooks.IndexOf(existing)] = clone;
             }
         }
 

--- a/src/NineLives/Services/CredentialStore.cs
+++ b/src/NineLives/Services/CredentialStore.cs
@@ -311,6 +311,12 @@ public class AppConfig
     /// </summary>
     public AppMode? Mode { get; set; }
 
+    /// <summary>
+    /// Where run notifications go (#242): Teams, Slack, or any JSON endpoint. The URLs are
+    /// secrets in all but name and never leave this machine in an export (#213).
+    /// </summary>
+    public List<WebhookEndpoint> Webhooks { get; set; } = [];
+
     /// <summary>Where the window was when the app closed, or null before the first close (#211).</summary>
     public WindowGeometry? Window { get; set; }
 

--- a/src/NineLives/Services/RunNotifications.cs
+++ b/src/NineLives/Services/RunNotifications.cs
@@ -1,0 +1,48 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>The three moments a run is worth interrupting somebody's other work for (#242).</summary>
+public enum RunPhase
+{
+    Started,
+    Succeeded,
+
+    /// <summary>Failed, cancelled, or a problem mid-run - anything where attention helps.</summary>
+    Problem
+}
+
+/// <summary>
+/// One thing that happened, described well enough to act on from a phone (#242).
+///
+/// The payload builders turn this into each provider's shape; the fields are chosen so the
+/// message answers the sofa questions - what ran, where, did it work, how long, and if not, what
+/// went wrong - without opening the app.
+/// </summary>
+/// <param name="Phase">Started, succeeded, or a problem.</param>
+/// <param name="Operation">"Restore", "Backup", "Copy" - the verb, capitalised for the title.</param>
+/// <param name="Subject">What it operated on - "MyDb", or "3 databases".</param>
+/// <param name="Target">Where - "SRV01", or "SRV01 → SRV02" for a copy.</param>
+/// <param name="Detail">The line that matters: the failure message, or the outcome summary.</param>
+/// <param name="Duration">How long it ran, for finished and failed runs.</param>
+public sealed record RunNotification(
+    RunPhase Phase,
+    string Operation,
+    string Subject,
+    string Target,
+    string? Detail = null,
+    TimeSpan? Duration = null);
+
+/// <summary>
+/// The seam the screens talk to (#242). Fire-and-forget by contract: a notification is about a
+/// run, and must never be able to slow, block or fail the run it is about.
+/// </summary>
+public interface IRunNotifier
+{
+    void Notify(RunNotification notification);
+}
+
+/// <summary>For screens constructed without notification wiring - the tests, mostly.</summary>
+public sealed class NullRunNotifier : IRunNotifier
+{
+    public static readonly NullRunNotifier Instance = new();
+    public void Notify(RunNotification notification) { }
+}

--- a/src/NineLives/Services/WebhookNotifier.cs
+++ b/src/NineLives/Services/WebhookNotifier.cs
@@ -1,0 +1,258 @@
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Builds and posts the notification payloads (#242).
+///
+/// The formats follow the PerformanceMonitor implementation deliberately - the same three
+/// providers, the same shapes that are already proven against real Teams and Slack channels:
+/// Teams gets a MessageCard (legacy connectors and Power Automate request-trigger flows both
+/// accept it), Slack gets Block Kit, and Generic gets plain JSON for anything home-made.
+///
+/// Delivery is best-effort with a short timeout, and a failure is a log line, never a dialog:
+/// the run's outcome must not be hostage to a chat service.
+/// </summary>
+public class WebhookNotifier
+{
+    private static readonly TimeSpan PostTimeout = TimeSpan.FromSeconds(10);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly HttpMessageHandler? _handler;
+
+    /// <param name="handler">Lets a test intercept the POST; null uses the real network.</param>
+    public WebhookNotifier(HttpMessageHandler? handler = null) => _handler = handler;
+
+    // ── what each phase looks like ──────────────────────────────────────────────
+
+    /// <summary>Colour, badge and emoji per phase - blue for started, green done, red trouble.</summary>
+    internal static (string ThemeColor, string Badge, string Emoji) Look(RunPhase phase) => phase switch
+    {
+        RunPhase.Started => ("0078D7", "STARTED", "\U0001F535"),
+        RunPhase.Succeeded => ("107C10", "COMPLETED", "✅"),
+        _ => ("D13438", "PROBLEM", "❌")
+    };
+
+    internal static string Title(RunNotification n)
+    {
+        var (_, badge, emoji) = Look(n.Phase);
+        return $"{emoji} {badge} — {n.Operation} {n.Subject}";
+    }
+
+    private static string DescribeDuration(TimeSpan d) =>
+        d.TotalHours >= 1 ? $"{(int)d.TotalHours}h {d.Minutes:D2}m {d.Seconds:D2}s"
+        : d.TotalMinutes >= 1 ? $"{(int)d.TotalMinutes}m {d.Seconds:D2}s"
+        : $"{d.TotalSeconds:N0}s";
+
+    // ── the payloads ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A MessageCard: activityTitle, facts, themeColor. The same card the PerformanceMonitor
+    /// webhooks send, which both the legacy Teams connectors and the Power Automate flows that
+    /// replaced them render.
+    /// </summary>
+    internal static string BuildTeamsPayload(RunNotification n, bool isTest = false)
+    {
+        var (themeColor, badge, _) = Look(n.Phase);
+
+        var facts = new List<object>();
+
+        if (isTest)
+        {
+            facts.Add(new { name = "Status", value = "Webhook configuration is working correctly" });
+            facts.Add(new { name = "Sent at", value = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") });
+        }
+        else
+        {
+            facts.Add(new { name = "Operation", value = $"{n.Operation} {n.Subject}" });
+            facts.Add(new { name = "Server", value = n.Target });
+            if (n.Duration is { } d)
+                facts.Add(new { name = "Duration", value = DescribeDuration(d) });
+            if (!string.IsNullOrWhiteSpace(n.Detail))
+                facts.Add(new { name = n.Phase == RunPhase.Problem ? "Problem" : "Detail", value = n.Detail });
+            facts.Add(new { name = "Time (Local)", value = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss") });
+            facts.Add(new { name = "Time (UTC)", value = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss") });
+        }
+
+        var card = new Dictionary<string, object>
+        {
+            // Dictionary keys, not anonymous-object members: MessageCard requires the literal
+            // "@type" and "@context", and @ in a C# identifier is an escape, not a character -
+            // the anonymous form serialises as "type", which Teams quietly drops on the floor.
+            ["@type"] = "MessageCard",
+            ["@context"] = "http://schema.org/extensions",
+            ["themeColor"] = themeColor,
+            ["summary"] = isTest
+                ? "[Nine Lives] Test Notification"
+                : $"[Nine Lives] {badge}: {n.Operation} {n.Subject} on {n.Target}",
+            ["sections"] = new object[]
+            {
+                new
+                {
+                    activityTitle = isTest ? "\U0001F535 TEST — Nine Lives notifications" : Title(n),
+                    activitySubtitle = $"Nine Lives {AppVersion.Display}",
+                    facts,
+                    markdown = true
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(card, JsonOptions);
+    }
+
+    /// <summary>Slack Block Kit: a header block, then mrkdwn fields - PerformanceMonitor's shape.</summary>
+    internal static string BuildSlackPayload(RunNotification n, bool isTest = false)
+    {
+        var fields = new List<object>();
+
+        if (isTest)
+        {
+            fields.Add(new { type = "mrkdwn", text = "*Status:*\nWebhook configuration is working correctly" });
+            fields.Add(new { type = "mrkdwn", text = $"*Sent at:*\n{DateTime.Now:yyyy-MM-dd HH:mm:ss}" });
+        }
+        else
+        {
+            fields.Add(new { type = "mrkdwn", text = $"*Operation:*\n{n.Operation} {n.Subject}" });
+            fields.Add(new { type = "mrkdwn", text = $"*Server:*\n{n.Target}" });
+            if (n.Duration is { } d)
+                fields.Add(new { type = "mrkdwn", text = $"*Duration:*\n{DescribeDuration(d)}" });
+            fields.Add(new { type = "mrkdwn", text = $"*Time (Local):*\n{DateTime.Now:yyyy-MM-dd HH:mm:ss}" });
+        }
+
+        var blocks = new List<object>
+        {
+            new
+            {
+                type = "header",
+                text = new
+                {
+                    type = "plain_text",
+                    text = isTest ? "\U0001F535 TEST — Nine Lives notifications" : Title(n),
+                    emoji = true
+                }
+            },
+            new { type = "section", fields }
+        };
+
+        if (!isTest && !string.IsNullOrWhiteSpace(n.Detail))
+        {
+            blocks.Add(new { type = "divider" });
+            blocks.Add(new
+            {
+                type = "section",
+                text = new
+                {
+                    type = "mrkdwn",
+                    text = $"*{(n.Phase == RunPhase.Problem ? "Problem" : "Detail")}:*\n{n.Detail}"
+                }
+            });
+        }
+
+        return JsonSerializer.Serialize(new { blocks }, JsonOptions);
+    }
+
+    /// <summary>
+    /// Plain JSON for the home-made consumer - a Power Automate HTTP trigger, Zapier, a ticket
+    /// system. Everything the fancy formats carry, as fields, nothing needing parsing back out
+    /// of display text.
+    /// </summary>
+    internal static string BuildGenericPayload(RunNotification n, bool isTest = false)
+    {
+        var payload = new
+        {
+            app = "NineLives",
+            version = AppVersion.Display,
+            isTest,
+            phase = n.Phase.ToString(),
+            operation = n.Operation,
+            subject = n.Subject,
+            target = n.Target,
+            detail = n.Detail,
+            durationSeconds = n.Duration?.TotalSeconds,
+            atLocal = DateTime.Now,
+            atUtc = DateTime.UtcNow
+        };
+
+        return JsonSerializer.Serialize(payload, JsonOptions);
+    }
+
+    internal static string BuildPayload(WebhookFormat format, RunNotification n, bool isTest = false) =>
+        format switch
+        {
+            WebhookFormat.Slack => BuildSlackPayload(n, isTest),
+            WebhookFormat.Generic => BuildGenericPayload(n, isTest),
+            _ => BuildTeamsPayload(n, isTest)
+        };
+
+    // ── sending ─────────────────────────────────────────────────────────────────
+
+    /// <summary>Whether this endpoint wants to hear about this phase.</summary>
+    internal static bool Wants(WebhookEndpoint endpoint, RunPhase phase) => phase switch
+    {
+        RunPhase.Started => endpoint.NotifyStarted,
+        RunPhase.Succeeded => endpoint.NotifyFinished,
+        _ => endpoint.NotifyProblems
+        };
+
+    /// <summary>
+    /// Posts to every endpoint that wants this phase. Failures go to <paramref name="log"/> and
+    /// nowhere else - the run this describes must never be affected by its announcement.
+    /// </summary>
+    public async Task NotifyAsync(
+        IReadOnlyList<WebhookEndpoint> endpoints, RunNotification notification, Action<string>? log = null)
+    {
+        foreach (var endpoint in endpoints)
+        {
+            if (!endpoint.IsUsable || !Wants(endpoint, notification.Phase)) continue;
+
+            var error = await PostAsync(endpoint.Url, BuildPayload(endpoint.Format, notification));
+
+            log?.Invoke(error == null
+                ? $"[notify] {endpoint.Name}: {notification.Phase} {notification.Operation} {notification.Subject}"
+                : $"[notify] {endpoint.Name} FAILED: {error}");
+        }
+    }
+
+    /// <summary>A test message to one endpoint. Null on success, the error text on failure.</summary>
+    public Task<string?> SendTestAsync(WebhookEndpoint endpoint)
+    {
+        if (!endpoint.IsUsable) return Task.FromResult<string?>("The webhook URL is empty.");
+
+        var test = new RunNotification(RunPhase.Started, "Test", "notification", Environment.MachineName);
+        return PostAsync(endpoint.Url, BuildPayload(endpoint.Format, test, isTest: true));
+    }
+
+    private async Task<string?> PostAsync(string url, string payload)
+    {
+        try
+        {
+            using var client = _handler == null ? new HttpClient() : new HttpClient(_handler, false);
+            client.Timeout = PostTimeout;
+
+            using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+            using var response = await client.PostAsync(url, content);
+
+            if (response.IsSuccessStatusCode) return null;
+
+            var body = await response.Content.ReadAsStringAsync();
+            return $"HTTP {(int)response.StatusCode}: {Truncate(body)}";
+        }
+        catch (TaskCanceledException)
+        {
+            return $"No response within {PostTimeout.TotalSeconds:N0}s.";
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
+    }
+
+    private static string Truncate(string s) => s.Length <= 200 ? s : s[..200] + "...";
+}

--- a/src/NineLives/Services/WebhookRunNotifier.cs
+++ b/src/NineLives/Services/WebhookRunNotifier.cs
@@ -1,0 +1,58 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// The real <see cref="IRunNotifier"/>: reads the configured endpoints and posts to them in the
+/// background (#242).
+///
+/// The endpoint list is read fresh per notification rather than cached, so a webhook added in
+/// Settings starts working immediately - a restore is exactly the wrong moment to discover the
+/// app is still holding yesterday's list.
+///
+/// Fire-and-forget by construction: Notify returns before any network happens, and everything
+/// that can go wrong lands in the operation log. A notification is ABOUT a run; it must never
+/// slow, block or fail one.
+/// </summary>
+public sealed class WebhookRunNotifier : IRunNotifier
+{
+    private readonly ICredentialStore _store;
+    private readonly OperationLog _log;
+    private readonly WebhookNotifier _notifier;
+
+    public WebhookRunNotifier(ICredentialStore store, OperationLog log, WebhookNotifier? notifier = null)
+    {
+        _store = store;
+        _log = log;
+        _notifier = notifier ?? new WebhookNotifier();
+    }
+
+    public void Notify(RunNotification notification)
+    {
+        List<WebhookEndpoint> endpoints;
+        try
+        {
+            endpoints = _store.LoadConfig().Webhooks.Where(w => w.IsUsable).ToList();
+        }
+        catch
+        {
+            // An unreadable config is reported where it is loaded for real; a notification is
+            // not the place to add a second copy of that failure.
+            return;
+        }
+
+        if (endpoints.Count == 0) return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await _notifier.NotifyAsync(endpoints, notification, line => _log.Info(line));
+            }
+            catch (Exception ex)
+            {
+                _log.Warn($"[notify] delivery failed: {ex.Message}");
+            }
+        });
+    }
+}

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -20,14 +20,18 @@ namespace Blackcat.NineLives.ViewModels;
 /// </summary>
 public partial class BackupViewModel : ViewModelBase
 {
+    private readonly IRunNotifier _notifier;
     private readonly ICredentialStore _store;
     private readonly ISqlServerService _sql;
     private readonly BackupScriptGenerator _generator = new();
     private readonly OperationCancellation _cancellation = new();
     private readonly OperationLog _log;
 
-    public BackupViewModel(ICredentialStore store, ISqlServerService sql, OperationLog? log = null)
+    public BackupViewModel(
+        ICredentialStore store, ISqlServerService sql, OperationLog? log = null,
+        IRunNotifier? notifier = null)
     {
+        _notifier = notifier ?? NullRunNotifier.Instance;
         _store = store;
         _sql = sql;
         _log = log ?? App.Log;
@@ -491,6 +495,11 @@ public partial class BackupViewModel : ViewModelBase
             _log.Info($"Backup started: {run.Count} database(s) on {Server.ServerName}, " +
                       $"copyOnly={CopyOnly}, files={Destinations.Count}");
 
+            _notifier.Notify(new RunNotification(
+                RunPhase.Started, "Backup",
+                run.Count == 1 ? run[0].Database : $"{run.Count} databases",
+                Server.ServerName));
+
             foreach (var (database, script, destinations) in run)
             {
                 ct.ThrowIfCancellationRequested();
@@ -514,6 +523,12 @@ public partial class BackupViewModel : ViewModelBase
                     failed.Add(database);
                     lastFailureMessage = ex.Message;
                     _log.Error($"Backup failed: {database}: {ex.Message}");
+
+                    // At the moment of the problem, not minutes later in the summary (#242): the
+                    // rest of the run continues, and whoever is off watching something else can
+                    // decide NOW whether this failure changes their evening.
+                    _notifier.Notify(new RunNotification(
+                        RunPhase.Problem, "Backup", database, Server.ServerName, ex.Message));
                 }
             }
 
@@ -526,6 +541,11 @@ public partial class BackupViewModel : ViewModelBase
                     ? $"Backed up {run[0].Database} in {elapsed.TotalSeconds:N0}s."
                     : $"Backed up {run.Count} databases in {elapsed.TotalSeconds:N0}s.");
                 _log.Info($"Backup finished: {run.Count} database(s) in {elapsed.TotalSeconds:N0}s");
+
+                _notifier.Notify(new RunNotification(
+                    RunPhase.Succeeded, "Backup",
+                    run.Count == 1 ? run[0].Database : $"{run.Count} databases",
+                    Server.ServerName, Duration: elapsed));
             }
             else if (run.Count == 1)
             {
@@ -535,8 +555,15 @@ public partial class BackupViewModel : ViewModelBase
             }
             else
             {
-                SetError($"{failed.Count} of {run.Count} did not complete: {string.Join(", ", failed)}. " +
-                         "The others finished and are real backups - see the console for each failure.");
+                var summary = $"{failed.Count} of {run.Count} did not complete: {string.Join(", ", failed)}. " +
+                              "The others finished and are real backups - see the console for each failure.";
+                SetError(summary);
+
+                // The per-database problems already fired as they happened; this is the close of
+                // the run, so the channel shows it ENDED and how it ended.
+                _notifier.Notify(new RunNotification(
+                    RunPhase.Problem, "Backup", $"{run.Count} databases", Server.ServerName,
+                    summary, elapsed));
             }
 
             // What was just written is the thing to verify (#207) - only what actually succeeded,
@@ -551,6 +578,12 @@ public partial class BackupViewModel : ViewModelBase
             Append("Cancelled. Any file already written is incomplete and cannot be restored from.");
             SetStatus("Backup cancelled.");
             _log.Info("Backup cancelled");
+
+            _notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Backup",
+                run.Count == 1 ? run[0].Database : $"{run.Count} databases",
+                Server.ServerName,
+                "Cancelled. Any file already written is incomplete and cannot be restored from."));
 
             // What finished before the stop is still real.
             _lastWrittenDevices = succeededDevices;

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -27,6 +27,7 @@ namespace Blackcat.NineLives.ViewModels;
 /// </summary>
 public partial class CopyDatabaseViewModel : ViewModelBase
 {
+    private readonly IRunNotifier _notifier;
     private readonly ICredentialStore _store;
     private readonly ISqlServerService _sql;
     private readonly BackupScriptGenerator _backupGenerator = new();
@@ -34,8 +35,11 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     private readonly OperationCancellation _cancellation = new();
     private readonly OperationLog _log;
 
-    public CopyDatabaseViewModel(ICredentialStore store, ISqlServerService sql, OperationLog? log = null)
+    public CopyDatabaseViewModel(
+        ICredentialStore store, ISqlServerService sql, OperationLog? log = null,
+        IRunNotifier? notifier = null)
     {
+        _notifier = notifier ?? NullRunNotifier.Instance;
         _store = store;
         _sql = sql;
         _log = log ?? App.Log;
@@ -594,6 +598,12 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         _log.Info($"Copy started: {SourceDatabase} from {SourceServer.ServerName} " +
                   $"to {TargetServer!.ServerName} as {TargetDatabaseName}");
 
+        var copyStartedAt = DateTime.Now;
+        var copyRoute = $"{SourceServer.ServerName} \u2192 {TargetServer.ServerName}";
+
+        _notifier.Notify(new RunNotification(
+            RunPhase.Started, "Copy", SourceDatabase!, copyRoute, $"as {TargetDatabaseName}"));
+
         try
         {
             await _sql.ExecuteWithProgressAsync(SourceServer, BackupScript, Append, ct);
@@ -602,6 +612,9 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         {
             Append("Cancelled during the backup.");
             Outcome = CopyOutcome.BackupFailed;
+            _notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
+                "Cancelled during the backup half.", DateTime.Now - copyStartedAt));
             return;
         }
         catch (Exception ex)
@@ -609,6 +622,9 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             Append(ex.Message);
             Outcome = CopyOutcome.BackupFailed;
             _log.Error($"Copy failed during backup: {ex.Message}");
+            _notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
+                $"The backup half failed: {ex.Message}", DateTime.Now - copyStartedAt));
             return;
         }
 
@@ -624,6 +640,10 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         if (MediumIsSharedPath && !await TargetCanReadAsync(ct))
         {
             Outcome = CopyOutcome.BackupTakenRestoreFailed;
+            _notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
+                "The backup was taken, but the target cannot read it - usually a share " +
+                "permission for the target's service account.", DateTime.Now - copyStartedAt));
             return;
         }
 
@@ -638,6 +658,10 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         {
             Append("Cancelled during the restore.");
             Outcome = CopyOutcome.BackupTakenRestoreFailed;
+            _notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
+                "Cancelled during the restore half - the backup exists, the target is mid-restore.",
+                DateTime.Now - copyStartedAt));
             return;
         }
         catch (Exception ex)
@@ -645,12 +669,20 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             Append(ex.Message);
             Outcome = CopyOutcome.BackupTakenRestoreFailed;
             _log.Error($"Copy failed during restore: {ex.Message}");
+            _notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
+                $"The restore half failed: {ex.Message}", DateTime.Now - copyStartedAt));
             return;
         }
 
         Append("Restore complete.");
         Outcome = CopyOutcome.Copied;
         _log.Info($"Copy finished: {TargetDatabaseName} on {TargetServer.ServerName}");
+
+        _notifier.Notify(new RunNotification(
+            RunPhase.Succeeded, "Copy", SourceDatabase!, copyRoute,
+            $"Now on {TargetServer.ServerName} as {TargetDatabaseName}.",
+            DateTime.Now - copyStartedAt));
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -226,15 +226,19 @@ public partial class MainViewModel : ViewModelBase
         // and two instances pointed at the same file would be a way to lose an entry.
         _historyStore = new RestoreHistoryStore();
 
+        // One notifier for every screen that runs things (#242) - reads the endpoint list fresh
+        // per event, so a webhook added in Settings works without a restart.
+        var notifier = new WebhookRunNotifier(_credentialStore, App.Log);
+
         Restore = new RestoreViewModel(
             _blobService, _sqlService, _chainBuilder, _scriptGenerator, _credentialStore,
-            log: null, history: _historyStore);
+            log: null, history: _historyStore, notifier: notifier);
         ModeSelection = new ModeSelectionViewModel(_credentialStore);
         ModeSelection.Chosen += OnModeChosen;
         ModeSelection.Cancelled += OnModeCardsCancelled;
 
-        Backup = new BackupViewModel(_credentialStore, _sqlService);
-        CopyDatabase = new CopyDatabaseViewModel(_credentialStore, _sqlService);
+        Backup = new BackupViewModel(_credentialStore, _sqlService, notifier: notifier);
+        CopyDatabase = new CopyDatabaseViewModel(_credentialStore, _sqlService, notifier: notifier);
         History = new HistoryViewModel(_historyStore);
         Settings = new SettingsViewModel(_credentialStore);
         About = new AboutViewModel();

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -39,6 +39,7 @@ public sealed record RestoreRun(
 /// </summary>
 public partial class RestoreExecutionViewModel : ViewModelBase
 {
+    private readonly IRunNotifier _notifier;
     private readonly ISqlServerService _sql;
     private readonly IRestoreHistoryStore _history;
     private readonly OperationLog _log;
@@ -57,8 +58,10 @@ public partial class RestoreExecutionViewModel : ViewModelBase
         ISqlServerService sql,
         IRestoreHistoryStore history,
         OperationLog log,
-        OperationCancellation queryCancellation)
+        OperationCancellation queryCancellation,
+        IRunNotifier? notifier = null)
     {
+        _notifier = notifier ?? NullRunNotifier.Instance;
         _sql = sql;
         _history = history;
         _log = log;
@@ -226,6 +229,12 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             AppendLog("Beginning restore execution...\n");
 
+            // Announced AFTER the preflights: a run the preflight refused never started, and
+            // "started" messages for runs that went nowhere teach people to ignore the channel.
+            _notifier.Notify(new RunNotification(
+                RunPhase.Started, "Restore", run.TargetDatabase, run.Server.ServerName,
+                run.ChainSummary));
+
             await _sql.ExecuteWithProgressAsync(
                 run.Server,
                 run.Script,
@@ -262,6 +271,10 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             AppendLog("\nRestore completed successfully!");
             SetStatus("Restore execution completed successfully.");
 
+            _notifier.Notify(new RunNotification(
+                RunPhase.Succeeded, "Restore", run.TargetDatabase, run.Server.ServerName,
+                run.ChainSummary, DateTime.Now - startedAt));
+
             // The restore is not the end of the job (#205): nobody has verified the data yet, and
             // on a different server every SQL-auth user is orphaned. Reported while the outcome is
             // on screen, in the same shape as the recovery panel - read, then run.
@@ -285,6 +298,11 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             SetError("Restore cancelled. The target database has been left mid-restore - see below.");
 
+            _notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Restore", run.TargetDatabase, run.Server.ServerName,
+                "Cancelled part-way through the chain - the target is left mid-restore.",
+                DateTime.Now - startedAt));
+
             await ReportRecoveryStateAsync(run.Server, run.TargetDatabase);
         }
         catch (Exception ex)
@@ -294,6 +312,10 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             failure = ex.Message;
             AppendLog($"\nERROR: {ex.Message}");
             SetError($"Restore failed: {ex.Message}");
+
+            _notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Restore", run.TargetDatabase, run.Server.ServerName,
+                ex.Message, DateTime.Now - startedAt));
 
             // The restore has stopped part-way and the target is almost certainly not usable. Find
             // out exactly how, and say so, while the connection is still open (#14).

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -714,7 +714,8 @@ public partial class RestoreViewModel : ViewModelBase
         ICredentialStore credentialStore,
         OperationLog? log = null,
         IRestoreHistoryStore? history = null,
-        IBackupAuditStore? auditStore = null)
+        IBackupAuditStore? auditStore = null,
+        IRunNotifier? notifier = null)
     {
         _history = history ?? new RestoreHistoryStore();
 
@@ -794,7 +795,7 @@ public partial class RestoreViewModel : ViewModelBase
             }
         };
 
-        Execution = new RestoreExecutionViewModel(sqlService, _history, _log, _queryCancellation);
+        Execution = new RestoreExecutionViewModel(sqlService, _history, _log, _queryCancellation, notifier);
 
         // The run reports through the same status line as the rest of the screen, and its cancel
         // state feeds the one Stop button that covers every server call here.

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -24,6 +24,54 @@ public partial class SettingsViewModel : ViewModelBase
     private readonly ICredentialStore _credentialStore;
     private readonly OperationLog _log;
 
+    // ── notifications (#242) ────────────────────────────────────────────────────
+
+    /// <summary>The rows on screen. Each edits its model object; Save persists the lot.</summary>
+    public System.Collections.ObjectModel.ObservableCollection<WebhookEndpointViewModel> Webhooks { get; } = [];
+
+    /// <summary>What the last webhook test said, per the whole card - "sent" or the error.</summary>
+    [ObservableProperty]
+    private string _webhookTestResult = string.Empty;
+
+    private void LoadWebhooks(AppConfig config)
+    {
+        Webhooks.Clear();
+        foreach (var endpoint in config.Webhooks)
+            Webhooks.Add(new WebhookEndpointViewModel(endpoint, SaveWebhooks, TestWebhookAsync));
+    }
+
+    [RelayCommand]
+    private void AddWebhook()
+    {
+        var endpoint = new WebhookEndpoint { Name = $"Endpoint {Webhooks.Count + 1}" };
+        Webhooks.Add(new WebhookEndpointViewModel(endpoint, SaveWebhooks, TestWebhookAsync));
+        SaveWebhooks();
+    }
+
+    [RelayCommand]
+    private void RemoveWebhook(WebhookEndpointViewModel? row)
+    {
+        if (row == null) return;
+        Webhooks.Remove(row);
+        SaveWebhooks();
+    }
+
+    /// <summary>The whole list, rewritten from what is on screen - additive edits, no merging.</summary>
+    private void SaveWebhooks() =>
+        Save(config =>
+        {
+            config.Webhooks = Webhooks.Select(w => w.Model).ToList();
+        }, "The notification settings could not be saved");
+
+    private async Task TestWebhookAsync(WebhookEndpointViewModel row)
+    {
+        WebhookTestResult = $"Sending a test to {row.Name}...";
+        var error = await new WebhookNotifier().SendTestAsync(row.Model);
+        WebhookTestResult = error == null
+            ? $"Test sent to {row.Name} - check the channel."
+            : $"{row.Name}: {error}";
+    }
+
     // ── moving machines (#213) ──────────────────────────────────────────────────
 
     /// <summary>
@@ -113,6 +161,7 @@ public partial class SettingsViewModel : ViewModelBase
         _loading = true;
         try
         {
+            LoadWebhooks(_credentialStore.LoadConfig());
             var config = _credentialStore.LoadConfig();
             _selectedTheme = ThemeManager.Current;
             _currentMode = config.Mode ?? AppMode.Pro;

--- a/src/NineLives/ViewModels/WebhookEndpointViewModel.cs
+++ b/src/NineLives/ViewModels/WebhookEndpointViewModel.cs
@@ -1,0 +1,69 @@
+using Blackcat.NineLives.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// One notification endpoint row in Settings (#242): edits its model in place and asks the owner
+/// to persist after each meaningful change - the same read-change-write discipline the rest of
+/// the settings screen keeps.
+/// </summary>
+public partial class WebhookEndpointViewModel : ObservableObject
+{
+    private readonly Action _save;
+    private readonly Func<WebhookEndpointViewModel, Task> _test;
+
+    public WebhookEndpointViewModel(
+        WebhookEndpoint model, Action save, Func<WebhookEndpointViewModel, Task> test)
+    {
+        Model = model;
+        _save = save;
+        _test = test;
+
+        _name = model.Name;
+        _url = model.Url;
+        _format = model.Format;
+        _notifyStarted = model.NotifyStarted;
+        _notifyFinished = model.NotifyFinished;
+        _notifyProblems = model.NotifyProblems;
+    }
+
+    public WebhookEndpoint Model { get; }
+
+    public IReadOnlyList<WebhookFormat> Formats { get; } =
+        [WebhookFormat.Teams, WebhookFormat.Slack, WebhookFormat.Generic];
+
+    [ObservableProperty]
+    private string _name;
+
+    partial void OnNameChanged(string value) { Model.Name = value; _save(); }
+
+    [ObservableProperty]
+    private string _url;
+
+    partial void OnUrlChanged(string value) { Model.Url = value.Trim(); _save(); }
+
+    [ObservableProperty]
+    private WebhookFormat _format;
+
+    partial void OnFormatChanged(WebhookFormat value) { Model.Format = value; _save(); }
+
+    [ObservableProperty]
+    private bool _notifyStarted;
+
+    partial void OnNotifyStartedChanged(bool value) { Model.NotifyStarted = value; _save(); }
+
+    [ObservableProperty]
+    private bool _notifyFinished;
+
+    partial void OnNotifyFinishedChanged(bool value) { Model.NotifyFinished = value; _save(); }
+
+    [ObservableProperty]
+    private bool _notifyProblems;
+
+    partial void OnNotifyProblemsChanged(bool value) { Model.NotifyProblems = value; _save(); }
+
+    [RelayCommand]
+    private Task TestAsync() => _test(this);
+}

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -110,6 +110,94 @@
                 </StackPanel>
             </Border>
 
+            <!-- Notifications (#242): Teams, Slack, or any JSON endpoint - started, finished,
+                 problems. For everyone whose focus is rightly NOT on this application while a
+                 40-minute restore runs. -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,16,0,0">
+                <StackPanel>
+                    <TextBlock Text="Notifications" Style="{StaticResource SubHeaderText}" />
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,10"
+                               Text="Push a message to Teams (incoming webhook or Power Automate), Slack, or any endpoint that accepts JSON when a backup, restore or copy starts, finishes, or hits a problem. Webhook URLs are secrets - they stay on this machine and are never included in a configuration export." />
+
+                    <ItemsControl ItemsSource="{Binding Webhooks}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{DynamicResource InputBackgroundBrush}"
+                                        CornerRadius="4" Padding="10" Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="2*" />
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="3*" />
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <TextBox Grid.Column="0"
+                                                     Text="{Binding Name, UpdateSourceTrigger=LostFocus}"
+                                                     Style="{StaticResource DarkTextBox}"
+                                                     Margin="0,0,8,0"
+                                                     ToolTip="What this endpoint is called in the log." />
+                                            <ComboBox Grid.Column="1"
+                                                      ItemsSource="{Binding Formats}"
+                                                      SelectedItem="{Binding Format}"
+                                                      Style="{StaticResource DarkComboBox}"
+                                                      MinWidth="110"
+                                                      Margin="0,0,8,0" />
+                                            <TextBox Grid.Column="2"
+                                                     Text="{Binding Url, UpdateSourceTrigger=LostFocus}"
+                                                     Style="{StaticResource DarkTextBox}"
+                                                     Margin="0,0,8,0"
+                                                     FontFamily="Consolas"
+                                                     ToolTip="The webhook URL. Treated as a secret: never exported, only ever posted to." />
+                                            <Button Grid.Column="3" Content="Test"
+                                                    Command="{Binding TestCommand}"
+                                                    Style="{StaticResource SecondaryButton}"
+                                                    Padding="10,5" Margin="0,0,8,0" />
+                                            <Button Grid.Column="4" Content="Remove"
+                                                    Command="{Binding DataContext.RemoveWebhookCommand,
+                                                              RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Style="{StaticResource SecondaryButton}"
+                                                    Padding="10,5" />
+                                        </Grid>
+
+                                        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                                            <CheckBox Content="When a run starts"
+                                                      IsChecked="{Binding NotifyStarted}"
+                                                      Style="{StaticResource DarkCheckBox}"
+                                                      Margin="0,0,16,0" />
+                                            <CheckBox Content="When it finishes"
+                                                      IsChecked="{Binding NotifyFinished}"
+                                                      Style="{StaticResource DarkCheckBox}"
+                                                      Margin="0,0,16,0" />
+                                            <CheckBox Content="When there is a problem"
+                                                      IsChecked="{Binding NotifyProblems}"
+                                                      Style="{StaticResource DarkCheckBox}" />
+                                        </StackPanel>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,4,0,0">
+                        <Button Content="Add endpoint"
+                                Command="{Binding AddWebhookCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="14,7" />
+                    </StackPanel>
+
+                    <TextBlock Text="{Binding WebhookTestResult}"
+                               Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,8,0,0" />
+                </StackPanel>
+            </Border>
+
             <!-- Moving machines (#213). The boundary is the feature: the file holds shapes,
                  never secrets. -->
             <Border Style="{StaticResource CardBorder}" Margin="0,16,0,0">


### PR DESCRIPTION
For everyone whose focus is rightly **not** on the application while a long run executes — a message when a backup, restore or copy **starts**, when it **finishes**, and whenever there is a **problem**. A multi-database backup announces each database's failure *at the moment it happens* (the run continues; whoever is elsewhere decides now whether it changes their evening), then the close of the run says how it ended.

## The formats follow PerformanceMonitor's, deliberately

The same three providers, the shapes already proven against real channels:

- **Teams**: MessageCard — rendered by both legacy incoming-webhook connectors and the Power Automate flows that replaced them. The `@type`/`@context` keys are dictionary keys, because `@` in a C# identifier is an escape, not a character — the anonymous-object form serialises as `type`, which Teams quietly drops (caught by the payload test).
- **Slack**: Block Kit — header block, mrkdwn fields, the problem line in its own section.
- **Generic**: plain JSON fields (`phase`, `operation`, `subject`, `target`, `detail`, `durationSeconds`…) for Power Automate HTTP triggers, Zapier, or anything home-made.

## The contract

`IRunNotifier`, fire-and-forget by construction: `Notify` returns before any network happens, delivery failures are log lines, and a notification can never slow, block or fail the run it is about. The endpoint list is read fresh per event — a webhook added in Settings works without a restart. *Started* fires **after** the preflights: runs the preflight refused never started, and started-messages for runs that went nowhere teach people to ignore the channel.

## Settings, and the secret boundary

A Notifications card: any number of endpoints, each with a name, format, URL, the three toggles, and a **Test** button that reports null-or-error honestly. Webhook URLs carry their signatures in the path — they never leave the machine in a configuration export, and an import over a machine that holds one keeps it (#213's boundary, extended, with a test).

Rendered. 14 new tests, 1,502 pass.