### PR TITLE
The Exposure dashboard: how much data would be lost, right now (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **The Exposure dashboard: how much data would be lost, right now.** Every user database on
+  every configured server, judged from its own msdb - the derived loss window ("everything after
+  14:32 is gone - up to 47m of work"), traffic-lit worst-first. The silent failures are the
+  loudest: never backed up, FULL recovery with no log backups ever, chains that stopped days
+  ago - and a server that will not answer is itself an alarm row, because unknown is not the
+  same as fine. Rehearsal receipts join in as a "Proven" column: arithmetic says what could
+  restore, only a rehearsal says it does (#239)
 - **Restore rehearsal: prove a backup restores, with a receipt.** One button restores the chosen
   chain to a scratch database, proves the data with DBCC CHECKDB, and drops the scratch copy -
   the History entry records what was proven, when, and how long it took. Safety by construction:

--- a/src/NineLives.Tests/ExposureDashboardTests.cs
+++ b/src/NineLives.Tests/ExposureDashboardTests.cs
@@ -1,0 +1,187 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The exposure dashboard (#239): "if this server died now, how much work is gone?" - per
+/// database, across every configured server, worst first. The silent failures are the loudest:
+/// no backup ever, FULL recovery with no log backups, chains that stopped, servers that will not
+/// answer.
+/// </summary>
+public class ExposureDashboardTests
+{
+    private static readonly DateTime Now = new(2026, 8, 10, 12, 0, 0);
+
+    private static ExposureRow Row(
+        string db = "MyDb", string model = "FULL",
+        DateTime? full = null, DateTime? diff = null, DateTime? log = null) => new()
+    {
+        ServerName = "SRV01",
+        DatabaseName = db,
+        RecoveryModel = model,
+        StateDescription = "ONLINE",
+        LastFull = full,
+        LastDifferential = diff,
+        LastLog = log
+    };
+
+    // ── the advisor's rule table ────────────────────────────────────────────────
+
+    [Fact]
+    public void NeverBackedUpIsTheLoudestAlarm()
+    {
+        var row = Row();
+        ExposureAdvisor.Judge(row, Now);
+
+        Assert.Equal(ExposureLevel.Alarm, row.Level);
+        Assert.Contains("Never backed up", row.Verdict);
+    }
+
+    /// <summary>The classic silent failure: FULL recovery, log never backed up.</summary>
+    [Fact]
+    public void FullRecoveryWithNoLogBackupsIsAnAlarmAboutTwoThingsAtOnce()
+    {
+        var row = Row(full: Now.AddHours(-10));
+        ExposureAdvisor.Judge(row, Now);
+
+        Assert.Equal(ExposureLevel.Alarm, row.Level);
+        Assert.Contains("log file grows", row.Verdict);
+        Assert.Contains("unprotected", row.Verdict);
+    }
+
+    [Fact]
+    public void AHealthyLogChainIsQuietAndSaysWhatItCouldLose()
+    {
+        var row = Row(full: Now.AddDays(-1), log: Now.AddMinutes(-20));
+        ExposureAdvisor.Judge(row, Now);
+
+        Assert.Equal(ExposureLevel.Ok, row.Level);
+        Assert.Contains("up to 20m", row.Verdict);
+    }
+
+    [Theory]
+    [InlineData(-2, ExposureLevel.Warning)]   // 2h of log silence: look at the schedule
+    [InlineData(-30, ExposureLevel.Alarm)]    // 30h: the chain has stopped
+    public void LogSilenceEscalatesWithAge(int hoursAgo, ExposureLevel expected)
+    {
+        var row = Row(full: Now.AddDays(-2), log: Now.AddHours(hoursAgo));
+        ExposureAdvisor.Judge(row, Now);
+
+        Assert.Equal(expected, row.Level);
+    }
+
+    /// <summary>SIMPLE recovery is judged against its own cycle, not against log expectations.</summary>
+    [Fact]
+    public void SimpleRecoveryGetsADailyCycleGrace()
+    {
+        var healthy = Row(model: "SIMPLE", full: Now.AddHours(-20));
+        ExposureAdvisor.Judge(healthy, Now);
+        Assert.Equal(ExposureLevel.Ok, healthy.Level);
+
+        var stale = Row(model: "SIMPLE", full: Now.AddDays(-8));
+        ExposureAdvisor.Judge(stale, Now);
+        Assert.Equal(ExposureLevel.Alarm, stale.Level);
+    }
+
+    /// <summary>A differential moves the recovery point for SIMPLE databases.</summary>
+    [Fact]
+    public void ADifferentialCountsTowardTheRecoveryPoint()
+    {
+        var row = Row(model: "SIMPLE", full: Now.AddDays(-3), diff: Now.AddHours(-2));
+        ExposureAdvisor.Judge(row, Now);
+
+        Assert.Equal(ExposureLevel.Ok, row.Level);
+        Assert.Contains("up to 2h", row.Verdict);
+    }
+
+    // ── the sweep ───────────────────────────────────────────────────────────────
+
+    private static (ExposureViewModel vm, FakeSqlServerService sql, FakeRestoreHistoryStore history)
+        New(params string[] servers)
+    {
+        var store = new FakeCredentialStore();
+        foreach (var name in servers)
+            store.Config.Servers.Add(new ServerConnection
+            { Id = ServerConnection.NewId(), Name = name, ServerName = name });
+
+        var sql = new FakeSqlServerService();
+        var history = new FakeRestoreHistoryStore();
+        return (new ExposureViewModel(store, sql, history, TestLogs.Temp()), sql, history);
+    }
+
+    [Fact]
+    public async Task TheWorstThingIsTheFirstThing()
+    {
+        var (vm, sql, _) = New("SRV01");
+        sql.ExposureByServer["SRV01"] =
+        [
+            Row(db: "Healthy", full: DateTime.Now.AddDays(-1), log: DateTime.Now.AddMinutes(-5)),
+            Row(db: "Naked"),  // never backed up
+            Row(db: "Stale", full: DateTime.Now.AddDays(-2), log: DateTime.Now.AddHours(-3))
+        ];
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Equal("Naked", vm.Rows[0].DatabaseName);
+        Assert.Equal(ExposureLevel.Alarm, vm.Rows[0].Level);
+        Assert.Equal("Healthy", vm.Rows[^1].DatabaseName);
+        Assert.Contains("1 alarm(s), 1 warning(s)", vm.Summary);
+    }
+
+    /// <summary>
+    /// A server that will not answer is an ALARM row, not a silent absence - a dashboard that
+    /// omits the unreachable server reads "all clear" at the exact moment it should not.
+    /// </summary>
+    [Fact]
+    public async Task AServerThatWillNotAnswerIsAnAlarmRow()
+    {
+        var (vm, sql, _) = New("SRV01", "SRV02");
+        sql.ExposureByServer["SRV01"] =
+            [Row(db: "Fine", full: DateTime.Now.AddDays(-1), log: DateTime.Now.AddMinutes(-10))];
+        // SRV02 deliberately absent from the fake: it throws.
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        var down = Assert.Single(vm.Rows, r => r.StateDescription == "UNREACHABLE");
+        Assert.Equal("SRV02", down.ServerName);
+        Assert.Equal(ExposureLevel.Alarm, down.Level);
+        Assert.Contains("UNKNOWN, which is not the same as fine", down.Verdict);
+    }
+
+    /// <summary>The rehearsal receipts (#238) join in: proof, not just arithmetic.</summary>
+    [Fact]
+    public async Task RehearsalReceiptsShowWhenADatabaseWasLastProven()
+    {
+        var (vm, sql, history) = New("SRV01");
+        sql.ExposureByServer["SRV01"] =
+            [Row(db: "MyDb", full: DateTime.Now.AddDays(-1), log: DateTime.Now.AddMinutes(-10))];
+
+        history.Entries.Add(new RestoreHistoryEntry
+        {
+            ServerName = "SRV01",
+            SourceDatabase = "MyDb",
+            TargetDatabase = "MyDb_rehearsal_20260809_2100",
+            Kind = "Rehearsal",
+            Outcome = RestoreOutcome.Succeeded,
+            CompletedAt = new DateTime(2026, 8, 9, 21, 30, 0)
+        });
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Equal(new DateTime(2026, 8, 9, 21, 30, 0), vm.Rows.Single().LastProven);
+    }
+
+    [Fact]
+    public async Task NoServersSaysSoInsteadOfShowingAnEmptyAllClear()
+    {
+        var (vm, _, _) = New();
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Empty(vm.Rows);
+        Assert.Contains("No servers configured", vm.Summary);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -500,6 +500,19 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Paths the fake target refuses, and why. Anything not listed is readable.</summary>
     public Dictionary<string, BackupFileProblem> UnreadablePaths { get; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Exposure rows per server name (#239); a server absent from the map throws.</summary>
+    public Dictionary<string, List<ExposureRow>> ExposureByServer { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public Task<List<ExposureRow>> GetBackupExposureAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        if (!ExposureByServer.TryGetValue(server.ServerName, out var rows))
+            throw new InvalidOperationException($"fake: {server.ServerName} is not answering");
+
+        return Task.FromResult(rows.ToList());
+    }
+
     /// <summary>What each ad-hoc file's headers say, keyed by path (#203).</summary>
     public Dictionary<string, List<BackupHistoryEntry>> FileHeaders { get; } =
         new(StringComparer.OrdinalIgnoreCase);

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -77,6 +77,10 @@
         <DataTemplate DataType="{x:Type vm:HistoryViewModel}">
             <views:HistoryView />
         </DataTemplate>
+
+                <DataTemplate DataType="{x:Type vm:ExposureViewModel}">
+            <views:ExposureView />
+        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:AboutViewModel}">
             <views:AboutView />
         </DataTemplate>
@@ -306,6 +310,17 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#x1F4C2;" FontSize="15" VerticalAlignment="Center" Width="24" />
                                 <TextBlock Text="Browse Backups" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </RadioButton>
+
+                        <RadioButton Style="{StaticResource SidebarButton}"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Exposure'}"
+                                     Command="{Binding NavigateToCommand}"
+                                     Visibility="{Binding ShowBrowseBackups, Converter={StaticResource BoolToVis}}"
+                                     CommandParameter="Exposure">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#x1F6A6;" FontSize="15" VerticalAlignment="Center" Width="24" />
+                                <TextBlock Text="Exposure" VerticalAlignment="Center" />
                             </StackPanel>
                         </RadioButton>
 

--- a/src/NineLives/Services/ExposureAdvisor.cs
+++ b/src/NineLives/Services/ExposureAdvisor.cs
@@ -1,0 +1,116 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>How urgently a database's backup state needs a human (#239).</summary>
+public enum ExposureLevel
+{
+    Ok = 0,
+    Warning = 1,
+    Alarm = 2
+}
+
+/// <summary>
+/// One database's backup state on one server, as msdb tells it (#239).
+/// </summary>
+public sealed class ExposureRow
+{
+    public string ServerName { get; init; } = string.Empty;
+    public string DatabaseName { get; init; } = string.Empty;
+    public string RecoveryModel { get; init; } = string.Empty;
+    public string StateDescription { get; init; } = string.Empty;
+
+    public DateTime? LastFull { get; init; }
+    public DateTime? LastDifferential { get; init; }
+    public DateTime? LastLog { get; init; }
+
+    /// <summary>When a rehearsal last PROVED this database restores, from the app's own receipts.</summary>
+    public DateTime? LastProven { get; set; }
+
+    // Filled by the advisor.
+    public ExposureLevel Level { get; set; }
+    public string Verdict { get; set; } = string.Empty;
+
+    /// <summary>The moment recovery could reach - the newest backup of any kind.</summary>
+    public DateTime? RecoverableTo =>
+        new[] { LastLog, LastDifferential, LastFull }.Where(d => d != null).DefaultIfEmpty(null).Max();
+}
+
+/// <summary>
+/// Turns backup timestamps into the sentence a DBA actually lives with: "if this server died
+/// now, you lose up to X" (#239).
+///
+/// The thresholds are deliberate defaults, not laws: an hour of log silence on a FULL-recovery
+/// database is worth a look, a day of it is an alarm - and the silent failures are the loudest:
+/// FULL recovery with no log backups EVER is both a runaway log file and an unbounded loss
+/// window, and nobody notices silence without a screen that makes silence red.
+/// </summary>
+public static class ExposureAdvisor
+{
+    public static readonly TimeSpan LogWarnAfter = TimeSpan.FromHours(1);
+    public static readonly TimeSpan LogAlarmAfter = TimeSpan.FromHours(24);
+
+    /// <summary>A day-plus-grace, because a daily full cycle is the ordinary arrangement.</summary>
+    public static readonly TimeSpan SimpleWarnAfter = TimeSpan.FromHours(26);
+    public static readonly TimeSpan SimpleAlarmAfter = TimeSpan.FromDays(7);
+
+    public static void Judge(ExposureRow row, DateTime now)
+    {
+        // No full, no recovery - everything else is arithmetic on top of a full that must exist.
+        if (row.LastFull == null)
+        {
+            row.Level = ExposureLevel.Alarm;
+            row.Verdict = "Never backed up. There is no full backup, so nothing of this database " +
+                          "is recoverable at all.";
+            return;
+        }
+
+        var isSimple = string.Equals(row.RecoveryModel, "SIMPLE", StringComparison.OrdinalIgnoreCase);
+
+        if (!isSimple && row.LastLog == null)
+        {
+            row.Level = ExposureLevel.Alarm;
+            row.Verdict = $"{row.RecoveryModel} recovery with no log backup ever taken: the log " +
+                          "file grows until the disk fills, and everything since the last full " +
+                          $"({Age(row.LastFull.Value, now)} ago) is unprotected. Take log backups " +
+                          "or switch to SIMPLE - deliberately, not by default.";
+            return;
+        }
+
+        var recoverableTo = row.RecoverableTo!.Value;
+        var exposure = now - recoverableTo;
+
+        var (warn, alarm) = isSimple
+            ? (SimpleWarnAfter, SimpleAlarmAfter)
+            : (LogWarnAfter, LogAlarmAfter);
+
+        row.Level = exposure >= alarm ? ExposureLevel.Alarm
+            : exposure >= warn ? ExposureLevel.Warning
+            : ExposureLevel.Ok;
+
+        var loss = $"If this server died now, everything after {recoverableTo:yyyy-MM-dd HH:mm} " +
+                   $"is gone - up to {Age(recoverableTo, now)} of work.";
+
+        row.Verdict = row.Level switch
+        {
+            ExposureLevel.Alarm when isSimple =>
+                $"{loss} SIMPLE recovery relies on its full/differential cycle, and it has stopped.",
+            ExposureLevel.Alarm =>
+                $"{loss} The log backups have stopped - the chain last moved {Age(recoverableTo, now)} ago.",
+            ExposureLevel.Warning =>
+                $"{loss} Worth a look at the schedule.",
+            _ => loss
+        };
+    }
+
+    /// <summary>"47m", "3h 20m", "2d 4h" - the units a human compares against a schedule.</summary>
+    public static string Age(DateTime then, DateTime now)
+    {
+        var d = now - then;
+        if (d < TimeSpan.Zero) d = TimeSpan.Zero;
+
+        return d.TotalDays >= 1 ? $"{(int)d.TotalDays}d {d.Hours}h"
+            : d.TotalHours >= 1 ? $"{(int)d.TotalHours}h {d.Minutes:D2}m"
+            : $"{Math.Max(1, (int)d.TotalMinutes)}m";
+    }
+}

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -144,6 +144,13 @@ public interface ISqlServerService
         Action<string>? messageCallback = null, CancellationToken ct = default);
 
     /// <summary>What this instance recorded backing up, from msdb (#149).</summary>
+    /// <summary>
+    /// Every user database's backup state in one round trip (#239): recovery model, and the last
+    /// full, differential and log as msdb records them. The exposure dashboard's raw material.
+    /// </summary>
+    Task<List<ExposureRow>> GetBackupExposureAsync(
+        ServerConnection server, CancellationToken ct = default);
+
     Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
         ServerConnection server, string? databaseName = null, CancellationToken ct = default);
 

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -247,6 +247,53 @@ public class SqlServerService : ISqlServerService
     /// separately and on the target, because msdb keeps history for backups whose files were
     /// deleted, archived or pruned by a retention job long ago.
     /// </summary>
+    public async Task<List<ExposureRow>> GetBackupExposureAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        var rows = new List<ExposureRow>();
+
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandTimeout = 60;
+
+        // LEFT JOIN, because the databases with NO backup rows are the whole point - an INNER
+        // join would hide exactly the rows the dashboard exists to make red. database_id > 4
+        // excludes master/tempdb/model/msdb; snapshots and restoring states still list, because
+        // "it exists and is not backed up" is true of them too and the state column says why.
+        cmd.CommandText = @"
+            SELECT d.name                 AS DatabaseName,
+                   d.recovery_model_desc  AS RecoveryModel,
+                   d.state_desc           AS StateDescription,
+                   MAX(CASE WHEN b.type = 'D' THEN b.backup_finish_date END) AS LastFull,
+                   MAX(CASE WHEN b.type = 'I' THEN b.backup_finish_date END) AS LastDifferential,
+                   MAX(CASE WHEN b.type = 'L' THEN b.backup_finish_date END) AS LastLog
+            FROM sys.databases AS d
+            LEFT JOIN msdb.dbo.backupset AS b
+                   ON b.database_name = d.name
+            WHERE d.database_id > 4
+              AND d.source_database_id IS NULL
+            GROUP BY d.name, d.recovery_model_desc, d.state_desc
+            ORDER BY d.name";
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            rows.Add(new ExposureRow
+            {
+                ServerName = server.ServerName,
+                DatabaseName = reader["DatabaseName"]?.ToString() ?? string.Empty,
+                RecoveryModel = reader["RecoveryModel"]?.ToString() ?? string.Empty,
+                StateDescription = reader["StateDescription"]?.ToString() ?? string.Empty,
+                LastFull = GetDateTimeFromReader(reader, "LastFull"),
+                LastDifferential = GetDateTimeFromReader(reader, "LastDifferential"),
+                LastLog = GetDateTimeFromReader(reader, "LastLog")
+            });
+        }
+
+        return rows;
+    }
+
     public async Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
         ServerConnection server, string? databaseName = null, CancellationToken ct = default)
     {

--- a/src/NineLives/ViewModels/ExposureViewModel.cs
+++ b/src/NineLives/ViewModels/ExposureViewModel.cs
@@ -1,0 +1,180 @@
+using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The exposure dashboard (#239): how much data would be lost, right now, per database, across
+/// every configured server - with the worst thing first.
+///
+/// The question a DBA actually lives with is not "do I have backups?" but "how exposed am I right
+/// now?", and until this screen answering it meant a query against every instance's msdb and
+/// mental arithmetic. The silent failures are the loudest here: FULL recovery with no log backups,
+/// chains that stopped days ago, databases never backed up at all - and a server that will not
+/// answer is itself a red row, because silence is exactly what this screen exists to make visible.
+/// </summary>
+public partial class ExposureViewModel : ViewModelBase
+{
+    private readonly ICredentialStore _store;
+    private readonly ISqlServerService _sql;
+    private readonly IRestoreHistoryStore _history;
+    private readonly OperationLog _log;
+
+    public ExposureViewModel(
+        ICredentialStore store, ISqlServerService sql, IRestoreHistoryStore history,
+        OperationLog? log = null)
+    {
+        _store = store;
+        _sql = sql;
+        _history = history;
+        _log = log ?? App.Log;
+    }
+
+    [ObservableProperty]
+    private ObservableCollection<ExposureRow> _rows = [];
+
+    [ObservableProperty]
+    private string _summary = string.Empty;
+
+    [ObservableProperty]
+    private string _lastRefreshed = string.Empty;
+
+    [ObservableProperty]
+    private bool _isSweeping;
+
+    /// <summary>
+    /// Asks every configured server, in parallel, and shows the worst first.
+    ///
+    /// A server that will not answer becomes an alarm row rather than a silent absence - a
+    /// dashboard that quietly omits the unreachable server reads as "all clear" at the exact
+    /// moment it should not.
+    /// </summary>
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        IsSweeping = true;
+        ClearStatus();
+
+        try
+        {
+            List<ServerConnection> servers;
+            try
+            {
+                servers = _store.LoadConfig().Servers;
+            }
+            catch (Exception ex)
+            {
+                SetError($"The server list could not be read: {ex.Message}");
+                return;
+            }
+
+            if (servers.Count == 0)
+            {
+                Rows = [];
+                Summary = "No servers configured. Add one on the SQL Servers screen and the " +
+                          "exposure of every database on it appears here.";
+                return;
+            }
+
+            var now = DateTime.Now;
+
+            var sweeps = servers.Select(async server =>
+            {
+                try
+                {
+                    return await _sql.GetBackupExposureAsync(server);
+                }
+                catch (Exception ex)
+                {
+                    _log.Warn($"[exposure] {server.ServerName}: {ex.Message}");
+                    return
+                    [
+                        new ExposureRow
+                        {
+                            ServerName = server.ServerName,
+                            DatabaseName = "(server did not answer)",
+                            StateDescription = "UNREACHABLE",
+                            Level = ExposureLevel.Alarm,
+                            Verdict = $"The server would not answer: {ex.Message} Its databases' " +
+                                      "exposure is UNKNOWN, which is not the same as fine."
+                        }
+                    ];
+                }
+            }).ToList();
+
+            var results = await Task.WhenAll(sweeps);
+            var rows = results.SelectMany(r => r).ToList();
+
+            // The advisor judges everything that answered; unreachable rows arrive pre-judged.
+            foreach (var row in rows.Where(r => r.StateDescription != "UNREACHABLE"))
+                ExposureAdvisor.Judge(row, now);
+
+            AttachRehearsalReceipts(rows);
+
+            Rows = new ObservableCollection<ExposureRow>(rows
+                .OrderByDescending(r => r.Level)
+                .ThenBy(r => r.RecoverableTo ?? DateTime.MinValue)
+                .ThenBy(r => r.ServerName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(r => r.DatabaseName, StringComparer.OrdinalIgnoreCase));
+
+            var alarms = rows.Count(r => r.Level == ExposureLevel.Alarm);
+            var warnings = rows.Count(r => r.Level == ExposureLevel.Warning);
+
+            Summary = alarms == 0 && warnings == 0
+                ? $"All {rows.Count} database(s) across {servers.Count} server(s) are inside their windows."
+                : $"{alarms} alarm(s), {warnings} warning(s) across {servers.Count} server(s) - worst first.";
+
+            LastRefreshed = $"as of {now:HH:mm:ss}";
+        }
+        finally
+        {
+            IsSweeping = false;
+        }
+    }
+
+    /// <summary>
+    /// Joins the app's own receipts (#238): when a rehearsal last PROVED each database restores.
+    /// Recovery-point arithmetic says what COULD be restored; only a rehearsal says it actually
+    /// does.
+    /// </summary>
+    private void AttachRehearsalReceipts(List<ExposureRow> rows)
+    {
+        try
+        {
+            var proofs = _history.Load()
+                .Where(e => e.Kind == "Rehearsal" && e.Outcome == RestoreOutcome.Succeeded &&
+                            e.SourceDatabase != null)
+                .GroupBy(e => (e.ServerName, e.SourceDatabase!),
+                    StringTupleComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Max(e => e.CompletedAt),
+                    StringTupleComparer.OrdinalIgnoreCase);
+
+            foreach (var row in rows)
+            {
+                if (proofs.TryGetValue((row.ServerName, row.DatabaseName), out var provenAt))
+                    row.LastProven = provenAt;
+            }
+        }
+        catch
+        {
+            // Receipts are a bonus column; their absence must not empty the dashboard.
+        }
+    }
+
+    /// <summary>Case-insensitive comparer for (server, database) pairs.</summary>
+    private sealed class StringTupleComparer : IEqualityComparer<(string, string)>
+    {
+        public static readonly StringTupleComparer OrdinalIgnoreCase = new();
+
+        public bool Equals((string, string) x, (string, string) y) =>
+            string.Equals(x.Item1, y.Item1, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(x.Item2, y.Item2, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode((string, string) pair) =>
+            HashCode.Combine(
+                pair.Item1.ToUpperInvariant(), pair.Item2.ToUpperInvariant());
+    }
+}

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -150,6 +150,8 @@ public partial class MainViewModel : ViewModelBase
         Nav.Backup => ShowBackup,
         Nav.CopyDatabase => ShowCopyDatabase,
         Nav.BrowseBackups => ShowBrowseBackups,
+        // The same tier as browsing: read-only insight over the estate's backups.
+        Nav.Exposure => ShowBrowseBackups,
         _ => true
     };
 
@@ -185,6 +187,7 @@ public partial class MainViewModel : ViewModelBase
     public CopyDatabaseViewModel CopyDatabase { get; }
     public RestoreViewModel Restore { get; }
     public HistoryViewModel History { get; }
+    public ExposureViewModel Exposure { get; }
     public SettingsViewModel Settings { get; }
     public AboutViewModel About { get; }
 
@@ -240,6 +243,7 @@ public partial class MainViewModel : ViewModelBase
         Backup = new BackupViewModel(_credentialStore, _sqlService, notifier: notifier);
         CopyDatabase = new CopyDatabaseViewModel(_credentialStore, _sqlService, notifier: notifier);
         History = new HistoryViewModel(_historyStore);
+        Exposure = new ExposureViewModel(_credentialStore, _sqlService, _historyStore);
         Settings = new SettingsViewModel(_credentialStore);
         About = new AboutViewModel();
 
@@ -528,6 +532,7 @@ public partial class MainViewModel : ViewModelBase
         public const string BlobStorage = "Blob Storage";
         public const string SqlServers = "SQL Servers";
         public const string BrowseBackups = "Browse Backups";
+        public const string Exposure = "Exposure";
         public const string Backup = "Back Up";
         public const string Restore = "Restore";
         public const string CopyDatabase = "Copy Database";
@@ -536,7 +541,7 @@ public partial class MainViewModel : ViewModelBase
         public const string About = "About";
 
         public static IReadOnlyList<string> Views =>
-            [BlobStorage, SqlServers, BrowseBackups, Backup, Restore, CopyDatabase, History, Settings, About];
+            [BlobStorage, SqlServers, BrowseBackups, Exposure, Backup, Restore, CopyDatabase, History, Settings, About];
     }
 
     [RelayCommand]
@@ -548,6 +553,7 @@ public partial class MainViewModel : ViewModelBase
             Nav.BlobStorage => BlobConfig,
             Nav.SqlServers => ServerManager,
             Nav.BrowseBackups => BlobBrowser,
+            Nav.Exposure => Exposure,
             Nav.Backup => Backup,
             Nav.Restore => Restore,
             Nav.CopyDatabase => CopyDatabase,

--- a/src/NineLives/Views/ExposureView.xaml
+++ b/src/NineLives/Views/ExposureView.xaml
@@ -1,0 +1,119 @@
+<UserControl x:Class="Blackcat.NineLives.Views.ExposureView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:svc="clr-namespace:Blackcat.NineLives.Services">
+
+    <!-- The exposure dashboard (#239): how much data would be lost, right now, worst first.
+         Read-only by design - the screen that answers "how exposed am I?" must not also be a
+         screen where a mis-click changes anything. -->
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="24" MaxWidth="1400">
+            <TextBlock Text="Exposure" Style="{StaticResource HeaderText}" />
+            <TextBlock Style="{StaticResource SecondaryText}"
+                       TextWrapping="Wrap"
+                       Margin="0,4,0,16"
+                       Text="If a server died right now, how much work is gone? Every user database on every configured server, judged from its own msdb - and a server that will not answer is an alarm, because unknown is not the same as fine." />
+
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
+                <Button Content="Refresh"
+                        Command="{Binding RefreshCommand}"
+                        Style="{StaticResource PrimaryButton}"
+                        Padding="16,8" Margin="0,0,12,0" />
+                <ContentControl Template="{StaticResource BusySpinner}"
+                                Width="16" Height="16" Margin="0,0,8,0"
+                                VerticalAlignment="Center"
+                                Visibility="{Binding IsSweeping, Converter={StaticResource BoolToVis}}" />
+                <TextBlock Text="{Binding Summary}"
+                           Style="{StaticResource BodyText}"
+                           VerticalAlignment="Center" />
+                <TextBlock Text="{Binding LastRefreshed}"
+                           Style="{StaticResource SecondaryText}"
+                           VerticalAlignment="Center"
+                           Margin="12,0,0,0" />
+            </StackPanel>
+
+            <ContentControl Style="{StaticResource ErrorBanner}" Margin="0,0,0,12" />
+
+            <ItemsControl ItemsSource="{Binding Rows}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border CornerRadius="4" Padding="12,10" Margin="0,0,0,8"
+                                Background="{DynamicResource CardBackgroundBrush}"
+                                BorderThickness="1,1,1,1">
+                            <Border.Style>
+                                <Style TargetType="Border">
+                                    <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding Level}"
+                                                     Value="{x:Static svc:ExposureLevel.Alarm}">
+                                            <Setter Property="BorderBrush" Value="{DynamicResource ErrorBrush}" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Level}"
+                                                     Value="{x:Static svc:ExposureLevel.Warning}">
+                                            <Setter Property="BorderBrush" Value="{DynamicResource WarningBrush}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Border.Style>
+
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="16" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="5*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <!-- The dot carries the level for a glance across the room. -->
+                                <Ellipse Grid.Column="0" Width="10" Height="10"
+                                         VerticalAlignment="Top" Margin="0,5,0,0">
+                                    <Ellipse.Style>
+                                        <Style TargetType="Ellipse">
+                                            <Setter Property="Fill" Value="{DynamicResource SuccessBrush}" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Level}"
+                                                             Value="{x:Static svc:ExposureLevel.Alarm}">
+                                                    <Setter Property="Fill" Value="{DynamicResource ErrorBrush}" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding Level}"
+                                                             Value="{x:Static svc:ExposureLevel.Warning}">
+                                                    <Setter Property="Fill" Value="{DynamicResource WarningBrush}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Ellipse.Style>
+                                </Ellipse>
+
+                                <StackPanel Grid.Column="1" Margin="8,0,12,0">
+                                    <TextBlock FontWeight="SemiBold"
+                                               Foreground="{DynamicResource PrimaryTextBrush}">
+                                        <Run Text="{Binding ServerName, Mode=OneWay}" /><Run Text=" / " /><Run Text="{Binding DatabaseName, Mode=OneWay}" />
+                                    </TextBlock>
+                                    <TextBlock Style="{StaticResource SecondaryText}" FontSize="11">
+                                        <Run Text="{Binding RecoveryModel, Mode=OneWay}" /><Run Text=" " /><Run Text="{Binding StateDescription, Mode=OneWay}" />
+                                    </TextBlock>
+                                </StackPanel>
+
+                                <TextBlock Grid.Column="2"
+                                           Text="{Binding Verdict}"
+                                           Style="{StaticResource BodyText}"
+                                           TextWrapping="Wrap"
+                                           VerticalAlignment="Center" />
+
+                                <StackPanel Grid.Column="3" Margin="12,0,0,0" MinWidth="170">
+                                    <TextBlock Style="{StaticResource SecondaryText}" FontSize="11"
+                                               Text="{Binding LastFull, StringFormat='Full: {0:MM-dd HH:mm}', TargetNullValue='Full: never'}" />
+                                    <TextBlock Style="{StaticResource SecondaryText}" FontSize="11"
+                                               Text="{Binding LastLog, StringFormat='Log: {0:MM-dd HH:mm}', TargetNullValue='Log: never'}" />
+                                    <TextBlock Style="{StaticResource SecondaryText}" FontSize="11"
+                                               Text="{Binding LastProven, StringFormat='Proven: {0:MM-dd HH:mm}', TargetNullValue='Proven: never rehearsed'}"
+                                               ToolTip="When a rehearsal (#238) last PROVED this database restores. Arithmetic says what could restore; only a rehearsal says it does." />
+                                </StackPanel>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/NineLives/Views/ExposureView.xaml.cs
+++ b/src/NineLives/Views/ExposureView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class ExposureView : UserControl
+{
+    public ExposureView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
The question a DBA actually lives with is not "do I have backups?" but **"how exposed am I right now?"** One screen answers it: every user database on every configured server, the loss window in one sentence — *"if this server died now, everything after 14:32 is gone — up to 47m of work"* — traffic-lit, worst first.

## The silent failures are the loudest

- **Never backed up** — the loudest alarm there is.
- **FULL recovery with no log backup ever** — an alarm about two things at once: the log grows until the disk fills, and everything since the last full is unprotected.
- **Log silence escalates**: an hour is a warning, a day is an alarm. **SIMPLE** is judged against its own daily cycle with grace, not against log expectations it cannot meet; differentials move its recovery point.
- **A server that will not answer is an alarm row**, not a silent absence — a dashboard that omits the unreachable server reads "all clear" at the exact moment it should not. The sweep's LEFT JOIN is the same design in miniature: an INNER join would hide exactly the rows this screen exists to make red.

## Proof, not just arithmetic

The #238 rehearsal receipts join in as a **Proven** column — recovery-point arithmetic says what *could* restore; only a rehearsal says it *does*. The two features complete each other: the dashboard shows the exposure, the rehearsal turns a red "never proven" into a dated receipt.

Read-only by design, at the browsing tier. Rendered — alarms with red borders worst-first, the unreachable server included, the healthy row green with its receipt. 11 new tests, 1,521 pass.