### PR TITLE
The CLI executes, carefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,18 @@ more detail on the user-facing changes; this file is the short history.
   the exit code is the answer), and `exposure` (the dashboard's sweep with the worst level as
   the exit code, so a scheduled task turns quiet log-backup silence into a red pipeline).
   Distinct exit codes for warn, broken, could-not-answer and usage, because a pipeline
-  branches on numbers, not prose. Nothing executes against an instance - execution verbs
-  arrive later behind their own explicit flags
+  branches on numbers, not prose
+- **The CLI executes - carefully.** `9lives restore` and `9lives rehearse` run against a
+  target server, behind the safety defaults the CLI was designed around: nothing runs without
+  `--execute`; overwriting an existing database is said with `--with-replace`, its own flag
+  that `--force` cannot substitute for; and the same preflights the app fires - can the target
+  read the files, does the version direction work (error 3169), is the TDE certificate there
+  (error 33111) - refuse before anything is dropped, with `--force` as the deliberate,
+  evidence-only override. A generate-only invocation still runs the preflights and carries
+  their verdict in its exit code, so a pipeline can rehearse its own DR step for free.
+  Executed runs land in the same History the app lists and notify the same webhooks -
+  `9lives rehearse --execute` on a schedule is nightly proof with receipts, no SQL Agent
+  required
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ The same engine from a terminal - for the pipeline, the runbook step, the schedu
 
 Five read-only verbs. `list` says what a source holds; `points` is the timeline as text or JSON; `script` emits the validated restore T-SQL for a moment - the same chain calculation, striped-set grouping and STOPAT/marked-transaction handling the GUI runs, which is why the script it emits actually works; `validate` checks every chain is intact and answers in the exit code; `exposure` sweeps every configured server and exits with the worst level it found, so a scheduled task turns quiet log-backup silence into a red pipeline.
 
-Exit codes are the contract: `0` fine, `1` warnings, `2` broken or unreachable-by-chain, `3` could not answer, `64` usage. `--json` on the read verbs makes the output composable with jq and friends. Nothing in the CLI executes against an instance - execution verbs arrive later, behind their own explicit flags.
+Exit codes are the contract: `0` fine, `1` warnings, `2` broken or unreachable-by-chain, `3` could not answer, `64` usage. `--json` on the read verbs makes the output composable with jq and friends.
+
+Two verbs execute, and they are built out of refusals: `restore` and `rehearse` run nothing without `--execute`; overwriting an existing database is said with `--with-replace`, its own flag that `--force` cannot substitute for; and the same preflights the app fires - file readability, version direction (error 3169), the TDE certificate (error 33111) - refuse before anything is dropped, `--force` being the deliberate override for evidence only. Executed runs land in the app's History and notify the same webhooks, so `9lives rehearse --execute` on a schedule is nightly proof with receipts - no SQL Agent required.
 
 ## Features
 

--- a/src/NineLives.Cli/CliServices.cs
+++ b/src/NineLives.Cli/CliServices.cs
@@ -8,13 +8,21 @@ namespace Blackcat.NineLives.Cli;
 /// implementations the GUI composes - which is the entire point (#63): configure containers,
 /// servers and credentials once in the app, then script against that exact configuration here.
 /// Bundled so tests hand verbs fakes the same way the app's tests do.
+///
+/// History and notifications are the SAME stores and endpoints as the app's: a restore run
+/// from a pipeline lands in the History screen, a rehearsal's receipt feeds the exposure
+/// dashboard's Proven column, and the Teams channel hears about both. One estate, two front
+/// ends.
 /// </summary>
 internal sealed class CliServices(
-    ICredentialStore store, ISqlServerService sql, IBlobStorageService blobs)
+    ICredentialStore store, ISqlServerService sql, IBlobStorageService blobs,
+    IRestoreHistoryStore history, IRunNotifier notifier)
 {
     public ICredentialStore Store { get; } = store;
     public ISqlServerService Sql { get; } = sql;
     public IBlobStorageService Blobs { get; } = blobs;
+    public IRestoreHistoryStore History { get; } = history;
+    public IRunNotifier Notifier { get; } = notifier;
 
     public AppConfig Config => _config ??= Store.LoadConfig();
     private AppConfig? _config;

--- a/src/NineLives.Cli/Preflights.cs
+++ b/src/NineLives.Cli/Preflights.cs
@@ -1,0 +1,127 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Cli;
+
+/// <summary>
+/// The checks that run before anything destructive (#63's safety defaults) - the same four
+/// safety nets the GUI fires before WITH REPLACE drops anything, composed from the same Core
+/// services. Each returns a refusal message or nothing; --force downgrades the evidence-based
+/// refusals to loud warnings, but never the WITH REPLACE rule - overwriting a database is
+/// consented to by its own flag, not by a general-purpose override.
+///
+/// Best effort by the GUI's own rule: no verdict from silence. A header that cannot be read
+/// produces no version or TDE refusal, because refusing on a guess blocks legal restores.
+/// </summary>
+internal static class Preflights
+{
+    internal sealed record Result(List<string> Refusals, List<string> Warnings);
+
+    /// <summary>
+    /// Everything checkable before the run: does the target database already exist without
+    /// consent to overwrite, can the target read the files, does the version direction work,
+    /// and is the TDE certificate where the restore will need it.
+    /// </summary>
+    public static async Task<Result> RunAsync(
+        CliServices services, ServerConnection target, BackupChain chain,
+        string targetDatabase, bool withReplace, bool force)
+    {
+        var refusals = new List<string>();
+        var warnings = new List<string>();
+
+        void Verdict(string message)
+        {
+            if (force) warnings.Add(message + " (--force: proceeding anyway)");
+            else refusals.Add(message);
+        }
+
+        // 1. WITH REPLACE is its own consent - never inherited, never forced (#63).
+        var existing = await services.Sql.GetDatabaseListAsync(target);
+        if (!withReplace
+            && existing.Contains(targetDatabase, StringComparer.OrdinalIgnoreCase))
+        {
+            refusals.Add(
+                $"'{targetDatabase}' already exists on {target.ServerName}. Overwriting it " +
+                "is said with --with-replace, deliberately - there is no other way to mean it.");
+        }
+
+        // 2. Can the target's service account actually open the files? Only disk paths have an
+        // answer here; blob access fails later with its own clear error.
+        var diskPaths = chain.AllSets
+            .SelectMany(s => s.Files)
+            .Where(f => f.IsOnDisk)
+            .Select(f => f.RestoreDevice)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (diskPaths.Count > 0)
+        {
+            var checks = await services.Sql.CheckBackupFilesAsync(target, diskPaths);
+            foreach (var check in checks.Where(c => !c.CanBeRestored))
+                Verdict($"{target.ServerName} cannot read {check.Path}: " +
+                        (check.ServerMessage ?? check.Problem.ToString()));
+        }
+
+        // 3 and 4 both live in the full set's header - one HEADERONLY on the target serves
+        // both, device-aware since #203 so blob, shared path and ad-hoc all take this one path.
+        var devices = chain.FullSet.Files
+            .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+            .ToList();
+
+        BackupFileInfo? header;
+        try
+        {
+            header = await services.Sql.RestoreHeaderOnlyMultiAsync(target, devices);
+        }
+        catch
+        {
+            return new Result(refusals, warnings);
+        }
+
+        if (header == null) return new Result(refusals, warnings);
+
+        // 3. The one-directional law of RESTORE (#210): newer onto older is error 3169, caught
+        // here rather than after the target database is already gone.
+        if (header.SoftwareVersionMajor is { } backupMajor)
+        {
+            var targetMajor = await services.Sql.GetProductMajorVersionAsync(target);
+            if (VersionCompatibility.Check(backupMajor, targetMajor)
+                == VersionVerdict.Refuse)
+            {
+                Verdict(
+                    $"This backup was taken on {VersionCompatibility.Describe(backupMajor)} " +
+                    $"and {target.ServerName} is {VersionCompatibility.Describe(targetMajor!.Value)} - " +
+                    "a newer version's backup can never restore onto an older server " +
+                    "(error 3169). Restore onto a newer target instead.");
+            }
+        }
+
+        // 4. The certificate question, asked before the restore rather than answered by error
+        // 33111 halfway through the worst morning (#222).
+        foreach (var (thumbprint, what) in new[]
+                 {
+                     (header.TdeThumbprint, "TDE certificate"),
+                     (header.EncryptorThumbprint, "backup-encryption certificate")
+                 })
+        {
+            if (thumbprint == null) continue;
+
+            string? found = null;
+            try
+            {
+                found = await services.Sql.FindCertificateByThumbprintAsync(target, thumbprint);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (found == null)
+                Verdict(
+                    $"The {what} with thumbprint 0x{Convert.ToHexString(thumbprint)} is not on " +
+                    $"{target.ServerName}. Restore its certificate there first (error 33111 " +
+                    "otherwise) - the app's encryption panel spells out the export/import route.");
+        }
+
+        return new Result(refusals, warnings);
+    }
+}

--- a/src/NineLives.Cli/Program.cs
+++ b/src/NineLives.Cli/Program.cs
@@ -13,7 +13,8 @@ internal static class Program
 {
     private static readonly VerbSpec[] Verbs =
     [
-        ListVerb.Spec, PointsVerb.Spec, ScriptVerb.Spec, ValidateVerb.Spec, ExposureVerb.Spec
+        ListVerb.Spec, PointsVerb.Spec, ScriptVerb.Spec, ValidateVerb.Spec, ExposureVerb.Spec,
+        RestoreVerb.Spec, RehearseVerb.Spec
     ];
 
     private static async Task<int> Main(string[] rawArgs)
@@ -52,10 +53,12 @@ internal static class Program
         }
 
         // The same store, the same services, the same configuration the desktop app maintains:
-        // configure once there, script against it here.
+        // configure once there, script against it here. History and webhooks too - an executed
+        // run lands in the app's History screen and the same Teams channel hears about it.
         var store = new CredentialStore();
         var services = new CliServices(
-            store, new SqlServerService(store), new BlobStorageService(store));
+            store, new SqlServerService(store), new BlobStorageService(store),
+            new RestoreHistoryStore(), new WebhookRunNotifier(store, new OperationLog()));
 
         try
         {
@@ -66,6 +69,8 @@ internal static class Program
                 "script" => await ScriptVerb.RunAsync(args, services, Console.Out, Console.Error),
                 "validate" => await ValidateVerb.RunAsync(args, services, Console.Out, Console.Error),
                 "exposure" => await ExposureVerb.RunAsync(args, services, Console.Out, Console.Error),
+                "restore" => await RestoreVerb.RunAsync(args, services, Console.Out, Console.Error),
+                "rehearse" => await RehearseVerb.RunAsync(args, services, Console.Out, Console.Error),
                 _ => ExitCodes.Usage
             };
         }
@@ -82,8 +87,8 @@ internal static class Program
     {
         output.WriteLine("Nine Lives CLI - the restore engine from a terminal.");
         output.WriteLine("Reads the configuration the Nine Lives app maintains: its containers,");
-        output.WriteLine("its servers, its credentials. Read-only: nothing here executes against");
-        output.WriteLine("an instance.");
+        output.WriteLine("its servers, its credentials. Nothing executes without --execute, and");
+        output.WriteLine("overwriting a database is said with --with-replace, deliberately.");
         output.WriteLine();
         output.WriteLine("Verbs:");
         foreach (var verb in Verbs)
@@ -102,5 +107,7 @@ internal static class Program
         output.WriteLine("  9lives points --container backups --database Sales");
         output.WriteLine("  9lives script --container backups --database Sales --at \"2026-08-02 19:00\" --out restore.sql");
         output.WriteLine("  9lives validate --server SRV01 --json");
+        output.WriteLine("  9lives rehearse --container backups --database Sales --target SRV02 --execute");
+        output.WriteLine("  9lives restore --container backups --database Sales --target SRV02 --with-replace --execute");
     }
 }

--- a/src/NineLives.Cli/Verbs/RehearseVerb.cs
+++ b/src/NineLives.Cli/Verbs/RehearseVerb.cs
@@ -1,0 +1,192 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Cli.Verbs;
+
+/// <summary>
+/// The proof loop from a terminal (#63 step 3): restore the chain to a scratch database on the
+/// target, prove the data with DBCC CHECKDB, drop the scratch copy - and leave the receipt in
+/// the same history the app reads, so the exposure dashboard's Proven column and measured RTO
+/// fill in from a scheduled task nobody watches. "Nightly DR verification" was this issue's
+/// founding example, and this is that verb.
+///
+/// Safety by construction, same as the app's rehearsal (#238): a generated scratch name, never
+/// WITH REPLACE, every file relocated, and the cleanup runs LAST so a failure retains the
+/// evidence. The one database it can drop is the one it just created.
+/// </summary>
+internal static class RehearseVerb
+{
+    public static readonly VerbSpec Spec = new(
+        "rehearse",
+        "Prove a database restores: scratch restore + CHECKDB + drop, receipt in History",
+        "9lives rehearse (--container NAME | --server NAME) --database DB --target SERVER " +
+        "[--at \"yyyy-MM-dd HH:mm:ss\"] [--execute]",
+        Valued: ["container", "server", "database", "at", "target"],
+        Switches: ["execute"]);
+
+    public static async Task<int> RunAsync(
+        CliArguments args, CliServices services, TextWriter output, TextWriter errors)
+    {
+        if (args.Get("database") == null || args.Get("target") == null)
+        {
+            errors.WriteLine("rehearse needs --database and --target (the server the scratch " +
+                             "restore runs on - a configured server name).");
+            return ExitCodes.Usage;
+        }
+
+        DateTime? at = null;
+        if (args.Get("at") is { } atText)
+        {
+            at = CliArguments.ParseTime(atText);
+            if (at == null)
+            {
+                errors.WriteLine($"Could not read '{atText}' as a time. Formats: " +
+                                 "yyyy-MM-dd HH:mm:ss, yyyy-MM-dd HH:mm, yyyy-MM-dd.");
+                return ExitCodes.Usage;
+            }
+        }
+
+        var (target, targetError) = services.FindServer(args.Get("target")!);
+        if (target == null)
+        {
+            errors.WriteLine(targetError);
+            return ExitCodes.Usage;
+        }
+
+        var (sets, error) = await InventoryLoader.LoadAsync(args, services);
+        if (sets == null)
+        {
+            errors.WriteLine(error);
+            return ExitCodes.Usage;
+        }
+
+        var builder = new BackupChainBuilder();
+        var points = builder.ComputeRestorePoints(sets);
+        var (point, stopAt, chainError) = ScriptVerb.ChoosePoint(points, at);
+        if (point == null)
+        {
+            errors.WriteLine(chainError);
+            return ExitCodes.Failed;
+        }
+
+        var chain = builder.BuildChainFromRestorePoint(point);
+        var sourceDatabase = args.Get("database")!;
+        var scratch = RehearsalPlanner.ScratchName(sourceDatabase, DateTime.Now);
+
+        // Relocation is not optional here: the scratch copy must never collide with the real
+        // database's files, so every file moves to the target's defaults under the scratch name.
+        var devices = chain.FullSet.Files
+            .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+            .ToList();
+        var files = await services.Sql.RestoreFileListOnlyAsync(target, devices);
+        if (files.Count == 0)
+        {
+            errors.WriteLine("FILELISTONLY returned nothing - the rehearsal cannot relocate " +
+                             "files it cannot list.");
+            return ExitCodes.CouldNotAnswer;
+        }
+
+        var (dataPath, logPath) = await services.Sql.GetDefaultPathsAsync(target);
+        var moves = RehearsalPlanner.ScratchMoves(files, scratch, dataPath, logPath);
+
+        var restoreScript = new RestoreScriptGenerator().Generate(chain, new RestoreOptions
+        {
+            TargetDatabaseName = scratch,
+            WithReplace = false,
+            RecoveryMode = RecoveryMode.Recovery,
+            StopAt = stopAt,
+            FileMoves = moves
+        });
+
+        var script = RehearsalPlanner.BuildScript(restoreScript, scratch);
+
+        errors.WriteLine($"Rehearsal: {point.TypeDisplay} reaching " +
+                         $"{(stopAt ?? point.Timestamp):yyyy-MM-dd HH:mm:ss}, proving " +
+                         $"'{sourceDatabase}' as scratch '{scratch}' on {target.ServerName}.");
+
+        if (!args.Has("execute"))
+        {
+            output.WriteLine(script);
+            errors.WriteLine("Nothing was executed. Add --execute to run the rehearsal.");
+            return ExitCodes.Ok;
+        }
+
+        var startedAt = DateTime.Now;
+        var log = new System.Text.StringBuilder();
+
+        void Progress(string message)
+        {
+            log.AppendLine(message);
+            errors.WriteLine(message);
+        }
+
+        // The subject is the database being PROVEN, not the scratch copy it was proven on -
+        // "Rehearsal MyDb_rehearsal_20260810" answers a question nobody asked.
+        services.Notifier.Notify(new RunNotification(
+            RunPhase.Started, "Rehearsal", sourceDatabase, target.ServerName,
+            $"Proving the chain to {(stopAt ?? point.Timestamp):yyyy-MM-dd HH:mm:ss} on a " +
+            "scratch copy.", null));
+
+        try
+        {
+            await services.Sql.ExecuteWithProgressAsync(target, script, Progress);
+
+            var completedAt = DateTime.Now;
+            services.History.Append(new RestoreHistoryEntry
+            {
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                ServerName = target.ServerName,
+                TargetDatabase = scratch,
+                SourceDatabase = sourceDatabase,
+                ContainerName = args.Get("container"),
+                RestorePointTimestamp = stopAt ?? point.Timestamp,
+                ChainSummary = point.TypeDisplay,
+                Kind = "Rehearsal",
+                Outcome = RestoreOutcome.Succeeded,
+                Script = script,
+                Log = log.ToString()
+            });
+
+            services.Notifier.Notify(new RunNotification(
+                RunPhase.Succeeded, "Rehearsal", sourceDatabase, target.ServerName,
+                "Restored, CHECKDB clean, scratch copy dropped. The receipt is in History.",
+                completedAt - startedAt));
+
+            errors.WriteLine($"PROVEN: '{sourceDatabase}' restores. Took " +
+                             $"{(completedAt - startedAt).TotalSeconds:0}s - that is the " +
+                             "measured RTO, and the receipt is in the app's History.");
+            return ExitCodes.Ok;
+        }
+        catch (Exception ex)
+        {
+            var completedAt = DateTime.Now;
+            log.AppendLine(ex.Message);
+            services.History.Append(new RestoreHistoryEntry
+            {
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                ServerName = target.ServerName,
+                TargetDatabase = scratch,
+                SourceDatabase = sourceDatabase,
+                ContainerName = args.Get("container"),
+                RestorePointTimestamp = stopAt ?? point.Timestamp,
+                ChainSummary = point.TypeDisplay,
+                Kind = "Rehearsal",
+                Outcome = RestoreOutcome.Failed,
+                ErrorMessage = ex.Message,
+                Script = script,
+                Log = log.ToString()
+            });
+
+            services.Notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Rehearsal", sourceDatabase, target.ServerName,
+                ex.Message, completedAt - startedAt));
+
+            errors.WriteLine($"NOT PROVEN: {ex.Message}");
+            errors.WriteLine($"The scratch copy '{scratch}' is retained as evidence when the " +
+                             "failure happened after its restore began - inspect, then drop it.");
+            return ExitCodes.Failed;
+        }
+    }
+}

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -1,0 +1,217 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Cli.Verbs;
+
+/// <summary>
+/// The verb that touches an instance (#63 step 3), and therefore the verb built out of
+/// refusals. Without --execute nothing runs: the script, the plan and every preflight verdict
+/// print, and the exit code already says whether an --execute would have been allowed - so a
+/// pipeline can rehearse its own restore step for free. WITH REPLACE is consented to by its
+/// own flag, never by --force: --force overrides what the EVIDENCE says (version, TDE,
+/// readability), not what the OPERATOR must say.
+///
+/// An executed run lands in the same history the app's History screen lists, and the same
+/// webhooks hear about it - a restore at 3am from a runbook step is exactly the restore
+/// somebody wants a Teams message about.
+/// </summary>
+internal static class RestoreVerb
+{
+    public static readonly VerbSpec Spec = new(
+        "restore",
+        "Generate - and with --execute, run - a restore against a target server",
+        "9lives restore (--container NAME | --server NAME) --database DB --target SERVER " +
+        "[--at \"yyyy-MM-dd HH:mm:ss\"] [--target-database NAME] [--with-replace] [--norecovery] " +
+        "[--stop-before-mark NAME | --stop-at-mark NAME] [--execute] [--force]",
+        Valued: ["container", "server", "database", "at", "target", "target-database",
+                 "stop-before-mark", "stop-at-mark"],
+        Switches: ["execute", "with-replace", "norecovery", "force"]);
+
+    public static async Task<int> RunAsync(
+        CliArguments args, CliServices services, TextWriter output, TextWriter errors)
+    {
+        if (args.Get("database") == null || args.Get("target") == null)
+        {
+            errors.WriteLine("restore needs --database and --target (the server that runs the " +
+                             "RESTORE - a configured server name).");
+            return ExitCodes.Usage;
+        }
+
+        var markBefore = args.Get("stop-before-mark");
+        var markAt = args.Get("stop-at-mark");
+        if (markBefore != null && markAt != null)
+        {
+            errors.WriteLine("Give one of --stop-before-mark and --stop-at-mark, not both.");
+            return ExitCodes.Usage;
+        }
+
+        var mark = markBefore ?? markAt;
+        if (mark != null && args.Get("at") != null)
+        {
+            errors.WriteLine("Give a mark or a time, not both - they are the same mechanism " +
+                             "aimed differently.");
+            return ExitCodes.Usage;
+        }
+
+        DateTime? at = null;
+        if (args.Get("at") is { } atText)
+        {
+            at = CliArguments.ParseTime(atText);
+            if (at == null)
+            {
+                errors.WriteLine($"Could not read '{atText}' as a time. Formats: " +
+                                 "yyyy-MM-dd HH:mm:ss, yyyy-MM-dd HH:mm, yyyy-MM-dd.");
+                return ExitCodes.Usage;
+            }
+        }
+
+        var (target, targetError) = services.FindServer(args.Get("target")!);
+        if (target == null)
+        {
+            errors.WriteLine(targetError);
+            return ExitCodes.Usage;
+        }
+
+        var (sets, error) = await InventoryLoader.LoadAsync(args, services);
+        if (sets == null)
+        {
+            errors.WriteLine(error);
+            return ExitCodes.Usage;
+        }
+
+        var builder = new BackupChainBuilder();
+        var points = builder.ComputeRestorePoints(sets);
+        var (point, stopAt, chainError) = ScriptVerb.ChoosePoint(points, at);
+        if (point == null)
+        {
+            errors.WriteLine(chainError);
+            return ExitCodes.Failed;
+        }
+
+        var chain = builder.BuildChainFromRestorePoint(point);
+        var sourceDatabase = args.Get("database")!;
+        var targetDatabase = args.Get("target-database") ?? sourceDatabase;
+        var withReplace = args.Has("with-replace");
+
+        var script = new RestoreScriptGenerator().Generate(chain, new RestoreOptions
+        {
+            TargetDatabaseName = targetDatabase,
+            WithReplace = withReplace,
+            RecoveryMode = args.Has("norecovery") ? RecoveryMode.NoRecovery : RecoveryMode.Recovery,
+            StopAt = stopAt,
+            StopAtMark = mark,
+            StopBeforeMark = markAt == null
+        });
+
+        // The preflights run whether or not this is an --execute: a generate-only invocation
+        // that says "this WOULD be refused" is the pipeline's cheap rehearsal of its own DR step.
+        var preflight = await Preflights.RunAsync(
+            services, target, chain, targetDatabase, withReplace, args.Has("force"));
+
+        errors.WriteLine($"Chain: {point.TypeDisplay} reaching " +
+                         $"{(stopAt ?? point.Timestamp):yyyy-MM-dd HH:mm:ss}, restoring " +
+                         $"'{sourceDatabase}' as '{targetDatabase}' on {target.ServerName}.");
+        foreach (var warning in preflight.Warnings)
+            errors.WriteLine($"WARNING: {warning}");
+        foreach (var refusal in preflight.Refusals)
+            errors.WriteLine($"REFUSED: {refusal}");
+
+        if (!args.Has("execute"))
+        {
+            output.WriteLine(script);
+            errors.WriteLine(preflight.Refusals.Count > 0
+                ? "Nothing was executed - and --execute would be refused for the reasons above."
+                : "Nothing was executed. Add --execute to run this.");
+            return preflight.Refusals.Count > 0 ? ExitCodes.Failed : ExitCodes.Ok;
+        }
+
+        if (preflight.Refusals.Count > 0)
+        {
+            errors.WriteLine("Not run. Every refusal above must be resolved - or, for the " +
+                             "evidence-based ones, deliberately overridden with --force.");
+            return ExitCodes.Failed;
+        }
+
+        return await ExecuteAsync(
+            services, target, script, sourceDatabase, targetDatabase, point, stopAt,
+            chain, args.Get("container"), errors);
+    }
+
+    private static async Task<int> ExecuteAsync(
+        CliServices services, ServerConnection target, string script, string sourceDatabase,
+        string targetDatabase, RestorePoint point, DateTime? stopAt, BackupChain chain,
+        string? containerName, TextWriter errors)
+    {
+        var startedAt = DateTime.Now;
+        var log = new System.Text.StringBuilder();
+
+        void Progress(string message)
+        {
+            log.AppendLine(message);
+            errors.WriteLine(message);
+        }
+
+        services.Notifier.Notify(new RunNotification(
+            RunPhase.Started, "Restore", sourceDatabase, target.ServerName,
+            $"Restoring as '{targetDatabase}' to " +
+            $"{(stopAt ?? point.Timestamp):yyyy-MM-dd HH:mm:ss}.", null));
+
+        try
+        {
+            await services.Sql.ExecuteWithProgressAsync(target, script, Progress);
+
+            var completedAt = DateTime.Now;
+            services.History.Append(new RestoreHistoryEntry
+            {
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                ServerName = target.ServerName,
+                TargetDatabase = targetDatabase,
+                SourceDatabase = sourceDatabase,
+                ContainerName = containerName,
+                RestorePointTimestamp = stopAt ?? point.Timestamp,
+                ChainSummary = point.TypeDisplay,
+                Outcome = RestoreOutcome.Succeeded,
+                Script = script,
+                Log = log.ToString()
+            });
+
+            services.Notifier.Notify(new RunNotification(
+                RunPhase.Succeeded, "Restore", sourceDatabase, target.ServerName,
+                $"'{targetDatabase}' is restored and online.", completedAt - startedAt));
+
+            errors.WriteLine($"Done: '{targetDatabase}' restored on {target.ServerName} in " +
+                             $"{(completedAt - startedAt).TotalSeconds:0}s.");
+            return ExitCodes.Ok;
+        }
+        catch (Exception ex)
+        {
+            var completedAt = DateTime.Now;
+            log.AppendLine(ex.Message);
+            services.History.Append(new RestoreHistoryEntry
+            {
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                ServerName = target.ServerName,
+                TargetDatabase = targetDatabase,
+                SourceDatabase = sourceDatabase,
+                ContainerName = containerName,
+                RestorePointTimestamp = stopAt ?? point.Timestamp,
+                ChainSummary = point.TypeDisplay,
+                Outcome = RestoreOutcome.Failed,
+                ErrorMessage = ex.Message,
+                Script = script,
+                Log = log.ToString()
+            });
+
+            services.Notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Restore", sourceDatabase, target.ServerName,
+                ex.Message, completedAt - startedAt));
+
+            errors.WriteLine($"FAILED: {ex.Message}");
+            errors.WriteLine("The history entry records how far it got - check the target " +
+                             "database's state before retrying.");
+            return ExitCodes.Failed;
+        }
+    }
+}

--- a/src/NineLives.Tests/CliExecuteVerbTests.cs
+++ b/src/NineLives.Tests/CliExecuteVerbTests.cs
@@ -1,0 +1,318 @@
+using System.IO;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The CLI's execution verbs (#63 step 3), which exist to be hard to misuse: nothing runs
+/// without --execute, WITH REPLACE is its own consent and --force cannot substitute for it,
+/// the evidence-based preflights refuse before anything is dropped, and every executed run
+/// leaves the same receipts the GUI leaves - history entries and webhook notifications - so
+/// one estate has one story regardless of which front end acted.
+/// </summary>
+public class CliExecuteVerbTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static (CliServices services, FakeSqlServerService sql,
+        FakeRestoreHistoryStore history, FakeRunNotifier notifier) Stage(
+        params BackupHistoryEntry[] entries)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        var sql = new FakeSqlServerService { BackupHistory = entries.ToList() };
+        var history = new FakeRestoreHistoryStore();
+        var notifier = new FakeRunNotifier();
+        var services = new CliServices(
+            store, sql, new FakeBlobStorageService(), history, notifier);
+        return (services, sql, history, notifier);
+    }
+
+    private static BackupHistoryEntry Full(decimal checkpoint, DateTime at) => new()
+    {
+        DatabaseName = "MyDb",
+        Type = BackupType.Full,
+        StartedAt = at,
+        FinishedAt = at.AddMinutes(5),
+        CheckpointLsn = checkpoint,
+        Position = 1,
+        Files = [@"X:\backups\full.bak"]
+    };
+
+    private static async Task<(int exit, string output, string errors)> Run(
+        Func<CliArguments, CliServices, TextWriter, TextWriter, Task<int>> verb,
+        VerbSpec spec, string[] args, CliServices services)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await verb(CliArguments.Parse(args, spec), services, output, errors);
+        return (exit, output.ToString(), errors.ToString());
+    }
+
+    private static string[] RestoreArgs(params string[] extra) =>
+        [.. new[] { "--server", "SRV01", "--database", "MyDb", "--target", "SRV02" }, .. extra];
+
+    // ── nothing without --execute ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task WithoutExecuteTheScriptPrintsAndNothingRuns()
+    {
+        var (services, sql, history, notifier) = Stage(Full(100, T0));
+
+        var (exit, output, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs(), services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("RESTORE DATABASE", output);
+        Assert.Contains("Nothing was executed", errors);
+        Assert.Empty(sql.ExecutedScripts);
+        Assert.Empty(history.Entries);
+        Assert.Empty(notifier.Sent);
+    }
+
+    /// <summary>
+    /// The generate-only invocation still runs the preflights and carries their verdict in the
+    /// exit code - a pipeline rehearses its own DR step without touching anything.
+    /// </summary>
+    [Fact]
+    public async Task WithoutExecuteARefusalStillShowsInTheExitCode()
+    {
+        var (services, sql, _, _) = Stage(Full(100, T0));
+        sql.DatabaseList = ["MyDb"];
+
+        var (exit, output, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs(), services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("REFUSED", errors);
+        Assert.Contains("--execute would be refused", errors);
+        Assert.Contains("RESTORE DATABASE", output);
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    // ── WITH REPLACE is its own consent ─────────────────────────────────────────
+
+    [Fact]
+    public async Task OverwritingAnExistingDatabaseNeedsWithReplace()
+    {
+        var (services, sql, history, _) = Stage(Full(100, T0));
+        sql.DatabaseList = ["MyDb"];
+
+        var (exit, _, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs("--execute"), services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("--with-replace", errors);
+        Assert.Empty(sql.ExecutedScripts);
+        Assert.Empty(history.Entries);
+    }
+
+    /// <summary>--force overrides evidence, never consent: an existing database stays refused.</summary>
+    [Fact]
+    public async Task ForceDoesNotSubstituteForWithReplace()
+    {
+        var (services, sql, _, _) = Stage(Full(100, T0));
+        sql.DatabaseList = ["MyDb"];
+
+        var (exit, _, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec,
+            RestoreArgs("--execute", "--force"), services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("--with-replace", errors);
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    [Fact]
+    public async Task WithReplaceSaidExplicitlyTheRestoreRuns()
+    {
+        var (services, sql, history, _) = Stage(Full(100, T0));
+        sql.DatabaseList = ["MyDb"];
+
+        var (exit, _, _) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec,
+            RestoreArgs("--execute", "--with-replace"), services);
+
+        Assert.Equal(0, exit);
+        var script = Assert.Single(sql.ExecutedScripts);
+        Assert.Contains("REPLACE", script);
+        Assert.Single(history.Entries);
+    }
+
+    // ── the evidence-based preflights ───────────────────────────────────────────
+
+    [Fact]
+    public async Task ANewerBackupAimedAtAnOlderServerIsRefusedByName()
+    {
+        var (services, sql, _, _) = Stage(Full(100, T0));
+        sql.Header = new BackupFileInfo { SoftwareVersionMajor = 17 };
+        sql.MajorVersionByServer["SRV02"] = 16;
+
+        var (exit, _, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs("--execute"), services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("3169", errors);
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    [Fact]
+    public async Task AMissingTdeCertificateIsRefusedWithItsThumbprint()
+    {
+        var (services, sql, _, _) = Stage(Full(100, T0));
+        sql.Header = new BackupFileInfo { TdeThumbprint = [0xAA, 0xBB] };
+
+        var (exit, _, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs("--execute"), services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("0xAABB", errors);
+        Assert.Contains("33111", errors);
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    /// <summary>--force is the deliberate override for what the evidence says - loudly.</summary>
+    [Fact]
+    public async Task ForceDowngradesAnEvidenceRefusalToAWarningAndRuns()
+    {
+        var (services, sql, _, _) = Stage(Full(100, T0));
+        sql.Header = new BackupFileInfo { SoftwareVersionMajor = 17 };
+        sql.MajorVersionByServer["SRV02"] = 16;
+
+        var (exit, _, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec,
+            RestoreArgs("--execute", "--force"), services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("WARNING", errors);
+        Assert.Contains("--force", errors);
+        Assert.Single(sql.ExecutedScripts);
+    }
+
+    // ── receipts ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AnExecutedRestoreLeavesTheSameReceiptsTheAppLeaves()
+    {
+        var (services, sql, history, notifier) = Stage(Full(100, T0));
+
+        var (exit, _, _) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs("--execute"), services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("RESTORE DATABASE", Assert.Single(sql.ExecutedScripts));
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal("Restore", entry.Kind);
+        Assert.Equal("MyDb", entry.TargetDatabase);
+        Assert.Equal("SRV02", entry.ServerName);
+        Assert.Equal(RestoreOutcome.Succeeded, entry.Outcome);
+        Assert.Contains("RESTORE DATABASE", entry.Script);
+
+        Assert.Equal(2, notifier.Sent.Count);
+        Assert.Equal(RunPhase.Started, notifier.Sent[0].Phase);
+        Assert.Equal(RunPhase.Succeeded, notifier.Sent[1].Phase);
+        Assert.Equal("MyDb", notifier.Sent[1].Subject);
+    }
+
+    [Fact]
+    public async Task AFailedRestoreRecordsTheFailureAndNotifiesTheProblem()
+    {
+        var (services, sql, history, notifier) = Stage(Full(100, T0));
+        sql.FailOnExecuteNumber = 1;
+
+        var (exit, _, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs("--execute"), services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("FAILED", errors);
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(RestoreOutcome.Failed, entry.Outcome);
+        Assert.NotNull(entry.ErrorMessage);
+
+        Assert.Equal(RunPhase.Problem, notifier.Sent.Last().Phase);
+    }
+
+    // ── rehearse ────────────────────────────────────────────────────────────────
+
+    private static string[] RehearseArgs(params string[] extra) =>
+        [.. new[] { "--server", "SRV01", "--database", "MyDb", "--target", "SRV02" }, .. extra];
+
+    private static void GiveFileList(FakeSqlServerService sql) =>
+        sql.FileList =
+        [
+            new FileMoveOption
+            {
+                LogicalName = "MyDb",
+                PhysicalName = @"C:\SQL\MyDb.mdf",
+                NewPhysicalName = @"C:\SQL\MyDb.mdf",
+                SizeBytes = 1024
+            }
+        ];
+
+    [Fact]
+    public async Task ARehearsalProvesRestoresChecksAndDrops()
+    {
+        var (services, sql, history, notifier) = Stage(Full(100, T0));
+        GiveFileList(sql);
+
+        var (exit, _, errors) = await Run(
+            RehearseVerb.RunAsync, RehearseVerb.Spec, RehearseArgs("--execute"), services);
+
+        Assert.Equal(0, exit);
+        var script = Assert.Single(sql.ExecutedScripts);
+        Assert.Contains("RESTORE DATABASE", script);
+        Assert.Contains("DBCC CHECKDB", script);
+        Assert.Contains("DROP DATABASE", script);
+        Assert.DoesNotContain("REPLACE", script);
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal("Rehearsal", entry.Kind);
+        Assert.Equal("MyDb", entry.SourceDatabase);
+        Assert.StartsWith("MyDb_rehearsal_", entry.TargetDatabase);
+
+        // The notification names the database being PROVEN, not the scratch copy.
+        Assert.Equal("MyDb", notifier.Sent.Last().Subject);
+        Assert.Contains("PROVEN", errors);
+    }
+
+    [Fact]
+    public async Task WithoutExecuteTheRehearsalOnlyPrints()
+    {
+        var (services, sql, history, _) = Stage(Full(100, T0));
+        GiveFileList(sql);
+
+        var (exit, output, _) = await Run(
+            RehearseVerb.RunAsync, RehearseVerb.Spec, RehearseArgs(), services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("DBCC CHECKDB", output);
+        Assert.Empty(sql.ExecutedScripts);
+        Assert.Empty(history.Entries);
+    }
+
+    [Fact]
+    public async Task AFailedRehearsalSaysTheScratchCopyIsRetained()
+    {
+        var (services, sql, history, _) = Stage(Full(100, T0));
+        GiveFileList(sql);
+        sql.FailOnExecuteNumber = 1;
+
+        var (exit, _, errors) = await Run(
+            RehearseVerb.RunAsync, RehearseVerb.Spec, RehearseArgs("--execute"), services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("NOT PROVEN", errors);
+        Assert.Contains("retained", errors);
+        Assert.Equal("Rehearsal", Assert.Single(history.Entries).Kind);
+    }
+}

--- a/src/NineLives.Tests/CliReadVerbTests.cs
+++ b/src/NineLives.Tests/CliReadVerbTests.cs
@@ -27,7 +27,8 @@ public class CliReadVerbTests
         { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
 
         var sql = new FakeSqlServerService { BackupHistory = history.ToList() };
-        return (new CliServices(store, sql, new FakeBlobStorageService()), sql);
+        return (new CliServices(store, sql, new FakeBlobStorageService(),
+            new FakeRestoreHistoryStore(), new FakeRunNotifier()), sql);
     }
 
     private static BackupHistoryEntry Full(decimal checkpoint, DateTime at) => new()


### PR DESCRIPTION
Step 3 of #63, completing the CLI: \`restore\` and \`rehearse\` now run against a target server - behind exactly the safety defaults the issue sketched.

**Built out of refusals:**

- **Nothing runs without \`--execute\`.** The bare invocation prints the script, the plan and every preflight verdict, and its exit code already says whether an \`--execute\` would have been allowed - a pipeline rehearses its own DR step without touching anything.
- **WITH REPLACE is consent, not evidence.** Overwriting an existing database is said with \`--with-replace\`, deliberately; \`--force\` cannot substitute for it. \`--force\` overrides what the EVIDENCE says - version direction, TDE certificate, file readability - never what the operator must say.
- **The preflights are the app's own** (#210, #222, #149), composed from the same Core services: the target's read access to every disk file, the one-directional version law (refused by name with error 3169 before the target database is gone), and the TDE/backup-encryption certificate by thumbprint (error 33111 named before the worst morning finds it). Best effort by the app's rule: no verdict from silence.

**\`rehearse\` is the founding example shipped** - "nightly DR verification" from this issue's first paragraph: chain to scratch restore, DBCC CHECKDB, drop, safety by construction (generated name, never WITH REPLACE, every file relocated, cleanup last so failure retains the evidence). The receipt lands in the same History the app reads, so the exposure dashboard's **Proven** column and **measured RTO** fill in from a scheduled task - no SQL Agent required. Notifications name the database being proven, not the scratch copy.

**One estate, two front ends:** executed runs append to the app's History store and notify the same webhooks. A 3am restore from a runbook step shows up in the History screen and the Teams channel exactly as if it had been clicked.

**Tests**: 13 new (1,592 total) - the refusal ladder rung by rung, the force/consent distinction both ways, receipts (history entries, notification phases and subjects), and both failure paths including the retained-scratch-copy message.