### PR TITLE
Copy failures get the restore screen's follow-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,13 @@ more detail on the user-facing changes; this file is the short history.
   the moment the run ends. And Ctrl+C mid-run is a story, not a kill: the receipt says
   Cancelled, the channel is told, and the exit code is the conventional 130 so a wrapping
   script can tell an operator's interruption from a failure
+- Copy failures get the restore screen's follow-through (#283): a Stop pressed between the
+  halves is reported as the cancellation it is - not as a share-permission failure sending
+  somebody to chase an ACL that is fine; a failed restore half now says what state the
+  target is in (RESTORING, RECOVERY_PENDING, single-user) with the statements that get it
+  out; and a copy that worked runs the orphaned-user scan - a copy to a different server
+  being the canonical orphaned-login scenario. The copy's notification lifecycle gains its
+  first tests while here
 - A copy onto the same instance is refused up front, with the way out named (#282). The
   copy's restore carries no MOVE clauses - right for a different server, fatal on the same
   one, where the files land on the live source's own paths and SQL Server fails with

--- a/src/NineLives.Tests/CopyFollowThroughTests.cs
+++ b/src/NineLives.Tests/CopyFollowThroughTests.cs
@@ -1,0 +1,109 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Copy failures get the restore screen's follow-through (#283): a pressed Stop between the
+/// halves is reported as a cancellation rather than a share-permission failure, a failed
+/// restore half describes what state the target is in and the statements that get it out,
+/// and a copy that WORKED runs the orphaned-user scan - a copy to a different server being
+/// the canonical orphaned-login scenario. These are also the copy's first notification-path
+/// pins; it fires six distinct notifications and had zero coverage.
+/// </summary>
+public class CopyFollowThroughTests
+{
+    private static (CopyDatabaseViewModel vm, FakeSqlServerService sql, FakeRunNotifier notifier)
+        Stage(BackupMedium medium = BackupMedium.AzureBlob)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var notifier = new FakeRunNotifier();
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp(), notifier);
+        vm.SourceServer = vm.Servers.First(s => s.Name == "SRV01");
+        vm.TargetServer = vm.Servers.First(s => s.Name == "SRV02");
+        if (medium == BackupMedium.SharedPath)
+        {
+            vm.Medium = BackupMedium.SharedPath;
+            vm.SharedPathRoot = @"\\backuphost\sql";
+        }
+        else
+        {
+            vm.Container = vm.Containers.Single();
+        }
+
+        vm.SourceDatabases = ["MyDb"];
+        vm.SourceDatabase = "MyDb";
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.GenerateCommand.Execute(null);
+        return (vm, sql, notifier);
+    }
+
+    private static async Task Run(CopyDatabaseViewModel vm)
+    {
+        await vm.RunCommand.ExecuteAsync(null);
+        await vm.RunCommand.ExecuteAsync(null);
+    }
+
+    [Fact]
+    public async Task AStopBetweenTheHalvesIsACancellationNotASharePermissionStory()
+    {
+        var (vm, sql, notifier) = Stage(BackupMedium.SharedPath);
+
+        // Stop lands after the backup half: the cancelled token then reaches the
+        // between-halves readability check.
+        sql.OnExecute = n =>
+        {
+            if (n == 1) vm.CancelCommand.Execute(null);
+        };
+
+        await Run(vm);
+
+        var problem = notifier.Sent.Last(n => n.Phase == RunPhase.Problem);
+        Assert.Contains("Cancelled between the halves", problem.Detail);
+        Assert.DoesNotContain("share permission", problem.Detail);
+        Assert.Contains(vm.Console, line => line.Contains("Cancelled before the restore half"));
+    }
+
+    [Fact]
+    public async Task AFailedRestoreHalfDescribesTheTargetStateAndTheWayOut()
+    {
+        var (vm, sql, _) = Stage();
+        sql.FailOnExecuteNumber = 2;
+        sql.RecoveryState = new DatabaseRecoveryState(
+            Exists: true, StateDescription: "RESTORING", UserAccessDescription: "MULTI_USER");
+
+        await Run(vm);
+
+        Assert.Equal(CopyOutcome.BackupTakenRestoreFailed, vm.Outcome);
+        Assert.Contains(vm.Console, line => line.Contains("RESTORING", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(vm.Console, line => line.Contains("RESTORE DATABASE", StringComparison.OrdinalIgnoreCase)
+                                            || line.Contains("RECOVERY", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ASuccessfulCopyRunsTheOrphanScan()
+    {
+        var (vm, sql, notifier) = Stage();
+        sql.OrphanedUsers = [new OrphanedUser("app_user", true)];
+
+        await Run(vm);
+
+        Assert.Equal(CopyOutcome.Copied, vm.Outcome);
+        Assert.Contains(vm.Console, line => line.Contains("app_user"));
+        Assert.Equal(RunPhase.Succeeded, notifier.Sent.Last().Phase);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -631,6 +631,10 @@ public sealed class FakeSqlServerService : ISqlServerService
     public async Task<List<BackupFileCheck>> CheckBackupFilesAsync(
         ServerConnection server, IEnumerable<string> paths, CancellationToken ct = default)
     {
+        // Observed for the same reason the execute fake observes its token (#283): a pressed
+        // Stop reaches this check mid-copy, and a fake that ignores it lets a viewmodel
+        // misreport the cancellation without any test noticing.
+        ct.ThrowIfCancellationRequested();
         var results = new List<BackupFileCheck>();
         foreach (var path in paths)
         {

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -736,14 +736,36 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         // SOURCE wrote the file as its service account, and the TARGET has to read it as a
         // different one. The two are routinely not the same account, and nothing before this point
         // would have noticed.
-        if (MediumIsSharedPath && !await TargetCanReadAsync(destinations, ct))
+        if (MediumIsSharedPath)
         {
-            Outcome = CopyOutcome.BackupTakenRestoreFailed;
-            _notifier.Notify(new RunNotification(
-                RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
-                "The backup was taken, but the target cannot read it - usually a share " +
-                "permission for the target's service account.", DateTime.Now - copyStartedAt));
-            return;
+            bool targetCanRead;
+            try
+            {
+                targetCanRead = await TargetCanReadAsync(destinations, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                // Stop pressed between the halves (#283). This used to fall into the
+                // readability check's catch-all and report a share-permission failure -
+                // sending the DBA to chase an ACL that is fine.
+                Append("Cancelled before the restore half began.");
+                Outcome = CopyOutcome.BackupTakenRestoreFailed;
+                _notifier.Notify(new RunNotification(
+                    RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
+                    "Cancelled between the halves - the backup exists and is usable; " +
+                    "nothing was restored.", DateTime.Now - copyStartedAt));
+                return;
+            }
+
+            if (!targetCanRead)
+            {
+                Outcome = CopyOutcome.BackupTakenRestoreFailed;
+                _notifier.Notify(new RunNotification(
+                    RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
+                    "The backup was taken, but the target cannot read it - usually a share " +
+                    "permission for the target's service account.", DateTime.Now - copyStartedAt));
+                return;
+            }
         }
 
         // ── the target half ─────────────────────────────────────────────────────
@@ -761,6 +783,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
                 RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
                 "Cancelled during the restore half - the backup exists, the target is mid-restore.",
                 DateTime.Now - copyStartedAt));
+            await DescribeTargetStateAsync();
             return;
         }
         catch (Exception ex)
@@ -771,10 +794,12 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             _notifier.Notify(new RunNotification(
                 RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
                 $"The restore half failed: {ex.Message}", DateTime.Now - copyStartedAt));
+            await DescribeTargetStateAsync();
             return;
         }
 
         Append("Restore complete.");
+        await ReportOrphansAsync();
         Outcome = CopyOutcome.Copied;
         _log.Info($"Copy finished: {TargetDatabaseName} on {TargetServer.ServerName}");
 
@@ -782,6 +807,55 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             RunPhase.Succeeded, "Copy", SourceDatabase!, copyRoute,
             $"Now on {TargetServer.ServerName} as {TargetDatabaseName}.",
             DateTime.Now - copyStartedAt));
+    }
+
+    /// <summary>
+    /// What state did the failed restore half leave the target in, and what gets it out (#283)
+    /// - the same questions the restore screen answers, told through this screen's console.
+    /// Best effort: the restore failure is the news, and failing to describe the aftermath
+    /// must not replace the error the user needs to read.
+    /// </summary>
+    private async Task DescribeTargetStateAsync()
+    {
+        try
+        {
+            var state = await _sql.GetDatabaseRecoveryStateAsync(TargetServer!, TargetDatabaseName!);
+            if (!state.NeedsAttention)
+            {
+                if (!state.Exists)
+                    Append($"[{TargetDatabaseName}] is not on {TargetServer!.ServerName} - " +
+                           "nothing was left behind.");
+                return;
+            }
+
+            Append(state.Explain(TargetDatabaseName!));
+            foreach (var action in state.SuggestedActions(TargetDatabaseName!))
+                Append($"  {action.Title}:  {action.Sql}");
+        }
+        catch (Exception ex)
+        {
+            Append($"Could not check the state of [{TargetDatabaseName}]: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// The orphaned-user scan on the copy that WORKED (#283): a copy to a DIFFERENT server is
+    /// the canonical orphaned-login scenario - login succeeds, database access fails, and
+    /// nothing says why. One cheap query; console-only, best effort.
+    /// </summary>
+    private async Task ReportOrphansAsync()
+    {
+        try
+        {
+            var orphans = await _sql.FindOrphanedUsersAsync(TargetServer!, TargetDatabaseName!);
+            Append(PostRestoreAdvice.DescribeOrphans(orphans));
+            foreach (var orphan in orphans.Where(o => o.HasSameNamedLogin))
+                Append($"  {PostRestoreAdvice.FixOrphan(TargetDatabaseName!, orphan).Sql}");
+        }
+        catch (Exception ex)
+        {
+            Append($"Could not check [{TargetDatabaseName}] for orphaned users: {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -809,6 +883,12 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
             Append(failed.Explain(TargetServer.ServerName));
             return false;
+        }
+        catch (OperationCanceledException)
+        {
+            // The Stop button's cancellation is the caller's story to tell (#283) - swallowing
+            // it here is how a pressed Stop got reported as a share-permission failure.
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Closes #283.

Three gaps, each a place the restore screen already does the right thing:

- **A Stop between the halves was reported as a share-permission failure.** The readability check's catch-all swallowed \`OperationCanceledException\`, so pressing Stop sent the DBA to chase an ACL that was fine. The check now rethrows cancellation - and the fake observes its token, without which no test could ever catch the misreport - and the between-halves cancel has its own honest words: the backup exists and is usable; nothing was restored.
- **A failed or cancelled restore half left the target unexplained.** The outcome text stopped at "may be nothing"; the console now describes the target's actual state (RESTORING, RECOVERY_PENDING, single-user) and the statements that get out of it, through the same recovery-state machinery the restore screen uses.
- **A copy that WORKED never ran the orphan scan** - though a copy to a DIFFERENT server is the canonical orphaned-login scenario: login succeeds, database access fails, nothing says why. It runs now, console-only and best effort, with the fix statement per mappable orphan.

Three pins (1,658 total) - which are also the copy's first notification-path tests; it fires six distinct notifications and had zero coverage.