### PR TITLE
Every restore option in every mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Changed
 
+- **Every restore option is available in every mode.** Point-in-time, relocating files (WITH
+  MOVE), the advanced WITH options and additional containers no longer hide behind Standard or
+  Pro: the modes narrow which screens exist, never which restore options do. WITH MOVE is needed
+  most on restores to a different server - the Basic scenario itself - and hiding it made Basic
+  restores fail with directory errors the wider modes would not have hit
+
 - **One console, not two.** The restore screen no longer keeps an inline copy of the run's
   output behind the execution window - every line and panel was rendered twice. The window is
   the console; a "View the last run's output" button reopens it over the same record, and the

--- a/src/NineLives.Tests/AppModeTests.cs
+++ b/src/NineLives.Tests/AppModeTests.cs
@@ -23,13 +23,19 @@ public class AppModeTests
 
     /// <summary>Basic is what the app originally was: restore, from a container.</summary>
     [Fact]
-    public void BasicIsTheOriginalApp()
+    public void BasicIsTheRestoreScreenWithEveryOption()
     {
         Assert.False(AppModeCapabilities.CanBackUp(AppMode.Basic));
         Assert.False(AppModeCapabilities.CanUseSharedPath(AppMode.Basic));
         Assert.False(AppModeCapabilities.CanCopyBetweenServers(AppMode.Basic));
         Assert.False(AppModeCapabilities.CanVerifyAndAudit(AppMode.Basic));
-        Assert.False(AppModeCapabilities.CanRestoreToAPointInTime(AppMode.Basic));
+
+        // The ruling that reshaped this test: modes narrow which SCREENS exist, never which
+        // restore options do. WITH MOVE is needed most on restores to a DIFFERENT server - the
+        // Basic scenario itself - and hiding it made Basic restores fail with directory errors.
+        Assert.True(AppModeCapabilities.CanRestoreToAPointInTime(AppMode.Basic));
+        Assert.True(AppModeCapabilities.CanRelocateFiles(AppMode.Basic));
+        Assert.True(AppModeCapabilities.CanUseAdvancedRestoreOptions(AppMode.Basic));
     }
 
     [Fact]

--- a/src/NineLives.Tests/MultiContainerRestoreTests.cs
+++ b/src/NineLives.Tests/MultiContainerRestoreTests.cs
@@ -186,19 +186,20 @@ public class MultiContainerRestoreTests
     // ── the mode gate ───────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Pro only. It answers a question somebody has to know to ask - that a chain CAN be split
-    /// across containers - which is the test every other Pro-only feature had to pass.
+    /// Every mode. It used to be Pro-only, until the ruling that modes narrow which SCREENS
+    /// exist, never which restore options do - and a chain split across containers is a fact
+    /// about the backups, not about the person restoring them.
     /// </summary>
     [Theory]
-    [InlineData(AppMode.Basic, false)]
-    [InlineData(AppMode.Standard, false)]
-    [InlineData(AppMode.Pro, true)]
-    public void OnlyTheWidestModeOffersIt(AppMode mode, bool offered)
+    [InlineData(AppMode.Basic)]
+    [InlineData(AppMode.Standard)]
+    [InlineData(AppMode.Pro)]
+    public void EveryModeOffersIt(AppMode mode)
     {
         var vm = Restore(out _);
         vm.Mode = mode;
 
-        Assert.Equal(offered, vm.ShowMultipleContainers);
+        Assert.True(vm.ShowMultipleContainers);
     }
 
     /// <summary>A tick list with nothing in it is worse than no tick list.</summary>

--- a/src/NineLives/Models/AppMode.cs
+++ b/src/NineLives/Models/AppMode.cs
@@ -66,17 +66,19 @@ public static class AppModeCapabilities
     public static bool CanUseSharedPath(AppMode mode) => mode >= AppMode.Standard;
 
     /// <summary>
-    /// Restoring to a moment rather than to a backup.
-    ///
-    /// Standard, and it was the hardest call here. Point-in-time is close to the heart of what this
-    /// app is for, but it is also the thing somebody restoring last night's full will never touch -
-    /// and STOPAT with nothing selected is a checkbox that does nothing, which is its own kind of
-    /// clutter.
+    /// Restoring to a moment rather than to a backup. Every mode: the modes narrow which SCREENS
+    /// exist, not which restore options do - a Basic user restoring to just-before-the-mistake is
+    /// the app's founding scenario, not an advanced one.
     /// </summary>
-    public static bool CanRestoreToAPointInTime(AppMode mode) => mode >= AppMode.Standard;
+    public static bool CanRestoreToAPointInTime(AppMode mode) => true;
 
-    /// <summary>Relocating the database files. Needed whenever the target's layout differs.</summary>
-    public static bool CanRelocateFiles(AppMode mode) => mode >= AppMode.Standard;
+    /// <summary>
+    /// Relocating the database files (WITH MOVE). Every mode, decisively: it is needed whenever
+    /// the target's layout differs from the source's, which is most restores onto a DIFFERENT
+    /// server - the Basic scenario itself. Hiding it made Basic restores fail with directory
+    /// errors that Standard would not have hit.
+    /// </summary>
+    public static bool CanRelocateFiles(AppMode mode) => true;
 
     /// <summary>
     /// The chain checks, the VERIFYONLY pass and the header audit.
@@ -99,8 +101,12 @@ public static class AppModeCapabilities
     /// <summary>Handing a restore over as an Agent job.</summary>
     public static bool CanScriptAsAgentJob(AppMode mode) => mode >= AppMode.Pro;
 
-    /// <summary>The less common RESTORE options - KEEP_REPLICATION, the broker flags, CHECKSUM.</summary>
-    public static bool CanUseAdvancedRestoreOptions(AppMode mode) => mode >= AppMode.Pro;
+    /// <summary>
+    /// The less common RESTORE options - KEEP_REPLICATION, the broker flags, CHECKSUM. Every
+    /// mode, same ruling as MOVE: restore OPTIONS are the trade of the restore screen, and the
+    /// modes gate screens and machinery, not the statement somebody can write.
+    /// </summary>
+    public static bool CanUseAdvancedRestoreOptions(AppMode mode) => true;
 
     // ── what a mode is, in words ────────────────────────────────────────────────
 
@@ -138,7 +144,7 @@ public static class AppModeCapabilities
         AppMode.Basic =>
         [
             "Pick a container, pick a restore point, restore",
-            "The full restore chain worked out for you",
+            "Every restore option - a moment in time, relocated files, the lot",
             "Nothing else on screen"
         ],
 
@@ -146,8 +152,7 @@ public static class AppModeCapabilities
         [
             "Taking a backup, to blob or a file share",
             "Restoring from a path both servers can see",
-            "Restoring to a moment in time",
-            "Putting the database files somewhere else"
+            "Browsing backups, and the exposure dashboard"
         ],
 
         _ =>


### PR DESCRIPTION
The ruling that reshapes the mode boundary: **modes narrow which screens exist, never which restore options do.** Point-in-time, relocating files (WITH MOVE), the advanced WITH options and additional containers are all available in Basic now.

WITH MOVE decided it: it is needed most on restores to a *different* server — the Basic scenario itself — and hiding it behind Standard made exactly those restores fail with directory-lookup errors a wider mode would not have hit. An option gate that turns the narrow mode's core scenario into a failure is a gate in the wrong place.

Cards updated to match; the mode pins now assert the ruling rather than the old tiering. 1,530 pass.