### PR TITLE
Config saves merge with the disk, never replace it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- The SQL Servers and Blob Storage screens now MERGE their saves into the configuration on
+  disk instead of replacing it wholesale. Importing a config (or adding entries with the CLI)
+  and then saving anything on either screen used to silently delete everything added since
+  the screen loaded - the worst case being import, then Connect, and every imported server
+  gone. Both screens also catch up with outside additions on navigation, and only deletions
+  made on the screen itself delete (#276)
 - Find marks now asks the SOURCE instance's msdb on shared-path and ad-hoc restores - marked
   transactions are recorded where they ran, so asking the target answered "no marks" when the
   truth was "wrong catalogue". Blob still asks the connected server, which is the only

--- a/src/NineLives.Tests/ConfigWriteMergeTests.cs
+++ b/src/NineLives.Tests/ConfigWriteMergeTests.cs
@@ -1,0 +1,148 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Config writes merge, never replace (#276). The SQL Servers and Blob Storage screens load
+/// their lists once; Settings' import and the CLI's add verbs write entries at any time after
+/// that. A screen that saves its stale list wholesale silently deletes theirs - the production
+/// path was import, then Connect (which records the detected version), and every imported
+/// server was gone. These pins drive a save through each screen's dialog-free edit path and
+/// hold the merge to its promises: unseen entries survive, and this screen's edits win for
+/// the entries it knows.
+/// </summary>
+public class ConfigWriteMergeTests
+{
+    private static ServerConnection Server(string name) => new()
+    { Id = ServerConnection.NewId(), Name = name, ServerName = name };
+
+    private static BlobContainerConfig Container(string name) => new()
+    {
+        Id = BlobContainerConfig.NewId(),
+        Name = name,
+        ContainerUrl = $"https://a.blob.core.windows.net/{name}"
+    };
+
+    // ── servers ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AServerAddedElsewhereSurvivesThisScreensSave()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server("SRV01"));
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+
+        // The import (or 9lives add-server) writes AFTER the screen loaded its list.
+        store.Config.Servers.Add(Server("SRV02"));
+
+        // Any save from this screen used to clobber it - a rename is the dialog-free trigger.
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV01");
+        vm.EditCommand.Execute(null);
+        vm.EditName = "SRV01-renamed";
+        vm.SaveCommand.Execute(null);
+
+        var names = store.LoadConfig().Servers.Select(s => s.Name).ToList();
+        Assert.Contains("SRV01-renamed", names);
+        Assert.Contains("SRV02", names);
+        Assert.Equal(2, names.Count);
+    }
+
+    /// <summary>For an entry BOTH sides know, the screen actively editing it wins.</summary>
+    [Fact]
+    public void TheScreensEditWinsForAnEntryItKnows()
+    {
+        var store = new FakeCredentialStore();
+        var original = Server("SRV01");
+        store.Config.Servers.Add(original);
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+
+        // Something else rewrote the same entry (same id) behind the screen's back.
+        store.Config.Servers.Clear();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = original.Id, Name = "SRV01", ServerName = "rewritten-elsewhere" });
+
+        vm.SelectedServer = vm.Servers.Single();
+        vm.EditCommand.Execute(null);
+        vm.EditServerName = "edited-here";
+        vm.SaveCommand.Execute(null);
+
+        Assert.Equal("edited-here", store.LoadConfig().Servers.Single().ServerName);
+    }
+
+    [Fact]
+    public void NavigationRefreshPicksUpServersAddedElsewhere()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server("SRV01"));
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+        vm.SelectedServer = vm.Servers.Single();
+
+        store.Config.Servers.Add(Server("SRV02"));
+        vm.RefreshFromConfig();
+
+        Assert.Equal(2, vm.Servers.Count);
+        // Selection survives the rebuild by id.
+        Assert.Equal("SRV01", vm.SelectedServer?.Name);
+    }
+
+    /// <summary>Mid-edit, the list must NOT be rebuilt under the open editor.</summary>
+    [Fact]
+    public void NavigationRefreshLeavesAnOpenEditorAlone()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server("SRV01"));
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService());
+        vm.SelectedServer = vm.Servers.Single();
+        vm.EditCommand.Execute(null);
+        Assert.True(vm.IsEditing);
+
+        store.Config.Servers.Add(Server("SRV02"));
+        vm.RefreshFromConfig();
+
+        Assert.Single(vm.Servers);
+    }
+
+    // ── containers ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AContainerAddedElsewhereSurvivesThisScreensSave()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(Container("old"));
+
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+
+        store.Config.BlobContainers.Add(Container("added-elsewhere"));
+
+        vm.SelectedContainer = vm.Containers.Single(c => c.Name == "old");
+        vm.EditCommand.Execute(null);
+        vm.EditName = "renamed";
+        vm.SaveCommand.Execute(null);
+
+        var names = store.LoadConfig().BlobContainers.Select(c => c.Name).ToList();
+        Assert.Contains("renamed", names);
+        Assert.Contains("added-elsewhere", names);
+        Assert.Equal(2, names.Count);
+    }
+
+    [Fact]
+    public void NavigationRefreshPicksUpContainersAddedElsewhere()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(Container("one"));
+
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+        store.Config.BlobContainers.Add(Container("two"));
+
+        vm.RefreshFromConfig();
+
+        Assert.Equal(2, vm.Containers.Count);
+    }
+}

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -175,6 +175,31 @@ public partial class BlobConfigViewModel : ViewModelBase
     }
 
     /// <summary>
+    /// Containers deleted on THIS screen since the last successful save (#276) - the merge in
+    /// SaveContainers would otherwise resurrect them from the fresh config.
+    /// </summary>
+    private readonly HashSet<string> _pendingDeletes = [];
+
+    /// <summary>
+    /// Catches the list up with entries added elsewhere - Settings' import, the CLI's
+    /// add-container - since this screen loaded (#276). Called on navigation, like every other
+    /// screen's refresh; skipped mid-edit so the open editor's selection survives.
+    /// </summary>
+    public void RefreshFromConfig()
+    {
+        if (IsEditing || IsBusy) return;
+
+        var config = _credentialStore.LoadConfig();
+        var onDisk = config.BlobContainers.Select(c => c.Id).ToHashSet();
+        if (onDisk.SetEquals(Containers.Select(c => c.Id))) return;
+
+        var selectedId = SelectedContainer?.Id;
+        LoadContainers();
+        SelectedContainer = Containers.FirstOrDefault(c => c.Id == selectedId)
+                            ?? Containers.FirstOrDefault();
+    }
+
+    /// <summary>
     /// Persists the container list. Returns false and sets the error when the write failed, so
     /// callers do not go on to report success - the config save used to swallow everything and
     /// the UI said "saved successfully" whether or not anything reached the disk.
@@ -184,8 +209,28 @@ public partial class BlobConfigViewModel : ViewModelBase
         try
         {
             var config = _credentialStore.LoadConfig();
-            config.BlobContainers = [.. Containers];
+
+            // Merge, never replace (#276). Assigning [.. Containers] deleted anything the
+            // import or the CLI's add-container had written since this screen loaded. Known
+            // entries come from this screen, edits included; unseen entries are kept; only
+            // the ledger's local deletions are dropped.
+            var mine = Containers.Where(c => c.Id != null).ToDictionary(c => c.Id!);
+            var merged = new List<BlobContainerConfig>();
+            foreach (var existing in config.BlobContainers)
+            {
+                if (existing.Id != null && _pendingDeletes.Contains(existing.Id)) continue;
+                merged.Add(existing.Id != null && mine.TryGetValue(existing.Id, out var ours)
+                    ? ours
+                    : existing);
+            }
+
+            foreach (var container in Containers)
+                if (!merged.Any(m => ReferenceEquals(m, container)))
+                    merged.Add(container);
+
+            config.BlobContainers = merged;
             _credentialStore.SaveConfig(config);
+            _pendingDeletes.Clear();
             return true;
         }
         catch (Exception ex)
@@ -637,9 +682,11 @@ public partial class BlobConfigViewModel : ViewModelBase
         // container in config.json pointing at a credential that no longer exists.
         var removed = SelectedContainer;
         Containers.Remove(removed);
+        if (removed.Id != null) _pendingDeletes.Add(removed.Id);
         if (!SaveContainers())
         {
             Containers.Add(removed);
+            if (removed.Id != null) _pendingDeletes.Remove(removed.Id);
             SelectedContainer = removed;
             return;
         }

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -595,6 +595,13 @@ public partial class MainViewModel : ViewModelBase
             // Re-read on every visit: a restore run since the last look must be here, and the
             // history is written by the Restore screen rather than by this one.
             History.Refresh();
+        else if (viewName is Nav.SqlServers)
+            // Catches up with servers the import or the CLI's add-server wrote since the last
+            // visit (#276) - without this, the screen's next save wrote its stale list over them.
+            ServerManager.RefreshFromConfig();
+        else if (viewName is Nav.BlobStorage)
+            // Same for containers, same reason (#276).
+            BlobConfig.RefreshFromConfig();
     }
 }
 

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -89,6 +89,13 @@ public partial class ServerManagerViewModel : ViewModelBase
     [ObservableProperty]
     private string _connectedServerDisplay = string.Empty;
 
+    /// <summary>
+    /// Servers deleted on THIS screen since the last successful save (#276). The save merges
+    /// with the config on disk rather than replacing it, and a merge with no memory of local
+    /// deletions would resurrect every one of them from the fresh copy.
+    /// </summary>
+    private readonly HashSet<string> _pendingDeletes = [];
+
     public ServerManagerViewModel(ICredentialStore credentialStore, ISqlServerService sqlService)
     {
         _credentialStore = credentialStore;
@@ -100,6 +107,25 @@ public partial class ServerManagerViewModel : ViewModelBase
     {
         var config = _credentialStore.LoadConfig();
         Servers = new ObservableCollection<ServerConnection>(config.Servers);
+    }
+
+    /// <summary>
+    /// Catches the list up with entries added elsewhere - Settings' import, the CLI's
+    /// add-server - since this screen loaded (#276). Called on navigation, like every other
+    /// screen's refresh. Skipped mid-edit: replacing the list under an open editor would
+    /// reset the selection the editor belongs to.
+    /// </summary>
+    public void RefreshFromConfig()
+    {
+        if (IsEditing || IsBusy) return;
+
+        var config = _credentialStore.LoadConfig();
+        var onDisk = config.Servers.Select(s => s.Id).ToHashSet();
+        if (onDisk.SetEquals(Servers.Select(s => s.Id))) return;
+
+        var selectedId = SelectedServer?.Id;
+        Servers = new ObservableCollection<ServerConnection>(config.Servers);
+        SelectedServer = Servers.FirstOrDefault(s => s.Id == selectedId) ?? Servers.FirstOrDefault();
     }
 
     /// <summary>
@@ -140,8 +166,29 @@ public partial class ServerManagerViewModel : ViewModelBase
         try
         {
             var config = _credentialStore.LoadConfig();
-            config.Servers = [.. Servers];
+
+            // Merge, never replace (#276). This screen's list was loaded when the screen was;
+            // Settings' import or the CLI's add-server may have written entries since, and
+            // assigning [.. Servers] silently deleted every one of them. Entries this screen
+            // knows are taken from this screen, edits included; entries it has never seen are
+            // kept; only entries deleted HERE - the ledger - are dropped.
+            var mine = Servers.Where(s => s.Id != null).ToDictionary(s => s.Id!);
+            var merged = new List<ServerConnection>();
+            foreach (var existing in config.Servers)
+            {
+                if (existing.Id != null && _pendingDeletes.Contains(existing.Id)) continue;
+                merged.Add(existing.Id != null && mine.TryGetValue(existing.Id, out var ours)
+                    ? ours
+                    : existing);
+            }
+
+            foreach (var server in Servers)
+                if (!merged.Any(m => ReferenceEquals(m, server)))
+                    merged.Add(server);
+
+            config.Servers = merged;
             _credentialStore.SaveConfig(config);
+            _pendingDeletes.Clear();
             return true;
         }
         catch (Exception ex)
@@ -357,9 +404,11 @@ public partial class ServerManagerViewModel : ViewModelBase
         var removed = SelectedServer;
         var index = Servers.IndexOf(removed);
         Servers.Remove(removed);
+        if (removed.Id != null) _pendingDeletes.Add(removed.Id);
         if (!SaveServers())
         {
             Servers.Insert(Math.Clamp(index, 0, Servers.Count), removed);
+            if (removed.Id != null) _pendingDeletes.Remove(removed.Id);
             SelectedServer = removed;
             return;
         }


### PR DESCRIPTION
Closes #276 - the worst finding of the review board: data loss, one click.

Both config-owning screens loaded their lists once, at construction, and every save wrote that list back wholesale. Anything written since - Settings' import, the CLI's \`add-server\`/\`add-container\` - was silently deleted. The production path: import a config, visit SQL Servers, click Connect; recording the detected version triggers a save, and every imported server is gone. No error, no confirmation. SettingsViewModel documents this exact hazard; these two screens were the violation.

**The fix, in both screens:**
- **Merge by id, never replace**: entries the screen knows are taken from the screen (edits included); entries it has never seen are kept; only deletions made on the screen delete - tracked in a ledger so the merge cannot resurrect them from the fresh copy.
- **Catch-up on navigation**, like every other screen's refresh: additions made elsewhere appear on the next visit. Skipped mid-edit, so the open editor's selection survives.

Six pins (1,638 total), driven through the dialog-free edit path since both Delete commands confirm via MessageBox: unseen entries survive a save, the screen's edit wins for an entry both sides know, navigation refresh picks up outside additions and preserves selection by id, and an open editor is left alone. (The Delete confirms make the ledger's don't-resurrect promise unreachable headlessly - noted for #291's server-lifecycle work, where the confirm should become injectable.)