### PR TITLE
Webhook deliveries take a route, and their URLs become secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,18 @@ more detail on the user-facing changes; this file is the short history.
   `NINELIVES_SQL_PASSWORD` / `NINELIVES_SAS` as the script-friendly alternative to flags.
   A point-in-time clone is three chained lines whose only variable is the moment
 
+- **Webhook deliveries can take a route** (#316): the machine's own proxy settings (the
+  default, and what always happened), no proxy at all, or an explicit proxy URL with
+  credentials - the password in Windows Credential Manager like every secret. One setting
+  beside the webhook list, used by every send: the app's runs, the test button, and the
+  CLI's alike. The route travels in an export as addressing only; the secret asks again on
+  the new machine
+- **Webhook URLs get the secret treatment** (#317): pasted, then committed with an explicit
+  Save - and from that moment obfuscated, stored in Windows Credential Manager, out of
+  config.json, and never displayed again. Replacing one means saving a new one. Deliveries
+  hydrate the URL at send time on clones; existing configs keep working from their in-file
+  URL until the row is next saved, which migrates it
+
 ### Changed
 
 - The engine - every service and model - now lives in NineLives.Core, a library with no UI

--- a/src/NineLives.Core/Models/WebhookEndpoint.cs
+++ b/src/NineLives.Core/Models/WebhookEndpoint.cs
@@ -56,4 +56,8 @@ public class WebhookEndpoint
 
     [JsonIgnore]
     public bool IsUsable => !string.IsNullOrWhiteSpace(Url);
+
+    /// <summary>Where this endpoint's URL lives in the vault once saved as a secret (#317).</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string CredentialKey => $"NineLives:Webhook:{Id}";
 }

--- a/src/NineLives.Core/Services/ConfigPortability.cs
+++ b/src/NineLives.Core/Services/ConfigPortability.cs
@@ -31,6 +31,12 @@ public sealed class ExportedConfig
     /// <summary>Endpoints travel as shapes - name, format, toggles - with their URLs stripped.</summary>
     public List<WebhookEndpoint> Webhooks { get; set; } = [];
 
+    /// <summary>
+    /// The delivery route travels as addressing only (#316): mode, URL, username. The proxy
+    /// password is a secret and stays in the vault, like every secret.
+    /// </summary>
+    public WebhookProxySettings? WebhookProxy { get; set; }
+
     // Mode is the one preference that travels: nullable, so "this machine never chose" is a
     // real state the merge can respect. Theme and the update/log settings used to be exported
     // too but were never applied on import - an export that carries what the import discards
@@ -99,7 +105,15 @@ public static class ConfigPortability
             Webhooks = config.Webhooks
                 .Select(w => { var c = CloneViaJson(w); c.Url = string.Empty; return c; })
                 .ToList(),
-            Mode = config.Mode
+            Mode = config.Mode,
+            WebhookProxy = config.WebhookProxy == null
+                ? null
+                : new WebhookProxySettings
+                {
+                    Mode = config.WebhookProxy.Mode,
+                    Url = config.WebhookProxy.Url,
+                    Username = config.WebhookProxy.Username
+                }
         };
 
         return JsonSerializer.Serialize(exported, Options);
@@ -217,6 +231,10 @@ public static class ConfigPortability
         // The one travelling preference: mode is taken from the file ONLY on a machine that
         // never chose one. Overwriting a choice this machine made is not an import's business.
         target.Mode ??= imported.Mode;
+
+        // Same rule for the delivery route (#316): it arrives only where none was chosen, and
+        // its password never travels - the custom proxy asks for it again on the new machine.
+        target.WebhookProxy ??= imported.WebhookProxy;
 
         return new ImportSummary(
             containersAdded, containersUpdated, serversAdded, serversUpdated,

--- a/src/NineLives.Core/Services/CredentialStore.cs
+++ b/src/NineLives.Core/Services/CredentialStore.cs
@@ -313,9 +313,14 @@ public class AppConfig
 
     /// <summary>
     /// Where run notifications go (#242): Teams, Slack, or any JSON endpoint. The URLs are
-    /// secrets in all but name and never leave this machine in an export (#213).
+    /// secrets in all but name and never leave this machine in an export (#213); once saved
+    /// through the Settings screen they live in Windows Credential Manager and this list's
+    /// entries carry no URL at all (#317).
     /// </summary>
     public List<WebhookEndpoint> Webhooks { get; set; } = [];
+
+    /// <summary>How webhook deliveries reach the network (#316). Null means the system default.</summary>
+    public WebhookProxySettings? WebhookProxy { get; set; }
 
     /// <summary>Where the window was when the app closed, or null before the first close (#211).</summary>
     public WindowGeometry? Window { get; set; }

--- a/src/NineLives.Core/Services/WebhookRunNotifier.cs
+++ b/src/NineLives.Core/Services/WebhookRunNotifier.cs
@@ -18,7 +18,7 @@ public sealed class WebhookRunNotifier : IRunNotifier
 {
     private readonly ICredentialStore _store;
     private readonly OperationLog _log;
-    private readonly WebhookNotifier _notifier;
+    private readonly WebhookNotifier? _injected;
 
     /// <summary>
     /// Deliveries still in flight, so a short-lived process can drain them before exiting
@@ -32,15 +32,20 @@ public sealed class WebhookRunNotifier : IRunNotifier
     {
         _store = store;
         _log = log;
-        _notifier = notifier ?? new WebhookNotifier();
+        _injected = notifier;
     }
 
     public void Notify(RunNotification notification)
     {
         List<WebhookEndpoint> endpoints;
+        WebhookProxySettings? proxy;
         try
         {
-            endpoints = _store.LoadConfig().Webhooks.Where(w => w.IsUsable).ToList();
+            var config = _store.LoadConfig();
+            // Hydrated clones (#317): saved URLs live in the vault, resolved at send time,
+            // and the config's own objects never carry the secret.
+            endpoints = WebhookTransport.HydrateUsable(config.Webhooks, _store);
+            proxy = config.WebhookProxy;
         }
         catch
         {
@@ -55,7 +60,19 @@ public sealed class WebhookRunNotifier : IRunNotifier
         {
             try
             {
-                await _notifier.NotifyAsync(endpoints, notification, line => _log.Info(line));
+                // The injected notifier (tests) is used as-is; the real one is built per
+                // delivery with the configured transport (#316), so a proxy change in
+                // Settings applies to the very next send.
+                if (_injected != null)
+                {
+                    await _injected.NotifyAsync(endpoints, notification, line => _log.Info(line));
+                }
+                else
+                {
+                    using var handler = WebhookTransport.BuildHandler(proxy, _store);
+                    var notifier = new WebhookNotifier(handler);
+                    await notifier.NotifyAsync(endpoints, notification, line => _log.Info(line));
+                }
             }
             catch (Exception ex)
             {

--- a/src/NineLives.Core/Services/WebhookTransport.cs
+++ b/src/NineLives.Core/Services/WebhookTransport.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>How webhook deliveries reach the network (#316).</summary>
+public enum WebhookProxyMode
+{
+    /// <summary>The machine's own proxy configuration - the default, and what happened before.</summary>
+    SystemDefault,
+
+    /// <summary>No proxy at all, even if the system has one configured.</summary>
+    Direct,
+
+    /// <summary>An explicit proxy URL, optionally authenticated.</summary>
+    Custom
+}
+
+/// <summary>
+/// The proxy webhook deliveries use (#316). Estate-level rather than per-endpoint: a corporate
+/// proxy is a property of the network the machine sits on, not of any one Teams channel. The
+/// password is NOT here - it lives in Windows Credential Manager like every other secret.
+/// </summary>
+public class WebhookProxySettings
+{
+    public WebhookProxyMode Mode { get; set; } = WebhookProxyMode.SystemDefault;
+    public string? Url { get; set; }
+    public string? Username { get; set; }
+}
+
+/// <summary>
+/// Builds the transport pieces every webhook delivery shares - the app's runs, the Settings
+/// test button and the CLI's drained sends alike (#316, #317). Pure construction, so the
+/// handler a given configuration produces is provable in a test without a live proxy.
+/// </summary>
+public static class WebhookTransport
+{
+    /// <summary>Where the custom proxy's password lives in the vault.</summary>
+    public const string ProxyCredentialKey = "NineLives:WebhookProxy";
+
+    public static HttpMessageHandler BuildHandler(
+        WebhookProxySettings? settings, ICredentialStore store)
+    {
+        var handler = new HttpClientHandler();
+
+        switch (settings?.Mode)
+        {
+            case WebhookProxyMode.Direct:
+                handler.UseProxy = false;
+                break;
+
+            case WebhookProxyMode.Custom when !string.IsNullOrWhiteSpace(settings.Url):
+                var proxy = new WebProxy(settings.Url);
+                if (!string.IsNullOrWhiteSpace(settings.Username))
+                {
+                    var (_, password) = store.ReadSecret(ProxyCredentialKey);
+                    proxy.Credentials = new NetworkCredential(settings.Username, password);
+                }
+
+                handler.Proxy = proxy;
+                handler.UseProxy = true;
+                break;
+
+            // SystemDefault and a Custom mode with no URL both fall through to the handler's
+            // own defaults: the system proxy, exactly as before this setting existed.
+        }
+
+        return handler;
+    }
+
+    /// <summary>
+    /// The URL a delivery should actually post to (#317): the vault first, the legacy in-file
+    /// value second. Old configs keep working untouched; a row's next explicit save migrates
+    /// its URL into the vault and blanks the file copy.
+    /// </summary>
+    public static string? ResolveUrl(WebhookEndpoint endpoint, ICredentialStore store)
+    {
+        var (_, stored) = store.ReadSecret(endpoint.CredentialKey);
+        if (!string.IsNullOrWhiteSpace(stored)) return stored;
+        return string.IsNullOrWhiteSpace(endpoint.Url) ? null : endpoint.Url;
+    }
+
+    /// <summary>True when the endpoint has a URL anywhere - the vault or the legacy file copy.</summary>
+    public static bool HasUrl(WebhookEndpoint endpoint, ICredentialStore store)
+        => ResolveUrl(endpoint, store) != null;
+
+    /// <summary>
+    /// Commits a URL as a secret (#317): into the vault, out of the file. After this the app
+    /// never displays it again - replacing it means saving a new one, not reading this one.
+    /// </summary>
+    public static void SaveUrl(WebhookEndpoint endpoint, ICredentialStore store, string url)
+    {
+        store.SaveSecret(endpoint.CredentialKey, "webhook", url.Trim());
+        endpoint.Url = string.Empty;
+    }
+
+    /// <summary>The endpoints ready to post, hydrated as CLONES - config objects never carry the secret.</summary>
+    public static List<WebhookEndpoint> HydrateUsable(
+        IEnumerable<WebhookEndpoint> endpoints, ICredentialStore store)
+    {
+        var usable = new List<WebhookEndpoint>();
+        foreach (var endpoint in endpoints)
+        {
+            var url = ResolveUrl(endpoint, store);
+            if (url == null) continue;
+
+            usable.Add(new WebhookEndpoint
+            {
+                Id = endpoint.Id,
+                Name = endpoint.Name,
+                Url = url,
+                Format = endpoint.Format,
+                NotifyStarted = endpoint.NotifyStarted,
+                NotifyFinished = endpoint.NotifyFinished,
+                NotifyProblems = endpoint.NotifyProblems
+            });
+        }
+
+        return usable;
+    }
+}

--- a/src/NineLives.Tests/WebhookSecrecyTests.cs
+++ b/src/NineLives.Tests/WebhookSecrecyTests.cs
@@ -1,0 +1,178 @@
+using System.Net;
+using System.Net.Http;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Webhook URLs get the secret treatment (#317) and deliveries get a route (#316). The URL
+/// commits on an explicit Save, moves to the vault, and is never displayed again; deliveries
+/// hydrate it at send time on clones, through a handler built from the configured proxy -
+/// System, Direct, or Custom with vault-held credentials.
+/// </summary>
+public class WebhookSecrecyTests
+{
+    private static WebhookEndpoint Endpoint() => new()
+    { Id = "w1", Name = "Ops", NotifyProblems = true };
+
+    // ── the URL as a secret (#317) ──────────────────────────────────────────────
+
+    [Fact]
+    public void SavingAUrlMovesItToTheVaultAndOutOfTheFile()
+    {
+        var store = new FakeCredentialStore();
+        var endpoint = Endpoint();
+        endpoint.Url = "https://legacy.example/hook";
+
+        WebhookTransport.SaveUrl(endpoint, store, "https://new.example/hook ");
+
+        Assert.Equal(string.Empty, endpoint.Url);
+        Assert.Equal("https://new.example/hook",
+            WebhookTransport.ResolveUrl(endpoint, store));
+    }
+
+    /// <summary>Configs that predate the vault keep delivering from their in-file URL.</summary>
+    [Fact]
+    public void ALegacyInFileUrlStillResolves()
+    {
+        var store = new FakeCredentialStore();
+        var endpoint = Endpoint();
+        endpoint.Url = "https://legacy.example/hook";
+
+        Assert.Equal("https://legacy.example/hook",
+            WebhookTransport.ResolveUrl(endpoint, store));
+        Assert.True(WebhookTransport.HasUrl(endpoint, store));
+    }
+
+    [Fact]
+    public void DeliveriesHydrateClonesAndTheConfigObjectStaysBlank()
+    {
+        var store = new FakeCredentialStore();
+        var endpoint = Endpoint();
+        WebhookTransport.SaveUrl(endpoint, store, "https://vaulted.example/hook");
+
+        var hydrated = WebhookTransport.HydrateUsable([endpoint], store);
+
+        Assert.Equal("https://vaulted.example/hook", hydrated.Single().Url);
+        Assert.Equal(string.Empty, endpoint.Url);
+        Assert.True(hydrated.Single().NotifyProblems);
+    }
+
+    [Fact]
+    public void AnEndpointWithNoUrlAnywhereIsNotUsable()
+    {
+        var store = new FakeCredentialStore();
+
+        Assert.Empty(WebhookTransport.HydrateUsable([Endpoint()], store));
+    }
+
+    /// <summary>The row's whole contract: explicit save, masked after, never read back.</summary>
+    [Fact]
+    public void TheRowCommitsOnSaveAndMasksAfter()
+    {
+        var store = new FakeCredentialStore();
+        var saves = 0;
+        var row = new WebhookEndpointViewModel(
+            Endpoint(), store, () => saves++, _ => Task.CompletedTask);
+
+        Assert.False(row.HasStoredUrl);
+        Assert.Contains("No URL saved", row.UrlDisplay);
+        Assert.False(row.SaveUrlCommand.CanExecute(null));
+
+        row.UrlInput = "https://hooks.example/T000/B000/secret";
+        Assert.True(row.SaveUrlCommand.CanExecute(null));
+        row.SaveUrlCommand.Execute(null);
+
+        Assert.True(row.HasStoredUrl);
+        Assert.Equal(string.Empty, row.UrlInput);
+        Assert.Equal(string.Empty, row.Model.Url);
+        Assert.DoesNotContain("secret", row.UrlDisplay);
+        Assert.Equal(1, saves);
+    }
+
+    // ── the delivery route (#316) ───────────────────────────────────────────────
+
+    [Fact]
+    public void TheDefaultRouteIsTheSystemsOwn()
+    {
+        using var handler = (HttpClientHandler)WebhookTransport.BuildHandler(
+            null, new FakeCredentialStore());
+
+        Assert.True(handler.UseProxy);
+        Assert.Null(handler.Proxy);
+    }
+
+    [Fact]
+    public void DirectBypassesAnyProxy()
+    {
+        using var handler = (HttpClientHandler)WebhookTransport.BuildHandler(
+            new WebhookProxySettings { Mode = WebhookProxyMode.Direct },
+            new FakeCredentialStore());
+
+        Assert.False(handler.UseProxy);
+    }
+
+    [Fact]
+    public void ACustomProxyCarriesItsAddressAndVaultedCredentials()
+    {
+        var store = new FakeCredentialStore();
+        store.SaveSecret(WebhookTransport.ProxyCredentialKey, "svc_proxy", "proxy-pass");
+
+        using var handler = (HttpClientHandler)WebhookTransport.BuildHandler(
+            new WebhookProxySettings
+            {
+                Mode = WebhookProxyMode.Custom,
+                Url = "http://proxy.internal:8080",
+                Username = "svc_proxy"
+            }, store);
+
+        Assert.True(handler.UseProxy);
+        var proxy = Assert.IsType<WebProxy>(handler.Proxy);
+        Assert.Equal("http://proxy.internal:8080/", proxy.Address!.ToString());
+        var credential = Assert.IsType<NetworkCredential>(proxy.Credentials);
+        Assert.Equal("svc_proxy", credential.UserName);
+        Assert.Equal("proxy-pass", credential.Password);
+    }
+
+    [Fact]
+    public void ACustomProxyWithoutAUsernameSendsNoCredentials()
+    {
+        using var handler = (HttpClientHandler)WebhookTransport.BuildHandler(
+            new WebhookProxySettings
+            { Mode = WebhookProxyMode.Custom, Url = "http://proxy.internal:8080" },
+            new FakeCredentialStore());
+
+        var proxy = Assert.IsType<WebProxy>(handler.Proxy);
+        Assert.Null(proxy.Credentials);
+    }
+
+    // ── what travels (#316's addressing rule) ───────────────────────────────────
+
+    [Fact]
+    public void TheProxyPasswordNeverReachesAnExport()
+    {
+        var store = new FakeCredentialStore();
+        store.SaveSecret(WebhookTransport.ProxyCredentialKey, "svc_proxy", "NEVER-THIS");
+        var config = new AppConfig
+        {
+            WebhookProxy = new WebhookProxySettings
+            {
+                Mode = WebhookProxyMode.Custom,
+                Url = "http://proxy.internal:8080",
+                Username = "svc_proxy"
+            }
+        };
+
+        var json = ConfigPortability.Export(config);
+
+        Assert.DoesNotContain("NEVER-THIS", json);
+        Assert.Contains("proxy.internal", json);
+
+        var fresh = new AppConfig();
+        ConfigPortability.Merge(fresh, ConfigPortability.Read(json)!);
+        Assert.Equal(WebhookProxyMode.Custom, fresh.WebhookProxy?.Mode);
+    }
+}

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -37,14 +37,70 @@ public partial class SettingsViewModel : ViewModelBase
     {
         Webhooks.Clear();
         foreach (var endpoint in config.Webhooks)
-            Webhooks.Add(new WebhookEndpointViewModel(endpoint, SaveWebhooks, TestWebhookAsync));
+            Webhooks.Add(new WebhookEndpointViewModel(
+                endpoint, _credentialStore, SaveWebhooks, TestWebhookAsync));
+
+        var proxy = config.WebhookProxy;
+        ProxyMode = proxy?.Mode ?? WebhookProxyMode.SystemDefault;
+        ProxyUrl = proxy?.Url ?? string.Empty;
+        ProxyUsername = proxy?.Username ?? string.Empty;
+    }
+
+    // ── how deliveries reach the network (#316) ────────────────────────────────
+
+    public IReadOnlyList<WebhookProxyMode> ProxyModes { get; } =
+        [WebhookProxyMode.SystemDefault, WebhookProxyMode.Direct, WebhookProxyMode.Custom];
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowsProxyDetails))]
+    private WebhookProxyMode _proxyMode = WebhookProxyMode.SystemDefault;
+
+    public bool ShowsProxyDetails => ProxyMode == WebhookProxyMode.Custom;
+
+    [ObservableProperty]
+    private string _proxyUrl = string.Empty;
+
+    [ObservableProperty]
+    private string _proxyUsername = string.Empty;
+
+    /// <summary>Typed, saved, cleared - the password is never read back out of the vault.</summary>
+    [ObservableProperty]
+    private string _proxyPasswordInput = string.Empty;
+
+    /// <summary>
+    /// Commits the delivery route (#316). The password goes to Windows Credential Manager and
+    /// the input clears; the mode, URL and username go to the config file - they are
+    /// addressing, not secrets.
+    /// </summary>
+    [RelayCommand]
+    private void SaveProxy()
+    {
+        Save(config =>
+        {
+            config.WebhookProxy = new WebhookProxySettings
+            {
+                Mode = ProxyMode,
+                Url = string.IsNullOrWhiteSpace(ProxyUrl) ? null : ProxyUrl.Trim(),
+                Username = string.IsNullOrWhiteSpace(ProxyUsername) ? null : ProxyUsername.Trim()
+            };
+        }, "The delivery route could not be saved");
+
+        if (!string.IsNullOrWhiteSpace(ProxyPasswordInput))
+        {
+            _credentialStore.SaveSecret(
+                WebhookTransport.ProxyCredentialKey, ProxyUsername, ProxyPasswordInput);
+            ProxyPasswordInput = string.Empty;
+        }
+
+        WebhookTestResult = "Delivery route saved. The next send - test or real - uses it.";
     }
 
     [RelayCommand]
     private void AddWebhook()
     {
         var endpoint = new WebhookEndpoint { Name = $"Endpoint {Webhooks.Count + 1}" };
-        Webhooks.Add(new WebhookEndpointViewModel(endpoint, SaveWebhooks, TestWebhookAsync));
+        Webhooks.Add(new WebhookEndpointViewModel(
+            endpoint, _credentialStore, SaveWebhooks, TestWebhookAsync));
         SaveWebhooks();
     }
 
@@ -66,7 +122,20 @@ public partial class SettingsViewModel : ViewModelBase
     private async Task TestWebhookAsync(WebhookEndpointViewModel row)
     {
         WebhookTestResult = $"Sending a test to {row.Name}...";
-        var error = await new WebhookNotifier().SendTestAsync(row.Model);
+
+        // Same transport and same hydration as a real delivery (#316, #317): a test that
+        // bypasses the proxy or reads a different URL proves nothing about the run.
+        var url = WebhookTransport.ResolveUrl(row.Model, _credentialStore);
+        if (url == null)
+        {
+            WebhookTestResult = $"{row.Name}: no URL saved yet.";
+            return;
+        }
+
+        var hydrated = WebhookTransport.HydrateUsable([row.Model], _credentialStore).Single();
+        using var handler = WebhookTransport.BuildHandler(
+            _credentialStore.LoadConfig().WebhookProxy, _credentialStore);
+        var error = await new WebhookNotifier(handler).SendTestAsync(hydrated);
         WebhookTestResult = error == null
             ? $"Test sent to {row.Name} - check the channel."
             : $"{row.Name}: {error}";

--- a/src/NineLives/ViewModels/WebhookEndpointViewModel.cs
+++ b/src/NineLives/ViewModels/WebhookEndpointViewModel.cs
@@ -1,4 +1,5 @@
 using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -8,25 +9,34 @@ namespace Blackcat.NineLives.ViewModels;
 /// One notification endpoint row in Settings (#242): edits its model in place and asks the owner
 /// to persist after each meaningful change - the same read-change-write discipline the rest of
 /// the settings screen keeps.
+///
+/// The URL is the exception (#317): it is a secret - anyone holding it can post as the
+/// integration - so it gets the SAS-token treatment. Typing goes into an input that commits
+/// only on an explicit Save; once saved it lives in Windows Credential Manager, the model's
+/// file copy is blanked, and the row shows an obfuscated placeholder. Replacing it means
+/// saving a new one - the old one is never displayed again.
 /// </summary>
 public partial class WebhookEndpointViewModel : ObservableObject
 {
     private readonly Action _save;
     private readonly Func<WebhookEndpointViewModel, Task> _test;
+    private readonly ICredentialStore _store;
 
     public WebhookEndpointViewModel(
-        WebhookEndpoint model, Action save, Func<WebhookEndpointViewModel, Task> test)
+        WebhookEndpoint model, ICredentialStore store,
+        Action save, Func<WebhookEndpointViewModel, Task> test)
     {
         Model = model;
+        _store = store;
         _save = save;
         _test = test;
 
         _name = model.Name;
-        _url = model.Url;
         _format = model.Format;
         _notifyStarted = model.NotifyStarted;
         _notifyFinished = model.NotifyFinished;
         _notifyProblems = model.NotifyProblems;
+        _hasStoredUrl = WebhookTransport.HasUrl(model, store);
     }
 
     public WebhookEndpoint Model { get; }
@@ -39,10 +49,37 @@ public partial class WebhookEndpointViewModel : ObservableObject
 
     partial void OnNameChanged(string value) { Model.Name = value; _save(); }
 
-    [ObservableProperty]
-    private string _url;
+    // ── the URL, as a secret (#317) ─────────────────────────────────────────────
 
-    partial void OnUrlChanged(string value) { Model.Url = value.Trim(); _save(); }
+    /// <summary>What is being typed. Never pre-filled: a saved URL is not for reading back.</summary>
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SaveUrlCommand))]
+    private string _urlInput = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UrlDisplay))]
+    private bool _hasStoredUrl;
+
+    /// <summary>The masked status line - proof a URL exists without showing a byte of it.</summary>
+    public string UrlDisplay => HasStoredUrl
+        ? "●●●●●●●●●●  saved"
+        : "No URL saved yet";
+
+    public bool CanSaveUrl => !string.IsNullOrWhiteSpace(UrlInput);
+
+    /// <summary>
+    /// The explicit commit (#317): into the vault, out of the file, off the screen. Also the
+    /// migration path for URLs that predate the vault - saving a replacement moves the
+    /// endpoint onto the new arrangement.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanSaveUrl))]
+    private void SaveUrl()
+    {
+        WebhookTransport.SaveUrl(Model, _store, UrlInput);
+        UrlInput = string.Empty;
+        HasStoredUrl = true;
+        _save();
+    }
 
     [ObservableProperty]
     private WebhookFormat _format;

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -147,12 +147,29 @@
                                                       Style="{StaticResource DarkComboBox}"
                                                       MinWidth="110"
                                                       Margin="0,0,8,0" />
-                                            <TextBox Grid.Column="2"
-                                                     Text="{Binding Url, UpdateSourceTrigger=LostFocus}"
-                                                     Style="{StaticResource DarkTextBox}"
-                                                     Margin="0,0,8,0"
-                                                     FontFamily="Consolas"
-                                                     ToolTip="The webhook URL. Treated as a secret: never exported, only ever posted to." />
+                                            <StackPanel Grid.Column="2" Margin="0,0,8,0">
+                                                <!-- The URL is a secret (#317): committed by an
+                                                     explicit Save, then never displayed again -
+                                                     the same treatment stored SAS tokens get. -->
+                                                <TextBlock Text="{Binding UrlDisplay}"
+                                                           Style="{StaticResource SecondaryText}"
+                                                           Margin="0,2,0,4" />
+                                                <Grid>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <TextBox Grid.Column="0"
+                                                             Text="{Binding UrlInput, UpdateSourceTrigger=PropertyChanged}"
+                                                             Style="{StaticResource DarkTextBox}"
+                                                             FontFamily="Consolas"
+                                                             ToolTip="Paste the webhook URL, then press Save. Once saved it is stored in Windows Credential Manager and never shown again." />
+                                                    <Button Grid.Column="1" Content="Save"
+                                                            Command="{Binding SaveUrlCommand}"
+                                                            Style="{StaticResource SecondaryButton}"
+                                                            Padding="10,5" Margin="6,0,0,0" />
+                                                </Grid>
+                                            </StackPanel>
                                             <Button Grid.Column="3" Content="Test"
                                                     Command="{Binding TestCommand}"
                                                     Style="{StaticResource SecondaryButton}"
@@ -189,6 +206,47 @@
                                 Command="{Binding AddWebhookCommand}"
                                 Style="{StaticResource SecondaryButton}"
                                 Padding="14,7" />
+                    </StackPanel>
+
+                    <!-- How every delivery reaches the network (#316) - estate-level, because a
+                         corporate proxy is a property of the machine's network, not of any one
+                         channel. The password goes to Windows Credential Manager on Save. -->
+                    <TextBlock Text="DELIVERY ROUTE" Style="{StaticResource LabelText}" Margin="0,16,0,4" />
+                    <StackPanel Orientation="Horizontal">
+                        <ComboBox ItemsSource="{Binding ProxyModes}"
+                                  SelectedItem="{Binding ProxyMode}"
+                                  Style="{StaticResource DarkComboBox}"
+                                  MinWidth="150" Margin="0,0,8,0"
+                                  ToolTip="SystemDefault uses the machine's own proxy settings. Direct bypasses any proxy. Custom names one explicitly." />
+                        <Button Content="Save route"
+                                Command="{Binding SaveProxyCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="10,5" />
+                    </StackPanel>
+                    <StackPanel Visibility="{Binding ShowsProxyDetails, Converter={StaticResource BoolToVis}}"
+                                Margin="0,8,0,0">
+                        <TextBlock Text="PROXY URL" Style="{StaticResource LabelText}" />
+                        <TextBox Text="{Binding ProxyUrl, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource DarkTextBox}"
+                                 FontFamily="Consolas" Margin="0,2,0,8"
+                                 ToolTip="http://proxy.example.internal:8080" />
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0" Margin="0,0,8,0">
+                                <TextBlock Text="USERNAME (OPTIONAL)" Style="{StaticResource LabelText}" />
+                                <TextBox Text="{Binding ProxyUsername, UpdateSourceTrigger=PropertyChanged}"
+                                         Style="{StaticResource DarkTextBox}" Margin="0,2,0,0" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="1">
+                                <TextBlock Text="PASSWORD" Style="{StaticResource LabelText}" />
+                                <TextBox Text="{Binding ProxyPasswordInput, UpdateSourceTrigger=PropertyChanged}"
+                                         Style="{StaticResource DarkTextBox}" Margin="0,2,0,0"
+                                         ToolTip="Stored in Windows Credential Manager on Save, then cleared here - it is never read back." />
+                            </StackPanel>
+                        </Grid>
                     </StackPanel>
 
                     <TextBlock Text="{Binding WebhookTestResult}"


### PR DESCRIPTION
Closes #316 and #317 - the two webhook asks, built together because they share one seam.

**The route (#316).** Estate-level proxy settings beside the webhook list: the machine's own settings (the default - exactly what happened before), **Direct** to bypass a broken or irrelevant system proxy, or **Custom** with an explicit URL and optional credentials - the password living in Windows Credential Manager like every other secret this app holds. Every send uses the route: the app's run notifications, the Settings test button, and the CLI's drained deliveries, each building its transport from the settings at send time, so a change in Settings applies to the very next message. In an export the route travels as addressing only; the password asks again on the new machine.

**The secret (#317).** A webhook URL carries its signature in the path - anyone holding it can post as the integration - and the export has always stripped them on exactly that reasoning. The UI now applies the same model the SAS token gets: paste, then commit with an explicit **Save** - and from that moment the field shows an obfuscated placeholder, the URL lives in Credential Manager keyed to the endpoint, config.json holds no URL, and it is never displayed again. Replacing it means saving a new one, never reading the old one back. Deliveries hydrate the URL at send time on clones, so no config object ever carries the resolved secret; legacy configs keep delivering from their in-file URL until the row's next save migrates them.

\`WebhookTransport\` centralises the machinery: handler construction (pinned without a live proxy - System/Direct/Custom, credentialed and not), URL resolution with the legacy fallback, vaulting, and clone hydration.

Eleven pins (1,677 total), plus a Settings render verifying the masked row with its disabled Save and the Custom route's URL/username/password fields.