### PR TITLE
Two proof-loop polish items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- Rehearsal notifications now name the database being PROVEN rather than the scratch copy it
+  was proven on - "Rehearsal MyDb", not "Rehearsal MyDb_rehearsal_20260810_0930"
+- The Exposure dashboard sweeps itself on first visit - arriving at an empty screen that needs a
+  button press first is the screen failing its own question. Refresh stays deliberate after that
 - The copy screen now checks the version direction at script generation - its restore half runs
   outside the restore preflights, so a 2025 source aimed at a 2022 target used to fail with
   error 3169 only AFTER the backup half had run. The warning says plainly that the copy cannot

--- a/src/NineLives.Tests/RestoreRehearsalTests.cs
+++ b/src/NineLives.Tests/RestoreRehearsalTests.cs
@@ -171,8 +171,10 @@ public class RestoreRehearsalTests
         Assert.Contains("DBCC CHECKDB", script);
         Assert.Contains("DROP DATABASE", script);
 
-        // The receipt and the announcement both say what this was.
-        Assert.Contains(notifier.Sent, n => n.Operation == "Rehearsal" && n.Phase == RunPhase.Succeeded);
+        // The receipt and the announcement both say what this was - and the announcement names
+        // the database being PROVEN, not the scratch copy it was proven on.
+        var done = notifier.Sent.Single(n => n.Operation == "Rehearsal" && n.Phase == RunPhase.Succeeded);
+        Assert.Equal("MyDb", done.Subject);
     }
 
     /// <summary>The whole design promise: a name that exists refuses, before anything runs.</summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -144,6 +144,19 @@ public partial class MainViewModel : ViewModelBase
     /// <summary>The geometry the last session saved, for the window to apply before first paint.</summary>
     public WindowGeometry? SavedGeometry { get; private set; }
 
+    /// <summary>
+    /// The dashboard answers "how exposed am I?" - arriving at an empty screen that needs a
+    /// button press first is the screen failing its own question. First visit sweeps
+    /// automatically; after that Refresh is deliberate, because a sweep touches every server.
+    /// </summary>
+    private ExposureViewModel SweepExposureOnFirstVisit()
+    {
+        if (Exposure.Rows.Count == 0 && !Exposure.IsSweeping)
+            _ = Exposure.RefreshCommand.ExecuteAsync(null);
+
+        return Exposure;
+    }
+
     /// <summary>Whether a sidebar entry is offered in the current mode.</summary>
     public bool IsViewAvailable(string viewName) => viewName switch
     {
@@ -554,7 +567,7 @@ public partial class MainViewModel : ViewModelBase
             Nav.BlobStorage => BlobConfig,
             Nav.SqlServers => ServerManager,
             Nav.BrowseBackups => BlobBrowser,
-            Nav.Exposure => Exposure,
+            Nav.Exposure => SweepExposureOnFirstVisit(),
             Nav.Backup => Backup,
             Nav.Restore => Restore,
             Nav.CopyDatabase => CopyDatabase,

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -182,6 +182,13 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     /// </param>
     public async Task RunAsync(RestoreRun run, Func<Action<string>, Task<CredentialPreflight>> preflight)
     {
+        // What the notifications call the run. A rehearsal's TARGET is the scratch copy, which
+        // is an implementation detail - the thing being PROVEN is the source database, and that
+        // is the name a Teams channel can recognise.
+        var subject = run.Kind == RunKind.Rehearsal && !string.IsNullOrWhiteSpace(run.SourceDatabase)
+            ? run.SourceDatabase!
+            : run.TargetDatabase;
+
         Disarm();
 
         // The recovery steps that may follow must agree with the run that produced them, even if
@@ -241,7 +248,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             // "started" messages for runs that went nowhere teach people to ignore the channel.
             _notifier.Notify(new RunNotification(
                 RunPhase.Started, run.Kind == RunKind.Rehearsal ? "Rehearsal" : "Restore",
-                run.TargetDatabase, run.Server.ServerName, run.ChainSummary));
+                subject, run.Server.ServerName, run.ChainSummary));
 
             await _sql.ExecuteWithProgressAsync(
                 run.Server,
@@ -281,7 +288,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             _notifier.Notify(new RunNotification(
                 RunPhase.Succeeded, run.Kind == RunKind.Rehearsal ? "Rehearsal" : "Restore",
-                run.TargetDatabase, run.Server.ServerName,
+                subject, run.Server.ServerName,
                 run.Kind == RunKind.Rehearsal
                     ? "Restored, CHECKDB passed, scratch copy dropped. The backup is proven."
                     : run.ChainSummary,
@@ -316,7 +323,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             _notifier.Notify(new RunNotification(
                 RunPhase.Problem, run.Kind == RunKind.Rehearsal ? "Rehearsal" : "Restore",
-                run.TargetDatabase, run.Server.ServerName,
+                subject, run.Server.ServerName,
                 "Cancelled part-way through the chain - the target is left mid-restore.",
                 DateTime.Now - startedAt));
 
@@ -332,7 +339,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             _notifier.Notify(new RunNotification(
                 RunPhase.Problem, run.Kind == RunKind.Rehearsal ? "Rehearsal" : "Restore",
-                run.TargetDatabase, run.Server.ServerName,
+                subject, run.Server.ServerName,
                 ex.Message, DateTime.Now - startedAt));
 
             // The restore has stopped part-way and the target is almost certainly not usable. Find


### PR DESCRIPTION
**Rehearsal notifications name the database being proven** — "Rehearsal MyDb", not "Rehearsal MyDb_rehearsal_20260810_0930". The scratch name is an implementation detail wearing the headline; it stays in the console and history where it belongs.

**The Exposure dashboard sweeps itself on first visit** — arriving at an empty screen that needs a button press first is the screen failing its own question. Refresh stays deliberate after that, because a sweep touches every server.

1,547 pass.