### PR TITLE
Check the version direction on the copy screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- The copy screen now checks the version direction at script generation - its restore half runs
+  outside the restore preflights, so a 2025 source aimed at a 2022 target used to fail with
+  error 3169 only AFTER the backup half had run. The warning says plainly that the copy cannot
+  work and which way it can
 - **The Proven column now carries the measured RTO** - "Proven: 08-09 21:30 (took 14m 00s)".
   The rehearsal times the real restore plus CHECKDB, which is the number RTO conversations are
   otherwise made up from, and the dashboard shows it beside the exposure it answers

--- a/src/NineLives.Tests/EncryptionPreflightTests.cs
+++ b/src/NineLives.Tests/EncryptionPreflightTests.cs
@@ -262,6 +262,40 @@ public class EncryptionPreflightTests
         Assert.False(vm.HasEncryptionWarning);
     }
 
+    /// <summary>
+    /// #210's law on the copy screen: the restore half runs outside the restore preflights, so
+    /// without this the version refusal arrived AFTER the backup half had already run.
+    /// </summary>
+    [Fact]
+    public async Task CopyingOntoAnOlderServerWarnsThatItCannotWork()
+    {
+        var (vm, sql) = Copy();
+        sql.MajorVersionByServer["SRV01"] = 17;   // 2025 source
+        sql.MajorVersionByServer["SRV02"] = 16;   // 2022 target
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.True(vm.HasVersionWarning);
+        Assert.Contains("cannot work", vm.VersionWarning);
+        Assert.Contains("SQL Server 2025 (17.x)", vm.VersionWarning);
+        Assert.Contains("SQL Server 2022 (16.x)", vm.VersionWarning);
+    }
+
+    /// <summary>The legal direction, and silence, both stay quiet.</summary>
+    [Fact]
+    public async Task ALegalCopyDirectionRaisesNoVersionAlarm()
+    {
+        var (vm, sql) = Copy();
+        sql.MajorVersionByServer["SRV01"] = 15;
+        sql.MajorVersionByServer["SRV02"] = 16;
+
+        vm.GenerateCommand.Execute(null);
+        await Task.Delay(50);
+
+        Assert.False(vm.HasVersionWarning);
+    }
+
     [Fact]
     public async Task CopyingAPlainDatabaseAsksNoCertificateQuestions()
     {

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -297,8 +297,13 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>What GetProductMajorVersionAsync answers - 16 is SQL Server 2022 (#210).</summary>
     public int? ProductMajorVersion { get; set; } = 16;
 
+    /// <summary>Per-server overrides, for the checks that compare two servers' versions.</summary>
+    public Dictionary<string, int?> MajorVersionByServer { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
     public Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default)
-        => Task.FromResult(ProductMajorVersion);
+        => Task.FromResult(
+            MajorVersionByServer.TryGetValue(server.ServerName, out var v) ? v : ProductMajorVersion);
 
     /// <summary>What GetDatabaseOverviewAsync answers (#205).</summary>
     public DatabaseOverview? DatabaseOverview { get; set; } = new(150, "FULL", "sa");

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -333,6 +333,58 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         // screen feel slower for checks that usually say "fine".
         _ = CheckSpaceAsync();
         _ = CheckEncryptionAsync();
+        _ = CheckVersionAsync();
+    }
+
+    // ── can the target even accept it (#210's law, on the copy screen) ─────────
+
+    [ObservableProperty]
+    private string _versionWarning = string.Empty;
+
+    public bool HasVersionWarning => VersionWarning.Length > 0;
+
+    partial void OnVersionWarningChanged(string value) => OnPropertyChanged(nameof(HasVersionWarning));
+
+    /// <summary>
+    /// The one-directional law of RESTORE, asked at generation time: a backup taken on a newer
+    /// major version can never be restored onto an older one - error 3169, no exceptions. The
+    /// restore screen has refused this since #210; the copy screen ran its restore half OUTSIDE
+    /// those preflights, so the refusal arrived from the server after the backup half had
+    /// already run. Both versions are one SERVERPROPERTY away, and the copy knows both servers
+    /// before anything starts.
+    ///
+    /// A warning rather than a block, like the screen's other checks - but a warning in the
+    /// STRONGEST terms, because unlike disk space nothing can change between generating and
+    /// running that makes this legal.
+    /// </summary>
+    private async Task CheckVersionAsync()
+    {
+        VersionWarning = string.Empty;
+
+        if (SourceServer == null || TargetServer == null) return;
+
+        try
+        {
+            var source = await _sql.GetProductMajorVersionAsync(SourceServer);
+            var target = await _sql.GetProductMajorVersionAsync(TargetServer);
+
+            if (VersionCompatibility.Check(source, target) == VersionVerdict.Refuse)
+            {
+                VersionWarning =
+                    $"This copy cannot work: {SourceServer.ServerName} is " +
+                    $"{VersionCompatibility.Describe(source!.Value)} and {TargetServer.ServerName} " +
+                    $"is {VersionCompatibility.Describe(target!.Value)}, and SQL Server can never " +
+                    "restore a newer version's backup onto an older server - error 3169, with no " +
+                    "exceptions. The backup half would run and the restore half would fail. Copy " +
+                    "the other way, or onto a newer target.";
+
+                _log.Warn($"[version] copy: {VersionWarning}");
+            }
+        }
+        catch
+        {
+            // An instance that will not say its version has not said the copy is illegal.
+        }
     }
 
     // ── will the target be able to READ it (#222) ───────────────────────────────

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -198,6 +198,18 @@
                 <StackPanel>
                     <TextBlock Text="4. Run it" Style="{StaticResource SubHeaderText}" />
 
+                    <!-- Can the target even ACCEPT it (#210's law). Unlike disk space, nothing
+                         can change between generating and running that makes this legal. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,10,0,0"
+                            Background="{DynamicResource DangerPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource ErrorBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding HasVersionWarning, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding VersionWarning}"
+                                   TextWrapping="Wrap"
+                                   Style="{StaticResource BodyText}" />
+                    </Border>
+
                     <!-- Will the target be able to READ it (#222). TDE rides along inside every
                          backup, and a copy of an encrypted database is only as good as the
                          target's certificate - warned here, before the backup half runs. -->


### PR DESCRIPTION
The copy's restore half runs outside the restore preflights, so #210's law was never asked here: a 2025 source aimed at a 2022 target took the whole backup, then failed the restore half with error 3169. The check joins the space and TDE checks at generation time — a warning in the strongest terms, because unlike disk space nothing can change between generating and running that makes this legal. The fake grew per-server versions so the test models the real case. 1,547 pass.