### PR TITLE
Generation-time checks answer for inputs, not keystrokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,13 @@ more detail on the user-facing changes; this file is the short history.
   the moment the run ends. And Ctrl+C mid-run is a story, not a kill: the receipt says
   Cancelled, the channel is told, and the exit code is the conventional 130 so a wrapping
   script can tell an operator's interruption from a failure
+- The copy's generation-time checks answer for their inputs, not for keystrokes (#285).
+  Typing in the target-name box used to launch six round trips across BOTH production
+  instances per character, the racing sweeps could clear each other's warnings, and a quick
+  Confirm ran with the panels still blank. One serialised sweep per input change now -
+  version first, previous sweep cancelled on re-entry so a stale answer can never erase a
+  fresh warning - and the run waits for the verdicts before anything executes. A credential
+  refusal before the run also finally uses the outcome the enum always had for it
 - Closing the app on the launch mode-cards no longer erases the remembered screen (#290).
   The cards show at every start, so opening the app and closing it without clicking through
   wiped the last-screen memory and the next launch forgot where its owner works. No choice

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -321,11 +321,17 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Set to make the version ask throw - a server that does not answer at all (#63).</summary>
     public Exception? ThrowOnMajorVersion { get; set; }
 
-    public Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default)
+    /// <summary>
+    /// Awaited before the version answer - a test gates this to hold a check sweep open and
+    /// prove the run waits for the verdicts (#285).
+    /// </summary>
+    public Func<Task>? BeforeMajorVersion { get; set; }
+
+    public async Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default)
     {
+        if (BeforeMajorVersion != null) await BeforeMajorVersion();
         if (ThrowOnMajorVersion != null) throw ThrowOnMajorVersion;
-        return Task.FromResult(
-            MajorVersionByServer.TryGetValue(server.ServerName, out var v) ? v : ProductMajorVersion);
+        return MajorVersionByServer.TryGetValue(server.ServerName, out var v) ? v : ProductMajorVersion;
     }
 
     /// <summary>What GetDatabaseOverviewAsync answers (#205).</summary>

--- a/src/NineLives.Tests/GenerationCheckDisciplineTests.cs
+++ b/src/NineLives.Tests/GenerationCheckDisciplineTests.cs
@@ -1,0 +1,131 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The copy's generation-time checks answer for their INPUTS, not for keystrokes (#285).
+/// They used to re-fire on every property change - six round trips across two production
+/// instances per character typed into the target-name box - with no cancellation, racing
+/// each other's warning clears, and nothing holding the run until the verdicts were in.
+/// One serialised sweep per input change now, and the run waits for it.
+/// </summary>
+public class GenerationCheckDisciplineTests
+{
+    private static (CopyDatabaseViewModel vm, FakeSqlServerService sql, int VersionAsks)
+        Stage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV03", ServerName = "SRV03" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp());
+        vm.SourceServer = vm.Servers.First(s => s.Name == "SRV01");
+        vm.TargetServer = vm.Servers.First(s => s.Name == "SRV02");
+        vm.Container = vm.Containers.Single();
+        vm.SourceDatabases = ["MyDb"];
+        vm.SourceDatabase = "MyDb";
+        vm.TargetDatabaseName = "MyDb_Copy";
+        return (vm, sql, 0);
+    }
+
+    [Fact]
+    public void TypingInTheTargetNameDoesNotReAskTheServers()
+    {
+        var (vm, sql, _) = Stage();
+        var asks = 0;
+        sql.BeforeMajorVersion = () => { asks++; return Task.CompletedTask; };
+
+        vm.GenerateCommand.Execute(null);
+        var afterFirstGenerate = asks;
+        Assert.True(afterFirstGenerate > 0);
+
+        // Six keystrokes; every one used to launch a fresh sweep.
+        foreach (var ch in "_Test1")
+            vm.TargetDatabaseName += ch;
+
+        Assert.Equal(afterFirstGenerate, asks);
+    }
+
+    [Fact]
+    public void ChangingTheTargetServerDoesReCheck()
+    {
+        var (vm, sql, _) = Stage();
+        var asks = 0;
+        sql.BeforeMajorVersion = () => { asks++; return Task.CompletedTask; };
+
+        vm.GenerateCommand.Execute(null);
+        var afterFirstGenerate = asks;
+
+        vm.TargetServer = vm.Servers.First(s => s.Name == "SRV03");
+
+        Assert.True(asks > afterFirstGenerate);
+    }
+
+    /// <summary>
+    /// The confirmation's warning panels must hold the CURRENT answers before anything runs -
+    /// a quick Confirm used to run with the panels blank while the checks were in flight.
+    /// </summary>
+    [Fact]
+    public async Task TheRunWaitsForTheChecksVerdict()
+    {
+        var (vm, sql, _) = Stage();
+        var gate = new TaskCompletionSource();
+        sql.BeforeMajorVersion = () => gate.Task;
+
+        vm.GenerateCommand.Execute(null);
+
+        var run = Task.Run(async () =>
+        {
+            await vm.RunCommand.ExecuteAsync(null);
+            await vm.RunCommand.ExecuteAsync(null);
+        });
+
+        await Task.Delay(150);
+        Assert.Empty(sql.ExecutedScripts);
+
+        gate.SetResult();
+        await run;
+
+        Assert.Equal(2, sql.ExecutedScripts.Count);
+        Assert.Equal(CopyOutcome.Copied, vm.Outcome);
+    }
+
+    /// <summary>A stale sweep's answers must not land after a fresh sweep took over.</summary>
+    [Fact]
+    public async Task AFreshSweepsVerdictOutlivesTheStaleOne()
+    {
+        var (vm, sql, _) = Stage();
+
+        // First sweep: gated open, so it is still in flight when the inputs change.
+        var firstGate = new TaskCompletionSource();
+        sql.BeforeMajorVersion = () => firstGate.Task;
+        vm.GenerateCommand.Execute(null);
+
+        // Inputs change: the second sweep answers instantly with a REFUSING version pair.
+        sql.BeforeMajorVersion = null;
+        sql.MajorVersionByServer["SRV01"] = 17;
+        sql.MajorVersionByServer["SRV03"] = 16;
+        vm.TargetServer = vm.Servers.First(s => s.Name == "SRV03");
+
+        // Now the stale first sweep finally completes - its clean verdict must not clear
+        // the fresh warning.
+        firstGate.SetResult();
+        await Task.Delay(150);
+
+        Assert.Contains("3169", vm.VersionWarning);
+    }
+}

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -363,12 +363,57 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
         SetStatus("Scripts generated.");
 
-        // Fire and forget: the scripts are usable immediately, and the answers arrive when the
-        // two instances have answered. A generation that had to wait on them would make the whole
-        // screen feel slower for checks that usually say "fine".
-        _ = CheckSpaceAsync();
-        _ = CheckEncryptionAsync();
-        _ = CheckVersionAsync();
+        // The checks depend on the SERVERS and the SOURCE database - not on the target
+        // name or any other keystroke-speed field. Re-asking two production instances six
+        // round trips per character typed was the disease (#285); racing sweeps whose
+        // leading clears could erase a fresher sweep's warning was its complication. One
+        // serialised sweep per input change, previous sweep cancelled, answers still
+        // arriving without the generation waiting on them.
+        var inputs = string.Join("|",
+            SourceServer?.Id, TargetServer?.Id, SourceDatabase,
+            MediumIsBlob ? Container?.Id : SharedPathRoot);
+        if (inputs != _lastCheckedInputs)
+        {
+            _lastCheckedInputs = inputs;
+            _checksTask = RunGenerationChecksAsync();
+        }
+    }
+
+    /// <summary>The inputs the last check sweep was answering for.</summary>
+    private string? _lastCheckedInputs;
+
+    /// <summary>The in-flight sweep, so the run can refuse to start before the verdicts are in.</summary>
+    private Task _checksTask = Task.CompletedTask;
+
+    private readonly OperationCancellation _checksCancellation = new();
+
+    /// <summary>
+    /// The three generation-time checks as one serialised sweep (#285): warnings cleared once
+    /// up front, verdicts in a fixed order (version - the hardest refusal - first), previous
+    /// sweep cancelled on re-entry so a stale answer can never clear or overwrite a fresh one.
+    /// </summary>
+    private async Task RunGenerationChecksAsync()
+    {
+        var ct = _checksCancellation.Begin();
+        try
+        {
+            VersionWarning = string.Empty;
+            EncryptionWarning = string.Empty;
+            SpaceWarning = string.Empty;
+            VolumeSpace = [];
+
+            await CheckVersionAsync(ct);
+            await CheckEncryptionAsync(ct);
+            await CheckSpaceAsync(ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // A newer sweep took over; its answers are the ones that matter.
+        }
+        finally
+        {
+            _checksCancellation.End();
+        }
     }
 
     // ── can the target even accept it (#210's law, on the copy screen) ─────────
@@ -392,16 +437,14 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// STRONGEST terms, because unlike disk space nothing can change between generating and
     /// running that makes this legal.
     /// </summary>
-    private async Task CheckVersionAsync()
+    private async Task CheckVersionAsync(CancellationToken ct)
     {
-        VersionWarning = string.Empty;
-
         if (SourceServer == null || TargetServer == null) return;
 
         try
         {
-            var source = await _sql.GetProductMajorVersionAsync(SourceServer);
-            var target = await _sql.GetProductMajorVersionAsync(TargetServer);
+            var source = await _sql.GetProductMajorVersionAsync(SourceServer, ct);
+            var target = await _sql.GetProductMajorVersionAsync(TargetServer, ct);
 
             if (VersionCompatibility.Check(source, target) == VersionVerdict.Refuse)
             {
@@ -444,16 +487,14 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// between generating and running, and this app is not the authority on somebody else's
     /// security estate. Failing to answer raises nothing - warn on evidence, not on silence.
     /// </summary>
-    private async Task CheckEncryptionAsync()
+    private async Task CheckEncryptionAsync(CancellationToken ct)
     {
-        EncryptionWarning = string.Empty;
-
         if (SourceServer == null || TargetServer == null || string.IsNullOrWhiteSpace(SourceDatabase))
             return;
 
         try
         {
-            var (isEncrypted, certName) = await _sql.GetDatabaseTdeInfoAsync(SourceServer, SourceDatabase!);
+            var (isEncrypted, certName) = await _sql.GetDatabaseTdeInfoAsync(SourceServer, SourceDatabase!, ct);
             if (!isEncrypted) return;
 
             // The certificate itself, by thumbprint, when the source will say which it is - the
@@ -513,18 +554,15 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// Failing to answer is not a warning, same stance as the restore screen: this is a courtesy
     /// check over somebody else's storage.
     /// </summary>
-    private async Task CheckSpaceAsync()
+    private async Task CheckSpaceAsync(CancellationToken ct)
     {
-        VolumeSpace = [];
-        SpaceWarning = string.Empty;
-
         if (SourceServer == null || TargetServer == null || string.IsNullOrWhiteSpace(SourceDatabase))
             return;
 
         try
         {
-            var files = await _sql.GetDatabaseFilesAsync(SourceServer, SourceDatabase!);
-            var free = await _sql.GetVolumeFreeSpaceAsync(TargetServer);
+            var files = await _sql.GetDatabaseFilesAsync(SourceServer, SourceDatabase!, ct);
+            var free = await _sql.GetVolumeFreeSpaceAsync(TargetServer, ct);
             var volumes = RestoreSpaceCheck.Check(files, free);
 
             VolumeSpace = new ObservableCollection<VolumeSpace>(volumes);
@@ -658,6 +696,10 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         Outcome = CopyOutcome.NotStarted;
         OutcomeText = string.Empty;
 
+        // The warnings the confirmation shows must be the CURRENT answers (#285): a quick
+        // Confirm used to run with the panels still blank while the checks were in flight.
+        await _checksTask;
+
         var ct = _runCancellation.Begin();
 
         // The run executes what was SHOWN, not what is on screen later (#280): these
@@ -711,7 +753,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
                     _store, _sql, _log, Container, end, Append);
                 if (!preflight.CanProceed)
                 {
-                    Outcome = CopyOutcome.NotStarted;
+                    Outcome = CopyOutcome.StoppedBeforeAnythingHappened;
                     _notifier.Notify(new RunNotification(
                         RunPhase.Problem, "Copy", SourceDatabase!, copyRoute,
                         preflight.Refusal));


### PR DESCRIPTION
Closes #285.

The copy's three generation-time checks - version direction, TDE certificate, disk space - fired fire-and-forget from \`Generate()\`, and \`Invalidate()\` calls \`Generate\` on every property change with the target-name box updating per keystroke. The arithmetic: **six round trips across two production instances per character typed**. No cancellation; each check cleared its own warning on entry, so an older sweep finishing last could erase a warning a newer sweep had just raised; and nothing held the run until the verdicts were in - a quick Confirm ran with the warning panels still blank.

**The discipline:**
- **One serialised sweep per INPUT change** - the checks depend on the servers, the source database and the container/path, not on the target name; the input tuple is tracked and keystrokes no longer re-ask anybody anything.
- **Previous sweep cancelled on re-entry**, warnings cleared once up front, verdicts in fixed order (version - the hardest refusal - first). A stale sweep's clean answer structurally cannot clear a fresh sweep's warning.
- **The run awaits the in-flight sweep** before executing, so the confirmation's panels always show the current answers.
- The copy's pre-run credential refusal (#284) now records \`StoppedBeforeAnythingHappened\` - the outcome the enum has carried unused since it was written - instead of \`NotStarted\`.

Four pins (1,667 total), made deterministic by a gate on the fake's version answer: keystrokes do not re-ask, a server change does, the run holds at the gate until the verdict lands, and the stale-sweep race is pinned dead.

(The same-instance auto-MOVE enhancement deferred here from #282 remains tracked on that issue - it needs the FILELISTONLY fetch designed into this sweep, a feature on top of this fix rather than part of it.)