### PR TITLE
The restore workflow asks WHERE, and the database list waits for an instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,16 @@ more detail on the user-facing changes; this file is the short history.
   config.json, and never displayed again. Replacing one means saving a new one. Deliveries
   hydrate the URL at send time on clones; existing configs keep working from their in-file
   URL until the row is next saved, which migrates it
+- **The restore workflow asks WHERE, as a step** (#318): step 2 is SELECT TARGET, offering
+  the saved server list right in the flow. Connecting on the SQL Servers screen first shows
+  the step already answered - and still changeable - instead of asking again; with nothing
+  connected, the answer no longer waits to surface as an execute-time error. Changing the
+  source keeps the target: it is an independent decision, and it survives backtracking
+- **The database list waits for an instance** (#319): with several instances in the loaded
+  backups, the DATABASE dropdown stays empty and disabled until the instance is chosen -
+  two servers both backing up a database called Sales are the everyday DR pair, and a mixed
+  list meant guessing whose history the timeline would show. One instance answers its own
+  filter automatically; the database choice itself always stays with the user
 
 ### Changed
 

--- a/src/NineLives.Tests/BackupInventorySeamTests.cs
+++ b/src/NineLives.Tests/BackupInventorySeamTests.cs
@@ -73,7 +73,9 @@ public class BackupInventorySeamTests
 
         await vm.LoadAsync(BackupLocation.Blob(Container()));
 
-        Assert.Null(vm.SelectedServerName);
+        // One discovered instance answers its own filter question (#319); the DATABASE -
+        // the decision that arms anything - stays unmade, and nothing is worked from.
+        Assert.Equal("SRV01", vm.SelectedServerName);
         Assert.Null(vm.SelectedDatabaseName);
         Assert.Empty(vm.WorkingSet);
         Assert.Equal(0, vm.SetCount);

--- a/src/NineLives.Tests/DatabaseCascadeTests.cs
+++ b/src/NineLives.Tests/DatabaseCascadeTests.cs
@@ -1,0 +1,106 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The database list waits for an instance (#319). Two instances that both back up a database
+/// called Sales are the everyday DR pair; a pre-filled list mixed them, and picking from it
+/// meant guessing whose history the timeline would show. One instance answers its own filter;
+/// several make the databases wait; none at all means there is no instance dimension and
+/// everything is offered.
+/// </summary>
+public class DatabaseCascadeTests
+{
+    private static BackupInventoryViewModel New(FakeBlobStorageService blob) =>
+        new(blob, new FakeSqlServerService(), TestLogs.Temp(), TestAuditStores.Temp());
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = "c1",
+        Name = "backups",
+        ContainerUrl = "https://acct.blob.core.windows.net/backups"
+    };
+
+    private static BackupFileInfo File(string server, string db) => new()
+    {
+        BlobName = $"FULL/{server}/{db}/20260801_220000.bak",
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/FULL/{server}/{db}/20260801_220000.bak",
+        Type = BackupType.Full,
+        InferredServerName = server,
+        InferredDatabaseName = db,
+        SizeBytes = 1024,
+        LastModified = new DateTimeOffset(2026, 8, 1, 22, 0, 0, TimeSpan.Zero)
+    };
+
+    [Fact]
+    public async Task TwoInstancesMakeTheDatabasesWait()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            Files = [File("SRV01", "Sales"), File("SRV02", "Sales"), File("SRV02", "Payroll")]
+        };
+        var vm = New(blob);
+
+        await vm.LoadAsync(BackupLocation.Blob(Container()));
+
+        Assert.Equal(2, vm.DiscoveredServers.Count);
+        Assert.Null(vm.SelectedServerName);
+        Assert.Empty(vm.DiscoveredDatabases);
+        Assert.False(vm.HasDatabaseChoices);
+    }
+
+    [Fact]
+    public async Task ChoosingTheInstanceFillsItsOwnDatabases()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            Files = [File("SRV01", "Sales"), File("SRV02", "Sales"), File("SRV02", "Payroll")]
+        };
+        var vm = New(blob);
+        await vm.LoadAsync(BackupLocation.Blob(Container()));
+
+        vm.SelectedServerName = vm.DiscoveredServers.First(s => s.Contains("SRV02"));
+
+        Assert.True(vm.HasDatabaseChoices);
+        Assert.Equal(2, vm.DiscoveredDatabases.Count);
+        Assert.Contains("Payroll", vm.DiscoveredDatabases);
+    }
+
+    [Fact]
+    public async Task DeselectingTheInstanceEmptiesTheListAgain()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            Files = [File("SRV01", "Sales"), File("SRV02", "Payroll")]
+        };
+        var vm = New(blob);
+        await vm.LoadAsync(BackupLocation.Blob(Container()));
+        vm.SelectedServerName = vm.DiscoveredServers[0];
+        Assert.NotEmpty(vm.DiscoveredDatabases);
+
+        vm.SelectedServerName = null;
+
+        Assert.Empty(vm.DiscoveredDatabases);
+    }
+
+    /// <summary>A single instance answers its own filter - one-answer questions gate nothing.</summary>
+    [Fact]
+    public async Task ASingleInstanceIsChosenAutomatically()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            Files = [File("SRV01", "Sales"), File("SRV01", "Payroll")]
+        };
+        var vm = New(blob);
+
+        await vm.LoadAsync(BackupLocation.Blob(Container()));
+
+        Assert.NotNull(vm.SelectedServerName);
+        Assert.Equal(2, vm.DiscoveredDatabases.Count);
+        // The DATABASE - the decision that arms anything - stays unmade.
+        Assert.Null(vm.SelectedDatabaseName);
+    }
+}

--- a/src/NineLives.Tests/RestoreStepTests.cs
+++ b/src/NineLives.Tests/RestoreStepTests.cs
@@ -105,9 +105,10 @@ public class RestoreStepTests
         var steps = new RestoreStepsViewModel();
 
         Assert.StartsWith("1.", steps.Source.Title);
-        Assert.StartsWith("2.", steps.Point.Title);
-        Assert.StartsWith("3.", steps.Options.Title);
-        Assert.StartsWith("4.", steps.Execute.Title);
+        Assert.StartsWith("2.", steps.Target.Title);
+        Assert.StartsWith("3.", steps.Point.Title);
+        Assert.StartsWith("4.", steps.Options.Title);
+        Assert.StartsWith("5.", steps.Execute.Title);
     }
 
     // ── the accordion ───────────────────────────────────────────────────────────
@@ -122,15 +123,17 @@ public class RestoreStepTests
     {
         var steps = new RestoreStepsViewModel();
         steps.Report(steps.Source, true, "a source");
+        steps.Report(steps.Target, true, "SRV01");
         steps.Point.CanConfirm = true;
         steps.Point.ConfirmCommand.Execute(null);
 
-        // The hand-over has already opened step 3, so reopen step 2 - going BACK is the case
+        // The hand-over has already opened step 4, so reopen step 3 - going BACK is the case
         // worth pinning anyway, and it must still close whatever was open.
         steps.Point.ToggleCommand.Execute(null);
 
         Assert.True(steps.Point.IsExpanded);
         Assert.False(steps.Source.IsExpanded);
+        Assert.False(steps.Target.IsExpanded);
         Assert.False(steps.Options.IsExpanded);
         Assert.False(steps.Execute.IsExpanded);
     }
@@ -156,6 +159,11 @@ public class RestoreStepTests
         steps.Report(steps.Source, isComplete: true, summary: "backups, MyDb on SRV01");
 
         Assert.False(steps.Source.IsExpanded);
+        Assert.True(steps.Target.IsExpanded);
+
+        steps.Report(steps.Target, isComplete: true, summary: "SRV01");
+
+        Assert.False(steps.Target.IsExpanded);
         Assert.True(steps.Point.IsExpanded);
     }
 
@@ -166,17 +174,21 @@ public class RestoreStepTests
     {
         var steps = Confirmed();
 
-        // Choosing a different database: step 1 goes incomplete, which withdraws everything after
-        // it, and answering it again puts the user back at the restore point rather than at the
-        // end of a sequence whose answers have just been thrown away.
+        // Choosing a different database: step 1 goes incomplete, which withdraws everything
+        // after it, and answering it again puts the user back at the next unanswered step rather
+        // than at the end of a sequence whose answers have just been thrown away. The container
+        // re-offers the TARGET first (#318); the screen re-reports the answer still in its combo,
+        // which RestoreTargetStepTests pins - so a user with a target lands back on the point.
         steps.Report(steps.Source, isComplete: false, summary: string.Empty);
+        Assert.False(steps.Target.IsVisible);
         Assert.False(steps.Point.IsVisible);
 
         steps.Report(steps.Source, isComplete: true, summary: "backups, OtherDb on SRV01");
 
-        Assert.True(steps.Point.IsVisible);
-        Assert.True(steps.Point.IsExpanded);
-        Assert.False(steps.Point.IsComplete);
+        Assert.True(steps.Target.IsVisible);
+        Assert.True(steps.Target.IsExpanded);
+        Assert.False(steps.Target.IsComplete);
+        Assert.False(steps.Point.IsVisible);
     }
 
     /// <summary>
@@ -204,6 +216,7 @@ public class RestoreStepTests
     {
         var steps = new RestoreStepsViewModel();
         steps.Report(steps.Source, true, "backups, MyDb on SRV01");
+        steps.Report(steps.Target, true, "SRV01");
 
         steps.Point.CanConfirm = true;
         steps.Point.ConfirmCommand.Execute(null);
@@ -232,6 +245,7 @@ public class RestoreStepTests
     {
         var steps = new RestoreStepsViewModel();
         steps.Report(steps.Source, true, "backups, MyDb on SRV01");
+        steps.Report(steps.Target, true, "SRV01");
         steps.Point.CanConfirm = true;
         steps.Point.ConfirmCommand.Execute(null);
         steps.Options.CanConfirm = true;
@@ -250,6 +264,7 @@ public class RestoreStepTests
         var steps = new RestoreStepsViewModel();
 
         Assert.True(steps.Source.IsVisible);
+        Assert.False(steps.Target.IsVisible);
         Assert.False(steps.Point.IsVisible);
         Assert.False(steps.Options.IsVisible);
         Assert.False(steps.Execute.IsVisible);
@@ -261,6 +276,10 @@ public class RestoreStepTests
         var steps = new RestoreStepsViewModel();
 
         steps.Report(steps.Source, true, "backups, MyDb on SRV01");
+        Assert.True(steps.Target.IsVisible);
+        Assert.False(steps.Point.IsVisible);
+
+        steps.Report(steps.Target, true, "SRV01");
         Assert.True(steps.Point.IsVisible);
         Assert.False(steps.Options.IsVisible);
 
@@ -286,6 +305,7 @@ public class RestoreStepTests
     {
         var steps = new RestoreStepsViewModel();
         steps.Report(steps.Source, true, "a source");
+        steps.Report(steps.Target, true, "SRV01");
 
         steps.Point.Describe("2026-01-10 22:00, Full + 2 logs");
         steps.Point.CanConfirm = true;
@@ -300,6 +320,7 @@ public class RestoreStepTests
     {
         var steps = new RestoreStepsViewModel();
         steps.Report(steps.Source, true, "a source");
+        steps.Report(steps.Target, true, "SRV01");
 
         steps.Point.ConfirmCommand.Execute(null);
 
@@ -316,6 +337,7 @@ public class RestoreStepTests
     {
         var steps = new RestoreStepsViewModel();
         steps.Report(steps.Source, true, "a source");
+        steps.Report(steps.Target, true, "SRV01");
 
         steps.Point.CanConfirm = true;
         Assert.True(steps.Point.IsAwaitingConfirmation);

--- a/src/NineLives.Tests/RestoreTargetStepTests.cs
+++ b/src/NineLives.Tests/RestoreTargetStepTests.cs
@@ -1,0 +1,122 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// WHERE the restore runs is a step, not an ambient fact (#318). It used to be whatever the SQL
+/// Servers screen last connected to - answered on a different screen, invisible in the workflow,
+/// and met for the first time as an execute-time error when nothing was connected. Now it is
+/// step 2: pre-answered (and still changeable) when a connection already exists, asked outright
+/// with the saved-server list when it does not.
+/// </summary>
+public class RestoreTargetStepTests
+{
+    private static RestoreViewModel New(FakeCredentialStore? store = null) => new(
+        new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+        new RestoreScriptGenerator(), store ?? new FakeCredentialStore(), TestLogs.Temp(),
+        new FakeRestoreHistoryStore(), TestAuditStores.Temp());
+
+    private static ServerConnection Server(string id = "s1", string name = "SRV01") =>
+        new() { Id = id, Name = name, ServerName = name };
+
+    [Fact]
+    public void TheStepWaitsForTheSourceThenAsks()
+    {
+        var vm = New();
+        Assert.False(vm.Steps.Target.IsVisible);
+
+        vm.Steps.Report(vm.Steps.Source, true, "backups, MyDb on SRV01");
+
+        Assert.True(vm.Steps.Target.IsVisible);
+        Assert.False(vm.Steps.Target.IsComplete);
+        Assert.False(vm.Steps.Point.IsVisible);
+    }
+
+    [Fact]
+    public void ChoosingATargetConnectsItAndFinishesTheStep()
+    {
+        var vm = New();
+        vm.Steps.Report(vm.Steps.Source, true, "backups, MyDb on SRV01");
+        var server = Server();
+
+        vm.SelectedTargetServer = server;
+
+        Assert.Same(server, vm.ConnectedServer);
+        Assert.True(vm.Steps.Target.IsComplete);
+        Assert.Equal("SRV01", vm.Steps.Target.Summary);
+        Assert.True(vm.Steps.Point.IsVisible);
+    }
+
+    /// <summary>
+    /// Connecting on the SQL Servers screen is the same decision made elsewhere - the step shows
+    /// it as already answered instead of asking again.
+    /// </summary>
+    [Fact]
+    public void AServersScreenConnectionPreAnswersTheStep()
+    {
+        var vm = New();
+        var server = Server(name: "SRV02");
+
+        vm.ConnectedServer = server;                       // what MainViewModel's wiring does
+        Assert.Same(server, vm.SelectedTargetServer);
+
+        // Completion only means anything once the step is reachable - the withdrawal cascade
+        // clears it while the source is unanswered - so the experience is: answer the source,
+        // and the target step arrives already answered.
+        vm.Steps.Report(vm.Steps.Source, true, "backups, MyDb on SRV01");
+
+        Assert.True(vm.Steps.Target.IsComplete);
+        Assert.Equal("SRV02", vm.Steps.Target.Summary);
+        Assert.True(vm.Steps.Point.IsVisible);
+    }
+
+    /// <summary>
+    /// The target is independent of the source, so changing the source must not throw it away.
+    /// The generic withdrawal cascade cannot know that - it un-completes every later step - so
+    /// the screen re-reports the answer still sitting in the combo, and the user lands back on
+    /// the restore point rather than on a question they already answered.
+    /// </summary>
+    [Fact]
+    public void TheAnswerSurvivesChangingTheSource()
+    {
+        var vm = New();
+        vm.Steps.Report(vm.Steps.Source, true, "backups, MyDb on SRV01");
+        vm.SelectedTargetServer = Server();
+
+        vm.Steps.Report(vm.Steps.Source, false, string.Empty);
+        Assert.False(vm.Steps.Target.IsVisible);
+
+        vm.Steps.Report(vm.Steps.Source, true, "backups, OtherDb on SRV01");
+
+        Assert.True(vm.Steps.Target.IsComplete);
+        Assert.Equal("SRV01", vm.Steps.Target.Summary);
+        Assert.True(vm.Steps.Point.IsVisible);
+    }
+
+    /// <summary>
+    /// The step offers the saved list, and a connection made before the list existed is
+    /// re-pointed at the config instance so the combo shows it as the answer.
+    /// </summary>
+    [Fact]
+    public void RefreshOffersTheSavedServersAndRepointsTheAnswer()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server());
+        store.Config.Servers.Add(Server("s2", "SRV02"));
+        var vm = New(store);
+
+        // Connected on the Servers screen as a distinct object instance of the same saved server.
+        vm.ConnectedServer = Server("s2", "SRV02");
+
+        vm.RefreshContainers();
+
+        Assert.Equal(2, vm.TargetServers.Count);
+        Assert.Same(vm.TargetServers[1], vm.SelectedTargetServer);
+
+        vm.Steps.Report(vm.Steps.Source, true, "backups, MyDb on SRV01");
+        Assert.True(vm.Steps.Target.IsComplete);
+    }
+}

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -90,7 +90,9 @@ public class RestoreViewModelTests
         Assert.True(vm.Inventory.BackupsLoaded);
         Assert.NotEmpty(vm.Inventory.DiscoveredDatabases);
 
-        Assert.Null(vm.Inventory.SelectedServerName);
+        // The instance FILTER auto-answers when it has exactly one answer (#319) - that
+        // selects nobody's database. The choices that matter stay unmade.
+        Assert.Equal("SRV01", vm.Inventory.SelectedServerName);
         Assert.Null(vm.Inventory.SelectedDatabaseName);
         Assert.Null(vm.Timeline.SelectedPoint);
 

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -374,7 +374,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
             ApplyCachedAudit();
 
             DiscoveredServers = new ObservableCollection<string>(_blob.GetDiscoveredServers(_allBackups));
-            DiscoveredDatabases = new ObservableCollection<string>(_blob.GetDiscoveredDatabases(_allBackups));
+            OfferDatabasesForSelection();
 
             RefreshUnclassifiedCount();
             RebuildWorkingSet();
@@ -400,9 +400,58 @@ public partial class BackupInventoryViewModel : ViewModelBase
         }
     }
 
+
+    /// <summary>
+    /// The database list waits for an instance (#319). With several instances discovered, a
+    /// pre-filled list mixes every server's databases - two instances that both back up a
+    /// database called Sales is the everyday DR pair, and picking from the mixed list means
+    /// guessing whose history the timeline will show. So: no instance dimension at all -
+    /// offer everything; exactly one - choose it, since a question with a single answer
+    /// should not gate anything; several - the databases wait.
+    /// </summary>
+    private void OfferDatabasesForSelection()
+    {
+        if (DiscoveredServers.Count == 1)
+        {
+            SelectedServerName = DiscoveredServers[0];
+            return;
+        }
+
+        SelectedServerName = null;
+
+        if (DiscoveredServers.Count == 0)
+        {
+            DiscoveredDatabases = new ObservableCollection<string>(_allSets
+                .Where(x => !string.IsNullOrEmpty(x.DatabaseName))
+                .Select(x => x.DatabaseName!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase));
+            return;
+        }
+
+        DiscoveredDatabases = [];
+    }
+
+    /// <summary>Lets the view grey the database picker out while it is waiting (#319).</summary>
+    public bool HasDatabaseChoices => DiscoveredDatabases.Count > 0;
+
+    partial void OnDiscoveredDatabasesChanged(
+        System.Collections.ObjectModel.ObservableCollection<string> value)
+        => OnPropertyChanged(nameof(HasDatabaseChoices));
+
     partial void OnSelectedServerNameChanged(string? value)
     {
         if (_allSets.Count == 0) return;
+
+        // Deselecting the instance empties the list again (#319) - except when there was no
+        // instance dimension to begin with, where the guard in OfferDatabasesForSelection
+        // already offered everything.
+        if (string.IsNullOrEmpty(value) && DiscoveredServers.Count > 1)
+        {
+            DiscoveredDatabases = [];
+            RebuildWorkingSet();
+            return;
+        }
 
         // Compare the FULL server identity. Matching on the host alone made selecting
         // SQLHOST\PROD also match SQLHOST\TEST, so the database list offered databases that only
@@ -546,7 +595,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
             ApplyCachedAudit();
 
             DiscoveredServers = new ObservableCollection<string>(_blob.GetDiscoveredServers(files));
-            DiscoveredDatabases = new ObservableCollection<string>(_blob.GetDiscoveredDatabases(files));
+            OfferDatabasesForSelection();
             BackupsLoaded = files.Count > 0;
 
             RefreshUnclassifiedCount();
@@ -706,11 +755,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)!);
 
-        DiscoveredDatabases = new ObservableCollection<string>(
-            sets.Select(s => s.DatabaseName)
-                .Where(n => !string.IsNullOrEmpty(n))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)!);
+        OfferDatabasesForSelection();
 
         BackupsLoaded = sets.Count > 0;
 
@@ -747,11 +792,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)!);
 
-        DiscoveredDatabases = new ObservableCollection<string>(
-            sets.Select(s => s.DatabaseName)
-                .Where(n => !string.IsNullOrEmpty(n))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)!);
+        OfferDatabasesForSelection();
 
         BackupsLoaded = sets.Count > 0;
 

--- a/src/NineLives/ViewModels/RestoreStepsViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreStepsViewModel.cs
@@ -148,9 +148,17 @@ public partial class RestoreStep(string title, bool needsConfirmation = false) :
 public sealed class RestoreStepsViewModel
 {
     public RestoreStep Source { get; } = new("1. SELECT SOURCE");
-    public RestoreStep Point { get; } = new("2. SELECT RESTORE POINT", needsConfirmation: true);
-    public RestoreStep Options { get; } = new("3. RESTORE OPTIONS", needsConfirmation: true);
-    public RestoreStep Execute { get; } = new("4. GENERATE & EXECUTE");
+
+    /// <summary>
+    /// WHERE the restore runs (#318). The workflow's second real question - it used to be
+    /// answered on a different screen entirely (whatever the SQL Servers screen last
+    /// connected to), met for the first time as an error at execute time.
+    /// </summary>
+    public RestoreStep Target { get; } = new("2. SELECT TARGET");
+
+    public RestoreStep Point { get; } = new("3. SELECT RESTORE POINT", needsConfirmation: true);
+    public RestoreStep Options { get; } = new("4. RESTORE OPTIONS", needsConfirmation: true);
+    public RestoreStep Execute { get; } = new("5. GENERATE & EXECUTE");
 
     public IReadOnlyList<RestoreStep> All { get; }
 
@@ -159,13 +167,14 @@ public sealed class RestoreStepsViewModel
 
     public RestoreStepsViewModel()
     {
-        All = [Source, Point, Options, Execute];
+        All = [Source, Target, Point, Options, Execute];
 
         // One open, and it is the only one there is anything to do in yet. RefreshVisibility only
         // acts on a CHANGE, so the steps that start hidden have to start closed too - otherwise
         // they arrive already expanded the moment they become visible.
         Source.IsVisible = true;
         Source.IsExpanded = true;
+        Target.IsExpanded = false;
         Point.IsExpanded = false;
         Options.IsExpanded = false;
         Execute.IsExpanded = false;

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -246,6 +246,34 @@ public partial class RestoreViewModel : ViewModelBase
     private ServerConnection? _connectedServer;
 
     /// <summary>
+    /// The saved servers the target step offers (#318) - the same list the Servers screen
+    /// manages, refreshed with the rest of the config-derived lists.
+    /// </summary>
+    [ObservableProperty]
+    private ObservableCollection<ServerConnection> _targetServers = [];
+
+    /// <summary>
+    /// The chosen target. Setting it here or connecting on the Servers screen are the same
+    /// decision made in two places, so each reflects into the other - the preflights, the
+    /// execution and the credential panel all keep reading ConnectedServer, which both feed.
+    /// </summary>
+    [ObservableProperty]
+    private ServerConnection? _selectedTargetServer;
+
+    /// <summary>The step's empty-list hint - no saved servers means the combo has nothing to offer.</summary>
+    public bool HasNoTargetServers => TargetServers.Count == 0;
+
+    partial void OnTargetServersChanged(ObservableCollection<ServerConnection> value) =>
+        OnPropertyChanged(nameof(HasNoTargetServers));
+
+    partial void OnSelectedTargetServerChanged(ServerConnection? value)
+    {
+        Steps.Target.Report(value != null, value?.Name ?? string.Empty);
+        if (value != null && !ReferenceEquals(_connectedServer, value))
+            ConnectedServer = value;
+    }
+
+    /// <summary>
     /// The instance every server call on this screen runs against.
     ///
     /// Setting it re-checks the credential, rather than leaving the caller to remember: forgetting
@@ -260,6 +288,13 @@ public partial class RestoreViewModel : ViewModelBase
             _connectedServer = value;
             Credential.Server = value;
             _ = Credential.RefreshAsync();
+
+            // The Servers screen's connect answers the target step too (#318): already
+            // connected means the question is pre-answered, visibly and changeably.
+            if (!ReferenceEquals(SelectedTargetServer, value))
+                SelectedTargetServer = value == null
+                    ? null
+                    : TargetServers.FirstOrDefault(s => s.Id == value.Id) ?? value;
         }
     }
 
@@ -838,6 +873,18 @@ public partial class RestoreViewModel : ViewModelBase
                 RefreshSteps();
         };
 
+        // A chosen target survives source backtracking (#318). Changing the source withdraws
+        // every later step's completion - the container cannot know the target is an independent
+        // decision - so when the step is offered again this puts the answer still sitting in the
+        // combo straight back, and the user lands on the restore point, not on a question they
+        // already answered.
+        Steps.Target.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(RestoreStep.IsVisible) &&
+                Steps.Target.IsVisible && !Steps.Target.IsComplete && SelectedTargetServer != null)
+                Steps.Target.Report(true, SelectedTargetServer.Name);
+        };
+
         // The selection now lives on the timeline (#115 seam 2), which is a different object, so
         // this is a subscription rather than a generated partial hook.
         Timeline.PropertyChanged += (_, e) =>
@@ -888,6 +935,17 @@ public partial class RestoreViewModel : ViewModelBase
         SourceServers = new ObservableCollection<ServerConnection>(config.Servers);
         if (previousSource != null)
             SourceServer = SourceServers.FirstOrDefault(x => x.Id == previousSource);
+
+        // The target step offers the same saved list (#318). A selection survives the rebuild by
+        // identity; a target chosen on the Servers screen before this screen ever loaded is
+        // re-pointed at the config instance so the combo shows it as the answer.
+        var previousTarget = SelectedTargetServer?.Id ?? ConnectedServer?.Id;
+        TargetServers = new ObservableCollection<ServerConnection>(config.Servers);
+        if (previousTarget != null)
+        {
+            var match = TargetServers.FirstOrDefault(x => x.Id == previousTarget);
+            if (match != null) SelectedTargetServer = match;
+        }
 
         Containers = new ObservableCollection<BlobContainerConfig>(config.BlobContainers);
         foreach (var c in Containers)

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -348,9 +348,14 @@
 
                         <StackPanel Grid.Column="1" Margin="0,0,12,0">
                             <TextBlock Text="DATABASE" Style="{StaticResource LabelText}" />
+                            <!-- Greyed until an instance is chosen (#319): a pre-filled list
+                                 mixed every server's databases, and picking from it meant
+                                 guessing whose history the timeline would show. -->
                             <ComboBox ItemsSource="{Binding Inventory.DiscoveredDatabases}"
                                       SelectedItem="{Binding Inventory.SelectedDatabaseName}"
-                                      Style="{StaticResource DarkComboBox}" />
+                                      IsEnabled="{Binding Inventory.HasDatabaseChoices}"
+                                      Style="{StaticResource DarkComboBox}"
+                                      ToolTip="Waits for the server/instance on the left - the databases listed are the chosen instance's own." />
                         </StackPanel>
                     </Grid>
 

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -619,7 +619,44 @@
                 </StackPanel>
             </Border>
 
-            <!-- Step 2: Restore Point Selection -->
+            <!-- Step 2: Target instance (#318). WHERE the restore runs used to be implicit -
+                 whatever the SQL Servers screen last connected to - and a missing answer only
+                 surfaced as an execute-time error. Now it is a step: pre-answered (and still
+                 changeable) when a connection already exists, asked outright when it does not. -->
+            <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
+                    Visibility="{Binding Steps.Target.IsVisible, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <Button Style="{StaticResource StepHeader}" DataContext="{Binding Steps.Target}" />
+                    <StackPanel Visibility="{Binding Steps.Target.IsExpanded, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="The instance the restore will run ON. Connecting on the SQL Servers screen answers this for you; otherwise pick a saved server here."
+                                   Style="{StaticResource SecondaryText}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,0,0,12" />
+                        <TextBlock Text="TARGET SQL SERVER" Style="{StaticResource LabelText}" />
+                        <ComboBox ItemsSource="{Binding TargetServers}"
+                                  SelectedItem="{Binding SelectedTargetServer}"
+                                  Style="{StaticResource DarkComboBox}"
+                                  MinWidth="320"
+                                  MaxWidth="420"
+                                  HorizontalAlignment="Left"
+                                  ToolTip="The instance the restore runs on. The credential check below the script and the preflights all test this server.">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Name}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                        <TextBlock Style="{StaticResource SecondaryText}"
+                                   TextWrapping="Wrap"
+                                   Margin="0,8,0,0"
+                                   Visibility="{Binding HasNoTargetServers, Converter={StaticResource BoolToVis}}">
+                            <Run Text="No saved servers yet. Add one on the SQL Servers screen and it will appear here." />
+                        </TextBlock>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- Step 3: Restore Point Selection -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
                     Visibility="{Binding Steps.Point.IsVisible, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
@@ -1390,7 +1427,7 @@
                 </StackPanel>
             </Border>
 
-            <!-- Step 3: Restore Options -->
+            <!-- Step 4: Restore Options -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
                     Visibility="{Binding Steps.Options.IsVisible, Converter={StaticResource BoolToVis}}">
                 <StackPanel>
@@ -1937,7 +1974,7 @@
                 </StackPanel>
             </Border>
 
-            <!-- Step 4: Generate + Execute -->
+            <!-- Step 5: Generate + Execute -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16"
                     Visibility="{Binding Steps.Execute.IsVisible, Converter={StaticResource BoolToVis}}">
                 <StackPanel>


### PR DESCRIPTION
Closes #318, closes #319 - the restore-workflow pair.

**Select target is step 2** (#318). The workflow's second question is WHERE the restore runs, and it is now asked in the workflow: a SELECT TARGET step offering the saved server list, feeding the same `ConnectedServer` every preflight and execution already reads. Connecting on the SQL Servers screen first shows the step pre-answered - and still changeable - instead of asking again; with nothing connected, the missing answer no longer surfaces for the first time as an execute-time error. The target survives changing the source: the withdrawal cascade cannot know it is an independent decision, so the screen re-reports the answer still sitting in the combo when the step is re-offered, and the user lands back on the restore point. Later steps renumber to 3/4/5.

**The database dropdown waits for an instance** (#319). With several instances in the loaded backups the DATABASE list stays empty and disabled until the instance is chosen - two servers both backing up a database called Sales are the everyday DR pair, and a pre-filled mixed list meant guessing whose history the timeline would show. One instance answers its own filter automatically; none at all (no inferable server dimension) offers everything. The database decision itself always stays with the user.

Nine new pins across `RestoreTargetStepTests` and `DatabaseCascadeTests`; the step-container pins walk the longer chain; two older pins that encoded the pre-filled list as intent now pin the cascade instead. Rendered all three target-step states (asked, pre-answered, empty config) plus the cascade states. Suite at 1,686 + 10 integration, Release `-warnaserror` clean.