### PR TITLE
"All user databases" means it now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,11 @@ more detail on the user-facing changes; this file is the short history.
   the moment the run ends. And Ctrl+C mid-run is a story, not a kill: the receipt says
   Cancelled, the channel is told, and the exit code is the conventional 130 so a wrapping
   script can tell an operator's interruption from a failure
+- "All user databases" means it now (#279): the database list the backup screen ticks and
+  the copy screen offers is filtered to online user databases - no more tempdb (which cannot
+  be backed up at all), no master offered for copying, no RESTORING or OFFLINE databases
+  guaranteeing a red summary on the one-click patch-night path. Same predicate the exposure
+  query always used, now in one more place it belonged
 - Every long operation owns its cancellation (#281). Three screens shared one token across
   operations that can overlap, so the List databases button silently cancelled a running
   backup or copy, and a finished operation disposed the survivor's token - the container-wide

--- a/src/NineLives.Core/Services/SqlServerService.cs
+++ b/src/NineLives.Core/Services/SqlServerService.cs
@@ -226,7 +226,20 @@ public class SqlServerService : ISqlServerService
         await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);
         await using var cmd = conn.CreateCommand();
-        cmd.CommandText = "SELECT name FROM sys.databases ORDER BY name";
+
+        // User databases, online, and not snapshots - the same predicate the exposure query
+        // keeps, for the same reasons (#279). This list feeds "All user databases" on the
+        // backup screen and the copy screen's source dropdown: unfiltered, one click ticked
+        // tempdb (BACKUP DATABASE [tempdb] fails outright, Msg 3147) and every RESTORING or
+        // OFFLINE database, so the one-click patch-night path was guaranteed a red summary -
+        // and master was offered as a thing to copy onto another server.
+        cmd.CommandText = @"
+            SELECT name
+            FROM sys.databases
+            WHERE database_id > 4
+              AND source_database_id IS NULL
+              AND state_desc = 'ONLINE'
+            ORDER BY name";
         var databases = new List<string>();
         await using var reader = await cmd.ExecuteReaderAsync(ct);
         while (await reader.ReadAsync(ct))

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -241,6 +241,11 @@ public sealed class FakeSqlServerService : ISqlServerService
         => Task.FromResult("Microsoft SQL Server 2022");
 
     /// <summary>What the fake instance says it holds.</summary>
+    /// <summary>
+    /// Whatever a test puts here - which means the REAL query's user-databases-only filter
+    /// (#279) is invisible to the unit suite. The live pin in SqlExecutionFailureTests is
+    /// what proves the predicate; tests here should stock this with user databases only.
+    /// </summary>
     public List<string> DatabaseList { get; set; } = [];
 
     public Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)

--- a/src/NineLives.Tests/SqlExecutionFailureTests.cs
+++ b/src/NineLives.Tests/SqlExecutionFailureTests.cs
@@ -49,6 +49,23 @@ public class SqlExecutionFailureTests
 
     private static SqlServerService Service() => new(new CredentialStore());
 
+    /// <summary>
+    /// The list that feeds "All user databases" and the copy's source dropdown (#279). Only a
+    /// real instance can prove the predicate: the fake returns whatever a test puts in it, so
+    /// this class of defect is invisible to the unit suite - tempdb was offered for backup
+    /// (Msg 3147 guaranteed) and master offered for copying.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task TheDatabaseListExcludesSystemDatabases()
+    {
+        var databases = await Service().GetDatabaseListAsync(TestServer());
+
+        Assert.DoesNotContain("master", databases, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("tempdb", databases, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("model", databases, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("msdb", databases, StringComparer.OrdinalIgnoreCase);
+    }
+
     // Severity 16 is the band that matters: SQL Server reports almost every restore failure
     // there (3201 cannot open backup device, 3013 terminating abnormally, 4305 log too recent,
     // 3136 differential base mismatch).


### PR DESCRIPTION
Closes #279.

\`GetDatabaseListAsync\` was \`SELECT name FROM sys.databases\` with no filter - and it feeds the backup screen's "All user databases" tick-all and the copy screen's source dropdown. One click ticked **tempdb**, which SQL Server refuses to back up at all (Msg 3147), plus master/model/msdb, database snapshots, and anything RESTORING or OFFLINE - so the one-click patch-night path was guaranteed failures and a red summary, and \`master\` was offered as a thing to copy onto another server. The consuming code's comment claimed the list was already user-only; the code now agrees.

The predicate is the exposure query's own: \`database_id > 4\`, no \`source_database_id\` (snapshots), \`state_desc = 'ONLINE'\`.

The unit fake returns whatever a test stocks it with, so this class of defect is structurally invisible to the fast suite - that's now said on the fake itself, and the real predicate is pinned live: a \`RequiresSqlFact\` asserts the four system databases are absent from the list, skipping without \`NINELIVES_TEST_SQL\` and running on CI where LocalDB is started.