### PR TITLE
Provisioning from nothing: add-server and add-container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ more detail on the user-facing changes; this file is the short history.
   the per-verb exit codes, worked examples. The reference lives inside the exe, where it
   cannot drift from the parser it describes, and a test holds each page to the verb's own
   option list - an undocumented flag or a documented-but-refused one both fail the build
+- **Provisioning from nothing**: `add-server` and `add-container` create the configuration
+  from the command line on a machine the app has never run on - a Terraform clone, a DR
+  bubble. Validated by default (the server asked its version, the container asked to answer
+  with exactly the recorded SAS - a SAS looks right for weeks after it expired), converging
+  on re-run, secrets in the Credential Manager and never echoed, with
+  `NINELIVES_SQL_PASSWORD` / `NINELIVES_SAS` as the script-friendly alternative to flags.
+  A point-in-time clone is three chained lines whose only variable is the moment
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ Exit codes are the contract: `0` fine, `1` warnings, `2` broken or unreachable-b
 
 The full reference ships inside the exe: `9lives help` for the overview, `9lives help restore` (or any verb) for the complete page - every option, the behaviour, the exit codes, examples. Documentation that lives in the binary cannot drift from it, and a test holds every page to the parser's own option lists.
 
+**Provisioning from nothing.** A freshly built VM - a Terraform clone, a DR bubble, a scratch environment - has no app config and nobody at a screen. `add-server` and `add-container` create the configuration from the command line, validated by default: the server is asked its version (address, credentials and permissions proven in one round trip), the container is asked to answer with exactly the recorded SAS - because a SAS is a string that looks right for weeks after it expired. Both converge on re-run, secrets can ride in `NINELIVES_SQL_PASSWORD` / `NINELIVES_SAS` instead of flags, and a chained script stops at the first failed validation. The whole template is three lines, and the only variable is the moment:
+
+```
+9lives add-server --name target --address localhost --user svc_restore --password %SQL_PW%
+9lives add-container --name backups --url https://acct.blob.core.windows.net/sqlbackups --sas %SAS%
+9lives restore --container backups --database Sales --target target --at "%POINT_IN_TIME%" --execute
+```
+
 Two verbs execute, and they are built out of refusals: `restore` and `rehearse` run nothing without `--execute`; overwriting an existing database is said with `--with-replace`, its own flag that `--force` cannot substitute for; and the same preflights the app fires - file readability, version direction (error 3169), the TDE certificate (error 33111) - refuse before anything is dropped, `--force` being the deliberate override for evidence only. Executed runs land in the app's History and notify the same webhooks, so `9lives rehearse --execute` on a schedule is nightly proof with receipts - no SQL Agent required.
 
 ## Features

--- a/src/NineLives.Cli/HelpWriter.cs
+++ b/src/NineLives.Cli/HelpWriter.cs
@@ -44,6 +44,12 @@ internal static class HelpWriter
         output.WriteLine("  9lives script --container backups --database Sales --at \"2026-08-02 19:00\" --out restore.sql");
         output.WriteLine("  9lives rehearse --container backups --database Sales --target SRV02 --execute");
         output.WriteLine("  9lives restore --container backups --database Sales --target SRV02 --with-replace --execute");
+        output.WriteLine();
+        output.WriteLine("Provisioning a fresh machine to a point in time - three lines, each");
+        output.WriteLine("validated, chained on exit codes; the only variable is the moment:");
+        output.WriteLine("  9lives add-server --name target --address localhost --user svc_restore --password %SQL_PW%");
+        output.WriteLine("  9lives add-container --name backups --url https://acct.blob.core.windows.net/sqlbackups --sas %SAS%");
+        output.WriteLine("  9lives restore --container backups --database Sales --target target --at \"%POINT_IN_TIME%\" --execute");
     }
 
     public static void WriteVerb(VerbSpec verb, TextWriter output)

--- a/src/NineLives.Cli/Program.cs
+++ b/src/NineLives.Cli/Program.cs
@@ -87,6 +87,8 @@ internal static class Program
         {
             return spec.Name switch
             {
+                "add-server" => await AddServerVerb.RunAsync(args, services, Console.Out, Console.Error),
+                "add-container" => await AddContainerVerb.RunAsync(args, services, Console.Out, Console.Error),
                 "list" => await ListVerb.RunAsync(args, services, Console.Out, Console.Error),
                 "points" => await PointsVerb.RunAsync(args, services, Console.Out, Console.Error),
                 "script" => await ScriptVerb.RunAsync(args, services, Console.Out, Console.Error),

--- a/src/NineLives.Cli/VerbCatalogue.cs
+++ b/src/NineLives.Cli/VerbCatalogue.cs
@@ -11,6 +11,7 @@ internal static class VerbCatalogue
 {
     public static readonly VerbSpec[] All =
     [
+        AddServerVerb.Spec, AddContainerVerb.Spec,
         ListVerb.Spec, PointsVerb.Spec, ScriptVerb.Spec, ValidateVerb.Spec, ExposureVerb.Spec,
         RestoreVerb.Spec, RehearseVerb.Spec
     ];

--- a/src/NineLives.Cli/Verbs/AddContainerVerb.cs
+++ b/src/NineLives.Cli/Verbs/AddContainerVerb.cs
@@ -1,0 +1,124 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Cli.Verbs;
+
+/// <summary>
+/// The blob half of configuration-from-nothing: record a container and its SAS, and prove the
+/// SAS can actually reach it - the proof being the point. A SAS is a string that LOOKS right
+/// for weeks after it expired, and the worst place to discover that is the restore.
+/// </summary>
+internal static class AddContainerVerb
+{
+    public static readonly VerbSpec Spec = new(
+        "add-container",
+        "Add or update a blob container, and prove the SAS reaches it",
+        "9lives add-container --name NAME --url CONTAINER_URL [--sas TOKEN] [--no-validate]",
+        Valued: ["name", "url", "sas"],
+        Switches: ["no-validate"],
+        Options:
+        [
+            ("--name NAME", "The configured name the other verbs refer to (--container " +
+                "NAME). An existing entry with this name is updated in place, so a " +
+                "provisioning script re-runs cleanly - and a SAS refresh is just this verb " +
+                "again with the new token."),
+            ("--url CONTAINER_URL", "The container URL, no SAS in it: " +
+                "https://account.blob.core.windows.net/container"),
+            ("--sas TOKEN", "The SAS token, with or without its leading '?'. Stored in the " +
+                "Windows Credential Manager exactly as the app stores it. Prefer the " +
+                "NINELIVES_SAS environment variable in scripts - a variable stays out of " +
+                "shell history and process listings; a flag does not."),
+            ("--no-validate", "Record without reaching for the container. The default is " +
+                "to prove the SAS works before anything downstream trusts it.")
+        ],
+        Notes:
+        [
+            "Writes the same configuration the desktop app maintains, secret in the vault, " +
+            "so the app's browser and the CLI's verbs all see the container this recorded.",
+            "Validation asks the container to answer using exactly the recorded SAS - " +
+            "reachability, the account name, the container name and the token's validity " +
+            "all proven in one call. Restore needs List and Read permissions on the SAS; " +
+            "the app's SAS guidance in the README spells the grants out.",
+            "A failed validation still records the entry (a re-run with a fresh token " +
+            "overwrites it) but exits 3, so a chained script stops before the restore " +
+            "discovers it the hard way. The SAS itself is never echoed back.",
+            "Entra-authenticated containers are configured in the app, where the sign-in " +
+            "can happen - this verb is the SAS route, which is the one a headless template " +
+            "can use."
+        ],
+        ExitCodes:
+        [
+            "0   saved - and, unless --no-validate, the SAS proven against the container",
+            "3   saved, but the container did not answer with this SAS - fix and re-run",
+            "64  usage"
+        ],
+        Examples:
+        [
+            ("9lives add-container --name backups --url https://acct.blob.core.windows.net/sqlbackups --sas %SAS%",
+                "a provisioning script's second line: where the backups live"),
+            ("9lives add-container --name backups --url https://acct.blob.core.windows.net/sqlbackups",
+                "same, with the token read from NINELIVES_SAS")
+        ]);
+
+    public static async Task<int> RunAsync(
+        CliArguments args, CliServices services, TextWriter output, TextWriter errors)
+    {
+        var name = args.Get("name");
+        var url = args.Get("url");
+        if (name == null || url == null)
+        {
+            errors.WriteLine("add-container needs --name and --url.");
+            return ExitCodes.Usage;
+        }
+
+        var sas = args.Get("sas") ?? Environment.GetEnvironmentVariable("NINELIVES_SAS");
+        if (string.IsNullOrEmpty(sas))
+        {
+            errors.WriteLine("add-container needs the token: --sas, or the NINELIVES_SAS " +
+                             "environment variable (preferred in scripts - it stays out of " +
+                             "process listings).");
+            return ExitCodes.Usage;
+        }
+
+        var config = services.Store.LoadConfig();
+        var existing = config.BlobContainers.FirstOrDefault(
+            c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
+        var container = existing ?? new BlobContainerConfig { Id = BlobContainerConfig.NewId() };
+
+        container.Name = name;
+        container.ContainerUrl = url.TrimEnd('/');
+        container.AuthMode = BlobAuthMode.SasToken;
+
+        if (existing == null) config.BlobContainers.Add(container);
+        services.Store.SaveConfig(config);
+        services.Store.SaveSasToken(container, sas.TrimStart('?'));
+
+        errors.WriteLine($"{(existing == null ? "Added" : "Updated")} container '{name}' -> " +
+                         $"{container.ContainerUrl}.");
+
+        if (args.Has("no-validate"))
+        {
+            errors.WriteLine("Not validated, as asked.");
+            return ExitCodes.Ok;
+        }
+
+        try
+        {
+            if (await services.Blobs.VerifyConnectionAsync(container))
+            {
+                errors.WriteLine("Validated: the SAS reaches the container.");
+                return ExitCodes.Ok;
+            }
+
+            errors.WriteLine("VALIDATION FAILED: the container did not answer with this SAS.");
+        }
+        catch (Exception ex)
+        {
+            errors.WriteLine($"VALIDATION FAILED: {ex.Message}");
+        }
+
+        errors.WriteLine("The entry is saved - check the URL, the token's expiry and its " +
+                         "List/Read permissions, then re-run; a script chained on exit " +
+                         "codes stops here.");
+        return ExitCodes.CouldNotAnswer;
+    }
+}

--- a/src/NineLives.Cli/Verbs/AddServerVerb.cs
+++ b/src/NineLives.Cli/Verbs/AddServerVerb.cs
@@ -1,0 +1,136 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Cli.Verbs;
+
+/// <summary>
+/// Configuration from nothing: a freshly provisioned VM has no app config and nobody at a
+/// screen to create one, so the CLI creates it - which is what turns a Terraform template into
+/// a working restore. Add-or-update by name, so a re-run converges instead of erroring; and
+/// validation is the DEFAULT, because a template that records a dead server should fail at
+/// the add, not twenty minutes later at the restore.
+/// </summary>
+internal static class AddServerVerb
+{
+    public static readonly VerbSpec Spec = new(
+        "add-server",
+        "Add or update a configured server, and prove it answers",
+        "9lives add-server --name NAME --address SERVER[\\INSTANCE] [--user USER --password PW] [--no-validate]",
+        Valued: ["name", "address", "user", "password"],
+        Switches: ["no-validate"],
+        Options:
+        [
+            ("--name NAME", "The configured name the other verbs refer to (--target NAME, " +
+                "--server NAME). An existing entry with this name is updated in place - " +
+                "re-running a provisioning script converges rather than failing."),
+            ("--address SERVER", "What the connection string gets: host, host\\instance, or " +
+                "host,port."),
+            ("--user USER", "SQL authentication username. With it, --password (or the " +
+                "environment variable) is required; without it, the connection uses " +
+                "Windows authentication as the account running the CLI."),
+            ("--password PW", "SQL authentication password, stored in the Windows " +
+                "Credential Manager exactly as the app stores it. Prefer the " +
+                "NINELIVES_SQL_PASSWORD environment variable in scripts - a variable " +
+                "stays out of shell history and process listings; a flag does not."),
+            ("--no-validate", "Record without connecting. For preparing config the server " +
+                "will grow into - the default is to prove the server answers.")
+        ],
+        Notes:
+        [
+            "Writes the same configuration the desktop app maintains, in " +
+            "%LOCALAPPDATA%\\NineLives, with the password in the Windows Credential " +
+            "Manager - so everything the app would show is exactly what the CLI recorded, " +
+            "and either front end can carry on from here.",
+            "Validation connects and asks the server its version, which proves the address, " +
+            "the credentials and the permission to answer in one round trip - the answer is " +
+            "printed by name. A failed validation still records the entry (a re-run " +
+            "overwrites it) but exits 3, so a script chained on exit codes stops before " +
+            "anything downstream trusts a dead server.",
+            "Secrets are never echoed back, and the config file holds no secret - the " +
+            "password lives in the vault, keyed to this entry, as the app's own entries are."
+        ],
+        ExitCodes:
+        [
+            "0   saved - and, unless --no-validate, proven to answer",
+            "3   saved, but the server did not answer - fix and re-run",
+            "64  usage"
+        ],
+        Examples:
+        [
+            ("9lives add-server --name target --address localhost --user svc_restore --password %SQL_PW%",
+                "a provisioning script's first line: the freshly built VM's own instance"),
+            ("9lives add-server --name SRV01 --address SRV01\\PROD",
+                "Windows auth as the account running the CLI, validated")
+        ]);
+
+    public static async Task<int> RunAsync(
+        CliArguments args, CliServices services, TextWriter output, TextWriter errors)
+    {
+        var name = args.Get("name");
+        var address = args.Get("address");
+        if (name == null || address == null)
+        {
+            errors.WriteLine("add-server needs --name and --address.");
+            return ExitCodes.Usage;
+        }
+
+        var user = args.Get("user");
+        var password = args.Get("password")
+                       ?? Environment.GetEnvironmentVariable("NINELIVES_SQL_PASSWORD");
+        if (user == null && args.Get("password") != null)
+        {
+            errors.WriteLine("--password without --user makes no sense - SQL authentication " +
+                             "needs both.");
+            return ExitCodes.Usage;
+        }
+
+        if (user != null && string.IsNullOrEmpty(password))
+        {
+            errors.WriteLine("--user needs a password: --password, or the " +
+                             "NINELIVES_SQL_PASSWORD environment variable (preferred in " +
+                             "scripts - it stays out of process listings).");
+            return ExitCodes.Usage;
+        }
+
+        // Add or update by name: a provisioning script that runs twice must converge.
+        var config = services.Store.LoadConfig();
+        var existing = config.Servers.FirstOrDefault(
+            s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+        var server = existing ?? new ServerConnection { Id = ServerConnection.NewId() };
+
+        server.Name = name;
+        server.ServerName = address;
+        server.AuthMode = user != null ? AuthMode.SqlAuth : AuthMode.WindowsAuth;
+        server.Username = user;
+
+        if (existing == null) config.Servers.Add(server);
+        services.Store.SaveConfig(config);
+        if (user != null)
+            services.Store.SaveSqlPassword(server, password!);
+
+        errors.WriteLine($"{(existing == null ? "Added" : "Updated")} server '{name}' -> " +
+                         $"{address} ({server.AuthMode.Describe()}).");
+
+        if (args.Has("no-validate"))
+        {
+            errors.WriteLine("Not validated, as asked.");
+            return ExitCodes.Ok;
+        }
+
+        try
+        {
+            var major = await services.Sql.GetProductMajorVersionAsync(server);
+            errors.WriteLine(major is { } m
+                ? $"Validated: {address} answers as {VersionCompatibility.Describe(m)}."
+                : $"Validated: {address} answers.");
+            return ExitCodes.Ok;
+        }
+        catch (Exception ex)
+        {
+            errors.WriteLine($"VALIDATION FAILED: {ex.Message}");
+            errors.WriteLine("The entry is saved - fix the address or credentials and " +
+                             "re-run; a script chained on exit codes stops here.");
+            return ExitCodes.CouldNotAnswer;
+        }
+    }
+}

--- a/src/NineLives.Tests/CliProvisioningTests.cs
+++ b/src/NineLives.Tests/CliProvisioningTests.cs
@@ -1,0 +1,225 @@
+using System.IO;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Configuration from nothing (#63): a Terraform-built VM has no app config, so add-server
+/// and add-container create it - validated by default, converging on re-run, secrets in the
+/// vault and never echoed. These pins are the provisioning template's contract: three lines
+/// chained on exit codes, with the restore's moment as the only variable.
+/// </summary>
+public class CliProvisioningTests
+{
+    private static (CliServices services, FakeCredentialStore store, FakeSqlServerService sql,
+        FakeBlobStorageService blobs) Stage()
+    {
+        var store = new FakeCredentialStore();
+        var sql = new FakeSqlServerService();
+        var blobs = new FakeBlobStorageService();
+        return (new CliServices(store, sql, blobs,
+            new FakeRestoreHistoryStore(), new FakeRunNotifier()), store, sql, blobs);
+    }
+
+    private static async Task<(int exit, string errors)> Run(
+        Func<CliArguments, CliServices, TextWriter, TextWriter, Task<int>> verb,
+        VerbSpec spec, string[] args, CliServices services)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await verb(CliArguments.Parse(args, spec), services, output, errors);
+        return (exit, errors.ToString());
+    }
+
+    // ── add-server ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddServerSavesValidatesAndReportsTheVersion()
+    {
+        var (services, store, sql, _) = Stage();
+        sql.MajorVersionByServer["localhost"] = 16;
+
+        var (exit, errors) = await Run(AddServerVerb.RunAsync, AddServerVerb.Spec,
+            ["--name", "target", "--address", "localhost",
+             "--user", "svc_restore", "--password", "pw1"], services);
+
+        Assert.Equal(0, exit);
+        var server = Assert.Single(store.LoadConfig().Servers);
+        Assert.Equal("target", server.Name);
+        Assert.Equal("localhost", server.ServerName);
+        Assert.Equal(AuthMode.SqlAuth, server.AuthMode);
+        Assert.Equal("svc_restore", server.Username);
+        Assert.Equal("pw1", store.GetSqlPassword(server));
+        Assert.Contains("2022", errors);
+        // The secret goes to the vault, never back out the terminal.
+        Assert.DoesNotContain("pw1", errors);
+    }
+
+    /// <summary>A provisioning script that runs twice must converge, not error or duplicate.</summary>
+    [Fact]
+    public async Task AddServerUpdatesAnExistingEntryInPlace()
+    {
+        var (services, store, sql, _) = Stage();
+        sql.MajorVersionByServer["srv-a"] = 16;
+        sql.MajorVersionByServer["srv-b"] = 16;
+
+        await Run(AddServerVerb.RunAsync, AddServerVerb.Spec,
+            ["--name", "target", "--address", "srv-a"], services);
+        var (exit, errors) = await Run(AddServerVerb.RunAsync, AddServerVerb.Spec,
+            ["--name", "target", "--address", "srv-b"], services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Updated", errors);
+        var server = Assert.Single(store.LoadConfig().Servers);
+        Assert.Equal("srv-b", server.ServerName);
+    }
+
+    /// <summary>
+    /// The fail-fast the template depends on: a dead server exits 3 at the ADD, so the chain
+    /// stops before the restore trusts it. Saved anyway - the re-run overwrites.
+    /// </summary>
+    [Fact]
+    public async Task AddServerThatDoesNotAnswerExitsThree()
+    {
+        var (services, store, sql, _) = Stage();
+        sql.ThrowOnMajorVersion = new InvalidOperationException("network path not found");
+
+        var (exit, errors) = await Run(AddServerVerb.RunAsync, AddServerVerb.Spec,
+            ["--name", "target", "--address", "gone"], services);
+
+        Assert.Equal(3, exit);
+        Assert.Contains("VALIDATION FAILED", errors);
+        Assert.Single(store.LoadConfig().Servers);
+    }
+
+    [Fact]
+    public async Task AddServerReadsThePasswordFromTheEnvironmentWhenNotGiven()
+    {
+        var (services, store, sql, _) = Stage();
+        sql.MajorVersionByServer["localhost"] = 17;
+
+        Environment.SetEnvironmentVariable("NINELIVES_SQL_PASSWORD", "from-env");
+        try
+        {
+            var (exit, _) = await Run(AddServerVerb.RunAsync, AddServerVerb.Spec,
+                ["--name", "target", "--address", "localhost", "--user", "svc"], services);
+
+            Assert.Equal(0, exit);
+            Assert.Equal("from-env",
+                store.GetSqlPassword(store.LoadConfig().Servers.Single()));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NINELIVES_SQL_PASSWORD", null);
+        }
+    }
+
+    [Fact]
+    public async Task AddServerWithAUserButNoPasswordAnywhereIsAUsageError()
+    {
+        var (services, _, _, _) = Stage();
+
+        var (exit, errors) = await Run(AddServerVerb.RunAsync, AddServerVerb.Spec,
+            ["--name", "target", "--address", "localhost", "--user", "svc"], services);
+
+        Assert.Equal(64, exit);
+        Assert.Contains("NINELIVES_SQL_PASSWORD", errors);
+    }
+
+    // ── add-container ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddContainerSavesTheSasAndProvesItReaches()
+    {
+        var (services, store, _, blobs) = Stage();
+
+        var (exit, errors) = await Run(AddContainerVerb.RunAsync, AddContainerVerb.Spec,
+            ["--name", "backups", "--url", "https://acct.blob.core.windows.net/sqlbackups/",
+             "--sas", "?sv=2024&sig=secret123"], services);
+
+        Assert.Equal(0, exit);
+        var container = Assert.Single(store.LoadConfig().BlobContainers);
+        Assert.Equal("backups", container.Name);
+        // Normalised at the edge: no trailing slash on the URL, no leading ? on the token.
+        Assert.Equal("https://acct.blob.core.windows.net/sqlbackups", container.ContainerUrl);
+        Assert.Equal("sv=2024&sig=secret123", store.GetSasToken(container));
+        Assert.Equal(BlobAuthMode.SasToken, container.AuthMode);
+        // The verify call ran against the just-saved entry, and the secret never echoed.
+        Assert.NotNull(blobs.LastConfig);
+        Assert.Contains("Validated", errors);
+        Assert.DoesNotContain("secret123", errors);
+    }
+
+    /// <summary>The SAS that looks right but is not: recorded, refused, exit 3, chain stops.</summary>
+    [Fact]
+    public async Task AddContainerWithASasTheContainerRefusesExitsThree()
+    {
+        var (services, _, _, blobs) = Stage();
+        blobs.VerifyAnswer = false;
+
+        var (exit, errors) = await Run(AddContainerVerb.RunAsync, AddContainerVerb.Spec,
+            ["--name", "backups", "--url", "https://acct.blob.core.windows.net/sqlbackups",
+             "--sas", "sv=expired"], services);
+
+        Assert.Equal(3, exit);
+        Assert.Contains("VALIDATION FAILED", errors);
+        Assert.Contains("expiry", errors);
+    }
+
+    [Fact]
+    public async Task AddContainerReadsTheSasFromTheEnvironmentWhenNotGiven()
+    {
+        var (services, store, _, _) = Stage();
+
+        Environment.SetEnvironmentVariable("NINELIVES_SAS", "sv=env-token");
+        try
+        {
+            var (exit, _) = await Run(AddContainerVerb.RunAsync, AddContainerVerb.Spec,
+                ["--name", "backups",
+                 "--url", "https://acct.blob.core.windows.net/sqlbackups"], services);
+
+            Assert.Equal(0, exit);
+            Assert.Equal("sv=env-token",
+                store.GetSasToken(store.LoadConfig().BlobContainers.Single()));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NINELIVES_SAS", null);
+        }
+    }
+
+    [Fact]
+    public async Task AddContainerWithNoSasAnywhereIsAUsageError()
+    {
+        var (services, _, _, _) = Stage();
+
+        var (exit, errors) = await Run(AddContainerVerb.RunAsync, AddContainerVerb.Spec,
+            ["--name", "backups",
+             "--url", "https://acct.blob.core.windows.net/sqlbackups"], services);
+
+        Assert.Equal(64, exit);
+        Assert.Contains("NINELIVES_SAS", errors);
+    }
+
+    /// <summary>A SAS refresh is the add verb again - same name, new token, updated in place.</summary>
+    [Fact]
+    public async Task AddContainerRefreshesTheTokenOnAnExistingEntry()
+    {
+        var (services, store, _, _) = Stage();
+        var url = "https://acct.blob.core.windows.net/sqlbackups";
+
+        await Run(AddContainerVerb.RunAsync, AddContainerVerb.Spec,
+            ["--name", "backups", "--url", url, "--sas", "sv=old"], services);
+        var (exit, errors) = await Run(AddContainerVerb.RunAsync, AddContainerVerb.Spec,
+            ["--name", "backups", "--url", url, "--sas", "sv=new"], services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Updated", errors);
+        var container = Assert.Single(store.LoadConfig().BlobContainers);
+        Assert.Equal("sv=new", store.GetSasToken(container));
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -98,10 +98,13 @@ public sealed class FakeBlobStorageService : IBlobStorageService
     /// </summary>
     public BlobContainerConfig? LastConfig { get; private set; }
 
+    /// <summary>What VerifyConnectionAsync answers - false plays a SAS that cannot reach the container.</summary>
+    public bool VerifyAnswer { get; set; } = true;
+
     public Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
     {
         LastConfig = config;
-        return Task.FromResult(true);
+        return Task.FromResult(VerifyAnswer);
     }
 
     /// <summary>What DescribeSignedInIdentityAsync should answer.</summary>
@@ -301,9 +304,15 @@ public sealed class FakeSqlServerService : ISqlServerService
     public Dictionary<string, int?> MajorVersionByServer { get; } =
         new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Set to make the version ask throw - a server that does not answer at all (#63).</summary>
+    public Exception? ThrowOnMajorVersion { get; set; }
+
     public Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default)
-        => Task.FromResult(
+    {
+        if (ThrowOnMajorVersion != null) throw ThrowOnMajorVersion;
+        return Task.FromResult(
             MajorVersionByServer.TryGetValue(server.ServerName, out var v) ? v : ProductMajorVersion);
+    }
 
     /// <summary>What GetDatabaseOverviewAsync answers (#205).</summary>
     public DatabaseOverview? DatabaseOverview { get; set; } = new(150, "FULL", "sa");


### PR DESCRIPTION
The CLI could read the app's configuration; now it can CREATE it - which is the missing piece for the real end goal: a Terraform-provisioned VM restored to a point in time with no human and no GUI anywhere in the loop.

**The template** - three lines, each validated, chained on exit codes, with the moment as the only variable:

\`\`\`
9lives add-server --name target --address localhost --user svc_restore --password %SQL_PW%
9lives add-container --name backups --url https://acct.blob.core.windows.net/sqlbackups --sas %SAS%
9lives restore --container backups --database Sales --target target --at "%POINT_IN_TIME%" --execute
\`\`\`

**\`add-server\`** records a server and proves it answers: one round trip asks its version, which validates the address, the credentials and the permission at once - and reports the answer by name ("answers as SQL Server 2022"). SQL auth via \`--user\`/\`--password\`, Windows auth when neither is given.

**\`add-container\`** records a container and proves the SAS actually reaches it - because a SAS is a string that looks right for weeks after it expired, and the worst place to find out is the restore. A refresh is the same verb again with the new token.

**The contract both keep**: validation is the default and a failure exits 3 (the entry stays recorded, so fixing and re-running converges - add-or-update by name throughout); secrets go to the Windows Credential Manager exactly as the app stores them and are never echoed back; \`NINELIVES_SQL_PASSWORD\` and \`NINELIVES_SAS\` carry them in scripts where flags would sit in shell history and process listings. This also closes most of the service-account credential gap recorded on #63 - the config no longer has to be born in an interactive session.

Both verbs carry full \`9lives help\` pages, enforced by the existing drift-pins. 16 new tests (1,632 total): save-and-validate, the exit-3 fail-fast, re-run convergence, env-var fallbacks, SAS normalisation, and that no secret ever appears in output.