### PR TITLE
Restore to a marked transaction, not a guessed clock time (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Changed
 
+- **Restore to a marked transaction (STOPATMARK/STOPBEFOREMARK)** - the sharper point-in-time
+  tool: plant a mark with BEGIN TRANSACTION ... WITH MARK before risky work, and afterwards the
+  restore target is the transaction itself, found from msdb's own logmarkhistory, not a clock
+  time reconstructed from chat messages. Stops just BEFORE the mark by default (the deployment
+  never happened); the mark and the clock time are mutually exclusive on screen, and a mark with
+  no log chain refuses with the reason (#243)
 - **The retention referee: what would an age-based deletion rule actually do?** Report-only,
   over the loaded backups: what a keep-N-days rule keeps, what it can safely delete (with the
   bytes reclaimed), what must survive its own age because kept restores depend on it - the base

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -500,6 +500,15 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Paths the fake target refuses, and why. Anything not listed is readable.</summary>
     public Dictionary<string, BackupFileProblem> UnreadablePaths { get; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Marks per database name (#243).</summary>
+    public Dictionary<string, List<LogMark>> LogMarksByDatabase { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public Task<List<LogMark>> GetLogMarksAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+        => Task.FromResult(
+            LogMarksByDatabase.TryGetValue(database, out var marks) ? marks.ToList() : []);
+
     /// <summary>Percent values the polling execute reports before completing (#user CHECKDB feedback).</summary>
     public List<double> PollPercents { get; set; } = [50];
 

--- a/src/NineLives.Tests/StopAtMarkTests.cs
+++ b/src/NineLives.Tests/StopAtMarkTests.cs
@@ -1,0 +1,111 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// STOPATMARK/STOPBEFOREMARK (#243): restore to a NAMED transaction, planted before risky work,
+/// instead of a clock time reconstructed afterwards from chat messages and guilt. A mark and a
+/// time are the same mechanism aimed differently, so the mark rides in exactly STOPAT's position
+/// and inherits its repeat-on-every-log rule.
+/// </summary>
+public class StopAtMarkTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 10, 9, 0, 0);
+
+    private static BackupChain Chain(int logs = 2)
+    {
+        var chain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                SetId = "full",
+                DatabaseName = "MyDb",
+                Type = BackupType.Full,
+                Timestamp = T0,
+                Files = [new BackupFileInfo { BlobName = "f.bak", LocalPath = @"D:\f.bak" }]
+            }
+        };
+
+        for (var i = 0; i < logs; i++)
+        {
+            chain.LogSets.Add(new BackupSet
+            {
+                SetId = $"log{i}",
+                DatabaseName = "MyDb",
+                Type = BackupType.TransactionLog,
+                Timestamp = T0.AddMinutes(30 * (i + 1)),
+                Files = [new BackupFileInfo { BlobName = $"l{i}.trn", LocalPath = $@"D:\l{i}.trn" }]
+            });
+        }
+
+        return chain;
+    }
+
+    private static string Generate(string? mark, bool before = true, DateTime? stopAt = null) =>
+        new RestoreScriptGenerator().Generate(Chain(), new RestoreOptions
+        {
+            TargetDatabaseName = "MyDb",
+            StopAtMark = mark,
+            StopBeforeMark = before,
+            StopAt = stopAt
+        });
+
+    /// <summary>STOPAT's own rule, inherited: the mark goes on EVERY log restore in the chain.</summary>
+    [Fact]
+    public void TheMarkRidesOnEveryLogRestore()
+    {
+        var script = Generate("deploy_v2");
+
+        var count = script.Split("STOPBEFOREMARK = N'deploy_v2'").Length - 1;
+        Assert.Equal(2, count);
+        Assert.DoesNotContain("STOPAT =", script);
+    }
+
+    [Fact]
+    public void AtInsteadOfBeforeWhenAskedFor()
+    {
+        var script = Generate("deploy_v2", before: false);
+
+        Assert.Contains("STOPATMARK = N'deploy_v2'", script);
+        Assert.DoesNotContain("STOPBEFOREMARK", script);
+    }
+
+    /// <summary>The mark wins over a stray clock time - it is the more deliberate of the two.</summary>
+    [Fact]
+    public void TheMarkWinsWhenBothAreSomehowSet()
+    {
+        var script = Generate("deploy_v2", stopAt: T0.AddMinutes(45));
+
+        Assert.Contains("STOPBEFOREMARK", script);
+        Assert.DoesNotContain("STOPAT =", script);
+    }
+
+    [Fact]
+    public void AnApostropheInTheMarkNameCannotBreakOut()
+    {
+        var script = Generate("o'brien_deploy");
+
+        Assert.Contains("N'o''brien_deploy'", script);
+    }
+
+    [Fact]
+    public void NoMarkMeansTheScriptIsUntouched()
+    {
+        var script = Generate(null);
+
+        Assert.DoesNotContain("MARK", script.Replace("-- ", ""));
+    }
+
+    /// <summary>The display line carries what the picker needs: name, when, and the description.</summary>
+    [Fact]
+    public void AMarkDisplaysItsNameTimeAndDescription()
+    {
+        var mark = new LogMark("deploy_v2", "the v2 schema deployment", T0);
+
+        Assert.Contains("deploy_v2", mark.Display);
+        Assert.Contains("2026-08-10 09:00:00", mark.Display);
+        Assert.Contains("the v2 schema deployment", mark.Display);
+    }
+}

--- a/src/NineLives/Models/RestoreOptions.cs
+++ b/src/NineLives/Models/RestoreOptions.cs
@@ -18,6 +18,21 @@ public class RestoreOptions
     public bool DisconnectSessions { get; set; } = true;
     public int StatsPercent { get; set; } = 10;
     public DateTime? StopAt { get; set; }
+
+    /// <summary>
+    /// The named transaction to stop at, instead of a clock time (#243). For planned risky work
+    /// that began with BEGIN TRANSACTION ... WITH MARK, the mark IS the target - not a time
+    /// reconstructed afterwards from chat messages and guilt. Mutually exclusive with StopAt;
+    /// the mark wins if both are somehow set.
+    /// </summary>
+    public string? StopAtMark { get; set; }
+
+    /// <summary>
+    /// STOPBEFOREMARK instead of STOPATMARK: recover to just BEFORE the marked transaction -
+    /// the deployment never happened - rather than to just after it began. Before is the
+    /// default, because "undo the deployment" is what the mark was planted for.
+    /// </summary>
+    public bool StopBeforeMark { get; set; } = true;
     public bool KeepReplication { get; set; }
     public bool EnableBroker { get; set; }
     public bool NewBroker { get; set; }

--- a/src/NineLives/Services/ISqlServerService.cs
+++ b/src/NineLives/Services/ISqlServerService.cs
@@ -65,6 +65,13 @@ public interface ISqlServerService
     Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default);
 
     /// <summary>
+    /// The marked transactions msdb knows for a database (#243) - name, description and when.
+    /// Almost no tooling reads logmarkhistory, which is why almost nobody uses marks.
+    /// </summary>
+    Task<List<LogMark>> GetLogMarksAsync(
+        ServerConnection server, string database, CancellationToken ct = default);
+
+    /// <summary>
     /// Runs one statement while a second connection polls sys.dm_exec_requests for its
     /// percent_complete - which DBCC CHECKDB and RESTORE both report. Best effort: no
     /// VIEW SERVER STATE means no percentage, and the statement still runs.

--- a/src/NineLives/Services/LogMark.cs
+++ b/src/NineLives/Services/LogMark.cs
@@ -1,0 +1,19 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// One marked transaction, as msdb.dbo.logmarkhistory recorded it (#243).
+///
+/// A mark is planted deliberately - BEGIN TRANSACTION deploy_v2 WITH MARK - before risky work,
+/// and afterwards the restore target is the TRANSACTION, not a clock time reconstructed from
+/// chat messages. Almost no tooling surfaces logmarkhistory, which is why almost nobody uses
+/// the sharpest point-in-time tool SQL Server has.
+/// </summary>
+/// <param name="Name">The mark's name - what STOPATMARK/STOPBEFOREMARK take.</param>
+/// <param name="Description">The free-text description, when one was given.</param>
+/// <param name="MarkedAt">When the marked transaction began.</param>
+public sealed record LogMark(string Name, string? Description, DateTime MarkedAt)
+{
+    public string Display =>
+        $"{Name} — {MarkedAt:yyyy-MM-dd HH:mm:ss}" +
+        (string.IsNullOrWhiteSpace(Description) ? "" : $" ({Description})");
+}

--- a/src/NineLives/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives/Services/RestoreScriptGenerator.cs
@@ -135,7 +135,13 @@ public class RestoreScriptGenerator
         //
         // The UI bounds the target to within the SELECTED log's window, so earlier logs in the
         // chain end before it and are applied in full - no gap is introduced.
-        if (usePit && options.StopAt.HasValue)
+        // A mark and a time are the same mechanism with a different target, so the mark rides
+        // in exactly STOPAT's position and inherits its repeat-on-every-log rule (#243). The
+        // mark wins when both are somehow set - it is the more deliberate of the two.
+        if (!string.IsNullOrWhiteSpace(options.StopAtMark))
+            sb.AppendLine($"         {(options.StopBeforeMark ? "STOPBEFOREMARK" : "STOPATMARK")} = " +
+                          $"N'{TSql.EscapeLiteral(options.StopAtMark)}',");
+        else if (usePit && options.StopAt.HasValue)
             sb.AppendLine($"         STOPAT = '{options.StopAt.Value:yyyy-MM-ddTHH:mm:ss}',");
 
         sb.AppendLine($"         {recoveryClause},");

--- a/src/NineLives/Services/SqlServerService.cs
+++ b/src/NineLives/Services/SqlServerService.cs
@@ -1389,6 +1389,34 @@ public class SqlServerService : ISqlServerService
             reader["OwnerName"] as string);
     }
 
+    public async Task<List<LogMark>> GetLogMarksAsync(
+        ServerConnection server, string database, CancellationToken ct = default)
+    {
+        var marks = new List<LogMark>();
+
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+        await using var cmd = conn.CreateCommand();
+
+        cmd.CommandText = @"
+            SELECT TOP 50 mark_name, description, mark_time
+            FROM msdb.dbo.logmarkhistory
+            WHERE database_name = @database
+            ORDER BY mark_time DESC";
+        cmd.Parameters.AddWithValue("@database", database);
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            marks.Add(new LogMark(
+                reader["mark_name"]?.ToString() ?? string.Empty,
+                reader["description"] as string,
+                GetDateTimeFromReader(reader, "mark_time") ?? DateTime.MinValue));
+        }
+
+        return marks;
+    }
+
     public async Task ExecuteWithPercentPollingAsync(
         ServerConnection server, string sql, IProgress<double>? percent = null,
         CancellationToken ct = default)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -849,9 +849,15 @@ public partial class RestoreViewModel : ViewModelBase
         // The STOPAT target feeds the generated script, so any change to it has to reach the
         // script (#115 seam 3). Skipped while SetWindow is rewriting several properties at once -
         // the caller updates once at the end rather than four times through a half-built state.
-        PointInTime.PropertyChanged += (_, _) =>
+        PointInTime.PropertyChanged += (_, e) =>
         {
             if (PointInTime.IsUpdating) return;
+
+            // The other half of the mark/time exclusivity (#243): turning the clock-time target
+            // on clears the mark, exactly as choosing a mark turned the clock off.
+            if (e.PropertyName == nameof(PointInTimeViewModel.Use) && PointInTime.Use)
+                SelectedLogMark = null;
+
             Steps.Options.Invalidate();
             UpdateRestoreSummary();
         };
@@ -1789,6 +1795,10 @@ public partial class RestoreViewModel : ViewModelBase
         var blocked =
             chain == null
                 ? "Select a restore point above and the script appears here."
+            : SelectedLogMark != null && chain.LogSets.Count == 0
+                ? "The marked transaction lives in a log backup, and this chain has none - " +
+                  "restoring it would silently replay everything the mark was meant to stop. " +
+                  "Pick a restore point with log backups, or clear the mark."
             : string.IsNullOrWhiteSpace(TargetDatabaseName)
                 ? "Enter a target database name and the script appears here."
             : PointInTime.Use && PointInTime.CanUse && PointInTime.Effective == null
@@ -1811,6 +1821,8 @@ public partial class RestoreViewModel : ViewModelBase
         // ended up, and where the files land - each worked out somewhere that knows about the
         // chain or the server.
         var options = Options.Build(TargetDatabaseName, PointInTime.Effective, BuildFileMoves());
+        options.StopAtMark = SelectedLogMark?.Name;
+        options.StopBeforeMark = StopBeforeMark;
 
         GeneratedScript = _scriptGenerator.Generate(chain!, options);
         HasScript = true;
@@ -2155,6 +2167,64 @@ public partial class RestoreViewModel : ViewModelBase
                 $"WITH REPLACE={Options.WithReplace}, recovery={Options.RecoveryMode}, " +
                 $"stopAt={PointInTime.Effective?.ToString("s") ?? "none"}"),
             appendLog => PreflightAsync(server, appendLog));
+    }
+
+    // ── marked transactions (#243) ──────────────────────────────────────────────
+
+    /// <summary>The marks msdb knows for the selected database, newest first.</summary>
+    [ObservableProperty]
+    private System.Collections.ObjectModel.ObservableCollection<LogMark> _logMarks = [];
+
+    /// <summary>
+    /// The mark to stop at. Choosing one turns the time-based target OFF - a mark and a clock
+    /// time are the same mechanism aimed differently, and two targets on one restore is a script
+    /// that stops where the READER did not decide.
+    /// </summary>
+    [ObservableProperty]
+    private LogMark? _selectedLogMark;
+
+    partial void OnSelectedLogMarkChanged(LogMark? value)
+    {
+        if (value != null && PointInTime.Use) PointInTime.Use = false;
+        UpdateRestoreSummary();
+    }
+
+    /// <summary>STOPBEFOREMARK by default: "undo the deployment" is what the mark was planted for.</summary>
+    [ObservableProperty]
+    private bool _stopBeforeMark = true;
+
+    partial void OnStopBeforeMarkChanged(bool value) => UpdateRestoreSummary();
+
+    /// <summary>
+    /// Reads logmarkhistory for the selected database (#243). On demand, because most databases
+    /// have no marks and the combo should not cost a round trip to prove it.
+    /// </summary>
+    [RelayCommand]
+    private async Task LoadLogMarksAsync()
+    {
+        var server = ConnectedServer;
+        var database = Inventory.SelectedDatabaseName;
+
+        if (server == null || string.IsNullOrWhiteSpace(database))
+        {
+            SetError("Connect to a server and choose a database first - the marks live in its msdb.");
+            return;
+        }
+
+        try
+        {
+            var marks = await _sqlService.GetLogMarksAsync(server, database!);
+            LogMarks = new System.Collections.ObjectModel.ObservableCollection<LogMark>(marks);
+
+            SetStatus(marks.Count == 0
+                ? $"No marked transactions recorded for {database}. Marks are planted with " +
+                  "BEGIN TRANSACTION ... WITH MARK before risky work."
+                : $"{marks.Count} marked transaction(s) found for {database}.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not read the marks: {ex.Message}");
+        }
     }
 
     // ── retention (#241) ────────────────────────────────────────────────────────

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1691,6 +1691,28 @@
                                         </Style>
                                     </TextBlock.Style>
                                 </TextBlock>
+
+                                <!-- The sharper point-in-time tool (#243): restore to a NAMED
+                                     transaction planted before risky work, not a clock time
+                                     reconstructed afterwards. -->
+                                <TextBlock Text="MARKED TRANSACTIONS" Style="{StaticResource LabelText}" />
+                                <StackPanel Orientation="Horizontal" Margin="0,4,0,4">
+                                    <Button Content="Find marks"
+                                            Command="{Binding LoadLogMarksCommand}"
+                                            Style="{StaticResource SecondaryButton}"
+                                            Padding="10,5" Margin="0,0,8,0"
+                                            ToolTip="Reads msdb.dbo.logmarkhistory on the connected server for the selected database. Marks are planted with BEGIN TRANSACTION ... WITH MARK before risky work." />
+                                    <ComboBox ItemsSource="{Binding LogMarks}"
+                                              SelectedItem="{Binding SelectedLogMark}"
+                                              DisplayMemberPath="Display"
+                                              Style="{StaticResource DarkComboBox}"
+                                              MinWidth="320" />
+                                </StackPanel>
+                                <CheckBox Content="Stop just BEFORE the mark (the deployment never happened)"
+                                          IsChecked="{Binding StopBeforeMark}"
+                                          Style="{StaticResource DarkCheckBox}"
+                                          Margin="0,0,0,16"
+                                          ToolTip="STOPBEFOREMARK recovers to the instant before the marked transaction began - undoing it. Unticked, STOPATMARK includes the marked transaction itself." />
                             </StackPanel>
 
                             <TextBlock Text="STATS PERCENT" Style="{StaticResource LabelText}" />


### PR DESCRIPTION
The sharper point-in-time tool, and the one almost no tooling surfaces: plant `BEGIN TRANSACTION deploy_v2 WITH MARK` before the risky work, and afterwards the restore target is the **transaction itself** — not a time reconstructed from chat messages and guilt.

- **Discoverable**: *Find marks* reads `msdb.dbo.logmarkhistory` for the selected database, newest first — name, moment, description.
- **STOPBEFOREMARK by default** — recover to the instant before the marked transaction began ("the deployment never happened"); STOPATMARK is a tick away.
- **Rides in exactly STOPAT's position** and inherits its repeat-on-every-log rule, so SQL Server stops in whichever log actually contains the mark. The mark wins over a stray clock time — it is the more deliberate of the two.
- **Mutually exclusive on screen**: choosing a mark turns the clock-time target off; turning the clock on clears the mark. Two targets on one restore is a script that stops where the reader did not decide.
- **A mark with no log chain refuses with the reason** — restoring it would silently replay everything the mark was meant to stop.

6 new tests, 1,542 pass.