### PR TITLE
Imports must not destroy and must not lie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ more detail on the user-facing changes; this file is the short history.
   the screen loaded - the worst case being import, then Connect, and every imported server
   gone. Both screens also catch up with outside additions on navigation, and only deletions
   made on the screen itself delete (#276)
+- Imports no longer destroy and no longer lie (#277): the webhook list refreshes immediately
+  after an import, so the next row edit cannot erase what was just imported; a matching
+  container keeps the SAS pasted into its local URL (the same protection webhook URLs always
+  had), unless the base URL changed - a SAS is scoped to what it was issued for; the summary
+  counts webhooks; and a file without a format version - an empty JSON object used to import
+  as "Nothing new" - is refused as not an export, as is a file from a newer format. Theme and
+  the update/log preferences are no longer exported, because the import never applied them -
+  a file must not carry what the import discards
 - Find marks now asks the SOURCE instance's msdb on shared-path and ad-hoc restores - marked
   transactions are recorded where they ran, so asking the target answered "no marks" when the
   truth was "wrong catalogue". Blob still asks the connected server, which is the only

--- a/src/NineLives.Core/Services/ConfigPortability.cs
+++ b/src/NineLives.Core/Services/ConfigPortability.cs
@@ -11,8 +11,16 @@ namespace Blackcat.NineLives.Services;
 /// </summary>
 public sealed class ExportedConfig
 {
-    /// <summary>Format version, for reading files from newer or older builds politely.</summary>
-    public int FormatVersion { get; set; } = 1;
+    /// <summary>
+    /// Format version. Nullable so ABSENCE is detectable (#277): with a defaulted int, any
+    /// well-formed JSON - an empty object included - deserialised into a plausible-looking
+    /// export and imported as "Nothing new". Export always writes it; Read refuses a file
+    /// without it, or from a newer format than this build knows.
+    /// </summary>
+    public int? FormatVersion { get; set; }
+
+    /// <summary>The newest format this build can read - and the one it writes.</summary>
+    public const int CurrentFormatVersion = 1;
 
     public string? ExportedBy { get; set; }
     public DateTime ExportedAt { get; set; }
@@ -23,16 +31,19 @@ public sealed class ExportedConfig
     /// <summary>Endpoints travel as shapes - name, format, toggles - with their URLs stripped.</summary>
     public List<WebhookEndpoint> Webhooks { get; set; } = [];
 
+    // Mode is the one preference that travels: nullable, so "this machine never chose" is a
+    // real state the merge can respect. Theme and the update/log settings used to be exported
+    // too but were never applied on import - an export that carries what the import discards
+    // is a promise the file cannot keep, so they are gone (#277). Old files' extra fields
+    // deserialise harmlessly.
     public AppMode? Mode { get; set; }
-    public AppTheme Theme { get; set; }
-    public bool CheckForUpdates { get; set; } = true;
-    public int LogRetentionDays { get; set; }
 }
 
 /// <summary>What an import did, in words somebody can check against what they expected.</summary>
 public sealed record ImportSummary(
     int ContainersAdded, int ContainersUpdated,
     int ServersAdded, int ServersUpdated,
+    int WebhooksAdded, int WebhooksUpdated,
     IReadOnlyList<string> NeedCredentials)
 {
     public string Describe()
@@ -43,6 +54,8 @@ public sealed record ImportSummary(
         if (ContainersUpdated > 0) parts.Add($"{ContainersUpdated} container(s) updated");
         if (ServersAdded > 0) parts.Add($"{ServersAdded} server(s) added");
         if (ServersUpdated > 0) parts.Add($"{ServersUpdated} server(s) updated");
+        if (WebhooksAdded > 0) parts.Add($"{WebhooksAdded} webhook(s) added");
+        if (WebhooksUpdated > 0) parts.Add($"{WebhooksUpdated} webhook(s) updated");
         if (parts.Count == 0) parts.Add("Nothing new - everything in the file was already here");
 
         var summary = string.Join(", ", parts) + ".";
@@ -75,6 +88,7 @@ public static class ConfigPortability
     {
         var exported = new ExportedConfig
         {
+            FormatVersion = ExportedConfig.CurrentFormatVersion,
             ExportedBy = $"Nine Lives {AppVersion.Display}",
             ExportedAt = DateTime.Now,
             BlobContainers = config.BlobContainers.Select(Sanitise).ToList(),
@@ -85,21 +99,25 @@ public static class ConfigPortability
             Webhooks = config.Webhooks
                 .Select(w => { var c = CloneViaJson(w); c.Url = string.Empty; return c; })
                 .ToList(),
-            Mode = config.Mode,
-            Theme = config.Theme,
-            CheckForUpdates = config.CheckForUpdates,
-            LogRetentionDays = config.LogRetentionDays
+            Mode = config.Mode
         };
 
         return JsonSerializer.Serialize(exported, Options);
     }
 
-    /// <summary>Null when the file is not an exported configuration at all.</summary>
+    /// <summary>
+    /// Null when the file is not an exported configuration at all - malformed JSON, JSON that
+    /// never came from Export (no FormatVersion; an empty object used to import as "Nothing
+    /// new"), or a format newer than this build knows how to read honestly (#277).
+    /// </summary>
     public static ExportedConfig? Read(string json)
     {
         try
         {
-            return JsonSerializer.Deserialize<ExportedConfig>(json);
+            var read = JsonSerializer.Deserialize<ExportedConfig>(json);
+            return read?.FormatVersion is >= 1 and <= ExportedConfig.CurrentFormatVersion
+                ? read
+                : null;
         }
         catch (JsonException)
         {
@@ -115,6 +133,7 @@ public static class ConfigPortability
     public static ImportSummary Merge(AppConfig target, ExportedConfig imported)
     {
         int containersAdded = 0, containersUpdated = 0, serversAdded = 0, serversUpdated = 0;
+        int webhooksAdded = 0, webhooksUpdated = 0;
         var needCredentials = new List<string>();
 
         foreach (var incoming in imported.BlobContainers)
@@ -132,6 +151,22 @@ public static class ConfigPortability
             }
             else
             {
+                // The exported URL travels stripped, so an update must not delete the query
+                // this machine's URL carries - the same protection webhook URLs get below
+                // (#277). Only while the base still matches: a SAS is scoped to what it was
+                // issued for, so a changed base makes the old query meaningless and the
+                // entry goes back on the needs-credentials list instead.
+                var localQuery = existing.ContainerUrl.IndexOf('?');
+                if (localQuery >= 0)
+                {
+                    var localBase = existing.ContainerUrl[..localQuery].TrimEnd('/');
+                    if (string.Equals(localBase, clean.ContainerUrl.TrimEnd('/'),
+                            StringComparison.OrdinalIgnoreCase))
+                        clean.ContainerUrl += existing.ContainerUrl[localQuery..];
+                    else if (clean.AuthMode == BlobAuthMode.SasToken)
+                        needCredentials.Add($"container {clean.Name}");
+                }
+
                 var index = target.BlobContainers.IndexOf(existing);
                 target.BlobContainers[index] = clean;
                 containersUpdated++;
@@ -167,6 +202,7 @@ public static class ConfigPortability
             if (existing == null)
             {
                 target.Webhooks.Add(clone);
+                webhooksAdded++;
                 if (!clone.IsUsable) needCredentials.Add($"webhook {clone.Name}");
             }
             else
@@ -174,16 +210,17 @@ public static class ConfigPortability
                 // The URL never travels, so an update must not blank the one this machine holds.
                 clone.Url = existing.Url;
                 target.Webhooks[target.Webhooks.IndexOf(existing)] = clone;
+                webhooksUpdated++;
             }
         }
 
-        // Preferences travel only where the local machine has not said otherwise: mode and theme
-        // are taken from the file ONLY on a machine that never chose one. A jump box inheriting
-        // the exporting DBA's dark theme is fine; overwriting a choice this machine made is not.
+        // The one travelling preference: mode is taken from the file ONLY on a machine that
+        // never chose one. Overwriting a choice this machine made is not an import's business.
         target.Mode ??= imported.Mode;
 
         return new ImportSummary(
-            containersAdded, containersUpdated, serversAdded, serversUpdated, needCredentials);
+            containersAdded, containersUpdated, serversAdded, serversUpdated,
+            webhooksAdded, webhooksUpdated, needCredentials);
     }
 
     /// <summary>

--- a/src/NineLives.Tests/ConfigPortabilityTests.cs
+++ b/src/NineLives.Tests/ConfigPortabilityTests.cs
@@ -163,4 +163,73 @@ public class ConfigPortabilityTests
         ConfigPortability.Merge(fresh, ConfigPortability.Read(ConfigPortability.Export(Config()))!);
         Assert.Equal(AppMode.Pro, fresh.Mode);
     }
+
+    // ── imports must not destroy and must not lie (#277) ────────────────────────
+
+    /// <summary>{} used to deserialise into a plausible export and import as "Nothing new".</summary>
+    [Fact]
+    public void AnEmptyJsonObjectIsNotAnExport()
+        => Assert.Null(ConfigPortability.Read("{}"));
+
+    [Fact]
+    public void AFileFromANewerFormatIsRefusedNotMisread()
+    {
+        var json = ConfigPortability.Export(Config())
+            .Replace("\"FormatVersion\": 1", "\"FormatVersion\": 99");
+
+        Assert.Null(ConfigPortability.Read(json));
+    }
+
+    /// <summary>
+    /// The round-trip that used to destroy a credential: export on this machine, import the
+    /// same file back, and a SAS pasted into the container's URL was stripped by the merge.
+    /// The base URL still matching is what makes carrying the query safe.
+    /// </summary>
+    [Fact]
+    public void AMatchingContainerKeepsItsLocalSasQueryAcrossAnImport()
+    {
+        var local = Config();
+        local.BlobContainers[0].ContainerUrl =
+            "https://acct.blob.core.windows.net/backups?sv=2024&sig=LOCALSECRET";
+
+        var exported = ConfigPortability.Read(ConfigPortability.Export(Config()))!;
+        ConfigPortability.Merge(local, exported);
+
+        Assert.Contains("sig=LOCALSECRET", local.BlobContainers.Single().ContainerUrl);
+    }
+
+    /// <summary>A SAS is scoped to what it was issued for - a changed base cannot keep it.</summary>
+    [Fact]
+    public void AChangedBaseUrlDropsTheStaleQueryAndAsksForCredentials()
+    {
+        var local = Config();
+        local.BlobContainers[0].ContainerUrl =
+            "https://acct.blob.core.windows.net/backups?sv=2024&sig=OLD";
+
+        var incoming = Config();
+        incoming.BlobContainers[0].ContainerUrl = "https://other.blob.core.windows.net/backups";
+        var exported = ConfigPortability.Read(ConfigPortability.Export(incoming))!;
+
+        var summary = ConfigPortability.Merge(local, exported);
+
+        Assert.DoesNotContain("sig=OLD", local.BlobContainers.Single().ContainerUrl);
+        Assert.Contains(summary.NeedCredentials, n => n.Contains("backups"));
+    }
+
+    /// <summary>"Nothing new" after importing webhooks was the summary lying by omission.</summary>
+    [Fact]
+    public void WebhookCountsAppearInTheSummary()
+    {
+        var source = Config();
+        source.Webhooks.Add(new WebhookEndpoint { Id = "w1", Name = "Ops channel" });
+        var exported = ConfigPortability.Read(ConfigPortability.Export(source))!;
+
+        var fresh = new AppConfig();
+        var added = ConfigPortability.Merge(fresh, exported);
+        Assert.Equal(1, added.WebhooksAdded);
+        Assert.Contains("webhook", added.Describe());
+
+        var again = ConfigPortability.Merge(fresh, exported);
+        Assert.Equal(1, again.WebhooksUpdated);
+    }
 }

--- a/src/NineLives.Tests/SettingsImportTests.cs
+++ b/src/NineLives.Tests/SettingsImportTests.cs
@@ -1,0 +1,40 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The Settings screen's import, minus the file dialog (#277). The screen that runs the import
+/// is the same screen holding the webhook list, and that list rewrites the WHOLE config on any
+/// row edit - so the import must refresh it, or the next click erases what was just imported.
+/// </summary>
+public class SettingsImportTests
+{
+    [Fact]
+    public void ImportedWebhooksSurviveTheNextRowEdit()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Webhooks.Add(new WebhookEndpoint { Id = "w-local", Name = "Existing" });
+
+        var vm = new SettingsViewModel(store);
+
+        // The file being imported carries a webhook this machine has never seen.
+        var source = new AppConfig();
+        source.Webhooks.Add(new WebhookEndpoint { Id = "w-imported", Name = "Imported" });
+        var exported = ConfigPortability.Read(ConfigPortability.Export(source))!;
+
+        var summary = vm.ImportFrom(exported);
+        Assert.NotNull(summary);
+        Assert.Equal(1, summary!.WebhooksAdded);
+
+        // The next row edit rewrites the whole list from screen state - the erasing click.
+        vm.AddWebhookCommand.Execute(null);
+
+        var names = store.LoadConfig().Webhooks.Select(w => w.Name).ToList();
+        Assert.Contains("Existing", names);
+        Assert.Contains("Imported", names);
+        Assert.Equal(3, names.Count);
+    }
+}

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -127,27 +127,44 @@ public partial class SettingsViewModel : ViewModelBase
             var imported = ConfigPortability.Read(System.IO.File.ReadAllText(dialog.FileName));
             if (imported == null)
             {
-                SetError("That file is not a Nine Lives configuration export.");
+                SetError("That file is not a Nine Lives configuration export - or it came " +
+                         "from a newer version of the app than this one.");
                 return;
             }
 
-            var config = _credentialStore.LoadConfig();
-            if (config.LoadError != null)
-            {
-                SetError($"The local configuration could not be read, so nothing was imported: {config.LoadError}");
-                return;
-            }
+            var summary = ImportFrom(imported);
+            if (summary == null) return;
 
-            var summary = ConfigPortability.Merge(config, imported);
-            _credentialStore.SaveConfig(config);
-
-            SetStatus(summary.Describe() + " Restart screens that list servers or containers to see them.");
+            SetStatus(summary.Describe() + " Imported entries appear on the servers and " +
+                      "containers screens on their next visit.");
             _log.Info($"[config] imported from {dialog.FileName}: {summary.Describe()}");
         }
         catch (Exception ex)
         {
             SetError($"Import failed: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// The import minus the file dialog, so the merge-and-reload contract is testable (#277).
+    /// </summary>
+    internal ImportSummary? ImportFrom(ExportedConfig imported)
+    {
+        var config = _credentialStore.LoadConfig();
+        if (config.LoadError != null)
+        {
+            SetError($"The local configuration could not be read, so nothing was imported: {config.LoadError}");
+            return null;
+        }
+
+        var summary = ConfigPortability.Merge(config, imported);
+        _credentialStore.SaveConfig(config);
+
+        // The on-screen webhook list catches up NOW, not on restart: the next edit to any row
+        // rewrites the whole webhook list from screen state, and a stale list would erase
+        // exactly what was just imported (#277).
+        LoadWebhooks(config);
+        return summary;
     }
 
     /// <summary>True while the constructor is filling the properties from config.</summary>


### PR DESCRIPTION
Closes #277 - the second data-loss finding of the review board.

**Destroy, fixed twice:**
- Importing webhooks then touching ANY webhook row erased the imported ones: the Settings screen holds both the import button and the webhook list, the list rewrites the whole webhook config on every row edit, and the import never refreshed it. It refreshes now, immediately.
- Round-tripping an export destroyed the exporting machine's own credential: the merge replaced a matching container with the sanitised copy, stripping a SAS pasted into the local URL. The local query now survives an id-matched update - the exact protection webhook URLs always had - unless the base URL changed, where a scoped SAS is meaningless anyway: the stale query is dropped and the entry goes back on the needs-credentials list.

**Lie, fixed three ways:**
- The summary counts webhooks - importing them no longer reports "Nothing new".
- \`FormatVersion\` is now nullable, always written, and actually checked: an empty JSON object used to deserialise into a plausible export and import as "Nothing new"; it and any newer-format file are refused as not-an-export, with the error message saying the newer-version case out loud.
- Theme and the update/log preferences are no longer exported, because the import never applied them - the comment claimed theme travels and it never did. An export must not carry what the import discards. (Old files' extra fields deserialise harmlessly.)

The import body is extracted from behind the file dialog (\`ImportFrom\`), so the merge-and-reload contract is testable: six new pins including the erasing-click path end to end, plus the import status text updated to match #304's navigation refresh ("appear on their next visit" rather than "restart").