### PR TITLE
Let the exposure rows act, not just alarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **The exposure dashboard's rows act, not just alarm** - "Open in Restore" on every reachable
+  row jumps to the restore screen with that server's backup history loaded and the database
+  selected, one click from seeing to acting. From there, Rehearse proves it. A red row's
+  distance to being acted on should be one click, or the dashboard is a wall of guilt rather
+  than a to-do list
 - **Scheduled rehearsals: the proof renews itself.** The rehearsal wrapped as a disabled,
   unscheduled Agent job - add a weekly schedule and every run restores the chain to a stable
   scratch name, proves it with CHECKDB, and drops it, receipts accumulating in the job history.

--- a/src/NineLives.Tests/ExposureDashboardTests.cs
+++ b/src/NineLives.Tests/ExposureDashboardTests.cs
@@ -174,6 +174,44 @@ public class ExposureDashboardTests
         Assert.Equal(new DateTime(2026, 8, 9, 21, 30, 0), vm.Rows.Single().LastProven);
     }
 
+    /// <summary>
+    /// From seeing to acting in one click (#202's pattern): the row hands its server and database
+    /// to the restore screen through the server's own msdb - exactly where the numbers came from.
+    /// </summary>
+    [Fact]
+    public async Task ARowHandsItsServerAndDatabaseToTheRestoreScreen()
+    {
+        var (vm, sql, _) = New("SRV01");
+        sql.ExposureByServer["SRV01"] =
+            [Row(db: "Payroll", full: DateTime.Now.AddHours(-10))];
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        BrowseHandoff? handoff = null;
+        vm.RestoreRequested += h => handoff = h;
+
+        vm.RestoreFromRowCommand.Execute(vm.Rows.Single());
+
+        Assert.NotNull(handoff);
+        Assert.Equal(BackupMedium.SharedPath, handoff!.Medium);
+        Assert.Equal("SRV01", handoff.SourceServer?.ServerName);
+        Assert.Equal("Payroll", handoff.Database);
+    }
+
+    /// <summary>An unreachable row has nowhere to hand over to - the click does nothing.</summary>
+    [Fact]
+    public async Task AnUnreachableRowDoesNotHandOff()
+    {
+        var (vm, _, _) = New("SRV01", "SRV02");
+        var fired = false;
+        await vm.RefreshCommand.ExecuteAsync(null);
+        vm.RestoreRequested += _ => fired = true;
+
+        vm.RestoreFromRowCommand.Execute(
+            vm.Rows.First(r => r.StateDescription == "UNREACHABLE"));
+
+        Assert.False(fired);
+    }
+
     [Fact]
     public async Task NoServersSaysSoInsteadOfShowingAnEmptyAllClear()
     {

--- a/src/NineLives/ViewModels/ExposureViewModel.cs
+++ b/src/NineLives/ViewModels/ExposureViewModel.cs
@@ -45,6 +45,29 @@ public partial class ExposureViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isSweeping;
 
+    /// <summary>The connections behind the rows, by server name - the handoff needs the object.</summary>
+    private Dictionary<string, ServerConnection> _serversByName =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Raised when somebody wants to act on a row. The shell wires it (#202's pattern).</summary>
+    public event Action<BrowseHandoff>? RestoreRequested;
+
+    /// <summary>
+    /// From seeing to acting in one click: the row's server and database, handed to the restore
+    /// screen through the source that MUST know these backups - the server's own msdb, which is
+    /// exactly where the row's numbers came from. A red row's distance to being acted on should
+    /// be one click, or the dashboard is a wall of guilt rather than a to-do list.
+    /// </summary>
+    [RelayCommand]
+    private void RestoreFromRow(ExposureRow? row)
+    {
+        if (row == null || row.StateDescription == "UNREACHABLE") return;
+        if (!_serversByName.TryGetValue(row.ServerName, out var server)) return;
+
+        RestoreRequested?.Invoke(new BrowseHandoff(
+            BackupMedium.SharedPath, null, server, row.ServerName, row.DatabaseName));
+    }
+
     /// <summary>
     /// Asks every configured server, in parallel, and shows the worst first.
     ///
@@ -80,6 +103,9 @@ public partial class ExposureViewModel : ViewModelBase
             }
 
             var now = DateTime.Now;
+            _serversByName = servers
+                .GroupBy(s => s.ServerName, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
             var sweeps = servers.Select(async server =>
             {

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -263,6 +263,14 @@ public partial class MainViewModel : ViewModelBase
             _ = Restore.AcceptHandoffAsync(handoff);
         };
 
+        // The dashboard's rows get the same one-click path (#202's pattern): a red row's
+        // distance to being acted on is one click, or the screen is guilt rather than a to-do.
+        Exposure.RestoreRequested += handoff =>
+        {
+            NavigateTo(Nav.Restore);
+            _ = Restore.AcceptHandoffAsync(handoff);
+        };
+
         // Changing the mode from Settings has to move the app immediately - a sidebar that still
         // offers a screen the new mode hides, or a screen left on display underneath one that no
         // longer lists it, is worse than not offering the setting (#176).

--- a/src/NineLives/Views/ExposureView.xaml
+++ b/src/NineLives/Views/ExposureView.xaml
@@ -108,6 +108,15 @@
                                     <TextBlock Style="{StaticResource SecondaryText}" FontSize="11"
                                                Text="{Binding LastProven, StringFormat='Proven: {0:MM-dd HH:mm}', TargetNullValue='Proven: never rehearsed'}"
                                                ToolTip="When a rehearsal (#238) last PROVED this database restores. Arithmetic says what could restore; only a rehearsal says it does." />
+
+                                    <Button Content="Open in Restore"
+                                            Command="{Binding DataContext.RestoreFromRowCommand,
+                                                      RelativeSource={RelativeSource AncestorType=ItemsControl}}"
+                                            CommandParameter="{Binding}"
+                                            Style="{StaticResource SecondaryButton}"
+                                            Padding="10,4" Margin="0,6,0,0"
+                                            HorizontalAlignment="Left"
+                                            ToolTip="Jumps to the Restore screen with this server's backup history loaded and this database selected - one click from seeing to acting. From there, Rehearse proves it." />
                                 </StackPanel>
                             </Grid>
                         </Border>


### PR DESCRIPTION
A red row's distance to being acted on should be one click, or the dashboard is a wall of guilt rather than a to-do list. Every reachable row gains **Open in Restore** — the #202 handoff aimed through the server's own backup history (exactly where the row's numbers came from), landing on the restore screen loaded and pointed at the database. From there, Rehearse proves it. Unreachable rows have nowhere to hand over to, so their click does nothing — the row itself says what needs fixing first. 2 new tests, 1,545 pass.