### PR TITLE
Say what protects a backup where its header is shown (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ more detail on the user-facing changes; this file is the short history.
   generic format is plain JSON fields. Configured in Settings with a per-endpoint test button;
   webhook URLs never leave the machine in a configuration export (#242)
 
+- The backup metadata inspector now states which SQL Server version took the backup and what
+  protects it - TDE, backup encryption, or "Not encrypted", because absence is information too
+  (#222)
+
 ### Changed
 
 - **One console, not two.** The restore screen no longer keeps an inline copy of the run's

--- a/src/NineLives.Tests/EncryptionPreflightTests.cs
+++ b/src/NineLives.Tests/EncryptionPreflightTests.cs
@@ -63,6 +63,18 @@ public class EncryptionPreflightTests
         Assert.Contains("encrypted", both);
     }
 
+    /// <summary>
+    /// Part 4 of #222: what protects a backup is said where the header is shown, and absence is
+    /// stated too - "not encrypted" is information, not the lack of it.
+    /// </summary>
+    [Fact]
+    public void TheMetadataInspectorNamesTheProtection()
+    {
+        Assert.Contains("TDE-encrypted",
+            EncryptionGuidance.DescribeProtection(Thumbprint, null));
+        Assert.Empty(EncryptionGuidance.DescribeProtection(null, null));
+    }
+
     // ── the restore preflight ───────────────────────────────────────────────────
 
     private static ServerConnection Server(string name = "SRV02") =>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1970,6 +1970,17 @@ public partial class RestoreViewModel : ViewModelBase
             sb.AppendLine($"First LSN: {header.FirstLsn?.ToString() ?? "(null)"}");
             sb.AppendLine($"Last LSN: {header.LastLsn?.ToString() ?? "(null)"}");
             sb.AppendLine($"Database backup LSN: {header.DatabaseBackupLsn?.ToString() ?? "(null)"}");
+
+            if (header.SoftwareVersionMajor is int major)
+                sb.AppendLine($"Taken on: {VersionCompatibility.Describe(major)}");
+
+            // What protects it (#222 part 4): the certificate question, answered where the header
+            // is on screen instead of only failing later. Absence is stated too - "not encrypted"
+            // is information, not the lack of it.
+            var protection = EncryptionGuidance.DescribeProtection(
+                header.TdeThumbprint, header.EncryptorThumbprint);
+            sb.AppendLine($"Protection: {(protection.Length == 0 ? "Not encrypted." : protection)}");
+
             BackupMetadataSummary = sb.ToString();
             SetStatus("Header read. See the metadata below.");
         }


### PR DESCRIPTION
Part 4, the last piece of #222: the metadata inspector states which SQL Server version took the backup and what protects it — TDE, backup encryption, or "Not encrypted", because absence is information too. The fields were already read for the preflight; this puts them where somebody inspecting a backup is looking. 1,510 pass.