### PR TITLE
Retire the Generate Script button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Changed
 
+- **The Generate Script button is gone** - the script has built itself live on every option
+  change for a while, which made the button a ritual with no effect. When the pane is empty it
+  now says why, passively, where the script would be ("Enter a target database name and the
+  script appears here"), instead of a dialog per keystroke. Ctrl+G retires with it
 - **Every restore option is available in every mode.** Point-in-time, relocating files (WITH
   MOVE), the advanced WITH options and additional containers no longer hide behind Standard or
   Pro: the modes narrow which screens exist, never which restore options do. WITH MOVE is needed

--- a/src/NineLives.Tests/KeyboardShortcutTests.cs
+++ b/src/NineLives.Tests/KeyboardShortcutTests.cs
@@ -53,7 +53,7 @@ public class KeyboardShortcutTests
         var vm = New();
         vm.NavigateToCommand.Execute(MainViewModel.Nav.History);
 
-        vm.GenerateScriptCommand.Execute(null);
+        // The script builds itself live - nothing to press.
 
         Assert.False(vm.Restore.HasScript);
     }

--- a/src/NineLives.Tests/ScriptStaysInStepTests.cs
+++ b/src/NineLives.Tests/ScriptStaysInStepTests.cs
@@ -146,15 +146,15 @@ public class ScriptStaysInStepTests
     }
 
     [Fact]
-    public async Task GenerateSaysWhyWhenStandbyHasNoUndoFile()
+    public async Task TheEmptyPaneSaysWhyWhenStandbyHasNoUndoFile()
     {
         var vm = await Loaded();
         vm.Options.RecoveryMode = RecoveryMode.Standby;
 
-        vm.GenerateScriptCommand.Execute(null);
-
-        Assert.True(vm.HasError);
-        Assert.Contains("undo file", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+        // The script builds itself live now, so the explanation is a passive hint where the
+        // script would be - an error dialog per keystroke would be noise.
+        Assert.False(vm.HasScript);
+        Assert.Contains("undo file", vm.ScriptBlockedReason, StringComparison.OrdinalIgnoreCase);
     }
 
     // ── STATS ───────────────────────────────────────────────────────────────────

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -41,7 +41,6 @@
         <KeyBinding Modifiers="Ctrl" Key="D8" Command="{Binding NavigateToCommand}" CommandParameter="Settings" />
         <KeyBinding Modifiers="Ctrl" Key="D9" Command="{Binding NavigateToCommand}" CommandParameter="About" />
         <KeyBinding Key="F5" Command="{Binding ReloadCommand}" />
-        <KeyBinding Modifiers="Ctrl" Key="G" Command="{Binding GenerateScriptCommand}" />
         <KeyBinding Key="Escape" Command="{Binding CancelCurrentCommand}" />
     </Window.InputBindings>
 

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -495,13 +495,6 @@ public partial class MainViewModel : ViewModelBase
         }
     }
 
-    /// <summary>Ctrl+G: generate the restore script. Only the Restore screen generates anything.</summary>
-    [RelayCommand]
-    private void GenerateScript()
-    {
-        if (CurrentViewName != Nav.Restore) return;
-        if (Restore.GenerateScriptCommand.CanExecute(null)) Restore.GenerateScriptCommand.Execute(null);
-    }
 
     /// <summary>
     /// Esc: stop whatever is running.

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1652,42 +1652,12 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Explicit Generate. Same work as the live rebuild, but it says why nothing was produced -
-    /// the live path stays silent because reporting an error on every keystroke would be noise.
+    /// Why the script pane is empty, shown where the script would be (#user). The Generate
+    /// button used to carry these as error dialogs; the script builds itself live now, so the
+    /// explanation lives passively where the eye already is.
     /// </summary>
-    [RelayCommand]
-    private void GenerateScript()
-    {
-        if (RestoreChain == null)
-        {
-            SetError("No valid restore chain. Load backups and select a restore point first.");
-            return;
-        }
-
-        if (string.IsNullOrWhiteSpace(TargetDatabaseName))
-        {
-            SetError("Please enter a target database name.");
-            return;
-        }
-
-        // Refuse to silently fall back to a full-chain restore when the user asked to stop at a
-        // time we could not use - that would replay exactly the transactions they meant to skip.
-        if (PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null)
-        {
-            SetError($"Point-in-time target is not valid. {PointInTime.Message}");
-            return;
-        }
-
-        if (!Options.HasStandbyFileIfNeeded)
-        {
-            SetError("STANDBY needs an undo file path. Without one the script would end in " +
-                     "STANDBY = '', which fails after the database has already been overwritten.");
-            return;
-        }
-
-        RegenerateScript();
-        if (HasScript) SetStatus("Script generated successfully.");
-    }
+    [ObservableProperty]
+    private string _scriptBlockedReason = string.Empty;
 
     /// <summary>
     /// The WITH MOVE clauses the restore would use, or an empty list when it is not moving files.
@@ -1812,10 +1782,25 @@ public partial class RestoreViewModel : ViewModelBase
         // Leave the script alone mid-restore - it is the record of what is actually running.
         if (IsExecuting) return;
 
-        if (RestoreChain == null
-            || string.IsNullOrWhiteSpace(TargetDatabaseName)
-            || (PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null)
-            || !Options.HasStandbyFileIfNeeded)
+        // When nothing can be produced, say which input is missing - quietly, as a hint where
+        // the script would be, because this now happens live rather than on a button press and
+        // an error dialog per keystroke would be noise.
+        var chain = RestoreChain;
+        var blocked =
+            chain == null
+                ? "Select a restore point above and the script appears here."
+            : string.IsNullOrWhiteSpace(TargetDatabaseName)
+                ? "Enter a target database name and the script appears here."
+            : PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null
+                ? $"The point-in-time target is not valid yet. {PointInTime.Message}"
+            : !Options.HasStandbyFileIfNeeded
+                ? "STANDBY needs an undo file path - without one the script would end in " +
+                  "STANDBY = '', which fails after the database has already been overwritten."
+            : null;
+
+        ScriptBlockedReason = blocked ?? string.Empty;
+
+        if (blocked != null)
         {
             GeneratedScript = string.Empty;
             HasScript = false;
@@ -1827,7 +1812,7 @@ public partial class RestoreViewModel : ViewModelBase
         // chain or the server.
         var options = Options.Build(TargetDatabaseName, PointInTime.Effective, BuildFileMoves());
 
-        GeneratedScript = _scriptGenerator.Generate(RestoreChain, options);
+        GeneratedScript = _scriptGenerator.Generate(chain!, options);
         HasScript = true;
     }
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1872,10 +1872,6 @@
                     <StackPanel Visibility="{Binding Steps.Execute.IsExpanded, Converter={StaticResource BoolToVis}}">
 
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                        <Button Content="Generate Script"
-                                Style="{StaticResource PrimaryButton}"
-                                Command="{Binding GenerateScriptCommand}"
-                                Margin="0,0,8,0" />
                         <Button Content="Copy to Clipboard"
                                 Style="{StaticResource SecondaryButton}"
                                 Command="{Binding CopyScriptCommand}"
@@ -1986,6 +1982,15 @@
                         <StackPanel>
                             <Grid Margin="12,8,12,4">
                                 <TextBlock Text="GENERATED SCRIPT" Style="{StaticResource LabelText}" />
+
+                        <!-- Why the pane is empty, where the eye already is - the script builds
+                             itself live, so there is no button to press and no dialog to read. -->
+                        <TextBlock Text="{Binding ScriptBlockedReason}"
+                                   Style="{StaticResource SecondaryText}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,6,0,0">
+                            <TextBlock.Resources />
+                        </TextBlock>
                                 <TextBlock Text="updates as you change options"
                                            Style="{StaticResource SecondaryText}"
                                            FontSize="11"


### PR DESCRIPTION
The script has rebuilt itself live on every option change since the stale-script fix — the button was a ritual with no effect. Its one genuine value (saying **why** nothing was produced) moves into a passive hint where the script pane is: *"Enter a target database name and the script appears here"* — no dialog per keystroke. Ctrl+G retires with it, and the standby-undo-file pin follows the message to its new home. 1,530 pass.