### PR TITLE
The copy runs the scripts it showed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ more detail on the user-facing changes; this file is the short history.
   the moment the run ends. And Ctrl+C mid-run is a story, not a kill: the receipt says
   Cancelled, the channel is told, and the exit code is the conventional 130 so a wrapping
   script can tell an operator's interruption from a failure
+- The copy runs the scripts it showed, not the ones on screen later (#280). The view stayed
+  editable while the halves ran, and a keystroke in the target-name box mid-backup
+  regenerated the restore half with fresh timestamped destinations - so the copy then
+  restored from a file that was never written, and the outcome text pointed at the wrong
+  path. The run now snapshots both scripts and the destination list at the moment of
+  consent, the same immutable-run-record medicine the restore screen takes
 - A generated script no longer survives the change that invalidated it (#278). On the backup
   and copy screens, an input change that makes regeneration impossible now CLEARS the script,
   the destinations and the run button instead of leaving the old statements displayed and

--- a/src/NineLives.Tests/CopyRunSnapshotTests.cs
+++ b/src/NineLives.Tests/CopyRunSnapshotTests.cs
@@ -1,0 +1,60 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The copy runs the scripts it SHOWED, not the ones on screen later (#280). The view stays
+/// editable while the halves run and Generate stamps a fresh timestamp into the destinations -
+/// so one keystroke mid-backup used to regenerate the restore half and point it at a file
+/// that was never written. The run snapshots its three inputs at the moment of consent, the
+/// same medicine the restore screen's immutable run record takes.
+/// </summary>
+public class CopyRunSnapshotTests
+{
+    [Fact]
+    public async Task AnEditDuringTheBackupHalfCannotChangeWhatTheRestoreHalfRuns()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp());
+        vm.SourceServer = vm.Servers.First(s => s.Name == "SRV01");
+        vm.TargetServer = vm.Servers.First(s => s.Name == "SRV02");
+        vm.Container = vm.Containers.Single();
+        vm.SourceDatabases = ["MyDb"];
+        vm.SourceDatabase = "MyDb";
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.GenerateCommand.Execute(null);
+
+        var shownRestore = vm.RestoreScript;
+        Assert.Contains("MyDb_Copy", shownRestore);
+
+        // The keystroke lands while the BACKUP half is executing - the regeneration it
+        // triggers renames the target and stamps new destination filenames.
+        sql.OnExecute = n =>
+        {
+            if (n == 1) vm.TargetDatabaseName = "MyDb_Edited";
+        };
+
+        await vm.RunCommand.ExecuteAsync(null);
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, sql.ExecutedScripts.Count);
+        // The restore half ran the statements that were on screen at consent - byte for byte.
+        Assert.Equal(shownRestore, sql.ExecutedScripts[1]);
+        Assert.DoesNotContain("MyDb_Edited", sql.ExecutedScripts[1]);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -492,6 +492,12 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// </summary>
     public int? FailOnExecuteNumber { get; set; }
 
+    /// <summary>
+    /// Runs inside each execute call, 1-based - lets a test change screen state MID-RUN, which
+    /// is how the edit-during-copy defect is reproduced deterministically (#280).
+    /// </summary>
+    public Action<int>? OnExecute { get; set; }
+
     public Task ExecuteWithProgressAsync(
         ServerConnection server, string sql, Action<string>? messageCallback = null, CancellationToken ct = default)
     {
@@ -500,6 +506,7 @@ public sealed class FakeSqlServerService : ISqlServerService
         ct.ThrowIfCancellationRequested();
         ExecutedAgainst.Add(server);
         ExecutedScripts.Add(sql);
+        OnExecute?.Invoke(ExecutedScripts.Count);
         messageCallback?.Invoke("100 percent processed.");
 
         if (FailOnExecuteNumber == ExecutedScripts.Count)

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -640,15 +640,23 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
         var ct = _cancellation.Begin();
 
+        // The run executes what was SHOWN, not what is on screen later (#280): these
+        // properties are live, the view stays editable while the halves run, and Generate
+        // stamps a fresh timestamp into the destinations - so one keystroke mid-backup used
+        // to point the restore half at a file that was never written. Same medicine as the
+        // restore screen's immutable run record: snapshot at the moment of consent.
+        var run = (Backup: BackupScript, Restore: RestoreScript,
+                   Destinations: (IReadOnlyList<string>)Destinations.ToList());
+
         try
         {
-            await RunBothHalvesAsync(ct);
+            await RunBothHalvesAsync(run.Backup, run.Restore, run.Destinations, ct);
         }
         finally
         {
             _cancellation.End();
             IsRunning = false;
-            OutcomeText = CopyOutcomeText.Describe(Outcome, Destinations.FirstOrDefault());
+            OutcomeText = CopyOutcomeText.Describe(Outcome, run.Destinations.FirstOrDefault());
 
             if (Outcome == CopyOutcome.Copied)
                 SetStatus($"Copied {SourceDatabase} to {TargetServer.ServerName} as {TargetDatabaseName}.");
@@ -657,7 +665,9 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         }
     }
 
-    private async Task RunBothHalvesAsync(CancellationToken ct)
+    private async Task RunBothHalvesAsync(
+        string backupScript, string restoreScript, IReadOnlyList<string> destinations,
+        CancellationToken ct)
     {
         // ── the source half ─────────────────────────────────────────────────────
         Append($"Backing up {SourceDatabase} on {SourceServer!.ServerName}...");
@@ -675,7 +685,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
         try
         {
-            await _sql.ExecuteWithProgressAsync(SourceServer, BackupScript, Append, ct);
+            await _sql.ExecuteWithProgressAsync(SourceServer, backupScript, Append, ct);
         }
         catch (OperationCanceledException)
         {
@@ -706,7 +716,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         // SOURCE wrote the file as its service account, and the TARGET has to read it as a
         // different one. The two are routinely not the same account, and nothing before this point
         // would have noticed.
-        if (MediumIsSharedPath && !await TargetCanReadAsync(ct))
+        if (MediumIsSharedPath && !await TargetCanReadAsync(destinations, ct))
         {
             Outcome = CopyOutcome.BackupTakenRestoreFailed;
             _notifier.Notify(new RunNotification(
@@ -721,7 +731,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
         try
         {
-            await _sql.ExecuteWithProgressAsync(TargetServer, RestoreScript, Append, ct);
+            await _sql.ExecuteWithProgressAsync(TargetServer, restoreScript, Append, ct);
         }
         catch (OperationCanceledException)
         {
@@ -761,13 +771,14 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// read: the backup is real and fine, and the only thing wrong is a permission on a share. So
     /// it is reported in those terms rather than as a restore that failed.
     /// </summary>
-    private async Task<bool> TargetCanReadAsync(CancellationToken ct)
+    private async Task<bool> TargetCanReadAsync(
+        IReadOnlyList<string> destinations, CancellationToken ct)
     {
         Append($"Checking {TargetServer!.ServerName} can read the backup...");
 
         try
         {
-            var checks = await _sql.CheckBackupFilesAsync(TargetServer, Destinations, ct);
+            var checks = await _sql.CheckBackupFilesAsync(TargetServer, destinations, ct);
             var failed = checks.FirstOrDefault(c => !c.CanBeRestored);
 
             if (failed == null)


### PR DESCRIPTION
Closes #280.

\`RunAsync\` read \`BackupScript\`, \`RestoreScript\` and \`Destinations\` as live properties while the halves ran, and nothing on the view is disabled mid-run. \`Generate\` stamps a fresh timestamp into the destination filenames - so one keystroke in the target-name box during the backup half regenerated the restore half and pointed it at a file that was never written. The outcome text then told the DBA the backup "is real and usable" - at the wrong path.

The run now snapshots all three at the moment of consent and threads them through \`RunBothHalvesAsync\` and the target-readability check - the same immutable-run-record medicine \`RestoreRun\` gives the restore screen. The outcome text names the path THE RUN used.

The fake gains an \`OnExecute\` hook so the defect is reproduced deterministically rather than by racing: the pin edits the target name INSIDE the backup half and asserts the restore half executes the shown statements byte for byte (1,652 total).