### PR TITLE
Give the finishing panel's actions progress and a spoken outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ more detail on the user-facing changes; this file is the short history.
   protects it - TDE, backup encryption, or "Not encrypted", because absence is information too
   (#222)
 
+- **The finishing panel's actions show progress and speak their outcome.** DBCC CHECKDB (and any
+  long panel action) drives a progress bar from the server's own percent_complete, and the result
+  stays on the panel - "CHECKDB completed and found nothing wrong" - instead of scrolling away in
+  the console. Failures and cancellations stay visible the same way
+- The orphaned-user scan crashed with a collation conflict when the restored database's collation
+  differed from the server's - both sides of the login-name comparison are now forced to one
+  collation. Found in the field on the first cross-collation restore
+
 ### Changed
 
 - **One console, not two.** The restore screen no longer keeps an inline copy of the run's

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -500,6 +500,28 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Paths the fake target refuses, and why. Anything not listed is readable.</summary>
     public Dictionary<string, BackupFileProblem> UnreadablePaths { get; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Percent values the polling execute reports before completing (#user CHECKDB feedback).</summary>
+    public List<double> PollPercents { get; set; } = [50];
+
+    public Exception? PollingExecuteThrows { get; set; }
+
+    public List<string> PolledScripts { get; } = [];
+
+    public Task ExecuteWithPercentPollingAsync(
+        ServerConnection server, string sql, IProgress<double>? percent = null,
+        CancellationToken ct = default)
+    {
+        PolledScripts.Add(sql);
+        ct.ThrowIfCancellationRequested();
+        if (PollingExecuteThrows != null) throw PollingExecuteThrows;
+
+        if (percent != null)
+            foreach (var p in PollPercents)
+                ((IProgress<double>)percent).Report(p);
+
+        return Task.CompletedTask;
+    }
+
     /// <summary>Exposure rows per server name (#239); a server absent from the map throws.</summary>
     public Dictionary<string, List<ExposureRow>> ExposureByServer { get; } =
         new(StringComparer.OrdinalIgnoreCase);

--- a/src/NineLives.Tests/PanelActionProgressTests.cs
+++ b/src/NineLives.Tests/PanelActionProgressTests.cs
@@ -1,0 +1,85 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The finishing panel's actions gained progress and a spoken outcome: CHECKDB on a real
+/// database takes minutes, and "did it find anything?" should not have to be dug out of the
+/// console. percent_complete from dm_exec_requests drives the bar; the outcome line stays on
+/// the panel after the console has scrolled on.
+/// </summary>
+public class PanelActionProgressTests
+{
+    private static (RestoreExecutionViewModel vm, FakeSqlServerService sql) NewAfterRun()
+    {
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreExecutionViewModel(
+            sql, new FakeRestoreHistoryStore(), TestLogs.Temp(), new OperationCancellation());
+
+        // A run first, so _lastServer/_lastTarget are aimed - the panel only exists after one.
+        var run = new RestoreRun(
+            new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" },
+            "RESTORE DATABASE [MyDb] FROM DISK = N'D:\\b.bak' WITH REPLACE, RECOVERY;",
+            "MyDb", null, null, "1 full", null, "opts");
+        vm.RunAsync(run, _ => Task.FromResult(CredentialPreflight.Proceed)).GetAwaiter().GetResult();
+
+        return (vm, sql);
+    }
+
+    [Fact]
+    public async Task TheActionRunsThroughThePollingPathAndReportsPercent()
+    {
+        var (vm, sql) = NewAfterRun();
+        sql.PollPercents = [37.5];
+        double seen = -1;
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(vm.ActionPercent) && vm.ActionPercent > 0) seen = vm.ActionPercent;
+        };
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(PostRestoreAdvice.CheckDb("MyDb"));
+
+        Assert.Contains(sql.PolledScripts, s => s.Contains("DBCC CHECKDB"));
+        Assert.Equal(37.5, seen, 1);
+    }
+
+    /// <summary>The sentence the click exists to produce, on the panel, after the console moved on.</summary>
+    [Fact]
+    public async Task ACleanCheckdbSaysSoOnThePanel()
+    {
+        var (vm, _) = NewAfterRun();
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(PostRestoreAdvice.CheckDb("MyDb"));
+
+        Assert.Contains("found nothing wrong", vm.ActionOutcome);
+        Assert.False(vm.IsRunningAction);
+        Assert.True(vm.ActionPercentUnknown);   // the bar reset for the next action
+    }
+
+    [Fact]
+    public async Task AFailedActionKeepsItsFailureOnThePanel()
+    {
+        var (vm, sql) = NewAfterRun();
+        sql.PollingExecuteThrows = new InvalidOperationException("Msg 8921: CHECKDB aborted");
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(PostRestoreAdvice.CheckDb("MyDb"));
+
+        Assert.Contains("FAILED", vm.ActionOutcome);
+        Assert.Contains("Msg 8921", vm.ActionOutcome);
+        Assert.True(vm.HasError);
+    }
+
+    [Fact]
+    public async Task ANonCheckdbActionGetsItsTitleAsTheOutcome()
+    {
+        var (vm, _) = NewAfterRun();
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(new RecoveryAction(
+            "Bring the database online", "RESTORE DATABASE [MyDb] WITH RECOVERY", "caution"));
+
+        Assert.Contains("Bring the database online", vm.ActionOutcome);
+    }
+}

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -64,6 +64,15 @@ public interface ISqlServerService
     /// <summary>SERVERPROPERTY('ProductMajorVersion') - 16 is SQL Server 2022 - or null if it did not say (#210).</summary>
     Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default);
 
+    /// <summary>
+    /// Runs one statement while a second connection polls sys.dm_exec_requests for its
+    /// percent_complete - which DBCC CHECKDB and RESTORE both report. Best effort: no
+    /// VIEW SERVER STATE means no percentage, and the statement still runs.
+    /// </summary>
+    Task ExecuteWithPercentPollingAsync(
+        ServerConnection server, string sql, IProgress<double>? percent = null,
+        CancellationToken ct = default);
+
     /// <summary>What the restored database looks like now - compat level, recovery model, owner (#205).</summary>
     Task<DatabaseOverview?> GetDatabaseOverviewAsync(
         ServerConnection server, string database, CancellationToken ct = default);

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1389,6 +1389,59 @@ public class SqlServerService : ISqlServerService
             reader["OwnerName"] as string);
     }
 
+    public async Task ExecuteWithPercentPollingAsync(
+        ServerConnection server, string sql, IProgress<double>? percent = null,
+        CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+
+        short spid;
+        await using (var spidCmd = conn.CreateCommand())
+        {
+            spidCmd.CommandText = "SELECT @@SPID";
+            spid = Convert.ToInt16(await spidCmd.ExecuteScalarAsync(ct));
+        }
+
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.CommandTimeout = 0;
+
+        var run = cmd.ExecuteNonQueryAsync(ct);
+
+        if (percent != null)
+        {
+            try
+            {
+                await using var pollConn = CreateConnection(server);
+                await pollConn.OpenAsync(ct);
+
+                while (!run.IsCompleted)
+                {
+                    await Task.WhenAny(run, Task.Delay(TimeSpan.FromSeconds(2), ct));
+                    if (run.IsCompleted || ct.IsCancellationRequested) break;
+
+                    await using var poll = pollConn.CreateCommand();
+                    poll.CommandText =
+                        "SELECT TOP 1 percent_complete FROM sys.dm_exec_requests " +
+                        "WHERE session_id = @spid";
+                    poll.Parameters.AddWithValue("@spid", spid);
+
+                    var value = await poll.ExecuteScalarAsync(ct);
+                    if (value != null && value != DBNull.Value)
+                        percent.Report(Convert.ToDouble(value));
+                }
+            }
+            catch
+            {
+                // The poll is a courtesy over a second connection; the statement's own outcome
+                // arrives through the run task either way.
+            }
+        }
+
+        await run;
+    }
+
     public async Task<List<OrphanedUser>> FindOrphanedUsersAsync(
         ServerConnection server, string database, CancellationToken ct = default)
     {
@@ -1412,7 +1465,13 @@ public class SqlServerService : ISqlServerService
             LEFT JOIN sys.server_principals AS by_sid
                    ON by_sid.sid = dp.sid
             LEFT JOIN sys.server_principals AS same_named
-                   ON same_named.name = dp.name AND same_named.type = 'S'
+                   -- Both sides forced to one collation: server_principals.name carries the
+                   -- SERVER collation and the restored database's principals carry the SOURCE's,
+                   -- and equality between them throws when they differ - hit in the field on the
+                   -- first cross-collation restore.
+                   ON same_named.name COLLATE Latin1_General_100_CI_AS
+                      = dp.name COLLATE Latin1_General_100_CI_AS
+                  AND same_named.type = 'S'
             WHERE dp.type = 'S'
               AND dp.authentication_type = 1
               AND dp.principal_id > 4

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -562,6 +562,26 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     private ServerConnection? _lastServer;
     private string _lastTarget = string.Empty;
 
+    /// <summary>Overall percent of the running panel action, from dm_exec_requests. -1 = unknown.</summary>
+    [ObservableProperty]
+    private double _actionPercent = -1;
+
+    [ObservableProperty]
+    private bool _isRunningAction;
+
+    /// <summary>True until the first percent arrives - the bar runs indeterminate rather than lying at 0.</summary>
+    public bool ActionPercentUnknown => ActionPercent < 0;
+
+    partial void OnActionPercentChanged(double value) => OnPropertyChanged(nameof(ActionPercentUnknown));
+
+    /// <summary>
+    /// What the last panel action concluded, on the panel itself - the console scrolls, this
+    /// stays. "CHECKDB found nothing wrong" is the sentence the whole rehearsal of clicking Run
+    /// exists to produce, and it should not have to be dug out of 60 lines of output.
+    /// </summary>
+    [ObservableProperty]
+    private string _actionOutcome = string.Empty;
+
     /// <summary>Runs one remediation the user picked, then re-reads the state.</summary>
     [RelayCommand]
     private async Task RunRecoveryActionAsync(RecoveryAction? action)
@@ -575,11 +595,34 @@ public partial class RestoreExecutionViewModel : ViewModelBase
         var ct = _queryCancellation.Begin();
         RaiseCancelStateChanged();
 
+        IsRunningAction = true;
+        ActionPercent = -1;
+        ActionOutcome = string.Empty;
+        TaskbarState = System.Windows.Shell.TaskbarItemProgressState.Normal;
+        TaskbarValue = 0;
+
         try
         {
             AppendLog($"\nRunning: {action.Sql}");
-            await _sql.ExecuteRecoveryActionAsync(_lastServer, action.Sql, ct);
+
+            // percent_complete covers DBCC CHECKDB and RESTORE alike - the two long things this
+            // panel runs - so the bar moves for exactly the actions long enough to need one.
+            var progress = new Progress<double>(p =>
+            {
+                ActionPercent = p;
+                TaskbarValue = p / 100.0;
+            });
+
+            await _sql.ExecuteWithPercentPollingAsync(_lastServer, action.Sql, progress, ct);
             AppendLog("Completed.");
+
+            // On the panel, not only in the console: the console scrolls, this stays - and
+            // "CHECKDB found nothing wrong" is the sentence the whole click exists to produce.
+            ActionOutcome = action.Sql.Contains("DBCC CHECKDB", StringComparison.OrdinalIgnoreCase)
+                ? $"CHECKDB completed at {DateTime.Now:HH:mm:ss} and found nothing wrong - the " +
+                  "restore is proven, not just finished."
+                : $"Completed at {DateTime.Now:HH:mm:ss}: {action.Title}.";
+
             await ReportRecoveryStateAsync(_lastServer, _lastTarget);
 
             if (!HasRecoveryActions)
@@ -590,15 +633,21 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             // SQL Server rolls back the statement that was in flight, so the database is where it
             // was before this step - which is still whatever the failed restore left behind.
             AppendLog("\nCancelled. The database is in the same state as before this step.");
+            ActionOutcome = $"Cancelled at {DateTime.Now:HH:mm:ss} - the database is unchanged by this step.";
             SetStatus("Recovery step cancelled.");
         }
         catch (Exception ex)
         {
             AppendLog($"\nERROR: {ex.Message}");
+            ActionOutcome = $"FAILED at {DateTime.Now:HH:mm:ss}: {ex.Message}";
             SetError($"Recovery step failed: {ex.Message}");
         }
         finally
         {
+            IsRunningAction = false;
+            ActionPercent = -1;
+            TaskbarState = System.Windows.Shell.TaskbarItemProgressState.None;
+            TaskbarValue = 0;
             _queryCancellation.End();
             RaiseCancelStateChanged();
         }

--- a/src/NineLives/Views/ExecutionWindow.xaml
+++ b/src/NineLives/Views/ExecutionWindow.xaml
@@ -118,6 +118,31 @@
             <StackPanel>
                 <TextBlock Text="THE TARGET DATABASE NEEDS ATTENTION"
                            Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                <!-- The running action's own progress (percent_complete) and its outcome - on the
+                     panel, because the console scrolls and this should stay. -->
+                <StackPanel Visibility="{Binding Execution.IsRunningAction, Converter={StaticResource BoolToVis}}"
+                            Margin="0,0,0,8">
+                    <ProgressBar Height="8" Maximum="100"
+                                 Value="{Binding Execution.ActionPercent, Mode=OneWay}"
+                                 IsIndeterminate="{Binding Execution.ActionPercentUnknown}"
+                                 Style="{StaticResource DarkProgressBar}" />
+                </StackPanel>
+                <TextBlock Text="{Binding Execution.ActionOutcome}"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,8">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock" BasedOn="{StaticResource BodyText}">
+                            <Setter Property="Visibility" Value="Visible" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Execution.ActionOutcome}" Value="">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+
                 <TextBlock Text="{Binding Execution.RecoveryStateMessage}"
                            Style="{StaticResource BodyText}"
                            TextWrapping="Wrap" Margin="0,0,0,10" />
@@ -170,6 +195,31 @@
             <StackPanel>
                 <TextBlock Text="FINISHING THE JOB"
                            Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+                <!-- The running action's own progress (percent_complete) and its outcome - on the
+                     panel, because the console scrolls and this should stay. -->
+                <StackPanel Visibility="{Binding Execution.IsRunningAction, Converter={StaticResource BoolToVis}}"
+                            Margin="0,0,0,8">
+                    <ProgressBar Height="8" Maximum="100"
+                                 Value="{Binding Execution.ActionPercent, Mode=OneWay}"
+                                 IsIndeterminate="{Binding Execution.ActionPercentUnknown}"
+                                 Style="{StaticResource DarkProgressBar}" />
+                </StackPanel>
+                <TextBlock Text="{Binding Execution.ActionOutcome}"
+                           FontWeight="SemiBold"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,8">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock" BasedOn="{StaticResource BodyText}">
+                            <Setter Property="Visibility" Value="Visible" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Execution.ActionOutcome}" Value="">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
+
                 <TextBlock Text="{Binding Execution.PostRestoreMessage}"
                            Style="{StaticResource BodyText}"
                            TextWrapping="Wrap" Margin="0,0,0,10" />


### PR DESCRIPTION
Two findings from a real cross-collation restore.

**The orphan scan crashed with a collation conflict** — `sys.server_principals.name` carries the server collation, the restored database's principals carry the source's, and equality between them throws when they differ. Both sides of the same-named-login comparison are now forced to one collation (the by-SID join was never affected — SIDs are binary).

**CHECKDB ran silently** — minutes of nothing, then an outcome buried in console lines. Panel actions now run through a percent-polling execute: a second connection reads `percent_complete` from `dm_exec_requests` (which DBCC CHECKDB and RESTORE both report), driving a bar on the panel and the taskbar — indeterminate until the first sample, so it never lies at 0. The poll is a courtesy: no VIEW SERVER STATE means no percentage, and the statement still runs.

**The outcome stays on the panel** after the console scrolls on — *"CHECKDB completed at 14:32 and found nothing wrong — the restore is proven, not just finished"* — because that is the sentence the whole click exists to produce. Failures and cancellations stay visible the same way.

4 new tests, 1,530 pass.