### PR TITLE
Export a restore runbook: the printed folder for the worst day (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **Export a restore runbook** - one self-contained Markdown document per restore point: the
+  chain file by file, the prerequisites in the order the worst day needs them (credential,
+  TDE/encryption certificates by thumbprint, disk space), the exact script, what to do when it
+  stops part-way, and what finishes the job. Readable with no SQL tools installed, printable for
+  the change-board pack, committable to the DR repo (#240)
 - **The Exposure dashboard: how much data would be lost, right now.** Every user database on
   every configured server, judged from its own msdb - the derived loss window ("everything after
   14:32 is gone - up to 47m of work"), traffic-lit worst-first. The silent failures are the

--- a/src/NineLives.Tests/RunbookTests.cs
+++ b/src/NineLives.Tests/RunbookTests.cs
@@ -1,0 +1,122 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The DR runbook (#240): one self-contained document with everything the worst day needs, in
+/// the order the worst day needs it. Pure and offline by design - it states what to verify
+/// rather than reaching out to verify it, because it may be generated on a quiet Tuesday and
+/// executed the night the source server no longer answers.
+/// </summary>
+public class RunbookTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 10, 14, 0, 0);
+
+    private static BackupFileInfo File_(string device, long size = 0, byte[]? tde = null) => new()
+    {
+        BlobName = device,
+        BlobUrl = device.StartsWith("http") ? device : "",
+        LocalPath = device.StartsWith("http") ? null : device,
+        SizeBytes = size,
+        TdeThumbprint = tde
+    };
+
+    private static RunbookInputs Inputs(byte[]? tde = null, bool onDisk = false) => new()
+    {
+        Chain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                SetId = "full",
+                Type = BackupType.Full,
+                Timestamp = T0.AddHours(-10),
+                Files = [File_(onDisk
+                    ? @"\\nas01\backups\MyDb_full.bak"
+                    : "https://acct.blob.core.windows.net/backups/MyDb_full.bak", 1024 * 1024, tde)]
+            },
+            LogSets =
+            [
+                new BackupSet
+                {
+                    SetId = "log1",
+                    Type = BackupType.TransactionLog,
+                    Timestamp = T0.AddHours(-2),
+                    Files = [File_(onDisk
+                        ? @"\\nas01\backups\MyDb_log1.trn"
+                        : "https://acct.blob.core.windows.net/backups/MyDb_log1.trn")]
+                }
+            ]
+        },
+        Script = "RESTORE DATABASE [MyDb] FROM URL = N'https://...' WITH REPLACE, NORECOVERY;",
+        TargetDatabase = "MyDb",
+        ServerName = "SRV01",
+        ContainerName = "backups",
+        SourceDatabase = "MyDb",
+        RestorePoint = T0.AddHours(-1),
+        GeneratedAt = T0
+    };
+
+    [Fact]
+    public void TheSectionsArriveInTheOrderTheWorstDayNeeds()
+    {
+        var runbook = RunbookBuilder.Build(Inputs());
+
+        var files = runbook.IndexOf("## 1. The backups", StringComparison.Ordinal);
+        var prereq = runbook.IndexOf("## 2. Before the restore", StringComparison.Ordinal);
+        var script = runbook.IndexOf("## 3. The restore script", StringComparison.Ordinal);
+        var failure = runbook.IndexOf("## 4. If it stops", StringComparison.Ordinal);
+        var finish = runbook.IndexOf("## 5. Finishing the job", StringComparison.Ordinal);
+
+        Assert.True(0 < files && files < prereq && prereq < script && script < failure && failure < finish,
+            runbook[..200]);
+    }
+
+    [Fact]
+    public void EveryFileIsListedAndTheScriptIsVerbatim()
+    {
+        var runbook = RunbookBuilder.Build(Inputs());
+
+        Assert.Contains("MyDb_full.bak", runbook);
+        Assert.Contains("MyDb_log1.trn", runbook);
+        Assert.Contains("Log 1 of 1", runbook);
+        Assert.Contains("RESTORE DATABASE [MyDb] FROM URL", runbook);
+    }
+
+    /// <summary>Blob chains lead with the credential; disk chains with service-account readability.</summary>
+    [Fact]
+    public void ThePrerequisitesMatchTheMedium()
+    {
+        Assert.Contains("server-side credential", RunbookBuilder.Build(Inputs()));
+        Assert.Contains("SERVICE ACCOUNT", RunbookBuilder.Build(Inputs(onDisk: true)));
+    }
+
+    /// <summary>
+    /// When the chain knows it is TDE, the certificate is a numbered prerequisite with the
+    /// thumbprint spelled out - the 33111 that ends DR attempts, preempted on paper.
+    /// </summary>
+    [Fact]
+    public void ATdeChainMakesTheCertificateAPrerequisite()
+    {
+        var runbook = RunbookBuilder.Build(Inputs(tde: Convert.FromHexString("AABBCC")));
+
+        Assert.Contains("TDE-encrypted", runbook);
+        Assert.Contains("0xAABBCC", runbook);
+        Assert.Contains("BACKUP CERTIFICATE", runbook);
+        // The password never travels in a document that lives in tickets and repos.
+        Assert.Contains("belong in the DR kit, not in this document", runbook);
+    }
+
+    [Fact]
+    public void TheFailurePathAndTheFinishAreWrittenDown()
+    {
+        var runbook = RunbookBuilder.Build(Inputs());
+
+        Assert.Contains("WITH RECOVERY;", runbook);
+        Assert.Contains("SET MULTI_USER;", runbook);
+        Assert.Contains("DBCC CHECKDB", runbook);
+        Assert.Contains("ALTER USER", runbook);
+        Assert.Contains("stale runbook is a wrong runbook", runbook);
+    }
+}

--- a/src/NineLives/Services/RunbookBuilder.cs
+++ b/src/NineLives/Services/RunbookBuilder.cs
@@ -1,0 +1,191 @@
+using System.Text;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>What the runbook is built from - everything the restore screen already knows (#240).</summary>
+public sealed class RunbookInputs
+{
+    public required BackupChain Chain { get; init; }
+    public required string Script { get; init; }
+    public required string TargetDatabase { get; init; }
+
+    public string? ServerName { get; init; }
+    public string? ContainerName { get; init; }
+    public string? SourceDatabase { get; init; }
+    public DateTime? RestorePoint { get; init; }
+    public IReadOnlyList<FileMoveOption> FileMoves { get; init; } = [];
+    public DateTime GeneratedAt { get; init; } = DateTime.Now;
+}
+
+/// <summary>
+/// Writes the printed folder for the worst day (#240).
+///
+/// Every DR plan says "restore the databases" and almost none says HOW: which certificate has to
+/// exist first, which credential, which files, in which order, what to run when it fails. The
+/// knowledge lives in one person's head, and DR day is defined by that person being on holiday.
+/// The app GENERATES all of it per restore - this composes it into one self-contained Markdown
+/// document: readable on a laptop with no SQL tools, printable for the change-board pack,
+/// committable to the DR repo.
+///
+/// Pure, deliberately: it states what to verify rather than reaching out to verify it, because
+/// the runbook may be generated on a quiet Tuesday and executed the night the source server no
+/// longer answers.
+/// </summary>
+public static class RunbookBuilder
+{
+    public static string Build(RunbookInputs inputs)
+    {
+        var sb = new StringBuilder();
+        var chain = inputs.Chain;
+
+        // ── title ───────────────────────────────────────────────────────────────
+        sb.AppendLine($"# Restore runbook: {inputs.TargetDatabase}");
+        sb.AppendLine();
+        sb.AppendLine($"Generated {inputs.GeneratedAt:yyyy-MM-dd HH:mm} by Nine Lives {AppVersion.Display}. " +
+                      "Everything needed to run this restore is in this one document.");
+        sb.AppendLine();
+        sb.AppendLine($"| | |");
+        sb.AppendLine($"|---|---|");
+        if (inputs.SourceDatabase != null) sb.AppendLine($"| Source database | {inputs.SourceDatabase} |");
+        sb.AppendLine($"| Restore as | {inputs.TargetDatabase} |");
+        if (inputs.ServerName != null) sb.AppendLine($"| Target server | {inputs.ServerName} |");
+        if (inputs.ContainerName != null) sb.AppendLine($"| Container | {inputs.ContainerName} |");
+        if (inputs.RestorePoint != null) sb.AppendLine($"| Restore point | {inputs.RestorePoint:yyyy-MM-dd HH:mm:ss} |");
+        sb.AppendLine($"| Chain | {chain.Summary} |");
+        sb.AppendLine($"| Total to read | {ByteSize.Format(chain.AllFiles.Sum(f => f.SizeBytes))} |");
+        sb.AppendLine();
+
+        // ── the chain, file by file ─────────────────────────────────────────────
+        sb.AppendLine("## 1. The backups this restore reads");
+        sb.AppendLine();
+        sb.AppendLine("Confirm every file below exists and is reachable from the target server " +
+                      "BEFORE starting. A missing stripe fails the restore after `WITH REPLACE` " +
+                      "has already dropped the target.");
+        sb.AppendLine();
+
+        void DescribeSet(BackupSet set, string label)
+        {
+            sb.AppendLine($"**{label}** — {set.Timestamp:yyyy-MM-dd HH:mm:ss}" +
+                          (set.Position is int p ? $", file position {p}" : "") +
+                          $", {set.SizeDisplay}");
+            foreach (var file in set.Files)
+                sb.AppendLine($"- `{file.RestoreDevice}`");
+            sb.AppendLine();
+        }
+
+        DescribeSet(chain.FullSet, "Full");
+        foreach (var diff in chain.DiffSets) DescribeSet(diff, "Differential");
+        for (var i = 0; i < chain.LogSets.Count; i++) DescribeSet(chain.LogSets[i], $"Log {i + 1} of {chain.LogSets.Count}");
+
+        // ── prerequisites, in order ─────────────────────────────────────────────
+        sb.AppendLine("## 2. Before the restore, in this order");
+        sb.AppendLine();
+
+        var anyBlob = chain.AllFiles.Any(f => !f.IsOnDisk);
+        var step = 1;
+
+        if (anyBlob)
+        {
+            sb.AppendLine($"{step++}. **The server-side credential.** The target instance " +
+                          "authenticates to the container itself - the app's own access does not " +
+                          "travel. In `master`, confirm a credential exists whose name is the " +
+                          "container URL (`SELECT name FROM sys.credentials`), and create it from " +
+                          "the Restore screen's credential panel or your documented statement if " +
+                          "not. Without it, every `RESTORE ... FROM URL` fails with error 3201.");
+        }
+        else
+        {
+            sb.AppendLine($"{step++}. **Readability.** The paths above are opened by the target's " +
+                          "SQL Server SERVICE ACCOUNT, not by whoever runs the script. Confirm " +
+                          "that account can read them - error 3201 with OS error 5 at restore " +
+                          "time means it cannot.");
+        }
+
+        var tde = chain.AllFiles.FirstOrDefault(f => f.TdeThumbprint != null)?.TdeThumbprint;
+        var enc = chain.AllFiles.FirstOrDefault(f => f.EncryptorThumbprint != null)?.EncryptorThumbprint;
+
+        if (tde != null || enc != null)
+        {
+            var thumb = tde ?? enc!;
+            sb.AppendLine($"{step++}. **The certificate.** " +
+                          (tde != null
+                              ? "This database is TDE-encrypted; its backups can only be restored " +
+                                "where the TDE certificate exists. "
+                              : "These backups were taken WITH ENCRYPTION. ") +
+                          $"The target's `master` must hold the certificate with thumbprint " +
+                          $"`{EncryptionGuidance.Hex(thumb)}` - " +
+                          "`SELECT name FROM sys.certificates WHERE thumbprint = " +
+                          $"{EncryptionGuidance.Hex(thumb)}` - or the restore fails with error " +
+                          "33111. Export it from the source's master with `BACKUP CERTIFICATE`, " +
+                          "create it on the target with `CREATE CERTIFICATE ... FROM FILE`. The " +
+                          "certificate files and their password belong in the DR kit, not in this " +
+                          "document.");
+        }
+        else
+        {
+            sb.AppendLine($"{step++}. **Encryption check.** These backups did not declare TDE or " +
+                          "backup encryption when this runbook was generated. If the restore " +
+                          "fails with error 33111, a certificate is needed - see the source " +
+                          "server's `master.sys.certificates`.");
+        }
+
+        if (inputs.FileMoves.Count > 0)
+        {
+            sb.AppendLine($"{step++}. **Disk space.** The files land as follows - confirm each " +
+                          "volume has room:");
+            sb.AppendLine();
+            foreach (var move in inputs.FileMoves.Where(m => !string.IsNullOrWhiteSpace(m.NewPhysicalName)))
+                sb.AppendLine($"   - `{move.LogicalName}` → `{move.NewPhysicalName}` " +
+                              (move.SizeBytes > 0 ? $"({ByteSize.Format(move.SizeBytes)})" : ""));
+        }
+        else
+        {
+            sb.AppendLine($"{step++}. **Disk space.** Sizes are listed per backup above; the " +
+                          "restored files land at the paths recorded inside the backup unless the " +
+                          "script says `MOVE`. Confirm the volumes have room.");
+        }
+        sb.AppendLine();
+
+        // ── the script ──────────────────────────────────────────────────────────
+        sb.AppendLine("## 3. The restore script");
+        sb.AppendLine();
+        sb.AppendLine("Exactly as generated - run it batch by batch or whole:");
+        sb.AppendLine();
+        sb.AppendLine("```sql");
+        sb.AppendLine(inputs.Script.TrimEnd());
+        sb.AppendLine("```");
+        sb.AppendLine();
+
+        // ── when it fails ───────────────────────────────────────────────────────
+        sb.AppendLine("## 4. If it stops part-way");
+        sb.AppendLine();
+        sb.AppendLine("A chain that stops leaves the target in `RESTORING` (and `SINGLE_USER`, if " +
+                      "sessions were disconnected). Nothing is lost yet - the choices are:");
+        sb.AppendLine();
+        sb.AppendLine($"- **Carry on**: fix the cause and re-run from the failed statement onward.");
+        sb.AppendLine($"- **Give up and come online at the last restored point**: " +
+                      $"`RESTORE DATABASE {TSql.QuoteName(inputs.TargetDatabase)} WITH RECOVERY;`");
+        sb.AppendLine($"- **Let others back in** (if single-user): " +
+                      $"`ALTER DATABASE {TSql.QuoteName(inputs.TargetDatabase)} SET MULTI_USER;`");
+        sb.AppendLine();
+
+        // ── after it works ──────────────────────────────────────────────────────
+        sb.AppendLine("## 5. Finishing the job");
+        sb.AppendLine();
+        sb.AppendLine($"- **Prove the data**: `{PostRestoreAdvice.CheckDb(inputs.TargetDatabase).Sql}` — " +
+                      "no output means nothing wrong.");
+        sb.AppendLine($"- **Orphaned users**: on a different server every SQL-auth user is " +
+                      $"orphaned. For each, `USE {TSql.QuoteName(inputs.TargetDatabase)}; " +
+                      "ALTER USER [user] WITH LOGIN = [user];` where a same-named login exists.");
+        sb.AppendLine("- **Compatibility level and recovery model travel with the backup** - " +
+                      "review them if the target is a newer version.");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine($"*Runbook for {inputs.TargetDatabase}, generated {inputs.GeneratedAt:yyyy-MM-dd HH:mm}. " +
+                      "Regenerate after any change to the chain or the options - a stale runbook " +
+                      "is a wrong runbook that looks right.*");
+
+        return sb.ToString();
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1845,6 +1845,50 @@ public partial class RestoreViewModel : ViewModelBase
     /// The job is created disabled and unscheduled, so what is handed over is reviewable and inert
     /// until somebody deliberately starts it.
     /// </summary>
+    /// <summary>
+    /// Writes the printed folder for the worst day (#240): the chain, the prerequisites in
+    /// order, the exact script, what to do when it fails and what finishes the job - one
+    /// self-contained Markdown file, readable on a laptop with no SQL tools installed.
+    /// </summary>
+    [RelayCommand]
+    private void ExportRunbook()
+    {
+        if (!HasScript || RestoreChain == null) return;
+
+        try
+        {
+            var runbook = RunbookBuilder.Build(new RunbookInputs
+            {
+                Chain = RestoreChain,
+                Script = GeneratedScript,
+                TargetDatabase = TargetDatabaseName,
+                ServerName = ConnectedServer?.ServerName,
+                ContainerName = SelectedContainer?.Name,
+                SourceDatabase = Inventory.SelectedDatabaseName,
+                RestorePoint = Timeline.SelectedPoint?.Timestamp,
+                FileMoves = FetchedFileMoves.ToList()
+            });
+
+            var dialog = new SaveFileDialog
+            {
+                Title = "Export restore runbook",
+                FileName = $"runbook-{TargetDatabaseName}-{DateTime.Now:yyyyMMdd}.md",
+                Filter = "Markdown|*.md|All files|*.*",
+                DefaultExt = ".md"
+            };
+
+            if (dialog.ShowDialog() != true) return;
+
+            System.IO.File.WriteAllText(dialog.FileName, runbook);
+            SetStatus($"Runbook written to {dialog.FileName}. Regenerate it after any change to " +
+                      "the chain or options - a stale runbook is a wrong one that looks right.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"The runbook could not be written: {ex.Message}");
+        }
+    }
+
     [RelayCommand]
     private void CopyAsAgentJob()
     {

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1897,6 +1897,14 @@
                                 Visibility="{Binding ShowAgentJob, Converter={StaticResource BoolToVis}}"
                                 Margin="0,0,8,0"
                                 ToolTip="Wraps this restore as a SQL Server Agent job, one step per batch. The job is created DISABLED and with no schedule - enable or start it when the restore should actually happen." />
+
+                    <!-- The printed folder for the worst day (#240). -->
+                    <Button Content="Export runbook..."
+                            Command="{Binding ExportRunbookCommand}"
+                            Style="{StaticResource SecondaryButton}"
+                            Margin="0,0,8,0"
+                            IsEnabled="{Binding HasScript}"
+                            ToolTip="One self-contained Markdown document: the chain file by file, the prerequisites in order (credential, certificates, disk space), the exact script, what to do when it stops part-way, and what finishes the job. For the change-board pack and the DR repo." />
                         <Button Content="{Binding Execution.ButtonText}"
                                 Style="{StaticResource DangerButton}"
                                 Command="{Binding ExecuteScriptCommand}"


### PR DESCRIPTION
Every DR plan says "restore the databases" and almost none says HOW. The app already generates everything per restore; this composes it into one self-contained Markdown document — readable on a laptop with no SQL tools, printable for the change-board pack, committable to the DR repo.

## The five sections, in the order the worst day needs them

1. **The backups, file by file** — devices, sizes, positions, with the missing-stripe warning up front.
2. **Prerequisites, in order, matched to the medium** — blob chains lead with the server-side credential; disk chains with the service account's readability. A chain that knows it is TDE gets the certificate as a numbered prerequisite with the thumbprint spelled out (error 33111, preempted on paper) — and the certificate password *explicitly belongs in the DR kit, never in this document*.
3. **The exact script**, verbatim.
4. **If it stops part-way** — the RESTORING/SINGLE_USER reality and the three choices with their statements.
5. **Finishing the job** — CHECKDB, orphaned users, the properties that travel with a backup.

Pure and offline by design: it states what to verify rather than reaching out to verify it, because a runbook may be generated on a quiet Tuesday and executed the night the source server no longer answers.

5 new tests, 1,526 pass.