### PR TITLE
The CLI's endings are trustworthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ more detail on the user-facing changes; this file is the short history.
   the screen loaded - the worst case being import, then Connect, and every imported server
   gone. Both screens also catch up with outside additions on navigation, and only deletions
   made on the screen itself delete (#276)
+- The CLI's endings are trustworthy now (#296). Completion webhooks no longer race process
+  exit - the execution verbs drain pending deliveries (bounded, ten seconds) before
+  returning, so the success and problem messages actually arrive from a process that exits
+  the moment the run ends. And Ctrl+C mid-run is a story, not a kill: the receipt says
+  Cancelled, the channel is told, and the exit code is the conventional 130 so a wrapping
+  script can tell an operator's interruption from a failure
 - A generated script no longer survives the change that invalidated it (#278). On the backup
   and copy screens, an input change that makes regeneration impossible now CLEARS the script,
   the destinations and the run button instead of leaving the old statements displayed and

--- a/src/NineLives.Cli/ExitCodes.cs
+++ b/src/NineLives.Cli/ExitCodes.cs
@@ -30,4 +30,10 @@ internal static class ExitCodes
 
     /// <summary>Bad invocation: unknown verb, missing option, malformed time. BSD's EX_USAGE.</summary>
     public const int Usage = 64;
+
+    /// <summary>
+    /// Ctrl+C. The Unix convention (128+SIGINT), so a wrapping script tells an operator's
+    /// interruption from a failure - they call for different next steps (#296).
+    /// </summary>
+    public const int Interrupted = 130;
 }

--- a/src/NineLives.Cli/Program.cs
+++ b/src/NineLives.Cli/Program.cs
@@ -15,6 +15,16 @@ internal static class Program
     {
         Console.OutputEncoding = Encoding.UTF8;
 
+        // Ctrl+C cancels the run rather than killing the story (#296): the execution verbs
+        // turn the token into a Cancelled receipt, a Problem notification and exit 130. Cancel
+        // is marked handled so the runtime does not tear the process down mid-sentence.
+        using var interrupt = new CancellationTokenSource();
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            interrupt.Cancel();
+        };
+
         if (rawArgs.Length == 0
             || rawArgs[0] is "--help" or "-h" or "-?" or "/?")
         {
@@ -94,8 +104,8 @@ internal static class Program
                 "script" => await ScriptVerb.RunAsync(args, services, Console.Out, Console.Error),
                 "validate" => await ValidateVerb.RunAsync(args, services, Console.Out, Console.Error),
                 "exposure" => await ExposureVerb.RunAsync(args, services, Console.Out, Console.Error),
-                "restore" => await RestoreVerb.RunAsync(args, services, Console.Out, Console.Error),
-                "rehearse" => await RehearseVerb.RunAsync(args, services, Console.Out, Console.Error),
+                "restore" => await RestoreVerb.RunAsync(args, services, Console.Out, Console.Error, interrupt.Token),
+                "rehearse" => await RehearseVerb.RunAsync(args, services, Console.Out, Console.Error, interrupt.Token),
                 _ => ExitCodes.Usage
             };
         }

--- a/src/NineLives.Cli/Verbs/RehearseVerb.cs
+++ b/src/NineLives.Cli/Verbs/RehearseVerb.cs
@@ -62,7 +62,8 @@ internal static class RehearseVerb
             "0   PROVEN - restored, CHECKDB clean, scratch dropped (or, without --execute, printed)",
             "2   NOT PROVEN - the failure is recorded, the scratch copy retained as evidence",
             "3   the source or target could not be reached, or FILELISTONLY answered nothing",
-            "64  usage"
+            "64  usage",
+            "130 cancelled with Ctrl+C - recorded, told to the channel, scratch retained if begun"
         ],
         Examples:
         [
@@ -73,7 +74,8 @@ internal static class RehearseVerb
         ]);
 
     public static async Task<int> RunAsync(
-        CliArguments args, CliServices services, TextWriter output, TextWriter errors)
+        CliArguments args, CliServices services, TextWriter output, TextWriter errors,
+        CancellationToken ct = default)
     {
         if (args.Get("database") == null || args.Get("target") == null)
         {
@@ -177,7 +179,7 @@ internal static class RehearseVerb
 
         try
         {
-            await services.Sql.ExecuteWithProgressAsync(target, script, Progress);
+            await services.Sql.ExecuteWithProgressAsync(target, script, Progress, ct);
 
             var completedAt = DateTime.Now;
             services.History.Append(new RestoreHistoryEntry
@@ -204,7 +206,39 @@ internal static class RehearseVerb
             errors.WriteLine($"PROVEN: '{sourceDatabase}' restores. Took " +
                              $"{(completedAt - startedAt).TotalSeconds:0}s - that is the " +
                              "measured RTO, and the receipt is in the app's History.");
+            await services.Notifier.DrainAsync(NotificationDrain);
             return ExitCodes.Ok;
+        }
+        catch (OperationCanceledException)
+        {
+            // Ctrl+C mid-rehearsal (#296): recorded as Cancelled, told to the channel, and
+            // exited with 128+SIGINT - and the scratch copy note still applies, because the
+            // interruption may have landed after its restore began.
+            var completedAt = DateTime.Now;
+            log.AppendLine("Cancelled from the terminal.");
+            services.History.Append(new RestoreHistoryEntry
+            {
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                ServerName = target.ServerName,
+                TargetDatabase = scratch,
+                SourceDatabase = sourceDatabase,
+                ContainerName = args.Get("container"),
+                RestorePointTimestamp = stopAt ?? point.Timestamp,
+                ChainSummary = point.TypeDisplay,
+                Kind = "Rehearsal",
+                Outcome = RestoreOutcome.Cancelled,
+                ErrorMessage = "Cancelled from the terminal.",
+                Script = script,
+                Log = log.ToString()
+            });
+            services.Notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Rehearsal", sourceDatabase, target.ServerName,
+                "Cancelled from the terminal.", completedAt - startedAt));
+            await services.Notifier.DrainAsync(NotificationDrain);
+            errors.WriteLine($"CANCELLED. If the scratch restore had begun, '{scratch}' is " +
+                             "retained - inspect, then drop it.");
+            return ExitCodes.Interrupted;
         }
         catch (Exception ex)
         {
@@ -234,7 +268,11 @@ internal static class RehearseVerb
             errors.WriteLine($"NOT PROVEN: {ex.Message}");
             errors.WriteLine($"The scratch copy '{scratch}' is retained as evidence when the " +
                              "failure happened after its restore began - inspect, then drop it.");
+            await services.Notifier.DrainAsync(NotificationDrain);
             return ExitCodes.Failed;
         }
     }
+
+    /// <summary>Long enough for a slow webhook, short enough that a dead one cannot hold the exit.</summary>
+    private static readonly TimeSpan NotificationDrain = TimeSpan.FromSeconds(10);
 }

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -76,7 +76,8 @@ internal static class RestoreVerb
             "0   restored - or, without --execute, generated with nothing refused",
             "2   refused by a preflight, or the restore itself failed",
             "3   the source or target could not be reached at all",
-            "64  usage"
+            "64  usage",
+            "130 cancelled with Ctrl+C - the receipt says Cancelled, the channel was told"
         ],
         Examples:
         [
@@ -89,7 +90,8 @@ internal static class RestoreVerb
         ]);
 
     public static async Task<int> RunAsync(
-        CliArguments args, CliServices services, TextWriter output, TextWriter errors)
+        CliArguments args, CliServices services, TextWriter output, TextWriter errors,
+        CancellationToken ct = default)
     {
         if (args.Get("database") == null || args.Get("target") == null)
         {
@@ -195,13 +197,13 @@ internal static class RestoreVerb
 
         return await ExecuteAsync(
             services, target, script, sourceDatabase, targetDatabase, point, stopAt,
-            chain, args.Get("container"), errors);
+            chain, args.Get("container"), errors, ct);
     }
 
     private static async Task<int> ExecuteAsync(
         CliServices services, ServerConnection target, string script, string sourceDatabase,
         string targetDatabase, RestorePoint point, DateTime? stopAt, BackupChain chain,
-        string? containerName, TextWriter errors)
+        string? containerName, TextWriter errors, CancellationToken ct)
     {
         var startedAt = DateTime.Now;
         var log = new System.Text.StringBuilder();
@@ -219,7 +221,7 @@ internal static class RestoreVerb
 
         try
         {
-            await services.Sql.ExecuteWithProgressAsync(target, script, Progress);
+            await services.Sql.ExecuteWithProgressAsync(target, script, Progress, ct);
 
             var completedAt = DateTime.Now;
             services.History.Append(new RestoreHistoryEntry
@@ -243,7 +245,39 @@ internal static class RestoreVerb
 
             errors.WriteLine($"Done: '{targetDatabase}' restored on {target.ServerName} in " +
                              $"{(completedAt - startedAt).TotalSeconds:0}s.");
+            await services.Notifier.DrainAsync(NotificationDrain);
             return ExitCodes.Ok;
+        }
+        catch (OperationCanceledException)
+        {
+            // Ctrl+C mid-restore (#296): the process is ending, but the story must not - the
+            // receipt says Cancelled, the channel hears about it, and the exit code is the
+            // conventional 128+SIGINT so a wrapping script can tell interruption from failure.
+            var completedAt = DateTime.Now;
+            log.AppendLine("Cancelled from the terminal.");
+            services.History.Append(new RestoreHistoryEntry
+            {
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                ServerName = target.ServerName,
+                TargetDatabase = targetDatabase,
+                SourceDatabase = sourceDatabase,
+                ContainerName = containerName,
+                RestorePointTimestamp = stopAt ?? point.Timestamp,
+                ChainSummary = point.TypeDisplay,
+                Outcome = RestoreOutcome.Cancelled,
+                ErrorMessage = "Cancelled from the terminal.",
+                Script = script,
+                Log = log.ToString()
+            });
+            services.Notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Restore", sourceDatabase, target.ServerName,
+                "Cancelled from the terminal - check the target database's state before " +
+                "retrying.", completedAt - startedAt));
+            await services.Notifier.DrainAsync(NotificationDrain);
+            errors.WriteLine("CANCELLED. The history entry records how far it got - check " +
+                             "the target database's state before retrying.");
+            return ExitCodes.Interrupted;
         }
         catch (Exception ex)
         {
@@ -272,7 +306,11 @@ internal static class RestoreVerb
             errors.WriteLine($"FAILED: {ex.Message}");
             errors.WriteLine("The history entry records how far it got - check the target " +
                              "database's state before retrying.");
+            await services.Notifier.DrainAsync(NotificationDrain);
             return ExitCodes.Failed;
         }
     }
+
+    /// <summary>Long enough for a slow webhook, short enough that a dead one cannot hold the exit.</summary>
+    private static readonly TimeSpan NotificationDrain = TimeSpan.FromSeconds(10);
 }

--- a/src/NineLives.Core/Services/RunNotifications.cs
+++ b/src/NineLives.Core/Services/RunNotifications.cs
@@ -38,6 +38,15 @@ public sealed record RunNotification(
 public interface IRunNotifier
 {
     void Notify(RunNotification notification);
+
+    /// <summary>
+    /// Waits - bounded - for notifications already handed to Notify to actually deliver (#296).
+    /// Notify stays fire-and-forget, which is right in the app where the process lives on; a
+    /// short-lived process must drain before exiting or the completion events - the ones the
+    /// 3am story exists for - die with it. The timeout keeps a dead endpoint from holding the
+    /// process hostage: this waits for deliveries, it does not guarantee them.
+    /// </summary>
+    Task DrainAsync(TimeSpan timeout);
 }
 
 /// <summary>For screens constructed without notification wiring - the tests, mostly.</summary>
@@ -45,4 +54,5 @@ public sealed class NullRunNotifier : IRunNotifier
 {
     public static readonly NullRunNotifier Instance = new();
     public void Notify(RunNotification notification) { }
+    public Task DrainAsync(TimeSpan timeout) => Task.CompletedTask;
 }

--- a/src/NineLives.Core/Services/WebhookNotifier.cs
+++ b/src/NineLives.Core/Services/WebhookNotifier.cs
@@ -204,8 +204,10 @@ public class WebhookNotifier
     /// <summary>
     /// Posts to every endpoint that wants this phase. Failures go to <paramref name="log"/> and
     /// nowhere else - the run this describes must never be affected by its announcement.
+    /// Virtual for the drain pin (#296): proving DrainAsync waits needs a delivery that takes
+    /// a measurable moment, and the only honest slow delivery in a test is a substituted one.
     /// </summary>
-    public async Task NotifyAsync(
+    public virtual async Task NotifyAsync(
         IReadOnlyList<WebhookEndpoint> endpoints, RunNotification notification, Action<string>? log = null)
     {
         foreach (var endpoint in endpoints)

--- a/src/NineLives.Core/Services/WebhookRunNotifier.cs
+++ b/src/NineLives.Core/Services/WebhookRunNotifier.cs
@@ -20,6 +20,14 @@ public sealed class WebhookRunNotifier : IRunNotifier
     private readonly OperationLog _log;
     private readonly WebhookNotifier _notifier;
 
+    /// <summary>
+    /// Deliveries still in flight, so a short-lived process can drain them before exiting
+    /// (#296). Completed entries are pruned as new ones start; the lock guards the list, not
+    /// the deliveries.
+    /// </summary>
+    private readonly List<Task> _inFlight = [];
+    private readonly Lock _gate = new();
+
     public WebhookRunNotifier(ICredentialStore store, OperationLog log, WebhookNotifier? notifier = null)
     {
         _store = store;
@@ -43,7 +51,7 @@ public sealed class WebhookRunNotifier : IRunNotifier
 
         if (endpoints.Count == 0) return;
 
-        _ = Task.Run(async () =>
+        var delivery = Task.Run(async () =>
         {
             try
             {
@@ -54,5 +62,26 @@ public sealed class WebhookRunNotifier : IRunNotifier
                 _log.Warn($"[notify] delivery failed: {ex.Message}");
             }
         });
+
+        lock (_gate)
+        {
+            _inFlight.RemoveAll(t => t.IsCompleted);
+            _inFlight.Add(delivery);
+        }
+    }
+
+    public async Task DrainAsync(TimeSpan timeout)
+    {
+        Task[] pending;
+        lock (_gate)
+        {
+            pending = _inFlight.Where(t => !t.IsCompleted).ToArray();
+        }
+
+        if (pending.Length == 0) return;
+
+        // WhenAny against the clock: a dead endpoint must not hold a scheduled task's process
+        // open. The deliveries own their exceptions (logged above), so WhenAll cannot throw.
+        await Task.WhenAny(Task.WhenAll(pending), Task.Delay(timeout));
     }
 }

--- a/src/NineLives.Tests/CliEndingsTests.cs
+++ b/src/NineLives.Tests/CliEndingsTests.cs
@@ -1,0 +1,161 @@
+using System.IO;
+using System.Threading;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The CLI's endings (#296): a short-lived process must not exit before its story is told.
+/// The completion webhooks used to race process exit and mostly lose - fire-and-forget is
+/// right in the app, fatal in a process that returns from Main immediately after Notify -
+/// and Ctrl+C killed the process with no Cancelled receipt, no notification, no defined
+/// exit code.
+/// </summary>
+public class CliEndingsTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static (CliServices services, FakeSqlServerService sql,
+        FakeRestoreHistoryStore history, FakeRunNotifier notifier) Stage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "MyDb",
+                    Type = BackupType.Full,
+                    StartedAt = T0,
+                    FinishedAt = T0.AddMinutes(5),
+                    CheckpointLsn = 100m,
+                    Position = 1,
+                    Files = [@"X:\backups\full.bak"]
+                }
+            ]
+        };
+        var history = new FakeRestoreHistoryStore();
+        var notifier = new FakeRunNotifier();
+        return (new CliServices(store, sql, new FakeBlobStorageService(), history, notifier),
+            sql, history, notifier);
+    }
+
+    private static async Task<(int exit, string errors)> RunRestore(
+        CliServices services, CancellationToken ct, params string[] extra)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        string[] args = [.. new[]
+        { "--server", "SRV01", "--database", "MyDb", "--target", "SRV02" }, .. extra];
+        var exit = await RestoreVerb.RunAsync(
+            CliArguments.Parse(args, RestoreVerb.Spec), services, output, errors, ct);
+        return (exit, errors.ToString());
+    }
+
+    // ── Ctrl+C ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ACancelledRestoreLeavesTheCancelledReceiptAndExits130()
+    {
+        var (services, sql, history, notifier) = Stage();
+
+        var (exit, errors) = await RunRestore(
+            services, new CancellationToken(canceled: true), "--execute");
+
+        Assert.Equal(130, exit);
+        Assert.Contains("CANCELLED", errors);
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(RestoreOutcome.Cancelled, entry.Outcome);
+
+        Assert.Equal(RunPhase.Problem, notifier.Sent.Last().Phase);
+        Assert.True(notifier.DrainCalls >= 1);
+    }
+
+    // ── the drain before exit ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EveryExecutionEndingDrainsTheNotifier()
+    {
+        var (ok, _, _, okNotifier) = Stage();
+        await RunRestore(ok, CancellationToken.None, "--execute");
+        Assert.Equal(1, okNotifier.DrainCalls);
+
+        var (bad, badSql, _, badNotifier) = Stage();
+        badSql.FailOnExecuteNumber = 1;
+        await RunRestore(bad, CancellationToken.None, "--execute");
+        Assert.Equal(1, badNotifier.DrainCalls);
+    }
+
+    /// <summary>
+    /// The real notifier's drain genuinely waits: a delivery that takes a moment has completed
+    /// by the time DrainAsync returns. Without the drain this test's process-exit stand-in -
+    /// asserting immediately after Notify - observes the loss directly.
+    /// </summary>
+    [Fact]
+    public async Task TheRealNotifierDrainWaitsForInFlightDeliveries()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Webhooks.Add(new WebhookEndpoint
+        { Id = "w1", Name = "Ops", Url = "https://example.invalid/hook" });
+
+        var slow = new SlowWebhookNotifier();
+        var notifier = new WebhookRunNotifier(store, TestLogs.Temp(), slow);
+
+        notifier.Notify(new RunNotification(
+            RunPhase.Succeeded, "Restore", "MyDb", "SRV02", null, TimeSpan.FromMinutes(1)));
+
+        Assert.False(slow.Delivered);
+        await notifier.DrainAsync(TimeSpan.FromSeconds(5));
+        Assert.True(slow.Delivered);
+    }
+
+    /// <summary>And a dead endpoint cannot hold the process: the timeout wins.</summary>
+    [Fact]
+    public async Task TheDrainTimeoutBeatsAHungDelivery()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Webhooks.Add(new WebhookEndpoint
+        { Id = "w1", Name = "Ops", Url = "https://example.invalid/hook" });
+
+        var hung = new HungWebhookNotifier();
+        var notifier = new WebhookRunNotifier(store, TestLogs.Temp(), hung);
+        notifier.Notify(new RunNotification(RunPhase.Started, "Restore", "MyDb", "SRV02"));
+
+        var drain = notifier.DrainAsync(TimeSpan.FromMilliseconds(200));
+        var finished = await Task.WhenAny(drain, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        Assert.Same(drain, finished);
+    }
+
+    private sealed class SlowWebhookNotifier : WebhookNotifier
+    {
+        public volatile bool Delivered;
+
+        public override async Task NotifyAsync(
+            IReadOnlyList<WebhookEndpoint> endpoints, RunNotification notification,
+            Action<string>? log = null)
+        {
+            await Task.Delay(250);
+            Delivered = true;
+        }
+    }
+
+    private sealed class HungWebhookNotifier : WebhookNotifier
+    {
+        public override Task NotifyAsync(
+            IReadOnlyList<WebhookEndpoint> endpoints, RunNotification notification,
+            Action<string>? log = null)
+            => Task.Delay(Timeout.InfiniteTimeSpan);
+    }
+}

--- a/src/NineLives.Tests/CliExecuteVerbTests.cs
+++ b/src/NineLives.Tests/CliExecuteVerbTests.cs
@@ -48,12 +48,12 @@ public class CliExecuteVerbTests
     };
 
     private static async Task<(int exit, string output, string errors)> Run(
-        Func<CliArguments, CliServices, TextWriter, TextWriter, Task<int>> verb,
-        VerbSpec spec, string[] args, CliServices services)
+        Func<CliArguments, CliServices, TextWriter, TextWriter, CancellationToken, Task<int>> verb,
+        VerbSpec spec, string[] args, CliServices services, CancellationToken ct = default)
     {
         var output = new StringWriter();
         var errors = new StringWriter();
-        var exit = await verb(CliArguments.Parse(args, spec), services, output, errors);
+        var exit = await verb(CliArguments.Parse(args, spec), services, output, errors, ct);
         return (exit, output.ToString(), errors.ToString());
     }
 

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -195,7 +195,16 @@ public sealed class FakeRunNotifier : IRunNotifier
 {
     public List<RunNotification> Sent { get; } = [];
 
+    /// <summary>How many times a caller drained - the CLI's exit path must, or deliveries die with the process (#296).</summary>
+    public int DrainCalls { get; private set; }
+
     public void Notify(RunNotification notification) => Sent.Add(notification);
+
+    public Task DrainAsync(TimeSpan timeout)
+    {
+        DrainCalls++;
+        return Task.CompletedTask;
+    }
 }
 
 public sealed class FakeSqlServerService : ISqlServerService
@@ -486,6 +495,9 @@ public sealed class FakeSqlServerService : ISqlServerService
     public Task ExecuteWithProgressAsync(
         ServerConnection server, string sql, Action<string>? messageCallback = null, CancellationToken ct = default)
     {
+        // Same guard the VERIFYONLY fake carries, same reason: without it a test passes
+        // against a caller that ignores the token entirely (#296).
+        ct.ThrowIfCancellationRequested();
         ExecutedAgainst.Add(server);
         ExecutedScripts.Add(sql);
         messageCallback?.Invoke("100 percent processed.");


### PR DESCRIPTION
Closes #296 - the CLI half of the review board's silent-loss findings.

**The completion webhooks raced process exit, and mostly lost.** \`Notify\` is fire-and-forget by design - right in the app, where the process lives on; fatal in a CLI that returns from \`Main\` the moment the run ends. The Started event survived because the restore gave it time; the Succeeded and Problem events - the ones a scheduled 3am run exists to send - died with the process. \`IRunNotifier\` grows \`DrainAsync(timeout)\`: the real notifier tracks in-flight deliveries, and the execution verbs drain (bounded at ten seconds, so a dead endpoint cannot hold the process open) on every ending - success, failure, and cancellation alike. \`Notify\` itself stays fire-and-forget: the run is never slowed by its announcement.

**Ctrl+C now cancels the run instead of killing the story.** \`Program\` wires \`CancelKeyPress\` to a token threaded through to \`ExecuteWithProgressAsync\`; an interrupted run leaves a Cancelled history receipt (the same outcome the app records), notifies the channel, and exits **130** - the Unix 128+SIGINT convention, documented on both help pages, so a wrapping script can tell an operator's interruption from a failure.

Supporting: the execute fake now checks its token (the guard its VERIFYONLY sibling always had, without which no test can catch a caller ignoring cancellation - part of #295's finding), and \`WebhookNotifier.NotifyAsync\` is virtual so the drain pin can substitute a genuinely slow delivery.

Four pins (1,651 total): the cancelled receipt with exit 130, a drain on every ending, the real drain actually waiting for an in-flight delivery, and the drain timeout beating a hung endpoint.