### PR TITLE
Rehearse a restore: prove the backup, keep the receipt (#238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **Restore rehearsal: prove a backup restores, with a receipt.** One button restores the chosen
+  chain to a scratch database, proves the data with DBCC CHECKDB, and drops the scratch copy -
+  the History entry records what was proven, when, and how long it took. Safety by construction:
+  a generated name refused if it exists, never WITH REPLACE, every file relocated to
+  scratch-named files, and the guarded DROP runs last so any failure retains the scratch copy as
+  evidence. Rehearsals announce themselves through the run notifications (#238)
 - **Run notifications to Teams, Slack, or any JSON endpoint** - a message when a backup, restore
   or copy starts, when it finishes, and whenever there is a problem, including each database's
   failure in a multi-database backup AT the moment it happens. Teams gets a MessageCard (works

--- a/src/NineLives.Tests/RestoreRehearsalTests.cs
+++ b/src/NineLives.Tests/RestoreRehearsalTests.cs
@@ -1,0 +1,192 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The restore rehearsal (#238): the same chain, restored to a scratch name, proven with CHECKDB,
+/// dropped - leaving nothing behind but the receipt. The only tested backup is a restored backup,
+/// and this makes the test cheap enough to actually run.
+///
+/// The safety promise is BY CONSTRUCTION: generated name refused if it exists, no WITH REPLACE
+/// ever, every file MOVEd to scratch-named files, and the DROP guarded and last so any failure
+/// retains the evidence.
+/// </summary>
+public class RestoreRehearsalTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 10, 9, 30, 0);
+
+    // ── the planner ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheScratchNameSaysWhatItIs()
+    {
+        Assert.Equal("MyDb_rehearsal_20260810_0930", RehearsalPlanner.ScratchName("MyDb", T0));
+    }
+
+    /// <summary>Every file relocates - rows to data, logs to log, all scratch-named.</summary>
+    [Fact]
+    public void EveryFileMovesToScratchNamedFiles()
+    {
+        var files = new List<FileMoveOption>
+        {
+            new() { LogicalName = "MyDb", PhysicalName = @"D:\SQL\MyDb.mdf", Type = "D" },
+            new() { LogicalName = "MyDb_2", PhysicalName = @"D:\SQL\MyDb_2.ndf", Type = "D" },
+            new() { LogicalName = "MyDb_log", PhysicalName = @"L:\SQL\MyDb_log.ldf", Type = "L" }
+        };
+
+        var moves = RehearsalPlanner.ScratchMoves(files, "MyDb_rehearsal_20260810_0930",
+            @"C:\Data", @"C:\Log");
+
+        Assert.Equal(@"C:\Data\MyDb_rehearsal_20260810_0930.mdf", moves[0].NewPhysicalName);
+        Assert.Equal(@"C:\Data\MyDb_rehearsal_20260810_0930_2.ndf", moves[1].NewPhysicalName);
+        Assert.Equal(@"C:\Log\MyDb_rehearsal_20260810_0930_log.ldf", moves[2].NewPhysicalName);
+    }
+
+    /// <summary>Restore, then proof, then guarded cleanup - in that order, always.</summary>
+    [Fact]
+    public void TheScriptProvesBeforeItCleansUp()
+    {
+        var script = RehearsalPlanner.BuildScript(
+            "RESTORE DATABASE [MyDb_rehearsal_20260810_0930] FROM DISK = N'D:\\b.bak' WITH RECOVERY;",
+            "MyDb_rehearsal_20260810_0930");
+
+        var checkdb = script.IndexOf("DBCC CHECKDB", StringComparison.Ordinal);
+        var drop = script.IndexOf("DROP DATABASE", StringComparison.Ordinal);
+
+        Assert.True(checkdb > 0 && drop > checkdb, "order must be restore, CHECKDB, drop");
+        Assert.Contains("IF DB_ID('MyDb_rehearsal_20260810_0930') IS NOT NULL", script);
+        Assert.Contains("retained as the evidence", script);
+    }
+
+    // ── the command's construction promises ─────────────────────────────────────
+
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    /// <summary>A wired restore screen with a chain selected, connected, in the widest mode.</summary>
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql, FakeRunNotifier notifier)>
+        ReadyAsync()
+    {
+        var (vm, sql, notifier, _) = await ReadyWithHistoryAsync();
+        return (vm, sql, notifier);
+    }
+
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql, FakeRunNotifier notifier,
+            FakeRestoreHistoryStore history)>
+        ReadyWithHistoryAsync()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server());
+
+        var sql = new FakeSqlServerService
+        {
+            FileHeaders =
+            {
+                [@"D:\drop\MyDb.bak"] =
+                [
+                    new BackupHistoryEntry
+                    {
+                        DatabaseName = "MyDb",
+                        Type = BackupType.Full,
+                        StartedAt = T0.AddHours(-1),
+                        FinishedAt = T0.AddHours(-1).AddMinutes(1),
+                        CheckpointLsn = 100m,
+                        Position = 1,
+                        Files = [@"D:\drop\MyDb.bak"]
+                    }
+                ]
+            },
+            FileList =
+            [
+                new FileMoveOption { LogicalName = "MyDb", PhysicalName = @"D:\SQL\MyDb.mdf", Type = "D" },
+                new FileMoveOption { LogicalName = "MyDb_log", PhysicalName = @"L:\SQL\MyDb_log.ldf", Type = "L" }
+            ]
+        };
+
+        var notifier = new FakeRunNotifier();
+        var history = new FakeRestoreHistoryStore();
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), sql, new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(),
+            history, TestAuditStores.Temp(), notifier)
+        {
+            Mode = AppMode.Pro
+        };
+        vm.RefreshContainers();
+
+        vm.SelectedMedium = BackupMedium.AdHocFile;
+        vm.SourceServer = vm.SourceServers[0];
+        vm.AdHocPathsText = @"D:\drop\MyDb.bak";
+        await vm.Inventory.LoadAsync(vm.CurrentLocation!);
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Last();
+
+        vm.ConnectedServer = Server();
+        vm.IsConnectedToServer = true;
+
+        return (vm, sql, notifier, history);
+    }
+
+    [Fact]
+    public async Task ARehearsalRunsScratchCheckdbAndGuardedDrop()
+    {
+        var (vm, sql, notifier) = await ReadyAsync();
+
+        await vm.RehearseCommand.ExecuteAsync(null);
+
+        var script = Assert.Single(sql.ExecutedScripts);
+
+        Assert.Contains("_rehearsal_", script);
+        Assert.DoesNotContain("REPLACE", script);           // nothing to replace, ever
+        Assert.Contains("MOVE N'MyDb'", script);            // every file relocated
+        Assert.Contains("MOVE N'MyDb_log'", script);
+        Assert.Contains("DBCC CHECKDB", script);
+        Assert.Contains("DROP DATABASE", script);
+
+        // The receipt and the announcement both say what this was.
+        Assert.Contains(notifier.Sent, n => n.Operation == "Rehearsal" && n.Phase == RunPhase.Succeeded);
+    }
+
+    /// <summary>The whole design promise: a name that exists refuses, before anything runs.</summary>
+    [Fact]
+    public async Task AScratchNameThatSomehowExistsRefuses()
+    {
+        var (vm, sql, _) = await ReadyAsync();
+        sql.RecoveryState = new DatabaseRecoveryState(true, "ONLINE", "MULTI_USER");
+
+        await vm.RehearseCommand.ExecuteAsync(null);
+
+        Assert.Empty(sql.ExecutedScripts);
+        Assert.True(vm.HasError);
+        Assert.Contains("refused", vm.StatusMessage);
+    }
+
+    /// <summary>Rehearsal is part of the checking machinery - the widest mode only (#176).</summary>
+    [Fact]
+    public async Task TheNarrowerModesDoNotOfferIt()
+    {
+        var (vm, _, _) = await ReadyAsync();
+
+        Assert.True(vm.CanRehearse);
+
+        vm.Mode = AppMode.Standard;
+
+        Assert.False(vm.CanRehearse);
+    }
+
+    [Fact]
+    public async Task TheHistoryReceiptSaysRehearsal()
+    {
+        var (vm, _, _, history) = await ReadyWithHistoryAsync();
+
+        await vm.RehearseCommand.ExecuteAsync(null);
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal("Rehearsal", entry.Kind);
+        Assert.Contains("_rehearsal_", entry.TargetDatabase);
+        Assert.Equal(RestoreOutcome.Succeeded, entry.Outcome);
+    }
+}

--- a/src/NineLives/Models/RestoreHistoryEntry.cs
+++ b/src/NineLives/Models/RestoreHistoryEntry.cs
@@ -38,6 +38,13 @@ public sealed class RestoreHistoryEntry
     /// <summary>e.g. "1 Full + 2 Log(s)".</summary>
     public string ChainSummary { get; set; } = string.Empty;
 
+    /// <summary>
+    /// "Restore" or "Rehearsal" (#238). A string, not an enum, so records survive both
+    /// directions across versions; entries written before this field existed read as "Restore",
+    /// which is what they were.
+    /// </summary>
+    public string Kind { get; set; } = "Restore";
+
     public RestoreOutcome Outcome { get; set; }
 
     /// <summary>What went wrong, when something did.</summary>

--- a/src/NineLives/Services/RehearsalPlanner.cs
+++ b/src/NineLives/Services/RehearsalPlanner.cs
@@ -1,0 +1,91 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Plans a restore rehearsal (#238): the same chain, restored to a scratch name, proven with
+/// CHECKDB, and dropped - leaving nothing behind but the evidence.
+///
+/// The DBA proverb the whole industry repeats and almost nobody acts on: the only tested backup
+/// is a restored backup. A rehearsal is that test, made cheap enough to actually run - and its
+/// history entry is the receipt the audit question asks for.
+///
+/// Safety by construction, not by care:
+///  - the target name is GENERATED, timestamped, and refused outright if it somehow exists;
+///  - WITH REPLACE is never emitted - a fresh name has nothing to replace, and leaving the
+///    option off means a collision fails loudly instead of overwriting;
+///  - every file MOVEs to scratch-named files in the instance's default directories, so the
+///    rehearsal cannot touch the real database's files even in a path collision;
+///  - the DROP is guarded and LAST: if the restore or CHECKDB fails, it never runs, and the
+///    scratch copy is retained as the evidence of what failed.
+/// </summary>
+public static class RehearsalPlanner
+{
+    /// <summary>"MyDb_rehearsal_20260810_0930" - honest about what it is to anyone who sees it.</summary>
+    public static string ScratchName(string database, DateTime now) =>
+        $"{database}_rehearsal_{now:yyyyMMdd_HHmm}";
+
+    /// <summary>
+    /// Every logical file, relocated to a scratch-named file in the default directories. The
+    /// rehearsal must be incapable of writing where the real database lives.
+    /// </summary>
+    public static List<FileMoveOption> ScratchMoves(
+        IReadOnlyList<FileMoveOption> logicalFiles, string scratchName, string dataPath, string logPath)
+    {
+        var moves = new List<FileMoveOption>();
+        int rows = 0, logs = 0;
+
+        foreach (var file in logicalFiles)
+        {
+            var isLog = string.Equals(file.Type, "L", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(file.Type, "LOG", StringComparison.OrdinalIgnoreCase);
+
+            var target = isLog
+                ? Path.Combine(logPath, logs++ == 0 ? $"{scratchName}_log.ldf" : $"{scratchName}_log{logs}.ldf")
+                : Path.Combine(dataPath, rows++ == 0 ? $"{scratchName}.mdf" : $"{scratchName}_{rows}.ndf");
+
+            moves.Add(new FileMoveOption
+            {
+                LogicalName = file.LogicalName,
+                PhysicalName = file.PhysicalName,
+                Type = file.Type,
+                SizeBytes = file.SizeBytes,
+                NewPhysicalName = target
+            });
+        }
+
+        return moves;
+    }
+
+    /// <summary>
+    /// The full rehearsal script: the restore, then the proof, then the cleanup - in an order
+    /// where a failure at any step leaves the evidence standing.
+    /// </summary>
+    public static string BuildScript(string restoreScript, string scratchName)
+    {
+        var quoted = TSql.QuoteName(scratchName);
+        var literal = TSql.EscapeLiteral(scratchName);
+
+        return restoreScript.TrimEnd() + Environment.NewLine + Environment.NewLine +
+$@"-- ============================================================
+-- Rehearsal proof: CHECKDB reads every allocation and page.
+-- No output means the BACKUP is proven, not just restored.
+-- ============================================================
+DBCC CHECKDB ({quoted}) WITH NO_INFOMSGS;
+GO
+
+-- ============================================================
+-- Rehearsal cleanup. Runs ONLY if everything above succeeded -
+-- a failed restore or a CHECKDB finding stops the batch chain,
+-- and the scratch copy is retained as the evidence.
+-- ============================================================
+IF DB_ID('{literal}') IS NOT NULL
+BEGIN
+    ALTER DATABASE {quoted} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE {quoted};
+END
+GO
+";
+    }
+}

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -16,6 +16,13 @@ namespace Blackcat.NineLives.ViewModels;
 /// the screen behind it stays live, and reading the target database name at the end of a run that
 /// started against a different one is the class of bug this whole seam exists to make impossible.
 /// </summary>
+/// <summary>What a run IS - a real restore, or a rehearsal of one (#238).</summary>
+public enum RunKind
+{
+    Restore = 0,
+    Rehearsal = 1
+}
+
 public sealed record RestoreRun(
     ServerConnection Server,
     string Script,
@@ -24,7 +31,8 @@ public sealed record RestoreRun(
     string? ContainerName,
     string ChainSummary,
     DateTime? RestorePointTimestamp,
-    string OptionsForLog);
+    string OptionsForLog,
+    RunKind Kind = RunKind.Restore);
 
 /// <summary>
 /// Running a restore: arming, the countdown, execution, cancellation, what to do when it fails,
@@ -232,8 +240,8 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             // Announced AFTER the preflights: a run the preflight refused never started, and
             // "started" messages for runs that went nowhere teach people to ignore the channel.
             _notifier.Notify(new RunNotification(
-                RunPhase.Started, "Restore", run.TargetDatabase, run.Server.ServerName,
-                run.ChainSummary));
+                RunPhase.Started, run.Kind == RunKind.Rehearsal ? "Rehearsal" : "Restore",
+                run.TargetDatabase, run.Server.ServerName, run.ChainSummary));
 
             await _sql.ExecuteWithProgressAsync(
                 run.Server,
@@ -272,13 +280,21 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             SetStatus("Restore execution completed successfully.");
 
             _notifier.Notify(new RunNotification(
-                RunPhase.Succeeded, "Restore", run.TargetDatabase, run.Server.ServerName,
-                run.ChainSummary, DateTime.Now - startedAt));
+                RunPhase.Succeeded, run.Kind == RunKind.Rehearsal ? "Rehearsal" : "Restore",
+                run.TargetDatabase, run.Server.ServerName,
+                run.Kind == RunKind.Rehearsal
+                    ? "Restored, CHECKDB passed, scratch copy dropped. The backup is proven."
+                    : run.ChainSummary,
+                DateTime.Now - startedAt));
 
             // The restore is not the end of the job (#205): nobody has verified the data yet, and
             // on a different server every SQL-auth user is orphaned. Reported while the outcome is
             // on screen, in the same shape as the recovery panel - read, then run.
-            await ReportPostRestoreAsync(run.Server, run.TargetDatabase);
+            //
+            // Not for a rehearsal (#238): its CHECKDB already ran inside the script, and the
+            // database the panel would offer statements against was deliberately dropped.
+            if (run.Kind != RunKind.Rehearsal)
+                await ReportPostRestoreAsync(run.Server, run.TargetDatabase);
         }
         catch (OperationCanceledException)
         {
@@ -299,7 +315,8 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             SetError("Restore cancelled. The target database has been left mid-restore - see below.");
 
             _notifier.Notify(new RunNotification(
-                RunPhase.Problem, "Restore", run.TargetDatabase, run.Server.ServerName,
+                RunPhase.Problem, run.Kind == RunKind.Rehearsal ? "Rehearsal" : "Restore",
+                run.TargetDatabase, run.Server.ServerName,
                 "Cancelled part-way through the chain - the target is left mid-restore.",
                 DateTime.Now - startedAt));
 
@@ -314,7 +331,8 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             SetError($"Restore failed: {ex.Message}");
 
             _notifier.Notify(new RunNotification(
-                RunPhase.Problem, "Restore", run.TargetDatabase, run.Server.ServerName,
+                RunPhase.Problem, run.Kind == RunKind.Rehearsal ? "Rehearsal" : "Restore",
+                run.TargetDatabase, run.Server.ServerName,
                 ex.Message, DateTime.Now - startedAt));
 
             // The restore has stopped part-way and the target is almost certainly not usable. Find
@@ -364,6 +382,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             SourceDatabase = run.SourceDatabase,
             RestorePointTimestamp = run.RestorePointTimestamp,
             ChainSummary = run.ChainSummary,
+            Kind = run.Kind == RunKind.Rehearsal ? "Rehearsal" : "Restore",
             Outcome = outcome,
             ErrorMessage = failure,
             Script = run.Script,

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2117,6 +2117,100 @@ public partial class RestoreViewModel : ViewModelBase
             appendLog => PreflightAsync(server, appendLog));
     }
 
+    // ── rehearsal (#238) ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Everything a rehearsal needs to exist: a chain, a connection, and the mode that shows the
+    /// checking machinery. The rest is safety by construction inside the run itself.
+    /// </summary>
+    public bool CanRehearse =>
+        IsConnectedToServer && RestoreChain != null && !IsExecuting &&
+        AppModeCapabilities.CanVerifyAndAudit(Mode);
+
+    /// <summary>
+    /// Restores the chosen chain to a scratch name, proves it with CHECKDB, and drops it (#238) -
+    /// the only tested backup is a restored backup, and the History entry is the receipt.
+    ///
+    /// The real database is never touchable from here: the target name is generated and refused
+    /// if it exists, WITH REPLACE is never emitted, and every file MOVEs to scratch-named files
+    /// in the instance's default directories. A failure at any step stops the batch chain, so
+    /// the guarded DROP never runs and the scratch copy stands as the evidence.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanRehearse))]
+    private async Task RehearseAsync()
+    {
+        var server = ConnectedServer;
+        var chain = RestoreChain;
+        if (server == null || chain == null || !CanRehearse) return;
+
+        var sourceName = Inventory.SelectedDatabaseName ?? chain.FullSet.DatabaseName ?? "database";
+        var scratch = RehearsalPlanner.ScratchName(sourceName, DateTime.Now);
+
+        IsBusy = true;
+        try
+        {
+            // Astronomically unlikely with a timestamped name - checked anyway, because the whole
+            // design promise is "cannot touch anything that exists".
+            var state = await _sqlService.GetDatabaseRecoveryStateAsync(server, scratch);
+            if (state.Exists)
+            {
+                SetError($"[{scratch}] already exists on {server.ServerName} - rehearsal refused. " +
+                         "Try again in a minute, or drop the leftover scratch copy first.");
+                return;
+            }
+
+            SetStatus($"Preparing the rehearsal of {sourceName}...");
+
+            // The real file list, so every logical file gets a scratch MOVE - device-aware, so
+            // this works for blob, shared-path and ad-hoc chains alike (#203).
+            var devices = chain.FullSet.Files
+                .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+                .ToList();
+            var files = await _sqlService.RestoreFileListOnlyAsync(server, devices);
+            if (files.Count == 0)
+            {
+                SetError("FILELISTONLY returned nothing - the rehearsal cannot relocate files it " +
+                         "cannot list.");
+                return;
+            }
+
+            var (dataPath, logPath) = await _sqlService.GetDefaultPathsAsync(server);
+            var moves = RehearsalPlanner.ScratchMoves(files, scratch, dataPath, logPath);
+
+            var restoreScript = _scriptGenerator.Generate(chain, new RestoreOptions
+            {
+                TargetDatabaseName = scratch,
+                WithReplace = false,
+                RecoveryMode = RecoveryMode.Recovery,
+                FileMoves = moves,
+                StopAt = PointInTime.Effective
+            });
+
+            var script = RehearsalPlanner.BuildScript(restoreScript, scratch);
+
+            await Execution.RunAsync(
+                new RestoreRun(
+                    server,
+                    script,
+                    scratch,
+                    sourceName,
+                    SelectedContainer?.Name,
+                    $"REHEARSAL - {chain.Summary}",
+                    Timeline.SelectedPoint?.Timestamp,
+                    "rehearsal: restore + CHECKDB + drop",
+                    RunKind.Rehearsal),
+                appendLog => PreflightAsync(server, appendLog));
+        }
+        catch (Exception ex)
+        {
+            SetError($"The rehearsal could not be prepared: {ex.Message}");
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
     /// <summary>
     /// The last thing checked before a restore runs, and it differs by medium.
     ///

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1022,7 +1022,17 @@
                             </Button.Content>
                         </Button>
 
-                        <!-- A different question from Check chain: that one reads headers and
+<!-- The only tested backup is a restored backup (#238): the same chain, restored
+                             to a scratch name, proven with CHECKDB, dropped. The History entry is the
+                             receipt the audit question asks for. -->
+                        <Button Content="Rehearse this restore"
+                                Style="{StaticResource SecondaryButton}"
+                                Command="{Binding RehearseCommand}"
+                                Padding="12,6" Margin="0,0,8,0"
+                                Visibility="{Binding ShowVerifyAndAudit, Converter={StaticResource BoolToVis}}"
+                                ToolTip="Restores this chain to a scratch database (MyDb_rehearsal_...), runs DBCC CHECKDB to prove the data, then drops the scratch copy. The real database is never touched: fresh name, no REPLACE, files relocated to the default directories. Takes as long as a real restore plus CHECKDB." />
+
+                                                <!-- A different question from Check chain: that one reads headers and
                              checks the LSNs line up, this one reads each backup end to end and
                              checks it is intact. A truncated blob passes the first and fails this.
                              It is also the only one here that costs real time. -->


### PR DESCRIPTION
> The only tested backup is a restored backup.

Everyone repeats it; almost nobody has *evidence*. A rehearsal is that test made cheap enough to actually run — one button on the restore screen (widest mode), one modal, one receipt.

## What a rehearsal is

The chosen chain, through the same execution machinery as a real restore: restored to `MyDb_rehearsal_20260810_0930`, proven with `DBCC CHECKDB`, dropped. The History entry is the receipt — what was proven, from which restore point, how long — and the run announces itself through the #242 notifications as a **Rehearsal**, so the Teams channel that hears about real restores hears about the proof too. The duration is the real RTO number that conversations otherwise invent.

## Safety by construction, not by care

- The target name is **generated**, timestamped, and refused outright if it somehow exists — checked against the server before anything runs.
- **`WITH REPLACE` is never emitted** — a fresh name has nothing to replace, and a collision fails loudly instead of overwriting.
- **Every file MOVEs** to scratch-named files in the instance's default directories — the rehearsal cannot touch the real database's files even in a path collision.
- The **DROP is guarded and last**: a failed restore or a CHECKDB finding stops the batch chain, and the scratch copy is retained as the evidence of what failed.

All the preflights apply (credential, version direction, TDE certificates, readability) — a rehearsal that fails the preflight is a real finding. The post-restore panel stays out of it: its CHECKDB already ran inside the script, against a database that was then deliberately dropped.

7 new tests, 1,509 pass.