### PR TITLE
The retention referee: what an age-based rule would actually do (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Changed
 
+- **The retention referee: what would an age-based deletion rule actually do?** Report-only,
+  over the loaded backups: what a keep-N-days rule keeps, what it can safely delete (with the
+  bytes reclaimed), what must survive its own age because kept restores depend on it - the base
+  full outside the window, the newest differential under it, and the bridge logs that carry the
+  chain to the window's edge - and what is already broken. Before a lifecycle rule finds out via
+  error 3136 (#241)
 - **The Generate Script button is gone** - the script has built itself live on every option
   change for a while, which made the button a ritual with no effect. When the pane is empty it
   now says why, passively, where the script would be ("Enter a target database name and the

--- a/src/NineLives.Tests/RetentionAdvisorTests.cs
+++ b/src/NineLives.Tests/RetentionAdvisorTests.cs
@@ -1,0 +1,134 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The retention referee (#241): what a keep-N-days rule would actually do - what goes, what must
+/// stay DESPITE its age because kept restores depend on it, and what is already broken. The
+/// classic blind spot it exists for: a lifecycle rule deletes the base full of a differential
+/// somebody still needs, and the first sign is error 3136 mid-restore.
+/// </summary>
+public class RetentionAdvisorTests
+{
+    private static readonly DateTime Now = new(2026, 8, 10, 12, 0, 0);
+    private const int KeepDays = 30;
+
+    private static int _seq;
+
+    private static BackupSet Set(
+        BackupType type, int daysAgo, string db = "MyDb", long size = 100,
+        decimal? checkpoint = null, decimal? baseLsn = null) => new()
+    {
+        SetId = $"s{++_seq}",
+        DatabaseName = db,
+        Type = type,
+        Timestamp = Now.AddDays(-daysAgo),
+        CheckpointLsn = checkpoint,
+        DatabaseBackupLsn = baseLsn,
+        Files = [new BackupFileInfo { BlobName = $"f{_seq}", SizeBytes = size }]
+    };
+
+    private static RetentionVerdict VerdictOf(List<RetentionFinding> findings, BackupSet set) =>
+        findings.Single(f => ReferenceEquals(f.Set, set)).Verdict;
+
+    /// <summary>
+    /// The heart of it: the newest full OUTSIDE the window is what restores INSIDE the window
+    /// start from, so the rule's own promise depends on a set the rule wants to delete.
+    /// </summary>
+    [Fact]
+    public void TheBaseFullOutsideTheWindowIsKeptDespiteItsAge()
+    {
+        var oldFull = Set(BackupType.Full, daysAgo: 60);
+        var baseFull = Set(BackupType.Full, daysAgo: 35);
+        var keptLog = Set(BackupType.TransactionLog, daysAgo: 10);
+
+        var findings = RetentionAdvisor.Advise([oldFull, baseFull, keptLog], KeepDays, Now);
+
+        Assert.Equal(RetentionVerdict.Deletable, VerdictOf(findings, oldFull));
+        Assert.Equal(RetentionVerdict.KeepDespiteAge, VerdictOf(findings, baseFull));
+        Assert.Equal(RetentionVerdict.Keep, VerdictOf(findings, keptLog));
+    }
+
+    /// <summary>
+    /// The subtle one: logs BETWEEN the base full and the window's edge are the bridge - without
+    /// them point-in-time stops working at the window's own boundary.
+    /// </summary>
+    [Fact]
+    public void BridgeLogsAreKeptAndOlderLogsAreNot()
+    {
+        var baseFull = Set(BackupType.Full, daysAgo: 40);
+        var preBaseLog = Set(BackupType.TransactionLog, daysAgo: 45);
+        var bridgeLog = Set(BackupType.TransactionLog, daysAgo: 33);
+
+        var findings = RetentionAdvisor.Advise([baseFull, preBaseLog, bridgeLog], KeepDays, Now);
+
+        Assert.Equal(RetentionVerdict.Deletable, VerdictOf(findings, preBaseLog));
+        Assert.Equal(RetentionVerdict.KeepDespiteAge, VerdictOf(findings, bridgeLog));
+        Assert.Contains("bridge", findings.Single(f => ReferenceEquals(f.Set, bridgeLog)).Reason,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>A differential under the window shortens the bridge, and is kept for it.</summary>
+    [Fact]
+    public void TheNewestDiffUnderTheWindowShortensTheBridge()
+    {
+        var baseFull = Set(BackupType.Full, daysAgo: 40, checkpoint: 100m);
+        var baseDiff = Set(BackupType.Differential, daysAgo: 34, baseLsn: 100m);
+        var preDiffLog = Set(BackupType.TransactionLog, daysAgo: 37);
+        var bridgeLog = Set(BackupType.TransactionLog, daysAgo: 32);
+
+        var findings = RetentionAdvisor.Advise([baseFull, baseDiff, preDiffLog, bridgeLog], KeepDays, Now);
+
+        Assert.Equal(RetentionVerdict.KeepDespiteAge, VerdictOf(findings, baseDiff));
+        Assert.Equal(RetentionVerdict.Deletable, VerdictOf(findings, preDiffLog));
+        Assert.Equal(RetentionVerdict.KeepDespiteAge, VerdictOf(findings, bridgeLog));
+    }
+
+    /// <summary>A kept differential whose base full is GONE is not kept - it is already lost.</summary>
+    [Fact]
+    public void ADiffWhoseBaseIsGoneIsBrokenNotKept()
+    {
+        var wrongFull = Set(BackupType.Full, daysAgo: 20, checkpoint: 999m);
+        var orphanDiff = Set(BackupType.Differential, daysAgo: 10, baseLsn: 100m);
+
+        var findings = RetentionAdvisor.Advise([wrongFull, orphanDiff], KeepDays, Now);
+
+        Assert.Equal(RetentionVerdict.Broken, VerdictOf(findings, orphanDiff));
+    }
+
+    [Fact]
+    public void DatabasesAreJudgedIndependently()
+    {
+        var salesBase = Set(BackupType.Full, daysAgo: 35, db: "Sales");
+        var payrollOld = Set(BackupType.Full, daysAgo: 35, db: "Payroll");
+        var salesLog = Set(BackupType.TransactionLog, daysAgo: 5, db: "Sales");
+        var payrollFull = Set(BackupType.Full, daysAgo: 5, db: "Payroll");
+
+        var findings = RetentionAdvisor.Advise(
+            [salesBase, payrollOld, salesLog, payrollFull], KeepDays, Now);
+
+        // Sales still needs its out-of-window base; Payroll's old full carries nothing kept...
+        Assert.Equal(RetentionVerdict.KeepDespiteAge, VerdictOf(findings, salesBase));
+        // ...except being Payroll's base full for the window edge - which it IS, having no newer
+        // full before the window. It stays too: same rule, honestly applied.
+        Assert.Equal(RetentionVerdict.KeepDespiteAge, VerdictOf(findings, payrollOld));
+    }
+
+    [Fact]
+    public void TheSummaryCountsAndCountsBytes()
+    {
+        var oldFull = Set(BackupType.Full, daysAgo: 60, size: 4_000);
+        var baseFull = Set(BackupType.Full, daysAgo: 35, size: 5_000);
+        var keptFull = Set(BackupType.Full, daysAgo: 5, size: 6_000);
+
+        var findings = RetentionAdvisor.Advise([oldFull, baseFull, keptFull], KeepDays, Now);
+        var summary = RetentionAdvisor.Summarise(findings, KeepDays);
+
+        Assert.Contains("keeps 1 set(s)", summary);
+        Assert.Contains("ALSO keep 1 older", summary);
+        Assert.Contains("delete 1 set(s)", summary);
+        Assert.Contains("3.9 KB", summary);   // 4,000 bytes
+    }
+}

--- a/src/NineLives/Services/RetentionAdvisor.cs
+++ b/src/NineLives/Services/RetentionAdvisor.cs
@@ -1,0 +1,171 @@
+using System.Text;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>What a retention rule would do to one backup set (#241).</summary>
+public enum RetentionVerdict
+{
+    /// <summary>Inside the window - the rule keeps it.</summary>
+    Keep = 0,
+
+    /// <summary>
+    /// Outside the window, but a kept restore depends on it: the base full of a kept
+    /// differential, or a log that carries the chain from that base into the window. Deleting it
+    /// breaks restores the rule promised to keep.
+    /// </summary>
+    KeepDespiteAge = 1,
+
+    /// <summary>Outside the window and nothing kept depends on it - provably safe to delete.</summary>
+    Deletable = 2,
+
+    /// <summary>Already broken - a differential or log whose base full is gone entirely.</summary>
+    Broken = 3
+}
+
+/// <summary>One set, judged.</summary>
+public sealed record RetentionFinding(BackupSet Set, RetentionVerdict Verdict, string Reason);
+
+/// <summary>
+/// Referees the fight between the storage bill and restorability (#241).
+///
+/// A lifecycle rule deletes blobs by age, and nobody checks whether the full it just deleted was
+/// the base of a differential somebody still needs - the first sign is error 3136 mid-restore.
+/// The app knows the chains, so it can say what a rule WOULD do: what goes, what must stay
+/// despite its age, and what is already broken.
+///
+/// Report-only, deliberately. The app that exists to make restores safe should not also be the
+/// app that deletes backups; deleting stays a human act, done elsewhere, with this report in
+/// hand.
+/// </summary>
+public static class RetentionAdvisor
+{
+    /// <summary>Judges every set against a keep-window, per database, LSN-aware.</summary>
+    public static List<RetentionFinding> Advise(
+        IReadOnlyList<BackupSet> sets, int keepDays, DateTime now)
+    {
+        var windowStart = now.AddDays(-keepDays);
+        var findings = new List<RetentionFinding>();
+
+        foreach (var group in sets.GroupBy(s => s.DatabaseName ?? "", StringComparer.OrdinalIgnoreCase))
+        {
+            findings.AddRange(AdviseDatabase(group.OrderBy(s => s.Timestamp).ToList(), windowStart));
+        }
+
+        return findings
+            .OrderBy(f => f.Set.DatabaseName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(f => f.Set.Timestamp)
+            .ToList();
+    }
+
+    private static IEnumerable<RetentionFinding> AdviseDatabase(
+        List<BackupSet> sets, DateTime windowStart)
+    {
+        var fulls = sets.Where(s => s.Type == BackupType.Full).ToList();
+
+        // The base full: the newest full at or before the window opens. Restoring to the OLDEST
+        // kept moment starts from it, so the window's own promise depends on a set outside it.
+        var baseFull = fulls.LastOrDefault(f => f.Timestamp <= windowStart);
+
+        // The newest differential between the base full and the window - it shortens the log
+        // bridge the same way it shortens a restore.
+        var baseDiff = baseFull == null
+            ? null
+            : sets.LastOrDefault(s =>
+                s.Type == BackupType.Differential &&
+                s.Timestamp > baseFull.Timestamp && s.Timestamp <= windowStart &&
+                BelongsTo(s, baseFull));
+
+        var bridgeFrom = baseDiff?.Timestamp ?? baseFull?.Timestamp;
+
+        foreach (var set in sets)
+        {
+            if (set.Timestamp > windowStart)
+            {
+                // Inside the window - but a diff or log whose base full does not exist at all is
+                // not kept, it is already lost.
+                if (set.Type != BackupType.Full && FindBase(set, fulls) == null && fulls.Count > 0)
+                {
+                    yield return new RetentionFinding(set, RetentionVerdict.Broken,
+                        "Its base full is not in this listing - it cannot be restored from now, " +
+                        "whatever the retention rule says.");
+                    continue;
+                }
+
+                yield return new RetentionFinding(set, RetentionVerdict.Keep, "Inside the window.");
+                continue;
+            }
+
+            // Outside the window: the rule wants it gone. Does anything kept depend on it?
+            if (ReferenceEquals(set, baseFull))
+            {
+                yield return new RetentionFinding(set, RetentionVerdict.KeepDespiteAge,
+                    "The base full for the oldest kept moment - restores inside the window " +
+                    "start from it. Deleting it is error 3136 on a restore the rule promised.");
+                continue;
+            }
+
+            if (ReferenceEquals(set, baseDiff))
+            {
+                yield return new RetentionFinding(set, RetentionVerdict.KeepDespiteAge,
+                    "The newest differential under the window - it carries the chain from the " +
+                    "base full to the window's edge.");
+                continue;
+            }
+
+            if (set.Type == BackupType.TransactionLog && bridgeFrom != null &&
+                set.Timestamp >= bridgeFrom)
+            {
+                yield return new RetentionFinding(set, RetentionVerdict.KeepDespiteAge,
+                    "A bridge log: it carries the chain from the base into the window. Without " +
+                    "it, point-in-time stops working at the window's own edge.");
+                continue;
+            }
+
+            yield return new RetentionFinding(set, RetentionVerdict.Deletable,
+                "Outside the window, and no kept restore passes through it.");
+        }
+    }
+
+    /// <summary>LSN pairing when both sides know it; the latest-full-before fallback otherwise.</summary>
+    private static bool BelongsTo(BackupSet dependent, BackupSet full)
+    {
+        if (dependent.DatabaseBackupLsn is { } baseLsn && full.CheckpointLsn is { } checkpoint)
+            return baseLsn == checkpoint;
+
+        return true; // timestamp ordering already put it after this full
+    }
+
+    private static BackupSet? FindBase(BackupSet dependent, List<BackupSet> fulls)
+    {
+        if (dependent.DatabaseBackupLsn is { } baseLsn)
+        {
+            var byLsn = fulls.LastOrDefault(f => f.CheckpointLsn == baseLsn);
+            if (byLsn != null) return byLsn;
+            if (fulls.Any(f => f.CheckpointLsn != null)) return null; // LSNs known, none match
+        }
+
+        return fulls.LastOrDefault(f => f.Timestamp <= dependent.Timestamp);
+    }
+
+    // ── the report ──────────────────────────────────────────────────────────────
+
+    public static string Summarise(IReadOnlyList<RetentionFinding> findings, int keepDays)
+    {
+        var deletable = findings.Where(f => f.Verdict == RetentionVerdict.Deletable).ToList();
+        var kept = findings.Count(f => f.Verdict == RetentionVerdict.Keep);
+        var despite = findings.Count(f => f.Verdict == RetentionVerdict.KeepDespiteAge);
+        var broken = findings.Count(f => f.Verdict == RetentionVerdict.Broken);
+        var reclaim = deletable.Sum(f => f.Set.TotalSizeBytes);
+
+        var sb = new StringBuilder();
+        sb.Append($"A {keepDays}-day rule keeps {kept} set(s), must ALSO keep {despite} older " +
+                  $"set(s) that kept restores depend on, and can delete {deletable.Count} set(s)" +
+                  (reclaim > 0 ? $" reclaiming {ByteSize.Format(reclaim)}." : "."));
+
+        if (broken > 0)
+            sb.Append($" {broken} set(s) are already broken - their base full is gone.");
+
+        return sb.ToString();
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2157,6 +2157,52 @@ public partial class RestoreViewModel : ViewModelBase
             appendLog => PreflightAsync(server, appendLog));
     }
 
+    // ── retention (#241) ────────────────────────────────────────────────────────
+
+    /// <summary>The window a rule would keep, in days. 30 is the commonest policy default.</summary>
+    [ObservableProperty]
+    private int _retentionKeepDays = 30;
+
+    [ObservableProperty]
+    private string _retentionSummary = string.Empty;
+
+    /// <summary>The sets a rule must NOT delete despite their age, each with its reason.</summary>
+    [ObservableProperty]
+    private System.Collections.ObjectModel.ObservableCollection<string> _retentionWarnings = [];
+
+    public bool CanAdviseRetention => Inventory.AllSets.Count > 0;
+
+    /// <summary>
+    /// What a keep-N-days rule would do to the loaded backups (#241): what goes, what must stay
+    /// despite its age because kept restores depend on it, and what is already broken.
+    ///
+    /// Report-only, deliberately: the app that exists to make restores safe should not also be
+    /// the app that deletes backups. Deleting stays a human act, done elsewhere, with this
+    /// report in hand.
+    /// </summary>
+    [RelayCommand]
+    private void AdviseRetention()
+    {
+        if (Inventory.AllSets.Count == 0)
+        {
+            RetentionSummary = "Load backups first - the advisor judges what is on screen.";
+            return;
+        }
+
+        var findings = RetentionAdvisor.Advise(Inventory.AllSets, RetentionKeepDays, DateTime.Now);
+
+        RetentionSummary = RetentionAdvisor.Summarise(findings, RetentionKeepDays);
+
+        RetentionWarnings = new System.Collections.ObjectModel.ObservableCollection<string>(
+            findings
+                .Where(f => f.Verdict is RetentionVerdict.KeepDespiteAge or RetentionVerdict.Broken)
+                .Select(f => $"{f.Set.DatabaseName} {f.Set.Type} {f.Set.Timestamp:yyyy-MM-dd HH:mm} - " +
+                             (f.Verdict == RetentionVerdict.Broken ? "ALREADY BROKEN: " : "MUST KEEP: ") +
+                             f.Reason));
+
+        _log.Info($"[retention] {RetentionSummary}");
+    }
+
     // ── rehearsal (#238) ────────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -517,6 +517,48 @@
                                    Style="{StaticResource BodyText}" />
                     </Border>
 
+            <!-- Retention referee (#241): what a keep-N-days rule would do - report-only, because
+                 the app that makes restores safe should not also be the app that deletes backups. -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
+                    Visibility="{Binding ShowVerifyAndAudit, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Text="RETENTION" Style="{StaticResource LabelText}" />
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap"
+                               Margin="0,4,0,10"
+                               Text="What would an age-based deletion rule do to these backups? The answer is not obvious: restores INSIDE the window depend on the newest full OUTSIDE it, and on the logs that bridge the gap. This names what must survive its own age - before a lifecycle rule finds out via error 3136." />
+
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="KEEP" Style="{StaticResource LabelText}" VerticalAlignment="Center" Margin="0,0,8,0" />
+                        <TextBox Text="{Binding RetentionKeepDays, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource DarkTextBox}"
+                                 Width="60" VerticalContentAlignment="Center" />
+                        <TextBlock Text="DAYS" Style="{StaticResource LabelText}" VerticalAlignment="Center" Margin="8,0,12,0" />
+                        <Button Content="What would that rule do?"
+                                Command="{Binding AdviseRetentionCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="12,6" />
+                    </StackPanel>
+
+                    <TextBlock Text="{Binding RetentionSummary}"
+                               Style="{StaticResource BodyText}"
+                               TextWrapping="Wrap"
+                               Margin="0,10,0,0" />
+
+                    <ItemsControl ItemsSource="{Binding RetentionWarnings}" Margin="0,6,0,0">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}"
+                                           Style="{StaticResource SecondaryText}"
+                                           FontSize="11"
+                                           TextWrapping="Wrap"
+                                           Margin="0,0,0,2" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
                     <!-- Reported, not corrected. A database full of these almost always means the
                          PATH PATTERN is wrong, and fixing each symptom quietly would hide it. -->
                     <ItemsControl ItemsSource="{Binding Inventory.AuditFindings}" Margin="0,10,0,0">


### PR DESCRIPTION
A lifecycle rule deletes blobs by age, and nobody checks whether the full it just deleted was the base of a differential somebody still needs — the first sign is error 3136 mid-restore. The app knows the chains, so it referees.

## The verdicts

Given a keep-N-days window, every loaded set is judged:

- **Keep** — inside the window.
- **Deletable** — outside it, nothing kept depends on it, summed into reclaimable bytes.
- **Keep despite age** — the sets the rule's own promise hangs on: the **base full outside the window** (restores inside it start from it), the **newest differential under the window**, and the **bridge logs** that carry the chain from the base to the window's edge — without which point-in-time stops working at the window's own boundary.
- **Already broken** — a diff or log whose base full is gone entirely, which no retention setting can fix, only reveal.

LSN pairing decides where both sides know it; timestamp ordering where they don't.

## Report-only, deliberately

The app that exists to make restores safe should not also be the app that deletes backups. Deleting stays a human act, done elsewhere, with this report in hand — which doubles as the honest answer to "why is the storage bill this size?".

Rendered — the card sits with the audit machinery, and the MUST KEEP lines name their reasons. 6 new tests, 1,536 pass.