### PR TITLE
BACKUP TO URL and the copy ask the credential question first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ more detail on the user-facing changes; this file is the short history.
   the moment the run ends. And Ctrl+C mid-run is a story, not a kill: the receipt says
   Cancelled, the channel is told, and the exit code is the conventional 130 so a wrapping
   script can tell an operator's interruption from a failure
+- BACKUP TO URL and the copy now ask the credential question the restore always asked
+  (#284): the backup checks the source instance before its first statement, the copy checks
+  BOTH ends before the source is read at full speed - a missing credential is created, an
+  existing usable one (managed identity included) is left strictly alone, and an existing
+  unusable one refuses with the way out named, instead of Msg 3201 after the arm-and-confirm.
+  The decision now lives in one Core service all three screens share
 - Copy failures get the restore screen's follow-through (#283): a Stop pressed between the
   halves is reported as the cancellation it is - not as a share-permission failure sending
   somebody to chase an ACL that is fine; a failed restore half now says what state the

--- a/src/NineLives.Core/Services/BlobCredentialPreflight.cs
+++ b/src/NineLives.Core/Services/BlobCredentialPreflight.cs
@@ -1,0 +1,90 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Whether a run that talks TO URL may start, and what to say when it may not. A refusal here
+/// has touched nothing, so the caller has nothing to unwind.
+/// </summary>
+public readonly record struct CredentialPreflight(bool CanProceed, string? Refusal)
+{
+    public static CredentialPreflight Proceed => new(true, null);
+
+    public static CredentialPreflight Stop(string reason) => new(false, reason);
+}
+
+/// <summary>
+/// The credential question, asked BEFORE anything reads or writes a container (#284). This
+/// was the restore screen's preflight; BACKUP TO URL needs the credential on the source and
+/// the copy needs it on both ends, and neither used to check - a missing or wrong-identity
+/// credential surfaced as Msg 3201 after the arm-and-confirm, and on the copy after the
+/// source had already been read at full speed. Extracted here so every front end asks the
+/// same question the same way.
+///
+/// The rules it keeps are the ones learned the hard way on the restore screen: only create
+/// when genuinely missing (#10); never touch an existing credential that can already restore
+/// (#145 - "fixing" a managed identity into a SAS took every other job on the container with
+/// it); an existing-but-unusable identity is a refusal, not a conversion.
+/// </summary>
+public static class BlobCredentialPreflight
+{
+    public static async Task<CredentialPreflight> EnsureAsync(
+        ICredentialStore store, ISqlServerService sql, OperationLog? log,
+        BlobContainerConfig container, ServerConnection server, Action<string> appendLog)
+    {
+        var credentialName = container.ContainerUrl;
+
+        // No stored token means nothing this app could write anyway - an Entra container has
+        // none by design. Whatever is on the server is what the run will use.
+        var sasToken = store.GetSasToken(container);
+        if (string.IsNullOrEmpty(sasToken)) return CredentialPreflight.Proceed;
+
+        var credential = await sql.CredentialExistsAsync(server, credentialName);
+
+        if (credential.CanRestoreFromUrl)
+        {
+            appendLog(credential.Kind == BlobCredentialIdentity.ManagedIdentity
+                ? $"Using the existing SQL credential [{credentialName}] (Managed Identity) on " +
+                  $"{server.ServerName}. Server state not modified."
+                : $"Using the existing SQL credential [{credentialName}] on {server.ServerName}. " +
+                  "Server state not modified.");
+            return CredentialPreflight.Proceed;
+        }
+
+        if (credential.Exists)
+        {
+            // Neither usable nor ours to reinterpret. Converting it is a decision somebody
+            // makes on the credential panel, not a side effect of pressing a run button.
+            var refusal =
+                $"Credential [{credentialName}] exists on {server.ServerName} with identity " +
+                $"'{credential.Identity}', which TO URL cannot use. Left untouched: replacing " +
+                "it with the stored SAS token is what \"Create credential on server\" does, so " +
+                "that it stays a deliberate change.";
+            appendLog(refusal);
+            return CredentialPreflight.Stop(refusal);
+        }
+
+        appendLog($"Credential [{credentialName}] is missing on {server.ServerName} - creating it...");
+
+        // The one moment a secret crosses the wire; if the connection trusts an unvalidated
+        // certificate, say so here rather than only in settings (#17).
+        if (server.TrustServerCertificate)
+            appendLog(
+                "  Note: this connection trusts the server certificate without validating it, " +
+                "and the SAS token is sent over it.");
+
+        var written = await sql.EnsureCredentialExistsAsync(
+            server, credentialName, container.ContainerUrl, sasToken);
+
+        appendLog(written == CredentialChange.Created
+            ? "Credential created on the server."
+            : "Credential updated on the server.");
+
+        // Changing shared state on someone's instance belongs in the file, not only in a
+        // console that closes with the app.
+        log?.ServerChange(server.ServerName,
+            $"credential [{credentialName}] {written.ToString().ToLowerInvariant()}");
+
+        return CredentialPreflight.Proceed;
+    }
+}

--- a/src/NineLives.Tests/BlobCredentialPreflightTests.cs
+++ b/src/NineLives.Tests/BlobCredentialPreflightTests.cs
@@ -1,0 +1,119 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The credential question, asked before anything talks TO URL (#284). The restore screen
+/// always asked it; the backup screen (which needs the credential on the SOURCE) and the copy
+/// (which needs it on BOTH ends) did not - a missing or wrong-identity credential surfaced as
+/// Msg 3201 after the arm-and-confirm, and on the copy after the source had been read at
+/// full speed.
+/// </summary>
+public class BlobCredentialPreflightTests
+{
+    private static (BackupViewModel vm, FakeSqlServerService sql, FakeCredentialStore store,
+        FakeRunNotifier notifier) BackupStage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        var container = new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        };
+        store.Config.BlobContainers.Add(container);
+        store.SaveSasToken(container, "sv=2024&sig=token");
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var notifier = new FakeRunNotifier();
+        var vm = new BackupViewModel(store, sql, TestLogs.Temp(), notifier);
+        vm.Server = vm.Servers.Single();
+        vm.Container = vm.Containers.Single();
+        return (vm, sql, store, notifier);
+    }
+
+    private static async Task RunBackup(BackupViewModel vm)
+    {
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.SelectedDatabase = "MyDb";
+        vm.GenerateCommand.Execute(null);
+        await vm.ExecuteCommand.ExecuteAsync(null);
+        await vm.ExecuteCommand.ExecuteAsync(null);
+    }
+
+    [Fact]
+    public async Task ABackupRefusesWhenTheCredentialExistsButCannotBeUsed()
+    {
+        var (vm, sql, _, notifier) = BackupStage();
+        sql.Credential = new BlobCredentialStatus(
+            BlobCredentialIdentity.Other, "SOME SERVICE PRINCIPAL");
+
+        await RunBackup(vm);
+
+        Assert.Empty(sql.ExecutedScripts);
+        Assert.Empty(sql.CredentialIdentitiesWritten);
+        var problem = notifier.Sent.Last();
+        Assert.Equal(RunPhase.Problem, problem.Phase);
+        Assert.Contains("deliberate change", problem.Detail);
+    }
+
+    [Fact]
+    public async Task AMissingCredentialIsCreatedAndTheBackupProceeds()
+    {
+        var (vm, sql, _, _) = BackupStage();
+        sql.Credential = BlobCredentialStatus.Missing;
+        sql.CredentialWriteResult = CredentialChange.Created;
+
+        await RunBackup(vm);
+
+        Assert.Single(sql.ExecutedScripts);
+        Assert.Contains(vm.Console, line => line.Contains("creating it"));
+    }
+
+    [Fact]
+    public async Task TheCopyAsksBothEndsBeforeTheBackupHalf()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+        var container = new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        };
+        store.Config.BlobContainers.Add(container);
+        store.SaveSasToken(container, "sv=2024&sig=token");
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var checks = 0;
+        sql.OnCredentialCheck = (_, _) =>
+        {
+            checks++;
+            return Task.FromResult(new BlobCredentialStatus(
+                BlobCredentialIdentity.SharedAccessSignature, "SHARED ACCESS SIGNATURE"));
+        };
+
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp());
+        vm.SourceServer = vm.Servers.First(s => s.Name == "SRV01");
+        vm.TargetServer = vm.Servers.First(s => s.Name == "SRV02");
+        vm.Container = vm.Containers.Single();
+        vm.SourceDatabases = ["MyDb"];
+        vm.SourceDatabase = "MyDb";
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.GenerateCommand.Execute(null);
+
+        await vm.RunCommand.ExecuteAsync(null);
+        await vm.RunCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, checks);
+        Assert.Equal(CopyOutcome.Copied, vm.Outcome);
+    }
+}

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -506,6 +506,26 @@ public partial class BackupViewModel : ViewModelBase
         var ct = _runCancellation.Begin();
         var started = DateTime.Now;
 
+        // BACKUP TO URL needs the credential on THIS instance (#284) - asked before the first
+        // statement, because Msg 3201 after the arm-and-confirm is the class of late refusal
+        // this screen exists to kill.
+        if (MediumIsBlob && Container != null)
+        {
+            var preflight = await BlobCredentialPreflight.EnsureAsync(
+                _store, _sql, _log, Container, Server, Append);
+            if (!preflight.CanProceed)
+            {
+                _notifier.Notify(new RunNotification(
+                    RunPhase.Problem, "Backup",
+                    MultiSelect ? $"{PickedDatabases.Count} database(s)" : SelectedDatabase ?? "backup",
+                    Server.ServerName, preflight.Refusal));
+                SetError(preflight.Refusal!);
+                _runCancellation.End();
+                IsRunning = false;
+                return;
+            }
+        }
+
         // Database-at-a-time, deliberately (#208): a failure on the sixth database names the
         // sixth database and the rest still run - the patch-night semantics. One database is the
         // one-item case of the same loop.

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -700,6 +700,27 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         var copyStartedAt = DateTime.Now;
         var copyRoute = $"{SourceServer.ServerName} \u2192 {TargetServer.ServerName}";
 
+        // Blob needs the credential on BOTH ends (#284) - the source to write, the target to
+        // read - and both are checkable before the source is read at full speed. Refusing
+        // here beats Msg 3201 after the backup half ran.
+        if (MediumIsBlob && Container != null)
+        {
+            foreach (var end in new[] { SourceServer, TargetServer })
+            {
+                var preflight = await BlobCredentialPreflight.EnsureAsync(
+                    _store, _sql, _log, Container, end, Append);
+                if (!preflight.CanProceed)
+                {
+                    Outcome = CopyOutcome.NotStarted;
+                    _notifier.Notify(new RunNotification(
+                        RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
+                        preflight.Refusal));
+                    SetError(preflight.Refusal!);
+                    return;
+                }
+            }
+        }
+
         _notifier.Notify(new RunNotification(
             RunPhase.Started, "Copy", SourceDatabase!, copyRoute, $"as {TargetDatabaseName}"));
 

--- a/src/NineLives/ViewModels/ServerCredentialViewModel.cs
+++ b/src/NineLives/ViewModels/ServerCredentialViewModel.cs
@@ -425,83 +425,11 @@ public partial class ServerCredentialViewModel : ObservableObject
     {
         if (Container == null) return CredentialPreflight.Proceed;
 
-        // No stored token means nothing this app could write anyway - an Entra container has none
-        // by design. Whatever is on the server is what the restore will use, and it is not this
-        // app's to guess at.
-        var sasToken = _store.GetSasToken(Container);
-        if (string.IsNullOrEmpty(sasToken)) return CredentialPreflight.Proceed;
-
-        // Only write when the credential is genuinely missing. This used to drop and recreate on
-        // every single execute, regardless of the status the panel was displaying, which
-        // contradicted the UI's own "creating it is optional" wording and briefly removed a
-        // credential that other sessions may have been using (#10).
-        //
-        // A credential that exists and is SAS is left alone. Its secret could still be a rotated
-        // SAS that no longer works - unknowable from here, since the secret cannot be read back -
-        // so the fix for that case is the explicit button, not rewriting server state on every run.
-        //
-        // A managed identity is left alone for a stronger reason: it restores perfectly well, this
-        // app cannot create one, and ALTER would reset the identity. Reading "not SAS" as "broken"
-        // is what silently converted somebody's working managed identity into a SAS token here,
-        // taking every other job on that container with it, under the log line "Credential updated
-        // on the server" (#145).
-        var credential = await _sql.CredentialExistsAsync(server, Name);
-
-        if (credential.CanRestoreFromUrl)
-        {
-            appendLog(credential.Kind == BlobCredentialIdentity.ManagedIdentity
-                ? $"Using the existing SQL credential [{Name}] (Managed Identity). Server state not modified."
-                : $"Using the existing SQL credential [{Name}]. Server state not modified.");
-            return CredentialPreflight.Proceed;
-        }
-
-        if (credential.Exists)
-        {
-            // Neither usable nor ours to reinterpret. Converting it is a real option - it is what
-            // the button on the panel does - but it must be a decision somebody made, not a side
-            // effect of pressing Execute. Stopping costs a restore that was about to fail on blob
-            // access anyway.
-            var refusal =
-                $"Credential [{Name}] exists with identity '{credential.Identity}', which a " +
-                "restore from URL cannot use. Left untouched: replacing it with the stored SAS " +
-                "token is what \"Create credential on server\" does, so that it is a deliberate change.";
-            appendLog(refusal);
-            return CredentialPreflight.Stop(refusal);
-        }
-
-        appendLog($"Credential [{Name}] is missing - creating it...");
-
-        // This statement carries the SAS token to the server. It is the one moment in a restore
-        // where a secret crosses the wire, so if the connection is encrypted but unverified, say so
-        // here rather than only in settings (#17).
-        if (server.TrustServerCertificate)
-            appendLog(
-                "  Note: this connection trusts the server certificate without validating it, " +
-                "and the SAS token is sent over it.");
-
-        var written = await _sql.EnsureCredentialExistsAsync(
-            server, Name, Container.ContainerUrl, sasToken);
-
-        appendLog(written == CredentialChange.Created
-            ? "Credential created on the server."
-            : "Credential updated on the server.");
-
-        // Changing a credential is a change to shared state on someone's instance. It belongs in
-        // the file, not only in a console that closes with the app.
-        _log.ServerChange(server.ServerName,
-            $"credential [{Name}] {written.ToString().ToLowerInvariant()}");
-
-        return CredentialPreflight.Proceed;
+        // The decision itself lives in Core now (#284), shared with the backup and copy
+        // screens - this panel remains the place a human sees and manages the credential.
+        return await BlobCredentialPreflight.EnsureAsync(
+            _store, _sql, _log, Container, server, appendLog);
     }
+
 }
 
-/// <summary>
-/// Whether a restore may start, and what to say when it may not. A refusal here has touched
-/// nothing, so the caller has nothing to unwind.
-/// </summary>
-public readonly record struct CredentialPreflight(bool CanProceed, string? Refusal)
-{
-    public static CredentialPreflight Proceed => new(true, null);
-
-    public static CredentialPreflight Stop(string reason) => new(false, reason);
-}


### PR DESCRIPTION
Closes #284.

The restore screen always asked the blob credential question before running. The backup screen - which needs the credential on the SOURCE, as its own tooltip says - and the copy - which needs it on BOTH ends - never did: a missing or wrong-identity credential surfaced as **Msg 3201** after the arm-and-confirm, and on the copy after the source had already been read at full speed. That is the exact class of late refusal the copy's version check (#266) was added to kill.

**The decision moves to Core** (\`BlobCredentialPreflight.EnsureAsync\`), keeping every rule the restore screen learned the hard way: create only when genuinely missing (#10, no drop-and-recreate); never touch an existing credential that can already restore - a managed identity especially (#145, where "fixing" one into a SAS took every job on the container down); an existing-but-unusable identity is a refusal with the way out named, because converting it is the credential panel's deliberate button, not a run's side effect. The \`CredentialPreflight\` record moves to Core alongside; the panel VM now delegates to the shared service, so all three screens ask the same question the same way - and the CLI can ask it too, later.

The backup asks its source before the first statement (multi-select included); the copy asks both ends before the backup half. Refusals notify the channel and stop with nothing to unwind.

Three pins (1,661 total): the unusable-credential refusal executes nothing and says "deliberate change"; the missing credential is created and the run proceeds; the copy checks exactly two ends before copying.