### PR TITLE
Scheduled rehearsals: the proof renews itself (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Added
+
+- **Scheduled rehearsals: the proof renews itself.** The rehearsal wrapped as a disabled,
+  unscheduled Agent job - add a weekly schedule and every run restores the chain to a stable
+  scratch name, proves it with CHECKDB, and drops it, receipts accumulating in the job history.
+  Each run clears its own previous leftover first, which is safe precisely because the name
+  belongs to the rehearsal alone; a failed run still retains its scratch copy as evidence until
+  the next run has been seen (#259)
+
 ## [1.5.0] - 2026-08-10
 
 ### Added

--- a/src/NineLives.Tests/RestoreRehearsalTests.cs
+++ b/src/NineLives.Tests/RestoreRehearsalTests.cs
@@ -61,6 +61,31 @@ public class RestoreRehearsalTests
         Assert.Contains("retained as the evidence", script);
     }
 
+    // ── the scheduled variant (#259) ────────────────────────────────────────────
+
+    /// <summary>
+    /// A job runs the same text weekly, so the scheduled name is STABLE and each run clears its
+    /// own leftover first - which by then has been seen in the job history.
+    /// </summary>
+    [Fact]
+    public void TheScheduledScriptClearsItsOwnLeftoverBeforeRestoring()
+    {
+        var scratch = RehearsalPlanner.ScheduledScratchName("MyDb");
+        Assert.Equal("MyDb_rehearsal_scheduled", scratch);
+
+        var script = RehearsalPlanner.BuildScheduledScript(
+            $"RESTORE DATABASE [{scratch}] FROM DISK = N'D:/b.bak' WITH RECOVERY;", scratch);
+
+        var preDrop = script.IndexOf("DROP DATABASE", StringComparison.Ordinal);
+        var restore = script.IndexOf("RESTORE DATABASE", StringComparison.Ordinal);
+        var checkdb = script.IndexOf("DBCC CHECKDB", StringComparison.Ordinal);
+        var postDrop = script.LastIndexOf("DROP DATABASE", StringComparison.Ordinal);
+
+        Assert.True(preDrop < restore && restore < checkdb && checkdb < postDrop,
+            "order must be pre-drop, restore, CHECKDB, post-drop");
+        Assert.Contains("safe by construction", script);
+    }
+
     // ── the command's construction promises ─────────────────────────────────────
 
     private static ServerConnection Server() =>

--- a/src/NineLives/Services/RehearsalPlanner.cs
+++ b/src/NineLives/Services/RehearsalPlanner.cs
@@ -27,6 +27,42 @@ public static class RehearsalPlanner
         $"{database}_rehearsal_{now:yyyyMMdd_HHmm}";
 
     /// <summary>
+    /// The STABLE scratch name a scheduled rehearsal reuses (#259). A job runs the same text
+    /// weekly, so a timestamp baked in at generation would collide with its own leftovers on the
+    /// second run - instead the name is fixed, and each run begins by clearing its own previous
+    /// evidence, which by then has been seen in the job history.
+    /// </summary>
+    public static string ScheduledScratchName(string database) =>
+        $"{database}_rehearsal_scheduled";
+
+    /// <summary>
+    /// The scheduled form of the rehearsal script (#259): identical to the clicked form, plus a
+    /// guarded PRE-drop of the previous run's leftover - safe precisely because the name is the
+    /// rehearsal's own, never a real database's.
+    /// </summary>
+    public static string BuildScheduledScript(string restoreScript, string scratchName)
+    {
+        var quoted = TSql.QuoteName(scratchName);
+        var literal = TSql.EscapeLiteral(scratchName);
+
+        var preamble =
+$@"-- ============================================================
+-- Scheduled rehearsal. This name belongs to the rehearsal alone,
+-- so clearing last week's leftover - retained if last week FAILED,
+-- and visible in this job's history - is safe by construction.
+-- ============================================================
+IF DB_ID('{literal}') IS NOT NULL
+BEGIN
+    ALTER DATABASE {quoted} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
+    DROP DATABASE {quoted};
+END
+GO
+
+";
+        return preamble + BuildScript(restoreScript, scratchName);
+    }
+
+    /// <summary>
     /// Every logical file, relocated to a scratch-named file in the default directories. The
     /// rehearsal must be incapable of writing where the real database lives.
     /// </summary>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2368,6 +2368,70 @@ public partial class RestoreViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// The rehearsal as a disabled, unscheduled Agent job (#259): the proof renews itself weekly
+    /// once somebody adds a schedule, receipts accumulating in the job history. Same prep as the
+    /// clicked rehearsal, but the scratch name is STABLE with a guarded pre-drop of its own
+    /// leftover - a timestamped name would collide with itself on the job's second run.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanRehearse))]
+    private async Task CopyRehearsalAsAgentJobAsync()
+    {
+        var server = ConnectedServer;
+        var chain = RestoreChain;
+        if (server == null || chain == null || !CanRehearse) return;
+
+        var sourceName = Inventory.SelectedDatabaseName ?? chain.FullSet.DatabaseName ?? "database";
+        var scratch = RehearsalPlanner.ScheduledScratchName(sourceName);
+
+        IsBusy = true;
+        try
+        {
+            var devices = chain.FullSet.Files
+                .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+                .ToList();
+            var files = await _sqlService.RestoreFileListOnlyAsync(server, devices);
+            if (files.Count == 0)
+            {
+                SetError("FILELISTONLY returned nothing - the rehearsal cannot relocate files it " +
+                         "cannot list.");
+                return;
+            }
+
+            var (dataPath, logPath) = await _sqlService.GetDefaultPathsAsync(server);
+            var moves = RehearsalPlanner.ScratchMoves(files, scratch, dataPath, logPath);
+
+            var restoreScript = _scriptGenerator.Generate(chain, new RestoreOptions
+            {
+                TargetDatabaseName = scratch,
+                WithReplace = false,
+                RecoveryMode = RecoveryMode.Recovery,
+                FileMoves = moves
+            });
+
+            var script = RehearsalPlanner.BuildScheduledScript(restoreScript, scratch);
+
+            var job = SqlAgentJobScript.Wrap(
+                script,
+                $"NineLives rehearsal - {sourceName}",
+                $"Weekly proof that {sourceName} restores: scratch restore, DBCC CHECKDB, drop. " +
+                "A failed run retains the scratch copy as evidence until the next run clears it.");
+
+            TryCopyToClipboard(job,
+                "Rehearsal job copied to clipboard. Created disabled and unscheduled - add the " +
+                "weekly schedule and enable it deliberately. Each run's outcome lands in the " +
+                "job history; a failure retains the scratch copy as evidence.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"The rehearsal job could not be prepared: {ex.Message}");
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>
     /// The last thing checked before a restore runs, and it differs by medium.
     ///
     /// Blob needs the server-side credential to be usable. A shared path needs no credential at all

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1074,6 +1074,13 @@
                                 Visibility="{Binding ShowVerifyAndAudit, Converter={StaticResource BoolToVis}}"
                                 ToolTip="Restores this chain to a scratch database (MyDb_rehearsal_...), runs DBCC CHECKDB to prove the data, then drops the scratch copy. The real database is never touched: fresh name, no REPLACE, files relocated to the default directories. Takes as long as a real restore plus CHECKDB." />
 
+                        <Button Content="Rehearsal as Agent job"
+                                Style="{StaticResource SecondaryButton}"
+                                Command="{Binding CopyRehearsalAsAgentJobCommand}"
+                                Padding="12,6" Margin="0,0,8,0"
+                                Visibility="{Binding ShowVerifyAndAudit, Converter={StaticResource BoolToVis}}"
+                                ToolTip="The same rehearsal wrapped as a disabled, unscheduled SQL Server Agent job - add a weekly schedule and the proof renews itself, receipts accumulating in the job history. Uses a stable scratch name that clears its own leftover each run." />
+
                                                 <!-- A different question from Check chain: that one reads headers and
                              checks the LSNs line up, this one reads each backup end to end and
                              checks it is intact. A truncated blob passes the first and fails this.


### PR DESCRIPTION
The rehearsal proves a backup restores — once, when somebody clicks it. This completes the original promise: proof **on a schedule**, receipts accumulating in the job history, nobody at a keyboard.

The one design decision was the scratch name. A clicked rehearsal uses a timestamped name, refused if it exists; a scheduled job runs the same text weekly, so a baked-in timestamp would collide with its own leftovers on run two. The scheduled form uses a **stable name** (`MyDb_rehearsal_scheduled`) and each run begins by clearing its own previous leftover — safe precisely because the name belongs to the rehearsal alone, never to a real database. A failed run still strands its scratch copy as evidence; it stands until the next run, by which time the failure has been seen in the job history.

Order pinned by test: pre-drop → restore → CHECKDB → guarded post-drop. Created disabled and unscheduled, as every handover is.

1,543 pass.