### PR TITLE
The CLI documents itself: full reference inside --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ more detail on the user-facing changes; this file is the short history.
   Executed runs land in the same History the app lists and notify the same webhooks -
   `9lives rehearse --execute` on a schedule is nightly proof with receipts, no SQL Agent
   required
+- **The CLI documents itself**: `9lives help` for the overview, `9lives help restore` (or
+  any verb, or `--help` after one) for the full page - every option explained, the behaviour,
+  the per-verb exit codes, worked examples. The reference lives inside the exe, where it
+  cannot drift from the parser it describes, and a test holds each page to the verb's own
+  option list - an undocumented flag or a documented-but-refused one both fail the build
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Five read-only verbs. `list` says what a source holds; `points` is the timeline 
 
 Exit codes are the contract: `0` fine, `1` warnings, `2` broken or unreachable-by-chain, `3` could not answer, `64` usage. `--json` on the read verbs makes the output composable with jq and friends.
 
+The full reference ships inside the exe: `9lives help` for the overview, `9lives help restore` (or any verb) for the complete page - every option, the behaviour, the exit codes, examples. Documentation that lives in the binary cannot drift from it, and a test holds every page to the parser's own option lists.
+
 Two verbs execute, and they are built out of refusals: `restore` and `rehearse` run nothing without `--execute`; overwriting an existing database is said with `--with-replace`, its own flag that `--force` cannot substitute for; and the same preflights the app fires - file readability, version direction (error 3169), the TDE certificate (error 33111) - refuse before anything is dropped, `--force` being the deliberate override for evidence only. Executed runs land in the app's History and notify the same webhooks, so `9lives rehearse --execute` on a schedule is nightly proof with receipts - no SQL Agent required.
 
 ## Features

--- a/src/NineLives.Cli/CliArguments.cs
+++ b/src/NineLives.Cli/CliArguments.cs
@@ -1,21 +1,31 @@
 namespace Blackcat.NineLives.Cli;
 
 /// <summary>
-/// What a verb accepts: which options take a value, which are bare switches. The parser
-/// validates against this rather than guessing, so "--json 2026-08-01" is an error about an
-/// unexpected value instead of a silently swallowed timestamp.
+/// What a verb accepts - and what it MEANS. The parser validates against the option lists, so
+/// "--json 2026-08-01" is an error about an unexpected value instead of a silently swallowed
+/// timestamp; the documentation fields are what "9lives help verb" renders. Both live on the
+/// same record, beside the verb they describe, so the reference the exe carries cannot drift
+/// from the parser the exe runs - and a test holds the two to each other.
 /// </summary>
 /// <param name="Name">The verb itself, e.g. "points".</param>
-/// <param name="Summary">One line for the help screen.</param>
+/// <param name="Summary">One line for the overview screen.</param>
 /// <param name="Usage">The synopsis line shown on usage errors and in help.</param>
 /// <param name="Valued">Options that take a value: "container", "at", ...</param>
 /// <param name="Switches">Options that stand alone: "json", ...</param>
+/// <param name="Options">Each option's term and explanation, e.g. ("--at TIME", "...").</param>
+/// <param name="Notes">Behaviour paragraphs for the verb's help page, wrapped at render.</param>
+/// <param name="ExitCodes">This verb's exit codes, each "N  meaning".</param>
+/// <param name="Examples">Command and one-line meaning pairs.</param>
 internal sealed record VerbSpec(
     string Name,
     string Summary,
     string Usage,
     string[] Valued,
-    string[] Switches);
+    string[] Switches,
+    (string Term, string Help)[] Options,
+    string[] Notes,
+    string[] ExitCodes,
+    (string Command, string Meaning)[] Examples);
 
 /// <summary>
 /// One parsed command line, validated against a <see cref="VerbSpec"/>. Pure and small on

--- a/src/NineLives.Cli/HelpWriter.cs
+++ b/src/NineLives.Cli/HelpWriter.cs
@@ -1,0 +1,131 @@
+namespace Blackcat.NineLives.Cli;
+
+/// <summary>
+/// Renders the documentation the specs carry (#63): the overview for bare --help, and the full
+/// per-verb page for "9lives help verb" or "9lives verb --help". The reference lives INSIDE
+/// the exe on purpose - a markdown file beside it would drift, and a test holds these pages to
+/// the parser's own option lists so the help cannot describe flags that do not exist or omit
+/// ones that do.
+/// </summary>
+internal static class HelpWriter
+{
+    private const int Width = 78;
+
+    public static void WriteOverview(IReadOnlyList<VerbSpec> verbs, TextWriter output)
+    {
+        output.WriteLine("Nine Lives CLI - the restore engine from a terminal.");
+        output.WriteLine();
+        Wrapped(output,
+            "Reads the configuration the Nine Lives app maintains - its containers, its " +
+            "servers, its Credential Manager entries - from %LOCALAPPDATA%\\NineLives. " +
+            "Configure once in the app; script against it here, as the user who configured it.");
+        output.WriteLine();
+        output.WriteLine("Verbs (9lives help VERB for the full story on each):");
+        foreach (var verb in verbs)
+            output.WriteLine($"  {verb.Name,-10} {verb.Summary}");
+        output.WriteLine();
+        output.WriteLine("Usage:");
+        foreach (var verb in verbs)
+            output.WriteLine($"  {verb.Usage}");
+        output.WriteLine();
+        output.WriteLine("Exit codes: 0 fine; 1 warnings; 2 the thing checked is broken or");
+        output.WriteLine("refused; 3 the question could not be answered; 64 usage.");
+        output.WriteLine();
+        Wrapped(output,
+            "Two disciplines every verb keeps: data goes to stdout and everything human goes " +
+            "to stderr, so output pipes and redirects cleanly; and timestamps parse exact " +
+            "invariant formats only (yyyy-MM-dd HH:mm:ss, yyyy-MM-dd HH:mm, yyyy-MM-dd) - a " +
+            "string that means different moments on two machines is refused.");
+        output.WriteLine();
+        output.WriteLine("Examples:");
+        output.WriteLine("  9lives exposure                          the estate, judged, in one exit code");
+        output.WriteLine("  9lives list --container backups");
+        output.WriteLine("  9lives points --container backups --database Sales");
+        output.WriteLine("  9lives script --container backups --database Sales --at \"2026-08-02 19:00\" --out restore.sql");
+        output.WriteLine("  9lives rehearse --container backups --database Sales --target SRV02 --execute");
+        output.WriteLine("  9lives restore --container backups --database Sales --target SRV02 --with-replace --execute");
+    }
+
+    public static void WriteVerb(VerbSpec verb, TextWriter output)
+    {
+        output.WriteLine($"9lives {verb.Name} - {verb.Summary}");
+        output.WriteLine();
+        output.WriteLine("Usage:");
+        output.WriteLine($"  {verb.Usage}");
+
+        if (verb.Options.Length > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("Options:");
+            var width = verb.Options.Max(o => o.Term.Length);
+            foreach (var (term, help) in verb.Options)
+                WrappedIndented(output, $"  {term.PadRight(width + 2)}", help);
+        }
+
+        if (verb.Notes.Length > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("Behaviour:");
+            foreach (var note in verb.Notes)
+            {
+                Wrapped(output, note, indent: "  ");
+                output.WriteLine();
+            }
+        }
+
+        if (verb.ExitCodes.Length > 0)
+        {
+            output.WriteLine("Exit codes:");
+            foreach (var code in verb.ExitCodes)
+                output.WriteLine($"  {code}");
+        }
+
+        if (verb.Examples.Length > 0)
+        {
+            output.WriteLine();
+            output.WriteLine("Examples:");
+            foreach (var (command, meaning) in verb.Examples)
+            {
+                output.WriteLine($"  {command}");
+                output.WriteLine($"      {meaning}");
+            }
+        }
+    }
+
+    /// <summary>Plain greedy word-wrap. Terminals reflow nothing; this text has to arrive wrapped.</summary>
+    private static void Wrapped(TextWriter output, string text, string indent = "")
+    {
+        var line = indent;
+        foreach (var word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (line.Length > indent.Length && line.Length + word.Length + 1 > Width)
+            {
+                output.WriteLine(line);
+                line = indent;
+            }
+
+            line += line.Length > indent.Length ? " " + word : word;
+        }
+
+        if (line.Length > indent.Length) output.WriteLine(line);
+    }
+
+    /// <summary>First line carries the option term; continuations align under the help text.</summary>
+    private static void WrappedIndented(TextWriter output, string head, string help)
+    {
+        var indent = new string(' ', head.Length);
+        var line = head;
+        foreach (var word in help.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (line.Length > head.Length && line.Length + word.Length + 1 > Width)
+            {
+                output.WriteLine(line);
+                line = indent;
+            }
+
+            line += line == head || line == indent ? word : " " + word;
+        }
+
+        if (line != indent) output.WriteLine(line);
+    }
+}

--- a/src/NineLives.Cli/Program.cs
+++ b/src/NineLives.Cli/Program.cs
@@ -11,21 +11,37 @@ namespace Blackcat.NineLives.Cli;
 /// </summary>
 internal static class Program
 {
-    private static readonly VerbSpec[] Verbs =
-    [
-        ListVerb.Spec, PointsVerb.Spec, ScriptVerb.Spec, ValidateVerb.Spec, ExposureVerb.Spec,
-        RestoreVerb.Spec, RehearseVerb.Spec
-    ];
-
     private static async Task<int> Main(string[] rawArgs)
     {
         Console.OutputEncoding = Encoding.UTF8;
 
         if (rawArgs.Length == 0
-            || rawArgs[0] is "--help" or "-h" or "help" or "-?" or "/?")
+            || rawArgs[0] is "--help" or "-h" or "-?" or "/?")
         {
-            WriteHelp(Console.Out);
+            HelpWriter.WriteOverview(VerbCatalogue.All, Console.Out);
             return rawArgs.Length == 0 ? ExitCodes.Usage : ExitCodes.Ok;
+        }
+
+        // "9lives help" and "9lives help restore" - the reference lives in the exe, so the
+        // exe is where it is read.
+        if (string.Equals(rawArgs[0], "help", StringComparison.OrdinalIgnoreCase))
+        {
+            if (rawArgs.Length == 1)
+            {
+                HelpWriter.WriteOverview(VerbCatalogue.All, Console.Out);
+                return ExitCodes.Ok;
+            }
+
+            var asked = VerbCatalogue.Find(rawArgs[1]);
+            if (asked == null)
+            {
+                Console.Error.WriteLine($"No verb called '{rawArgs[1]}'.");
+                HelpWriter.WriteOverview(VerbCatalogue.All, Console.Error);
+                return ExitCodes.Usage;
+            }
+
+            HelpWriter.WriteVerb(asked, Console.Out);
+            return ExitCodes.Ok;
         }
 
         if (rawArgs[0] is "--version")
@@ -34,13 +50,20 @@ internal static class Program
             return ExitCodes.Ok;
         }
 
-        var spec = Verbs.FirstOrDefault(
-            v => string.Equals(v.Name, rawArgs[0], StringComparison.OrdinalIgnoreCase));
+        var spec = VerbCatalogue.Find(rawArgs[0]);
         if (spec == null)
         {
             Console.Error.WriteLine($"Unknown verb '{rawArgs[0]}'.");
-            WriteHelp(Console.Error);
+            HelpWriter.WriteOverview(VerbCatalogue.All, Console.Error);
             return ExitCodes.Usage;
+        }
+
+        // "--help" anywhere after the verb wins over parsing: someone asking how to hold the
+        // tool must never be told off for holding it wrongly mid-question.
+        if (rawArgs.Skip(1).Any(a => a is "--help" or "-h" or "-?"))
+        {
+            HelpWriter.WriteVerb(spec, Console.Out);
+            return ExitCodes.Ok;
         }
 
         var args = CliArguments.Parse(rawArgs.Skip(1).ToArray(), spec);
@@ -81,33 +104,5 @@ internal static class Program
             Console.Error.WriteLine($"Could not answer: {ex.Message}");
             return ExitCodes.CouldNotAnswer;
         }
-    }
-
-    private static void WriteHelp(TextWriter output)
-    {
-        output.WriteLine("Nine Lives CLI - the restore engine from a terminal.");
-        output.WriteLine("Reads the configuration the Nine Lives app maintains: its containers,");
-        output.WriteLine("its servers, its credentials. Nothing executes without --execute, and");
-        output.WriteLine("overwriting a database is said with --with-replace, deliberately.");
-        output.WriteLine();
-        output.WriteLine("Verbs:");
-        foreach (var verb in Verbs)
-            output.WriteLine($"  {verb.Name,-10} {verb.Summary}");
-        output.WriteLine();
-        output.WriteLine("Usage:");
-        foreach (var verb in Verbs)
-            output.WriteLine($"  {verb.Usage}");
-        output.WriteLine();
-        output.WriteLine("Exit codes: 0 fine; 1 warnings; 2 the thing checked is broken or");
-        output.WriteLine("unreachable-by-chain; 3 the question could not be answered; 64 usage.");
-        output.WriteLine();
-        output.WriteLine("Examples:");
-        output.WriteLine("  9lives exposure                          the estate, judged, in one exit code");
-        output.WriteLine("  9lives list --container backups");
-        output.WriteLine("  9lives points --container backups --database Sales");
-        output.WriteLine("  9lives script --container backups --database Sales --at \"2026-08-02 19:00\" --out restore.sql");
-        output.WriteLine("  9lives validate --server SRV01 --json");
-        output.WriteLine("  9lives rehearse --container backups --database Sales --target SRV02 --execute");
-        output.WriteLine("  9lives restore --container backups --database Sales --target SRV02 --with-replace --execute");
     }
 }

--- a/src/NineLives.Cli/VerbCatalogue.cs
+++ b/src/NineLives.Cli/VerbCatalogue.cs
@@ -1,0 +1,20 @@
+using Blackcat.NineLives.Cli.Verbs;
+
+namespace Blackcat.NineLives.Cli;
+
+/// <summary>
+/// Every verb the exe knows, in the order help lists them. Its own class rather than a private
+/// table in Program so the tests can hold the WHOLE catalogue to its promises - every declared
+/// option documented, every verb carrying notes, exit codes and examples.
+/// </summary>
+internal static class VerbCatalogue
+{
+    public static readonly VerbSpec[] All =
+    [
+        ListVerb.Spec, PointsVerb.Spec, ScriptVerb.Spec, ValidateVerb.Spec, ExposureVerb.Spec,
+        RestoreVerb.Spec, RehearseVerb.Spec
+    ];
+
+    public static VerbSpec? Find(string name) => All.FirstOrDefault(
+        v => string.Equals(v.Name, name, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/NineLives.Cli/Verbs/ExposureVerb.cs
+++ b/src/NineLives.Cli/Verbs/ExposureVerb.cs
@@ -18,7 +18,46 @@ internal static class ExposureVerb
         "Sweep every server: if it died now, what is lost? Exit code = worst level",
         "9lives exposure [--server NAME] [--json]",
         Valued: ["server"],
-        Switches: ["json"]);
+        Switches: ["json"],
+        Options:
+        [
+            ("--server NAME", "Sweep one configured server. Omitted, every configured server " +
+                "is swept in parallel - the estate, not a sample."),
+            ("--json", "Rows as JSON on stdout: server, database, level, recoveryModel, " +
+                "lastFull, lastDifferential, lastLog, recoverableTo, verdict.")
+        ],
+        Notes:
+        [
+            "Every user database judged by the same advisor as the app's dashboard, worst " +
+            "first: never backed up is an alarm; FULL recovery with no log backups is the " +
+            "double alarm (the model promises point-in-time and the estate cannot deliver " +
+            "it); log silence beyond 1 hour warns and beyond 24 hours alarms; SIMPLE " +
+            "recovery warns past 26 hours since a full or diff and alarms past 7 days. " +
+            "Warnings and alarms come from EVIDENCE of staleness, never from mere absence " +
+            "of information.",
+            "A server that will not answer becomes an ALARM ROW, not a dead verb: its " +
+            "databases' exposure is unknown, which is not the same as fine - and on the " +
+            "worst morning the servers that do answer still get judged.",
+            "The worst level found IS the exit code, which makes this the scheduled-task " +
+            "verb: wire it to a scheduler and a failing exit turns quiet log-backup silence " +
+            "into a red pipeline while attention is elsewhere. The app's webhooks cover the " +
+            "push side; this is the pull side any monitoring system can poll."
+        ],
+        ExitCodes:
+        [
+            "0   every database fine",
+            "1   warnings - amber, worth a look today",
+            "2   alarms - including any unreachable server",
+            "3   the sweep itself could not run",
+            "64  usage"
+        ],
+        Examples:
+        [
+            ("9lives exposure",
+                "the whole estate, one exit code"),
+            ("9lives exposure --server SRV01 --json",
+                "one server's rows for a dashboard or jq")
+        ]);
 
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)

--- a/src/NineLives.Cli/Verbs/ListVerb.cs
+++ b/src/NineLives.Cli/Verbs/ListVerb.cs
@@ -15,7 +15,44 @@ internal static class ListVerb
         "The databases a source holds backups for, with counts and freshness",
         "9lives list (--container NAME | --server NAME) [--json]",
         Valued: ["container", "server"],
-        Switches: ["json"]);
+        Switches: ["json"],
+        Options:
+        [
+            ("--container NAME",
+                "A blob container configured in the app, by its configured name. The whole " +
+                "container is listed and grouped into backup sets, exactly as the app's " +
+                "browser groups it - striped sets count once, not per file."),
+            ("--server NAME",
+                "A server configured in the app. What ITS msdb recorded backing up - which " +
+                "covers everything that instance wrote, wherever it wrote it."),
+            ("--json",
+                "The same rows as JSON on stdout: database, fulls, diffs, logs, latest. " +
+                "camelCase names, ISO 8601 dates.")
+        ],
+        Notes:
+        [
+            "One line per database: how many fulls, differentials and logs the source holds, " +
+            "and when the newest of any kind was taken. This is the discovery step - the " +
+            "answer to \"what can I even ask about?\" - and the value every other verb's " +
+            "--database option is chosen from.",
+            "Give exactly one source. A container and a server are different catalogues " +
+            "answering the same question, and which one is meant matters: the container " +
+            "knows what is IN it, the server knows what it WROTE."
+        ],
+        ExitCodes:
+        [
+            "0   listed",
+            "2   the source holds no recognisable backups",
+            "3   the source could not be read at all",
+            "64  usage"
+        ],
+        Examples:
+        [
+            ("9lives list --container backups",
+                "every database the container holds, with freshness"),
+            ("9lives list --server SRV01 --json",
+                "what SRV01's msdb recorded, for jq and friends")
+        ]);
 
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)

--- a/src/NineLives.Cli/Verbs/PointsVerb.cs
+++ b/src/NineLives.Cli/Verbs/PointsVerb.cs
@@ -16,7 +16,43 @@ internal static class PointsVerb
         "The restore points a database's chains can reach",
         "9lives points (--container NAME | --server NAME) --database DB [--json]",
         Valued: ["container", "server", "database"],
-        Switches: ["json"]);
+        Switches: ["json"],
+        Options:
+        [
+            ("--container NAME", "A blob container configured in the app."),
+            ("--server NAME", "A configured server, read from its msdb history."),
+            ("--database DB", "Which database's chains to compute. Required - points are " +
+                "per-database by nature. The list verb says what names exist."),
+            ("--json", "Points as JSON on stdout: timestamp, type, chain, files, approximate.")
+        ],
+        Notes:
+        [
+            "Every discrete moment a VALID chain reaches, computed by the same chain builder " +
+            "the app's timeline is drawn from: each full, each differential with its base " +
+            "full in hand, each log connected LSN-to-LSN back to an anchor. If a moment is " +
+            "not in this list, no chain in the source reaches it - which is exactly what a " +
+            "DR pipeline wants to assert BEFORE it needs the moment, not during.",
+            "A trailing ~ marks a timestamp inferred from the blob's name or write time " +
+            "rather than read from a backup header - close, but not the header's word. The " +
+            "app's audit reads the headers when it matters.",
+            "STOPAT moments BETWEEN log points are reachable too - the script and restore " +
+            "verbs handle that windowing; this verb lists the discrete points the windows " +
+            "hang off."
+        ],
+        ExitCodes:
+        [
+            "0   points listed",
+            "2   nothing in the source forms a valid chain for this database",
+            "3   the source could not be read at all",
+            "64  usage"
+        ],
+        Examples:
+        [
+            ("9lives points --container backups --database Sales",
+                "the timeline as a table"),
+            ("9lives points --server SRV01 --database Sales --json",
+                "the timeline for tooling")
+        ]);
 
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)

--- a/src/NineLives.Cli/Verbs/RehearseVerb.cs
+++ b/src/NineLives.Cli/Verbs/RehearseVerb.cs
@@ -22,7 +22,55 @@ internal static class RehearseVerb
         "9lives rehearse (--container NAME | --server NAME) --database DB --target SERVER " +
         "[--at \"yyyy-MM-dd HH:mm:ss\"] [--execute]",
         Valued: ["container", "server", "database", "at", "target"],
-        Switches: ["execute"]);
+        Switches: ["execute"],
+        Options:
+        [
+            ("--container NAME", "A blob container configured in the app, as the source."),
+            ("--server NAME", "A configured server's msdb history, as the source."),
+            ("--database DB", "The database to PROVE. Required. The scratch copy is named " +
+                "after it: MyDb becomes MyDb_rehearsal_20260810_0930."),
+            ("--target SERVER", "The configured server the scratch restore runs on. " +
+                "Required. Its default data and log paths receive the relocated files."),
+            ("--at TIME", "Prove the chain to this moment. Omitted, the newest reachable " +
+                "point - which is the honest answer to \"could I restore what I have NOW?\""),
+            ("--execute", "Actually run it. Without this, the full rehearsal script prints " +
+                "and nothing is touched.")
+        ],
+        Notes:
+        [
+            "\"The only tested backup is a restored backup.\" Everyone repeats it; this verb " +
+            "produces the evidence: restore the chain to a scratch database, prove the data " +
+            "with DBCC CHECKDB, drop the scratch copy. The elapsed time is a MEASURED " +
+            "restore time - the number RTO conversations are otherwise made up from.",
+            "Safety by construction, same as the app's rehearsal: the scratch name is " +
+            "generated and honest about what it is, the restore refuses if that name " +
+            "somehow exists, WITH REPLACE never appears, every file is relocated to the " +
+            "target's defaults so nothing collides with the real database, and the cleanup " +
+            "runs LAST - a failed rehearsal retains the scratch copy as evidence to " +
+            "inspect, then drop.",
+            "The receipt lands in the same History the app reads, as a Rehearsal entry: " +
+            "the exposure dashboard's Proven column and measured RTO fill in from it, and " +
+            "webhook notifications name the database being proven, not the scratch copy. " +
+            "Scheduled - Task Scheduler, a CI job, anything that can run an exe nightly - " +
+            "this is proof that renews itself, with no SQL Agent required.",
+            "The app can also wrap this same loop as a disabled SQL Agent job (Rehearsal " +
+            "as Agent job, on the restore screen) for estates that prefer receipts in the " +
+            "job history."
+        ],
+        ExitCodes:
+        [
+            "0   PROVEN - restored, CHECKDB clean, scratch dropped (or, without --execute, printed)",
+            "2   NOT PROVEN - the failure is recorded, the scratch copy retained as evidence",
+            "3   the source or target could not be reached, or FILELISTONLY answered nothing",
+            "64  usage"
+        ],
+        Examples:
+        [
+            ("9lives rehearse --container backups --database Sales --target SRV02 --execute",
+                "prove Sales restores, right now, receipt in History"),
+            ("9lives rehearse --server SRV01 --database Sales --target SRV02",
+                "print the rehearsal script without running it")
+        ]);
 
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -19,13 +19,74 @@ internal static class RestoreVerb
 {
     public static readonly VerbSpec Spec = new(
         "restore",
-        "Generate - and with --execute, run - a restore against a target server",
+        "Generate, and with --execute run, a restore against a target server",
         "9lives restore (--container NAME | --server NAME) --database DB --target SERVER " +
         "[--at \"yyyy-MM-dd HH:mm:ss\"] [--target-database NAME] [--with-replace] [--norecovery] " +
         "[--stop-before-mark NAME | --stop-at-mark NAME] [--execute] [--force]",
         Valued: ["container", "server", "database", "at", "target", "target-database",
                  "stop-before-mark", "stop-at-mark"],
-        Switches: ["execute", "with-replace", "norecovery", "force"]);
+        Switches: ["execute", "with-replace", "norecovery", "force"],
+        Options:
+        [
+            ("--container NAME", "A blob container configured in the app, as the source."),
+            ("--server NAME", "A configured server's msdb history, as the source."),
+            ("--database DB", "The database whose chain to restore. Required."),
+            ("--target SERVER", "The configured server that RUNS the RESTORE. Required, " +
+                "always explicit - a destructive act aims at nothing by default."),
+            ("--at TIME", "The moment to restore to, by the same windowing rules the script " +
+                "verb documents. Omitted, the newest reachable point."),
+            ("--target-database NAME", "Restore AS this name. Defaults to the source name."),
+            ("--with-replace", "Consent to overwrite an existing database. Never inherited " +
+                "from anywhere, never implied by --force - this flag is the only way to " +
+                "mean it."),
+            ("--norecovery", "Leave the database restoring, ready for more log."),
+            ("--stop-before-mark NAME", "Stop just before the named marked transaction."),
+            ("--stop-at-mark NAME", "Stop at the mark, inclusive."),
+            ("--execute", "Actually run it. Without this, the script and every preflight " +
+                "verdict print and nothing is touched."),
+            ("--force", "Override what the EVIDENCE says - version direction, missing TDE " +
+                "certificate, unreadable files - loudly, as warnings. It cannot stand in " +
+                "for --with-replace: evidence is overridable, consent is not.")
+        ],
+        Notes:
+        [
+            "Built out of refusals, in a ladder. First, nothing runs without --execute: the " +
+            "bare invocation prints the script, the plan and every preflight verdict, and " +
+            "its exit code already says whether an --execute would have been allowed - so a " +
+            "pipeline can rehearse its own DR step nightly without touching anything.",
+            "Second, the preflights - the same safety nets the app fires before WITH " +
+            "REPLACE drops anything, asked of the target before the run: does the target " +
+            "database already exist without --with-replace; can the target's service " +
+            "account actually read every disk file; was the backup taken on a NEWER major " +
+            "version than the target (error 3169, the one-directional law of RESTORE); and " +
+            "is the TDE or backup-encryption certificate on the target, found by " +
+            "thumbprint (error 33111 otherwise, named here before the worst morning finds " +
+            "it). No verdict comes from silence: a header that cannot be read refuses " +
+            "nothing, because refusing on a guess blocks legal restores.",
+            "Executed runs leave the receipts the app leaves: an entry in the same History " +
+            "the app's History screen lists - script, console log, outcome, duration - and " +
+            "notifications to the same webhooks. A 3am restore from a runbook step looks " +
+            "exactly like a clicked one afterwards.",
+            "Files restore to the paths recorded in the backup. Relocation flags are not " +
+            "built yet - the rehearse verb relocates automatically, and the app's restore " +
+            "screen has full WITH MOVE control."
+        ],
+        ExitCodes:
+        [
+            "0   restored - or, without --execute, generated with nothing refused",
+            "2   refused by a preflight, or the restore itself failed",
+            "3   the source or target could not be reached at all",
+            "64  usage"
+        ],
+        Examples:
+        [
+            ("9lives restore --container backups --database Sales --target SRV02",
+                "generate only: script plus preflight verdicts, nothing touched"),
+            ("9lives restore --container backups --database Sales --target SRV02 --with-replace --execute",
+                "the real thing, consented to explicitly"),
+            ("9lives restore --server SRV01 --database Sales --target SRV02 --at \"2026-08-02 19:00\" --execute",
+                "a moment mid-log, STOPAT stamped on every log restore")
+        ]);
 
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)

--- a/src/NineLives.Cli/Verbs/ScriptVerb.cs
+++ b/src/NineLives.Cli/Verbs/ScriptVerb.cs
@@ -21,7 +21,53 @@ internal static class ScriptVerb
         "[--target-database NAME] [--with-replace] [--norecovery] [--stop-before-mark NAME | --stop-at-mark NAME] [--out FILE]",
         Valued: ["container", "server", "database", "at", "target-database",
                  "stop-before-mark", "stop-at-mark", "out"],
-        Switches: ["with-replace", "norecovery"]);
+        Switches: ["with-replace", "norecovery"],
+        Options:
+        [
+            ("--container NAME", "A blob container configured in the app."),
+            ("--server NAME", "A configured server, read from its msdb history."),
+            ("--database DB", "The database whose chain to script. Required."),
+            ("--at TIME", "The moment to restore to. Omitted, the newest reachable point is " +
+                "scripted. Formats: yyyy-MM-dd HH:mm:ss, yyyy-MM-dd HH:mm, yyyy-MM-dd - " +
+                "exact and invariant, nothing culture-shaped."),
+            ("--target-database NAME", "Restore AS this name. Defaults to the source name."),
+            ("--with-replace", "Adds WITH REPLACE. Off by default, always - overwriting is " +
+                "said explicitly here just as it is on the restore verb."),
+            ("--norecovery", "Leave the database restoring (NORECOVERY), ready for more log."),
+            ("--stop-before-mark NAME", "Stop just BEFORE the named marked transaction - the " +
+                "deployment never happened. Marks are planted with BEGIN TRANSACTION ... " +
+                "WITH MARK; the app's restore screen finds them in msdb."),
+            ("--stop-at-mark NAME", "Stop AT the mark, including the marked transaction."),
+            ("--out FILE", "Write the script to a file instead of stdout.")
+        ],
+        Notes:
+        [
+            "Stdout carries ONLY the script - the chain summary and every human word go to " +
+            "stderr - so \"> restore.sql\" and pipes stay clean. The script is built by the " +
+            "same chain calculation, striped-set grouping and generator the app runs, which " +
+            "is why what this emits actually executes.",
+            "The moment is matched by RESTORE's own rules. STOPAT can only ride a log chain " +
+            "that spans past the moment, so --at picks the log chain covering it and stamps " +
+            "STOPAT on every log restore in the chain. A moment between two non-log points " +
+            "is a hole no chain reaches: the verb refuses and names the nearest reachable " +
+            "points either side, because quietly restoring to somewhere nearby is worse.",
+            "A mark and a time are the same mechanism aimed differently, so giving both is " +
+            "refused rather than ranked."
+        ],
+        ExitCodes:
+        [
+            "0   script emitted",
+            "2   no chain covers the moment asked for",
+            "3   the source could not be read at all",
+            "64  usage"
+        ],
+        Examples:
+        [
+            ("9lives script --container backups --database Sales --at \"2026-08-02 19:00\" --out restore.sql",
+                "the validated script for that moment, into a file"),
+            ("9lives script --server SRV01 --database Sales --stop-before-mark deploy_v2",
+                "undo a marked deployment - the sharpest point-in-time tool SQL Server has")
+        ]);
 
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)

--- a/src/NineLives.Cli/Verbs/ValidateVerb.cs
+++ b/src/NineLives.Cli/Verbs/ValidateVerb.cs
@@ -21,7 +21,44 @@ internal static class ValidateVerb
         "Check every chain is intact; the exit code is the answer",
         "9lives validate (--container NAME | --server NAME) [--database DB] [--json]",
         Valued: ["container", "server", "database"],
-        Switches: ["json"]);
+        Switches: ["json"],
+        Options:
+        [
+            ("--container NAME", "A blob container configured in the app."),
+            ("--server NAME", "A configured server, read from its msdb history."),
+            ("--database DB", "Narrow to one database. Omitted, every database the source " +
+                "holds is judged - which is what a nightly check wants."),
+            ("--json", "Verdicts as JSON on stdout: database, intact, points, reaches, " +
+                "stranded (the reasons, spelled out).")
+        ],
+        Notes:
+        [
+            "The chain builder already refuses to offer what SQL Server would reject - a " +
+            "differential whose base full is not in hand, a log run broken before it. This " +
+            "verb makes those refusals VISIBLE: a set silently absent from the points list " +
+            "looks fine right up until the restore that needed it. Every stranded set is " +
+            "named with the error it prevents (a baseless differential is error 3136 at " +
+            "restore time; a disconnected log is a chain that stops early).",
+            "Chain logic only, deliberately, so it is cheap enough to run every night: " +
+            "nothing here opens a backup file. Whether each file is actually READABLE is " +
+            "the app's audit; whether every byte truly restores is what rehearse proves.",
+            "BROKEN in the table means at least one stranded set or a database whose " +
+            "backups reach nowhere at all."
+        ],
+        ExitCodes:
+        [
+            "0   every chain intact",
+            "2   something is broken - the stderr lines say what and why",
+            "3   the source could not be read at all",
+            "64  usage"
+        ],
+        Examples:
+        [
+            ("9lives validate --server SRV01",
+                "every database SRV01 backs up, judged in one exit code"),
+            ("9lives validate --container backups --database Sales --json",
+                "one database's verdict, for tooling")
+        ]);
 
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)

--- a/src/NineLives.Tests/CliArgumentsTests.cs
+++ b/src/NineLives.Tests/CliArgumentsTests.cs
@@ -14,7 +14,8 @@ public class CliArgumentsTests
     private static readonly VerbSpec Spec = new(
         "points", "summary", "usage",
         Valued: ["container", "database", "at"],
-        Switches: ["json"]);
+        Switches: ["json"],
+        Options: [], Notes: [], ExitCodes: [], Examples: []);
 
     [Fact]
     public void ValuedOptionsAndSwitchesParse()

--- a/src/NineLives.Tests/CliHelpTests.cs
+++ b/src/NineLives.Tests/CliHelpTests.cs
@@ -1,0 +1,120 @@
+using System.IO;
+using Blackcat.NineLives.Cli;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The CLI's documentation lives inside the exe, on each verb's spec - and these tests are
+/// what stops it drifting from the parser it describes. A flag the parser takes but the help
+/// omits is documentation lying by silence; a flag the help describes but the parser refuses
+/// is worse. Neither can merge while these hold.
+/// </summary>
+public class CliHelpTests
+{
+    public static TheoryData<string> VerbNames()
+    {
+        var data = new TheoryData<string>();
+        foreach (var verb in VerbCatalogue.All) data.Add(verb.Name);
+        return data;
+    }
+
+    private static VerbSpec Spec(string name) => VerbCatalogue.Find(name)!;
+
+    /// <summary>Every option the parser accepts appears in the help, spelled as typed.</summary>
+    [Theory]
+    [MemberData(nameof(VerbNames))]
+    public void EveryDeclaredOptionIsDocumented(string name)
+    {
+        var spec = Spec(name);
+        var documented = spec.Options.Select(o => o.Term).ToList();
+
+        foreach (var option in spec.Valued.Concat(spec.Switches))
+            Assert.Contains(documented, term => term == $"--{option}"
+                                                || term.StartsWith($"--{option} "));
+    }
+
+    /// <summary>And nothing else: help must not describe flags the parser would refuse.</summary>
+    [Theory]
+    [MemberData(nameof(VerbNames))]
+    public void TheHelpDescribesNoFlagTheParserRefuses(string name)
+    {
+        var spec = Spec(name);
+        var accepted = spec.Valued.Concat(spec.Switches).ToList();
+
+        foreach (var (term, _) in spec.Options)
+        {
+            var flag = term[2..].Split(' ')[0];
+            Assert.Contains(flag, accepted);
+        }
+    }
+
+    /// <summary>A verb page without behaviour, exit codes and examples is a stub, not a reference.</summary>
+    [Theory]
+    [MemberData(nameof(VerbNames))]
+    public void EveryVerbCarriesNotesExitCodesAndExamples(string name)
+    {
+        var spec = Spec(name);
+
+        Assert.NotEmpty(spec.Notes);
+        Assert.NotEmpty(spec.ExitCodes);
+        Assert.NotEmpty(spec.Examples);
+    }
+
+    [Fact]
+    public void TheOverviewListsEveryVerbAndTheHelpPointer()
+    {
+        var output = new StringWriter();
+        HelpWriter.WriteOverview(VerbCatalogue.All, output);
+        var text = output.ToString();
+
+        foreach (var verb in VerbCatalogue.All)
+            Assert.Contains(verb.Name, text);
+        Assert.Contains("9lives help VERB", text);
+    }
+
+    /// <summary>
+    /// The page for the destructive verb carries the safety story: consent, evidence, and the
+    /// two error numbers the preflights exist to pre-empt.
+    /// </summary>
+    [Fact]
+    public void TheRestorePageCarriesTheConsentAndEvidenceStory()
+    {
+        var output = new StringWriter();
+        HelpWriter.WriteVerb(Spec("restore"), output);
+        var text = output.ToString();
+
+        Assert.Contains("--with-replace", text);
+        Assert.Contains("--force", text);
+        Assert.Contains("3169", text);
+        Assert.Contains("33111", text);
+        Assert.Contains("consent", text);
+    }
+
+    /// <summary>
+    /// Prose must arrive wrapped - a terminal reflows nothing. Usage synopses and example
+    /// commands are exempt on purpose: wrapping a command breaks copy-paste, which is the one
+    /// thing an example command exists for. So the pin runs on a synthetic verb whose prose
+    /// is guaranteed longer than a line, and checks the sections that ARE prose.
+    /// </summary>
+    [Fact]
+    public void NotesAndOptionHelpWrapInsideEightyColumns()
+    {
+        var longText = string.Join(" ", Enumerable.Repeat("word", 60));
+        var spec = new VerbSpec(
+            "wrapcheck", "s", "usage", ["opt"], [],
+            Options: [("--opt VALUE", longText)],
+            Notes: [longText],
+            ExitCodes: ["0   fine"],
+            Examples: [("9lives wrapcheck", "example")]);
+
+        var output = new StringWriter();
+        HelpWriter.WriteVerb(spec, output);
+        var lines = output.ToString().Split('\n').Select(l => l.TrimEnd()).ToList();
+
+        var prose = lines.Where(l => l.Contains("word")).ToList();
+        Assert.True(prose.Count > 2, "the long text should have wrapped across lines");
+        foreach (var line in prose)
+            Assert.True(line.Length <= 80, $"prose line exceeds 80 columns: '{line}'");
+    }
+}


### PR DESCRIPTION
The answer to "do we have full documentation for the CLI?" - yes, and it lives where a CLI's documentation belongs: inside the exe.

- \`9lives help\` - the overview: verbs, usage, the global exit-code contract, the stdout/stderr discipline, the strict timestamp formats, where configuration comes from.
- \`9lives help restore\` (or any verb, or \`--help\` after one) - the full page: every option explained, the behaviour in prose (restore's consent-and-evidence ladder with 3169/33111 named, script's STOPAT windowing, rehearse's safety construction and its receipts feeding the Proven column, exposure's judge thresholds), per-verb exit codes, worked examples.

The reference lives on each verb's \`VerbSpec\`, beside the implementation it describes - and **tests hold the help to the parser**: every option the parser accepts must appear in the page, every option the page describes must be accepted, every verb must carry notes, exit codes and examples, and prose must arrive wrapped inside 80 columns. A flag added without documentation now fails the build, which is the only kind of documentation policy that survives contact with a Tuesday.

Usage synopses and example commands stay unwrapped deliberately - wrapping a command breaks the copy-paste it exists for.

24 new pins (1,616 total). README's CLI section points at \`9lives help\`.