### PR TITLE
A same-instance copy is refused up front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ more detail on the user-facing changes; this file is the short history.
   the moment the run ends. And Ctrl+C mid-run is a story, not a kill: the receipt says
   Cancelled, the channel is told, and the exit code is the conventional 130 so a wrapping
   script can tell an operator's interruption from a failure
+- A copy onto the same instance is refused up front, with the way out named (#282). The
+  copy's restore carries no MOVE clauses - right for a different server, fatal on the same
+  one, where the files land on the live source's own paths and SQL Server fails with
+  Msg 1834 AFTER the backup half has run. The refusal points at the Restore screen's full
+  WITH MOVE control; automatic relocation for this shape rides with the generation-time
+  check rework (#285)
 - "All user databases" means it now (#279): the database list the backup screen ticks and
   the copy screen offers is filtered to online user databases - no more tempdb (which cannot
   be backed up at all), no master offered for copying, no RESTORING or OFFLINE databases

--- a/src/NineLives.Tests/CopyDatabaseTests.cs
+++ b/src/NineLives.Tests/CopyDatabaseTests.cs
@@ -249,17 +249,24 @@ public class CopyDatabaseTests
         Assert.Contains("over itself", vm.Refusal);
     }
 
-    /// <summary>The same instance under a DIFFERENT name is an ordinary copy, and is allowed.</summary>
+    /// <summary>
+    /// The same instance under a DIFFERENT name is refused too (#282): with no MOVE clauses,
+    /// the restored files land on the live source's own paths and SQL Server fails the
+    /// restore with Msg 1834 - after the backup half has already run. This test used to
+    /// bless the copy as "ordinary"; the refusal names the way that works instead.
+    /// </summary>
     [Fact]
-    public async Task CopyingOntoTheSameInstanceUnderAnotherNameIsFine()
+    public async Task CopyingOntoTheSameInstanceUnderAnotherNameIsRefusedWithTheWayOut()
     {
         var (vm, _) = await ReadyAsync();
 
         vm.TargetServer = vm.SourceServer;
         vm.TargetDatabaseName = "MyDb_Copy";
 
-        Assert.False(vm.IsRefused);
-        Assert.True(vm.CanGenerate);
+        Assert.True(vm.IsRefused);
+        Assert.Contains("1834", vm.Refusal);
+        Assert.Contains("Restore screen", vm.Refusal);
+        Assert.False(vm.CanGenerate);
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -227,6 +227,18 @@ public partial class CopyDatabaseViewModel : ViewModelBase
                 return $"That would restore {SourceDatabase} over itself on {SourceServer.ServerName}. " +
                        "Give the copy a different name, or choose a different server to restore onto.";
 
+            // Same instance, new name: the copy's restore carries no MOVE clauses (the paths
+            // the source recorded are what a DIFFERENT server needs), so on the same instance
+            // the files land on top of the live source's and the restore fails with Msg 1834 -
+            // after the backup half has already run. Refusing beats failing late (#282); the
+            // restore screen has full WITH MOVE control for exactly this shape.
+            if (sameInstance)
+                return $"A copy onto the same instance would restore {TargetDatabaseName}'s files " +
+                       $"onto {SourceDatabase}'s own paths - SQL Server refuses that (Msg 1834) " +
+                       "after the backup half has already run. Copy onto a different server, or " +
+                       "take the backup and restore it on the Restore screen, where the files " +
+                       "can be relocated (WITH MOVE).";
+
             return string.Empty;
         }
     }


### PR DESCRIPTION
Closes #282.

The copy's restore deliberately carries no MOVE clauses - the paths the source recorded are exactly what a DIFFERENT server needs. On the same instance those paths belong to the live source database, so \`RESTORE ... WITH REPLACE\` fails with **Msg 1834** (a restore cannot steal files from an online database) - after the production backup half has already run, which is precisely the class of late refusal this screen's other checks were built to kill. A test blessed the case as "an ordinary copy, and is allowed"; SQL Server has always disagreed.

The \`Refusal\` now catches same-instance under ANY name and names the way out: copy onto a different server, or take the backup to the Restore screen, where WITH MOVE control is full.

**Deliberately not in this PR**: deriving MOVE targets automatically, the issue's richer fix direction. Doing it honestly means the FILELISTONLY fetch has to land in the on-screen script BEFORE consent - #285's generation-time check territory - because bolting it into the run would break the runs-what-it-showed snapshot #280 just established. Noted on the issue; the dead \`StoppedBeforeAnythingHappened\` outcome waits there too.

The blessing test is flipped into the refusal pin: 1834 named, the Restore screen pointed at, \`CanGenerate\` false (1,655 total).