### PR TITLE
Every long operation owns its cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,13 @@ more detail on the user-facing changes; this file is the short history.
   the moment the run ends. And Ctrl+C mid-run is a story, not a kill: the receipt says
   Cancelled, the channel is told, and the exit code is the conventional 130 so a wrapping
   script can tell an operator's interruption from a failure
+- Every long operation owns its cancellation (#281). Three screens shared one token across
+  operations that can overlap, so the List databases button silently cancelled a running
+  backup or copy, and a finished operation disposed the survivor's token - the container-wide
+  audit could die with "Cannot access a disposed object" while its Stop button vanished. One
+  instance per operation now (the rule the restore execution always kept), the list buttons
+  are dead while a run is in progress, and starting an inventory operation cancels the others
+  explicitly rather than through a shared disposal
 - The copy runs the scripts it showed, not the ones on screen later (#280). The view stayed
   editable while the halves ran, and a keystroke in the target-name box mid-backup
   regenerated the restore half with fresh timestamped destinations - so the copy then

--- a/src/NineLives.Tests/PerOperationCancellationTests.cs
+++ b/src/NineLives.Tests/PerOperationCancellationTests.cs
@@ -1,0 +1,114 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Every long operation owns its cancellation (#281). Three screens shared one instance
+/// across operations that overlap, so the List button's Begin() silently cancelled a running
+/// backup or copy, and the finished operation's End() disposed the survivor's token - the
+/// audit died with "Cannot access a disposed object" and its Stop button vanished.
+/// RestoreExecutionViewModel always kept one instance per concern; now everyone does.
+/// </summary>
+public class PerOperationCancellationTests
+{
+    private static (BackupViewModel vm, FakeSqlServerService sql) BackupStage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var vm = new BackupViewModel(store, sql, TestLogs.Temp());
+        vm.Server = vm.Servers.Single();
+        vm.Container = vm.Containers.Single();
+        return (vm, sql);
+    }
+
+    /// <summary>
+    /// The button that killed production backups: mid-run, the list is simply not fetchable -
+    /// and the run completes untouched.
+    /// </summary>
+    [Fact]
+    public async Task TheListButtonIsDeadWhileABackupRunsAndTheRunCompletes()
+    {
+        var (vm, sql) = BackupStage();
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.SelectedDatabase = "MyDb";
+        vm.GenerateCommand.Execute(null);
+
+        bool? gateMidRun = null;
+        sql.OnExecute = _ =>
+        {
+            gateMidRun = vm.CanLoadDatabases || vm.LoadDatabasesCommand.CanExecute(null);
+        };
+
+        await vm.ExecuteCommand.ExecuteAsync(null);
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        Assert.False(gateMidRun);
+        Assert.Single(sql.ExecutedScripts);
+        Assert.True(vm.CanLoadDatabases);
+    }
+
+    [Fact]
+    public async Task TheCopysListButtonIsDeadWhileACopyRuns()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp());
+        vm.SourceServer = vm.Servers.First(s => s.Name == "SRV01");
+        vm.TargetServer = vm.Servers.First(s => s.Name == "SRV02");
+        vm.Container = vm.Containers.Single();
+        vm.SourceDatabases = ["MyDb"];
+        vm.SourceDatabase = "MyDb";
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.GenerateCommand.Execute(null);
+
+        bool? gateMidRun = null;
+        sql.OnExecute = n =>
+        {
+            if (n == 1) gateMidRun = vm.CanLoadSourceDatabases;
+        };
+
+        await vm.RunCommand.ExecuteAsync(null);
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.False(gateMidRun);
+        Assert.Equal(2, sql.ExecutedScripts.Count);
+        Assert.True(vm.CanLoadSourceDatabases);
+    }
+
+    /// <summary>Stop with nothing running stays a no-op - three instances or one.</summary>
+    [Fact]
+    public void CancellingTheIdleInventoryDoesNotThrow()
+    {
+        var inventory = new BackupInventoryViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(),
+            TestLogs.Temp(), TestAuditStores.Temp());
+
+        var ex = Record.Exception(() => inventory.CancelLoadCommand.Execute(null));
+
+        Assert.Null(ex);
+        Assert.False(inventory.CanCancelLoad);
+    }
+}

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -31,7 +31,17 @@ public partial class BackupInventoryViewModel : ViewModelBase
     private readonly ISqlServerService _sql;
     private readonly OperationLog _log;
     private readonly IBackupAuditStore _auditStore;
+    // One instance per operation (#281): load, identify and the audit can overlap - the
+    // container-wide audit is the forty-minute one - and with a single shared instance a
+    // load's End() disposed the audit's token: the Stop button vanished and the audit died
+    // with "Cannot access a disposed object" instead of finishing or being stoppable.
+    private readonly OperationCancellation _auditCancellation = new();
+    private readonly OperationCancellation _identifyCancellation = new();
     private readonly OperationCancellation _loadCancellation = new();
+
+    private bool CanCancelAnything =>
+        _auditCancellation.CanCancel || _identifyCancellation.CanCancel
+                                     || _loadCancellation.CanCancel;
 
     /// <param name="log">
     /// Optional so a test can point it at a temp directory. Reaching for App.Log directly is what
@@ -230,7 +240,9 @@ public partial class BackupInventoryViewModel : ViewModelBase
     {
         var sets = AuditScope.ToList();
         if (sets.Count == 0) return;
-        var ct = _loadCancellation.Begin();
+        _identifyCancellation.Cancel();
+        _loadCancellation.Cancel();
+        var ct = _auditCancellation.Begin();
 
         IsAuditing = true;
         AuditProgress = 0;
@@ -276,7 +288,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
         }
         finally
         {
-            _loadCancellation.End();
+            _auditCancellation.End();
             IsAuditing = false;
             AuditProgressText = string.Empty;
             RaiseCancelStateChanged();
@@ -336,7 +348,9 @@ public partial class BackupInventoryViewModel : ViewModelBase
         var unidentified = _allBackups.Where(BackupHeaderIdentifier.NeedsIdentifying).ToList();
         if (unidentified.Count == 0) return;
 
-        var ct = _loadCancellation.Begin();
+        _auditCancellation.Cancel();
+        _loadCancellation.Cancel();
+        var ct = _identifyCancellation.Begin();
         IsBusy = true;
         ClearStatus();
         RaiseCancelStateChanged();
@@ -379,7 +393,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
         }
         finally
         {
-            _loadCancellation.End();
+            _identifyCancellation.End();
             IsBusy = false;
             IdentifyProgressText = string.Empty;
             RaiseCancelStateChanged();
@@ -471,6 +485,8 @@ public partial class BackupInventoryViewModel : ViewModelBase
     /// </summary>
     public async Task LoadAsync(BackupLocation location)
     {
+        _auditCancellation.Cancel();
+        _identifyCancellation.Cancel();
         var ct = _loadCancellation.Begin();
         IsBusy = true;
         LoadProgressText = location.IsSharedPath
@@ -777,8 +793,10 @@ public partial class BackupInventoryViewModel : ViewModelBase
     [RelayCommand]
     private void CancelLoad()
     {
-        if (!_loadCancellation.CanCancel) return;
+        if (!CanCancelAnything) return;
 
+        _auditCancellation.Cancel();
+        _identifyCancellation.Cancel();
         _loadCancellation.Cancel();
         RaiseCancelStateChanged();
         SetStatus("Stopping the scan...");
@@ -811,7 +829,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
 
     private void RaiseCancelStateChanged()
     {
-        CanCancelLoad = _loadCancellation.CanCancel;
+        CanCancelLoad = CanCancelAnything;
         CancelStateChanged?.Invoke();
     }
 }

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -24,7 +24,13 @@ public partial class BackupViewModel : ViewModelBase
     private readonly ICredentialStore _store;
     private readonly ISqlServerService _sql;
     private readonly BackupScriptGenerator _generator = new();
-    private readonly OperationCancellation _cancellation = new();
+    // One instance PER OPERATION (#281), the rule RestoreExecutionViewModel already keeps:
+    // with a single shared instance, the List button's Begin() silently cancelled a running
+    // backup, and the backup's End() then disposed the listing's token. The Stop button
+    // belongs to the run; the list and the verify each own their overlap story.
+    private readonly OperationCancellation _listCancellation = new();
+    private readonly OperationCancellation _runCancellation = new();
+    private readonly OperationCancellation _verifyCancellation = new();
     private readonly OperationLog _log;
 
     public BackupViewModel(
@@ -141,8 +147,11 @@ public partial class BackupViewModel : ViewModelBase
         foreach (var pick in DatabasePicks) pick.IsPicked = false;
     }
 
+    /// <summary>The list is not fetchable mid-run: it can wait; the backup cannot re-run (#281).</summary>
+    public bool CanLoadDatabases => !IsRunning;
+
     /// <summary>Asks the chosen instance what it has, rather than making somebody type a name.</summary>
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanLoadDatabases))]
     private async Task LoadDatabasesAsync()
     {
         if (Server == null)
@@ -151,7 +160,7 @@ public partial class BackupViewModel : ViewModelBase
             return;
         }
 
-        var ct = _cancellation.Begin();
+        var ct = _listCancellation.Begin();
         IsBusy = true;
         ClearStatus();
 
@@ -192,7 +201,7 @@ public partial class BackupViewModel : ViewModelBase
         }
         finally
         {
-            _cancellation.End();
+            _listCancellation.End();
             IsBusy = false;
         }
     }
@@ -469,6 +478,8 @@ public partial class BackupViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(ButtonText));
         ExecuteCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(CanLoadDatabases));
+        LoadDatabasesCommand.NotifyCanExecuteChanged();
     }
 
     /// <summary>SQL Server's own words as it goes, in the order it said them.</summary>
@@ -492,7 +503,7 @@ public partial class BackupViewModel : ViewModelBase
         ClearStatus();
         Console.Clear();
 
-        var ct = _cancellation.Begin();
+        var ct = _runCancellation.Begin();
         var started = DateTime.Now;
 
         // Database-at-a-time, deliberately (#208): a failure on the sixth database names the
@@ -612,7 +623,7 @@ public partial class BackupViewModel : ViewModelBase
         }
         finally
         {
-            _cancellation.End();
+            _runCancellation.End();
             IsRunning = false;
         }
     }
@@ -620,9 +631,9 @@ public partial class BackupViewModel : ViewModelBase
     [RelayCommand]
     private void Cancel()
     {
-        if (!_cancellation.CanCancel) return;
+        if (!_runCancellation.CanCancel) return;
 
-        _cancellation.Cancel();
+        _runCancellation.Cancel();
         SetStatus("Stopping...");
     }
 
@@ -683,7 +694,7 @@ public partial class BackupViewModel : ViewModelBase
     {
         if (Server == null || _lastWrittenDevices.Count == 0) return;
 
-        var ct = _cancellation.Begin();
+        var ct = _verifyCancellation.Begin();
         IsVerifying = true;
         Append($"Verifying {_lastWrittenDevices.Count} file(s) with RESTORE VERIFYONLY...");
 
@@ -713,7 +724,7 @@ public partial class BackupViewModel : ViewModelBase
         }
         finally
         {
-            _cancellation.End();
+            _verifyCancellation.End();
             IsVerifying = false;
         }
     }

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -32,7 +32,10 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     private readonly ISqlServerService _sql;
     private readonly BackupScriptGenerator _backupGenerator = new();
     private readonly RestoreScriptGenerator _restoreGenerator = new();
-    private readonly OperationCancellation _cancellation = new();
+    // One instance per operation (#281): the List button's Begin() used to cancel a running
+    // copy, and the copy's End() then disposed the listing's token. Stop belongs to the run.
+    private readonly OperationCancellation _listCancellation = new();
+    private readonly OperationCancellation _runCancellation = new();
     private readonly OperationLog _log;
 
     public CopyDatabaseViewModel(
@@ -129,7 +132,10 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         }
     }
 
-    [RelayCommand]
+    /// <summary>The list is not fetchable mid-run: it can wait; the copy cannot re-run (#281).</summary>
+    public bool CanLoadSourceDatabases => !IsRunning;
+
+    [RelayCommand(CanExecute = nameof(CanLoadSourceDatabases))]
     private async Task LoadSourceDatabasesAsync()
     {
         if (SourceServer == null)
@@ -138,7 +144,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             return;
         }
 
-        var ct = _cancellation.Begin();
+        var ct = _listCancellation.Begin();
         IsBusy = true;
         ClearStatus();
 
@@ -163,7 +169,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         }
         finally
         {
-            _cancellation.End();
+            _listCancellation.End();
             IsBusy = false;
         }
     }
@@ -616,6 +622,8 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(ButtonText));
         RunCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(CanLoadSourceDatabases));
+        LoadSourceDatabasesCommand.NotifyCanExecuteChanged();
     }
 
     public bool CanRun => HasScripts && !IsRunning && !IsRefused;
@@ -638,7 +646,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         Outcome = CopyOutcome.NotStarted;
         OutcomeText = string.Empty;
 
-        var ct = _cancellation.Begin();
+        var ct = _runCancellation.Begin();
 
         // The run executes what was SHOWN, not what is on screen later (#280): these
         // properties are live, the view stays editable while the halves run, and Generate
@@ -654,7 +662,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         }
         finally
         {
-            _cancellation.End();
+            _runCancellation.End();
             IsRunning = false;
             OutcomeText = CopyOutcomeText.Describe(Outcome, run.Destinations.FirstOrDefault());
 
@@ -802,9 +810,9 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     [RelayCommand]
     private void Cancel()
     {
-        if (!_cancellation.CanCancel) return;
+        if (!_runCancellation.CanCancel) return;
 
-        _cancellation.Cancel();
+        _runCancellation.Cancel();
         SetStatus("Stopping...");
     }
 


### PR DESCRIPTION
Closes #281.

Three screens shared one \`OperationCancellation\` across operations that can overlap, and \`Begin()\` cancels-and-disposes the previous source. The everyday casualty: the List databases button - live mid-run, no CanExecute - silently cancelled a running production BACKUP with one click, and the backup's \`finally\` then killed the listing's token. The worst one: on the inventory screen a load's \`End()\` disposed the forty-minute container audit's token - the Stop button vanished (\`CanCancel\` false) and the audit died with "Cannot access a disposed object". \`RestoreExecutionViewModel\` has always held one instance per concern, with a comment explaining exactly this ("the Stop button during a restore is not the same button as the one that stops a verify") - the pattern just never travelled.

**The fix:** one instance per operation everywhere. Backup: list / run / verify, Stop belongs to the run, and the list button is dead while a run is in progress (it can wait; the backup cannot re-run). Copy: the same split and gate. Inventory: audit / identify / load each own one, Stop cancels whichever is active, and starting one operation cancels the others EXPLICITLY - preserving the old serialise-by-cancellation contract without the shared disposal that broke it.

Three pins (1,655 total), made deterministic by the \`OnExecute\` mid-run hook: the list gate is closed mid-run on both screens while the run completes untouched, and cancelling the idle inventory stays a no-op.