### PR TITLE
Closing on the mode cards keeps the remembered screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ more detail on the user-facing changes; this file is the short history.
   the moment the run ends. And Ctrl+C mid-run is a story, not a kill: the receipt says
   Cancelled, the channel is told, and the exit code is the conventional 130 so a wrapping
   script can tell an operator's interruption from a failure
+- Closing the app on the launch mode-cards no longer erases the remembered screen (#290).
+  The cards show at every start, so opening the app and closing it without clicking through
+  wiped the last-screen memory and the next launch forgot where its owner works. No choice
+  made now means nothing recorded - not "record nothing"
 - BACKUP TO URL and the copy now ask the credential question the restore always asked
   (#284): the backup checks the source instance before its first statement, the copy checks
   BOTH ends before the source is read at full speed - a missing credential is created, an

--- a/src/NineLives.Tests/ModeCardsShutdownTests.cs
+++ b/src/NineLives.Tests/ModeCardsShutdownTests.cs
@@ -1,0 +1,48 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Closing the app on the launch mode-cards must not erase the remembered screen (#290). The
+/// cards are up at every start, so writing null there wiped #211's last-screen memory for
+/// anyone who started the app and closed it without clicking through - the next launch
+/// landed on the default instead of where they work.
+/// </summary>
+public class ModeCardsShutdownTests
+{
+    [Fact]
+    public void ClosingOnTheModeCardsKeepsTheRememberedScreen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = null;
+        store.Config.LastScreen = MainViewModel.Nav.Restore;
+
+        var vm = new MainViewModel(store);
+        Assert.True(vm.IsChoosingMode);
+
+        vm.SaveShutdownState(new WindowGeometry());
+
+        Assert.Equal(MainViewModel.Nav.Restore, store.LoadConfig().LastScreen);
+    }
+
+    [Fact]
+    public void ClosingOnARealScreenStillRecordsIt()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Pro;
+        store.Config.LastScreen = MainViewModel.Nav.Restore;
+
+        // The cards show on every launch; choosing is what dismisses them.
+        var vm = new MainViewModel(store);
+        vm.ModeSelection.ChooseCommand.Execute(
+            vm.ModeSelection.Cards.First(c => c.Mode == AppMode.Pro));
+        Assert.False(vm.IsChoosingMode);
+        vm.NavigateToCommand.Execute(MainViewModel.Nav.History);
+
+        vm.SaveShutdownState(new WindowGeometry());
+
+        Assert.Equal(MainViewModel.Nav.History, store.LoadConfig().LastScreen);
+    }
+}

--- a/src/NineLives.Tests/RememberedWindowTests.cs
+++ b/src/NineLives.Tests/RememberedWindowTests.cs
@@ -128,11 +128,14 @@ public class RememberedWindowTests
     }
 
     /// <summary>
-    /// Closing from the launch cards records no screen - the cards are a question, not a place,
-    /// and recording them would land the next session on a screen that is not one.
+    /// Closing from the launch cards keeps the remembered screen (#290). The cards are a
+    /// question, not a place - which is exactly why they must not be RECORDED and equally
+    /// why closing on them must not ERASE the real place already remembered. This pin used
+    /// to assert null here, and since the cards show at every start, that wiped the memory
+    /// for anyone who opened the app and closed it without clicking through.
     /// </summary>
     [Fact]
-    public void ClosingFromTheCardsRecordsNoScreen()
+    public void ClosingFromTheCardsKeepsTheRememberedScreen()
     {
         var store = new FakeCredentialStore();
         store.Config.Mode = AppMode.Pro;
@@ -143,7 +146,7 @@ public class RememberedWindowTests
 
         main.SaveShutdownState(At(0, 0));
 
-        Assert.Null(store.Config.LastScreen);
+        Assert.Equal(MainViewModel.Nav.History, store.Config.LastScreen);
     }
 
     /// <summary>A config that would not load is not written back (#7's rule, respected here too).</summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -132,7 +132,11 @@ public partial class MainViewModel : ViewModelBase
             if (config.LoadError != null) return;
 
             config.Window = geometry;
-            config.LastScreen = IsChoosingMode ? null : CurrentViewName;
+            // Closing on the launch mode-cards leaves the remembered screen alone (#290): the
+            // cards are up at every start, so writing null here wiped #211's memory whenever
+            // the app was closed without clicking through - and the next launch forgot where
+            // its owner worked. No choice made means nothing to record, not "record nothing".
+            if (!IsChoosingMode) config.LastScreen = CurrentViewName;
             _credentialStore.SaveConfig(config);
         }
         catch


### PR DESCRIPTION
Closes #290 - small fix, wide blast radius.

\`SaveShutdownState\` wrote \`LastScreen = null\` whenever the mode cards were showing - and the cards show at EVERY launch, so simply opening the app and closing it without clicking through wiped the remembered screen (#211). The next "Keep what I have" landed on the default instead of where its owner actually works.

The fix: no choice made means nothing RECORDED, not "record nothing" - the geometry still saves; \`LastScreen\` is left alone while the cards are up.

The old pin (\`ClosingFromTheCardsRecordsNoScreen\`) asserted the wipe as designed, reasoning "the cards are a question, not a place". That reasoning is right - and it is exactly why closing on them must not ERASE the real place already remembered, either. The pin now asserts preservation with the corrected rationale, and two new pins cover both endings (1,663 total).