### PR TITLE
Ask the source instance for marked transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ more detail on the user-facing changes; this file is the short history.
   belongs to the rehearsal alone; a failed run still retains its scratch copy as evidence until
   the next run has been seen (#259)
 
+### Fixed
+
+- Find marks now asks the SOURCE instance's msdb on shared-path and ad-hoc restores - marked
+  transactions are recorded where they ran, so asking the target answered "no marks" when the
+  truth was "wrong catalogue". Blob still asks the connected server, which is the only
+  catalogue that medium has (#268)
+- A combo's closed box now shows the same text as its open list. The custom combo template
+  dropped the template selector that DisplayMemberPath works through, so combos bound to
+  objects rendered their raw type name once closed - the marked-transactions picker being the
+  first to show it in daylight
+
 ## [1.5.0] - 2026-08-10
 
 ### Added

--- a/src/NineLives.Tests/ComboSelectionBoxTests.cs
+++ b/src/NineLives.Tests/ComboSelectionBoxTests.cs
@@ -1,0 +1,64 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The combo's CLOSED box, not its open list (#269).
+///
+/// DisplayMemberPath works through the items control's template SELECTOR, and a combo template
+/// must forward that selector to the selection-box presenter the way the stock template does.
+/// Without it the open list shows the right member while the closed box falls back to
+/// ToString() - "LogMark { Name = deploy_v2, ... }" rendered straight at the user - a failure
+/// the load tests cannot see, because the binding that breaks is one WPF never even creates.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class ComboSelectionBoxTests(WpfFixture wpf)
+{
+    [Fact]
+    public void TheClosedBoxShowsTheDisplayMemberNotToString()
+    {
+        wpf.Invoke(() =>
+        {
+            var combo = new ComboBox
+            {
+                ItemsSource = new[]
+                {
+                    new LogMark("deploy_v2", "v2 schema deployment", new DateTime(2026, 8, 5, 21, 30, 0))
+                },
+                DisplayMemberPath = nameof(LogMark.Display),
+                SelectedIndex = 0,
+                Style = (Style)Application.Current.FindResource("DarkComboBox")
+            };
+
+            combo.ApplyTemplate();
+            combo.Measure(new Size(800, 100));
+            combo.Arrange(new Rect(0, 0, 800, 100));
+            combo.UpdateLayout();
+
+            var texts = TextsUnder(combo);
+
+            Assert.Contains(texts, t => t.Contains("deploy_v2 — 2026-08-05 21:30:00"));
+            Assert.DoesNotContain(texts, t => t.Contains("LogMark {"));
+        });
+    }
+
+    /// <summary>Every rendered TextBlock's text. The closed popup realises nothing, so what this
+    /// finds is the selection box (and the collapsed placeholder) - exactly the surface under test.</summary>
+    private static List<string> TextsUnder(DependencyObject root)
+    {
+        var texts = new List<string>();
+        var count = VisualTreeHelper.GetChildrenCount(root);
+        for (var i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is TextBlock block) texts.Add(block.Text);
+            texts.AddRange(TextsUnder(child));
+        }
+
+        return texts;
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -509,10 +509,16 @@ public sealed class FakeSqlServerService : ISqlServerService
     public Dictionary<string, List<LogMark>> LogMarksByDatabase { get; } =
         new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Which instances were asked for marks, in order - the catalogue choice IS the bug surface (#268).</summary>
+    public List<string> LogMarkServersAsked { get; } = [];
+
     public Task<List<LogMark>> GetLogMarksAsync(
         ServerConnection server, string database, CancellationToken ct = default)
-        => Task.FromResult(
+    {
+        LogMarkServersAsked.Add(server.ServerName);
+        return Task.FromResult(
             LogMarksByDatabase.TryGetValue(database, out var marks) ? marks.ToList() : []);
+    }
 
     /// <summary>Percent values the polling execute reports before completing (#user CHECKDB feedback).</summary>
     public List<double> PollPercents { get; set; } = [50];

--- a/src/NineLives.Tests/StopAtMarkTests.cs
+++ b/src/NineLives.Tests/StopAtMarkTests.cs
@@ -1,5 +1,6 @@
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
 using Xunit;
 
 namespace Blackcat.NineLives.Tests;
@@ -107,5 +108,84 @@ public class StopAtMarkTests
         Assert.Contains("deploy_v2", mark.Display);
         Assert.Contains("2026-08-10 09:00:00", mark.Display);
         Assert.Contains("the v2 schema deployment", mark.Display);
+    }
+
+    // ── which catalogue gets asked (#268) ───────────────────────────────────────
+    //
+    // logmarkhistory is written where the marked transactions RAN. Ask the wrong instance and
+    // the answer is "no marks" - indistinguishable from there genuinely being none.
+
+    private static (RestoreViewModel vm, FakeSqlServerService sql,
+        ServerConnection source, ServerConnection target) TwoServers()
+    {
+        var store = new FakeCredentialStore();
+        var source = new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+        var target = new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" };
+        store.Config.Servers.Add(source);
+        store.Config.Servers.Add(target);
+
+        var sql = new FakeSqlServerService();
+        sql.LogMarksByDatabase["MyDb"] = [new LogMark("deploy_v2", null, T0)];
+
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), sql, new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store,
+            log: null, history: new FakeRestoreHistoryStore(), auditStore: TestAuditStores.Temp());
+        vm.RefreshContainers();
+
+        return (vm, sql, source, target);
+    }
+
+    /// <summary>
+    /// Restoring SRV01's backups onto SRV02: the marks live in SRV01's msdb, and SRV02's has
+    /// never heard of them. The connected (target) server must NOT be the one asked.
+    /// </summary>
+    [Fact]
+    public async Task SharedPathMarksComeFromTheSourceServersMsdb()
+    {
+        var (vm, sql, source, target) = TwoServers();
+        vm.SelectedMedium = BackupMedium.SharedPath;
+        vm.SourceServer = vm.SourceServers.Single(s => s.Id == source.Id);
+        vm.ConnectedServer = target;
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+
+        await vm.LoadLogMarksCommand.ExecuteAsync(null);
+
+        Assert.Equal(new[] { "SRV01" }, sql.LogMarkServersAsked);
+        Assert.Single(vm.LogMarks);
+    }
+
+    /// <summary>
+    /// The shared-path flow chooses its source in step 1 and never needed the Servers screen's
+    /// connect - finding marks must not demand one.
+    /// </summary>
+    [Fact]
+    public async Task ASharedPathFindsMarksWithoutAServersScreenConnection()
+    {
+        var (vm, sql, source, _) = TwoServers();
+        vm.SelectedMedium = BackupMedium.SharedPath;
+        vm.SourceServer = vm.SourceServers.Single(s => s.Id == source.Id);
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+
+        await vm.LoadLogMarksCommand.ExecuteAsync(null);
+
+        Assert.Equal(new[] { "SRV01" }, sql.LogMarkServersAsked);
+        Assert.Single(vm.LogMarks);
+    }
+
+    /// <summary>Blob has no source instance - the connected server is the only catalogue there is.</summary>
+    [Fact]
+    public async Task BlobMarksComeFromTheConnectedServer()
+    {
+        var (vm, sql, _, target) = TwoServers();
+        vm.ConnectedServer = target;
+        vm.Inventory.SelectedDatabaseName = "MyDb";
+
+        await vm.LoadLogMarksCommand.ExecuteAsync(null);
+
+        Assert.Equal(new[] { "SRV02" }, sql.LogMarkServersAsked);
+        Assert.Single(vm.LogMarks);
     }
 }

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -578,10 +578,15 @@
                                       Focusable="False"
                                       ClickMode="Press"
                                       IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                        <!-- ContentTemplateSelector forwarded like the stock template does:
+                             DisplayMemberPath works through the items control's template
+                             SELECTOR, so a closed box without it falls back to ToString()
+                             while the open list shows the right member (#269). -->
                         <ContentPresenter x:Name="ContentSite"
                                           IsHitTestVisible="False"
                                           Content="{TemplateBinding SelectionBoxItem}"
                                           ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                           ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
                                           Margin="12,8,28,8"
                                           VerticalAlignment="Center"

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -454,7 +454,7 @@ public partial class RestoreViewModel : ViewModelBase
         OnPropertyChanged(nameof(ShowAuditPanel));
         OnPropertyChanged(nameof(ShowCredentialPanel));
         OnPropertyChanged(nameof(ShowAgentJob));
-        OnPropertyChanged(nameof(ShowAdvancedOptions));
+        OnPropertyChanged(nameof(ShowAdvancedOptions));
         OnPropertyChanged(nameof(ShowMultipleContainers));
 
         // A medium that is no longer offered must not stay selected underneath a hidden control -
@@ -2198,16 +2198,25 @@ public partial class RestoreViewModel : ViewModelBase
     /// <summary>
     /// Reads logmarkhistory for the selected database (#243). On demand, because most databases
     /// have no marks and the combo should not cost a round trip to prove it.
+    ///
+    /// Asked on the SOURCE instance when the medium has one (#268): logmarkhistory is written
+    /// where the marked transactions RAN, so on a shared-path restore to a different target, the
+    /// target's msdb has never heard of them - asking it reports "no marks" when the truth is
+    /// "wrong catalogue". Blob has no source instance, so the connected server answers there;
+    /// it also covers ad-hoc's file-that-outlived-its-server case as best effort. The marks
+    /// themselves ride inside the log backups either way - this is discovery, not correctness.
     /// </summary>
     [RelayCommand]
     private async Task LoadLogMarksAsync()
     {
-        var server = ConnectedServer;
+        var server = (MediumIsBlob ? null : SourceServer) ?? ConnectedServer;
         var database = Inventory.SelectedDatabaseName;
 
         if (server == null || string.IsNullOrWhiteSpace(database))
         {
-            SetError("Connect to a server and choose a database first - the marks live in its msdb.");
+            SetError(MediumIsBlob
+                ? "Connect to a server and choose a database first - the marks live in its msdb."
+                : "Choose the source server and a database first - the marks were recorded in its msdb.");
             return;
         }
 


### PR DESCRIPTION
Closes #268.

A render sweep over the marks row caught two defects, one behavioural and one visual.

**1. Find marks asked the wrong instance.** \`LoadLogMarksAsync\` asked \`ConnectedServer\` - the Servers-screen connection - for \`msdb.dbo.logmarkhistory\`. But logmarkhistory is written on the instance where the marked transactions **ran**. Restoring SRV01's backups onto SRV02 asked SRV02's msdb, which answers "no marked transactions recorded" - indistinguishable from there genuinely being none, which is exactly the kind of silence this app exists to refuse. And with no Servers-screen connection at all, the row demanded a connect that the shared-path flow - which chooses its source in step 1 - never needed.

The fix resolves the catalogue the way the certificate preflight already resolves a source instance:

- **Shared path / ad-hoc:** \`SourceServer\` first - its msdb is where the marks were recorded. \`ConnectedServer\` as fallback covers the ad-hoc file that outlived its server, where best effort is all there is.
- **Blob:** \`ConnectedServer\`, unchanged - no source instance exists there.

The guard message is now medium-aware too: a shared-path user is told to choose the source server, not to go and connect on another screen. The generated STOPATMARK/STOPBEFOREMARK script was always correct - the marks ride inside the log backups - so this was purely discovery asking the wrong catalogue.

**2. The combo's closed box showed ToString().** With the marks now loading, the picker's closed box read \`LogMark { Name = deploy_v2, ... }\` while its open list showed the right text. The custom combo template bound \`SelectionBoxItemTemplate\` but not \`ContentTemplateSelector\` - and \`DisplayMemberPath\` works through the items control's template SELECTOR, which the stock template forwards. Forwarding it fixes every combo bound to objects rather than strings; the blob browser had already worked around this per-site with an explicit ItemTemplate. Explicit ItemTemplates and plain string combos are unaffected - a template still outranks the selector, and string items never had one.

**Tests** (4 new, 1,551 total): the fake records which instances were asked for marks; pins cover source preference when both servers are set, marks loading with no Servers-screen connection at all, and blob's unchanged path. A new WPF test realises a DarkComboBox with DisplayMemberPath and asserts the closed box renders the display member, not ToString().