### PR TITLE
Show the measured RTO on the Proven column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **The Proven column now carries the measured RTO** - "Proven: 08-09 21:30 (took 14m 00s)".
+  The rehearsal times the real restore plus CHECKDB, which is the number RTO conversations are
+  otherwise made up from, and the dashboard shows it beside the exposure it answers
 - **The exposure dashboard's rows act, not just alarm** - "Open in Restore" on every reachable
   row jumps to the restore screen with that server's backup history loaded and the database
   selected, one click from seeing to acting. From there, Rehearse proves it. A red row's

--- a/src/NineLives.Tests/ExposureDashboardTests.cs
+++ b/src/NineLives.Tests/ExposureDashboardTests.cs
@@ -166,12 +166,19 @@ public class ExposureDashboardTests
             TargetDatabase = "MyDb_rehearsal_20260809_2100",
             Kind = "Rehearsal",
             Outcome = RestoreOutcome.Succeeded,
+            StartedAt = new DateTime(2026, 8, 9, 21, 16, 0),
             CompletedAt = new DateTime(2026, 8, 9, 21, 30, 0)
         });
 
         await vm.RefreshCommand.ExecuteAsync(null);
 
-        Assert.Equal(new DateTime(2026, 8, 9, 21, 30, 0), vm.Rows.Single().LastProven);
+        var proven = vm.Rows.Single();
+        Assert.Equal(new DateTime(2026, 8, 9, 21, 30, 0), proven.LastProven);
+
+        // The receipt measured the real restore-plus-CHECKDB time - the RTO number that
+        // conversations otherwise invent - and the cell says it.
+        Assert.Equal(TimeSpan.FromMinutes(14), proven.MeasuredRestore);
+        Assert.Contains("took 14m", proven.ProvenDisplay);
     }
 
     /// <summary>

--- a/src/NineLives/Services/ExposureAdvisor.cs
+++ b/src/NineLives/Services/ExposureAdvisor.cs
@@ -27,6 +27,20 @@ public sealed class ExposureRow
     /// <summary>When a rehearsal last PROVED this database restores, from the app's own receipts.</summary>
     public DateTime? LastProven { get; set; }
 
+    /// <summary>
+    /// How long that rehearsal took - restore plus CHECKDB, measured, not estimated. The number
+    /// RTO conversations are otherwise made up from, and the rehearsal produces it for free.
+    /// </summary>
+    public TimeSpan? MeasuredRestore { get; set; }
+
+    /// <summary>The Proven cell: date plus the measured time, or the honest "never rehearsed".</summary>
+    public string ProvenDisplay =>
+        LastProven == null
+            ? "Proven: never rehearsed"
+            : MeasuredRestore is { } d
+                ? $"Proven: {LastProven:MM-dd HH:mm} (took {ExposureAdvisor.Age(LastProven.Value - d, LastProven.Value)})"
+                : $"Proven: {LastProven:MM-dd HH:mm}";
+
     // Filled by the advisor.
     public ExposureLevel Level { get; set; }
     public string Verdict { get; set; } = string.Empty;

--- a/src/NineLives/ViewModels/ExposureViewModel.cs
+++ b/src/NineLives/ViewModels/ExposureViewModel.cs
@@ -175,13 +175,21 @@ public partial class ExposureViewModel : ViewModelBase
                             e.SourceDatabase != null)
                 .GroupBy(e => (e.ServerName, e.SourceDatabase!),
                     StringTupleComparer.OrdinalIgnoreCase)
-                .ToDictionary(g => g.Key, g => g.Max(e => e.CompletedAt),
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderByDescending(e => e.CompletedAt).First(),
                     StringTupleComparer.OrdinalIgnoreCase);
 
             foreach (var row in rows)
             {
-                if (proofs.TryGetValue((row.ServerName, row.DatabaseName), out var provenAt))
-                    row.LastProven = provenAt;
+                if (!proofs.TryGetValue((row.ServerName, row.DatabaseName), out var proof)) continue;
+
+                row.LastProven = proof.CompletedAt;
+
+                // The receipt measured the real restore-plus-CHECKDB time - the RTO number that
+                // conversations otherwise invent.
+                if (proof.CompletedAt > proof.StartedAt)
+                    row.MeasuredRestore = proof.CompletedAt - proof.StartedAt;
             }
         }
         catch

--- a/src/NineLives/Views/ExposureView.xaml
+++ b/src/NineLives/Views/ExposureView.xaml
@@ -106,8 +106,8 @@
                                     <TextBlock Style="{StaticResource SecondaryText}" FontSize="11"
                                                Text="{Binding LastLog, StringFormat='Log: {0:MM-dd HH:mm}', TargetNullValue='Log: never'}" />
                                     <TextBlock Style="{StaticResource SecondaryText}" FontSize="11"
-                                               Text="{Binding LastProven, StringFormat='Proven: {0:MM-dd HH:mm}', TargetNullValue='Proven: never rehearsed'}"
-                                               ToolTip="When a rehearsal (#238) last PROVED this database restores. Arithmetic says what could restore; only a rehearsal says it does." />
+                                               Text="{Binding ProvenDisplay}"
+                                               ToolTip="When a rehearsal (#238) last PROVED this database restores, and how long the restore plus CHECKDB took - the measured RTO. Arithmetic says what could restore; only a rehearsal says it does." />
 
                                     <Button Content="Open in Restore"
                                             Command="{Binding DataContext.RestoreFromRowCommand,


### PR DESCRIPTION
The rehearsal receipt already times the real restore plus CHECKDB — the number RTO conversations are otherwise made up from. The dashboard now says it where the exposure it answers is shown: *Proven: 08-09 21:30 (took 14m 00s)*. RPO on one axis, measured RTO on the other, per database, with evidence. 1,545 pass.