### PR TITLE
A generated script does not survive the change that invalidated it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ more detail on the user-facing changes; this file is the short history.
   the screen loaded - the worst case being import, then Connect, and every imported server
   gone. Both screens also catch up with outside additions on navigation, and only deletions
   made on the screen itself delete (#276)
+- A generated script no longer survives the change that invalidated it (#278). On the backup
+  and copy screens, an input change that makes regeneration impossible now CLEARS the script,
+  the destinations and the run button instead of leaving the old statements displayed and
+  runnable - switching servers after generating used to leave a script for one instance
+  executable against another, with the previous server's multi-select ticks and certificate
+  list still standing
 - Imports no longer destroy and no longer lie (#277): the webhook list refreshes immediately
   after an import, so the next row edit cannot erase what was just imported; a matching
   container keeps the SAS pasted into its local URL (the same protection webhook URLs always

--- a/src/NineLives.Tests/StaleGeneratedStateTests.cs
+++ b/src/NineLives.Tests/StaleGeneratedStateTests.cs
@@ -1,0 +1,107 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A generated script must not survive the change that invalidated it (#278). Both the backup
+/// and copy screens rest on "nothing runs that was not on screen first" - and both used to
+/// leave the OLD script displayed and runnable when an input change made regeneration
+/// impossible: generate for a database on one server, switch the server box, and two presses
+/// executed the old statements against the new instance.
+/// </summary>
+public class StaleGeneratedStateTests
+{
+    private static (BackupViewModel vm, FakeSqlServerService sql) BackupStage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb", "OtherDb"] };
+        var vm = new BackupViewModel(store, sql, TestLogs.Temp());
+        vm.Server = vm.Servers.First(s => s.Name == "SRV01");
+        vm.Container = vm.Containers.Single();
+        return (vm, sql);
+    }
+
+    [Fact]
+    public async Task SwitchingServersAfterGeneratingLeavesNothingRunnable()
+    {
+        var (vm, _) = BackupStage();
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.SelectedDatabase = "MyDb";
+        vm.GenerateCommand.Execute(null);
+        Assert.True(vm.HasScript);
+
+        vm.Server = vm.Servers.First(s => s.Name == "SRV02");
+
+        Assert.False(vm.HasScript);
+        Assert.Equal(string.Empty, vm.GeneratedScript);
+        Assert.Empty(vm.Destinations);
+        Assert.False(vm.CanExecute);
+    }
+
+    /// <summary>The multi-select ticks belonged to the previous instance too.</summary>
+    [Fact]
+    public async Task SwitchingServersClearsTheMultiSelectTicksAndCertificates()
+    {
+        var (vm, _) = BackupStage();
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.MultiSelect = true;
+        vm.PickAllCommand.Execute(null);
+        Assert.True(vm.CanGenerate);
+
+        vm.Server = vm.Servers.First(s => s.Name == "SRV02");
+
+        Assert.Empty(vm.DatabasePicks);
+        Assert.Empty(vm.EncryptionCertificates);
+        Assert.Null(vm.SelectedEncryptionCertificate);
+        Assert.False(vm.CanGenerate);
+    }
+
+    [Fact]
+    public void BlankingTheCopyTargetLeavesNothingRunnable()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp());
+        vm.SourceServer = vm.Servers.First();
+        vm.TargetServer = vm.Servers.Last();
+        vm.Container = vm.Containers.Single();
+        vm.SourceDatabases = ["MyDb"];
+        vm.SourceDatabase = "MyDb";
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.GenerateCommand.Execute(null);
+        Assert.True(vm.HasScripts);
+
+        vm.TargetDatabaseName = "";
+
+        Assert.False(vm.HasScripts);
+        Assert.Equal(string.Empty, vm.BackupScript);
+        Assert.Equal(string.Empty, vm.RestoreScript);
+        Assert.Empty(vm.Destinations);
+        Assert.False(vm.CanRun);
+    }
+}

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -200,9 +200,15 @@ public partial class BackupViewModel : ViewModelBase
     partial void OnServerChanged(ServerConnection? value)
     {
         // The database list belonged to the previous instance. Leaving it up invites somebody to
-        // back up a name that exists on both and mean the other one.
+        // back up a name that exists on both and mean the other one - and the multi-select
+        // ticks and certificate list are the same hazard with the same fix (#278): stale ticks
+        // satisfied CanGenerate, so the regenerated statements named the OLD server's databases
+        // with destinations claiming the new one, encrypted by a certificate it does not hold.
         Databases = [];
         SelectedDatabase = null;
+        DatabasePicks = [];
+        EncryptionCertificates = [];
+        SelectedEncryptionCertificate = null;
         Invalidate();
     }
 
@@ -354,7 +360,22 @@ public partial class BackupViewModel : ViewModelBase
         // Disarm: an armed button that survives an option change is armed for something else.
         IsArmed = false;
 
-        if (HasScript) Generate();
+        if (!HasScript) return;
+
+        // Regenerate - or, when the inputs no longer support generating, CLEAR. Leaving the
+        // old script standing kept the Run button live: generate for a database on one server,
+        // switch the server box, and two presses executed the old statements against the new
+        // instance (#278). An empty screen is the truthful one here.
+        if (CanGenerate) Generate();
+        else ClearGenerated();
+    }
+
+    /// <summary>Removes every trace of the last generation, so nothing stale can run.</summary>
+    private void ClearGenerated()
+    {
+        _generated = [];
+        GeneratedScript = string.Empty;
+        Destinations = [];
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -282,7 +282,24 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         // An armed run that survives a change is armed for something else.
         IsArmed = false;
 
-        if (HasScripts) Generate();
+        if (!HasScripts) return;
+
+        // Regenerate - or, when the inputs no longer support generating, CLEAR (#278).
+        // Blanking the target name left the previous scripts standing and CanRun true: the
+        // Refusal getter answers nothing for incomplete input, so the screen showed runnable
+        // statements naming a target nobody was asking for any more.
+        if (CanGenerate) Generate();
+        else ClearGenerated();
+    }
+
+    /// <summary>Removes every trace of the last generation, so nothing stale can run.</summary>
+    private void ClearGenerated()
+    {
+        BackupScript = string.Empty;
+        RestoreScript = string.Empty;
+        Destinations = [];
+        OnPropertyChanged(nameof(CanRun));
+        RunCommand.NotifyCanExecuteChanged();
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #278 - the wrong-thing-runs finding of the review board.

Both screens' contract is "nothing runs that was not on screen first". Both broke it identically: \`Invalidate()\` regenerated only when \`CanGenerate\` held, so an input change that broke generability left the OLD script on screen with the Run button live. Generate for a database on SRV01, switch to SRV02, two presses - the SRV01 statements execute against SRV02. The copy screen's version: blank the target name and the previous scripts stay runnable, because the Refusal getter deliberately says nothing for incomplete input.

**The fix**: when invalidation cannot regenerate, it CLEARS - script, destinations, run availability, together. And switching servers on the backup screen now clears what the old instance owned: the multi-select ticks (which satisfied \`CanGenerate\` and made regeneration name the old server's databases with destinations claiming the new one) and the certificate list (\`WITH ENCRYPTION\` against a certificate the new server does not hold). The code's own comment described the hazard; now the code agrees.

Three pins (1,647 total): switch-after-generate leaves nothing runnable; ticks and certificates clear with the server; blanking the copy target clears both scripts and \`CanRun\`.