### PR TITLE
The browser no longer mixes two sources' answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,16 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The browser no longer mixes two sources' answers** (#286). Changing the container,
+  medium or source server mid-listing cancels the in-flight load instead of letting the
+  stale result land under the new source's name - and the set grouping runs with the
+  container that was ASKED, not a re-read of the selection, so a mid-flight switch can no
+  longer skew filename-less timestamps by the other container's time zone. A round trip to
+  another screen and back keeps the listing (the refresh compares identities before
+  reassigning selections), F5 now RELOADS the listing instead of emptying it, a cancelled
+  reload keeps the previous complete answer whole - rows and restore button in agreement -
+  the remembered container survives a rename by matching on Id, and both media report the
+  same thing in the status line: the source's total databases
 - The SQL Servers and Blob Storage screens now MERGE their saves into the configuration on
   disk instead of replacing it wholesale. Importing a config (or adding entries with the CLI)
   and then saving anything on either screen used to silently delete everything added since

--- a/src/NineLives.Tests/BrowserStateDisciplineTests.cs
+++ b/src/NineLives.Tests/BrowserStateDisciplineTests.cs
@@ -1,0 +1,204 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The browser must not mix two sources' answers (#286).
+///
+/// One screen, one question - "what do I actually have?" - and every defect here was a way of
+/// answering it with two sources' truths at once: a stale listing landing under a new source's
+/// name, a round trip emptying the screen, a cancelled reload leaving old rows without their
+/// restore button, a renamed container losing its selection.
+/// </summary>
+public class BrowserStateDisciplineTests
+{
+    private static BlobContainerConfig Container(string id = "c1", string name = "backups", string? tz = null) => new()
+    {
+        Id = id,
+        Name = name,
+        ContainerUrl = $"https://acct.blob.core.windows.net/{name}",
+        BackupServerTimeZoneId = tz
+    };
+
+    private static BackupFileInfo File(string server, string db) => new()
+    {
+        BlobName = $"FULL/{server}/{db}/20260801_220000.bak",
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/FULL/{server}/{db}/20260801_220000.bak",
+        Type = BackupType.Full,
+        InferredServerName = server,
+        InferredDatabaseName = db,
+        SizeBytes = 1024,
+        LastModified = new DateTimeOffset(2026, 8, 1, 22, 0, 0, TimeSpan.Zero)
+    };
+
+    private static FakeCredentialStore Store(params BlobContainerConfig[] containers)
+    {
+        var store = new FakeCredentialStore();
+        foreach (var c in containers) store.Config.BlobContainers.Add(c);
+        return store;
+    }
+
+    private static BlobBrowserViewModel New(FakeBlobStorageService blob, FakeCredentialStore store) =>
+        new(blob, new FakeSqlServerService(), store);
+
+    // ── a stale result must not land (#286 item 1) ──────────────────────────────
+
+    [Fact]
+    public async Task ChangingTheContainerMidListingDropsTheStaleResult()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            BeforeListReturns = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        blob.FilesByContainer["backups"] = [File("SRV01", "Sales")];
+        var store = Store(Container(), Container("c2", "archive"));
+        var vm = New(blob, store);
+        Assert.Equal("c1", vm.SelectedContainer?.Id);
+
+        var load = vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // The world moves on while container A's listing is still in flight.
+        vm.SelectedContainer = vm.Containers[1];
+
+        blob.BeforeListReturns.SetResult(true);
+        await load;
+
+        Assert.Empty(vm.FilteredFiles);
+        Assert.False(vm.HasFiles);
+        Assert.Empty(vm.DiscoveredServers);
+    }
+
+    /// <summary>
+    /// The grouping runs with the container that was ASKED. Re-reading the selection after the
+    /// await handed container A's files to container B's time zone - every filename-less
+    /// timestamp then wrong by the zone offset.
+    /// </summary>
+    [Fact]
+    public async Task TheGroupingIsHandedTheAskedContainersTimeZone()
+    {
+        var blob = new FakeBlobStorageService();
+        blob.FilesByContainer["backups"] = [File("SRV01", "Sales")];
+        var store = Store(Container(tz: "GMT Standard Time"));
+        var vm = New(blob, store);
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.Equal("GMT Standard Time", blob.LastGroupTimeZoneId);
+    }
+
+    // ── a round trip keeps the listing (#286 item 2) ────────────────────────────
+
+    [Fact]
+    public async Task ARoundTripAwayAndBackKeepsTheListing()
+    {
+        var blob = new FakeBlobStorageService();
+        blob.FilesByContainer["backups"] = [File("SRV01", "Sales"), File("SRV01", "Payroll")];
+        var store = Store(Container());
+        store.Config.Servers.Add(new ServerConnection { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        var vm = New(blob, store);
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        Assert.True(vm.HasFiles);
+        var rowsBefore = vm.FilteredFiles.Select(f => f.BlobName).ToList();
+        Assert.NotEmpty(rowsBefore);
+
+        // What navigating away and back does: the shell refreshes the source lists.
+        vm.RefreshContainers();
+
+        Assert.True(vm.HasFiles);
+        Assert.Equal(rowsBefore, vm.FilteredFiles.Select(f => f.BlobName).ToList());
+    }
+
+    [Fact]
+    public async Task F5ReloadsTheListingInsteadOfEmptyingIt()
+    {
+        var blob = new FakeBlobStorageService();
+        blob.FilesByContainer["backups"] = [File("SRV01", "Sales")];
+        var vm = New(blob, Store(Container()));
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        var listingsBefore = blob.ListCalls;
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Equal(listingsBefore + 1, blob.ListCalls);
+        Assert.True(vm.HasFiles);
+        Assert.NotEmpty(vm.FilteredFiles);
+    }
+
+    // ── a cancelled reload keeps the previous answer whole (#286 item 3) ────────
+
+    [Fact]
+    public async Task ACancelledReloadKeepsThePreviousAnswerWhole()
+    {
+        var blob = new FakeBlobStorageService();
+        blob.FilesByContainer["backups"] = [File("SRV01", "Sales")];
+        var vm = New(blob, Store(Container()));
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        Assert.True(vm.HasFiles);
+
+        // The reload is held in flight and cancelled - as the Cancel button does.
+        blob.BeforeListReturns = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reload = vm.LoadBackupsCommand.ExecuteAsync(null);
+        vm.CancelLoadCommand.Execute(null);
+        blob.BeforeListReturns.SetResult(true);
+        await reload;
+
+        // The rows from the completed listing are still the truth, and the screen still says so.
+        Assert.True(vm.HasFiles);
+        Assert.NotEmpty(vm.FilteredFiles);
+    }
+
+    // ── selection by identity (#286 item 4) ─────────────────────────────────────
+
+    [Fact]
+    public async Task ARenamedContainerKeepsItsSelectionAndItsListing()
+    {
+        var blob = new FakeBlobStorageService();
+        blob.FilesByContainer["backups"] = [File("SRV01", "Sales")];
+        var store = Store(Container());
+        var vm = New(blob, store);
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Renamed on the Blob Storage screen; same container, same Id.
+        store.Config.BlobContainers[0].Name = "backups-eu";
+        vm.RefreshContainers();
+
+        Assert.Equal("backups-eu", vm.SelectedContainer?.Name);
+        Assert.True(vm.HasFiles);
+    }
+
+    // ── the two media agree what the count means (#286 item 5) ──────────────────
+
+    [Fact]
+    public async Task TheHistoryCountReportsTheInstancesTotalDatabases()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "Sales", ServerName = "SRV01", Type = BackupType.Full,
+                    FinishedAt = new DateTime(2026, 8, 7, 22, 0, 0), Files = [@"\\nas01\sql\Sales_FULL.bak"]
+                },
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "Payroll", ServerName = "SRV02", Type = BackupType.Full,
+                    FinishedAt = new DateTime(2026, 8, 7, 22, 0, 0), Files = [@"\\nas01\sql\Payroll_FULL.bak"]
+                }
+            ]
+        };
+        var vm = new BlobBrowserViewModel(new FakeBlobStorageService(), sql, store);
+        vm.SelectedMedium = BackupMedium.SharedPath;
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        // Two databases in the history; the auto-picked server filter shows one. The status
+        // reports the total, as the blob path always has.
+        Assert.Contains("across 2 database(s)", vm.StatusMessage);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -120,7 +120,14 @@ public sealed class FakeBlobStorageService : IBlobStorageService
     public Task<List<BackupFileInfo>> ListBackupFilesAsync(BlobContainerConfig config, CancellationToken ct = default)
         => ListBackupFilesAsync(config, null, null, ct);
 
-    public Task<List<BackupFileInfo>> ListBackupFilesAsync(
+    /// <summary>
+    /// When set, the listing waits here before returning - and honours a cancellation that
+    /// arrived while it waited, as the real paged enumeration does. Lets a test hold a load
+    /// in flight, change the world, and only then let the result try to land.
+    /// </summary>
+    public TaskCompletionSource<bool>? BeforeListReturns { get; set; }
+
+    public async Task<List<BackupFileInfo>> ListBackupFilesAsync(
         BlobContainerConfig config, BlobListingScope? scope, IProgress<int>? progress, CancellationToken ct = default)
     {
         ListCalls++;
@@ -130,6 +137,12 @@ public sealed class FakeBlobStorageService : IBlobStorageService
         ct.ThrowIfCancellationRequested();
         if (ListThrows != null) throw ListThrows;
 
+        if (BeforeListReturns != null)
+        {
+            await BeforeListReturns.Task;
+            ct.ThrowIfCancellationRequested();
+        }
+
         var files = FilesByContainer.TryGetValue(config.Name, out var forContainer)
             ? forContainer
             : Files;
@@ -138,7 +151,7 @@ public sealed class FakeBlobStorageService : IBlobStorageService
 
         // A copy per call. The real service returns fresh objects each time, and handing the same
         // instances back twice would let one listing's ContainerId stamp overwrite another's.
-        return Task.FromResult(files.Select(Copy).ToList());
+        return files.Select(Copy).ToList();
     }
 
     /// <summary>
@@ -167,8 +180,14 @@ public sealed class FakeBlobStorageService : IBlobStorageService
 
     public ContainerSummary GetContainerSummary(List<BackupFileInfo> files) => _real.GetContainerSummary(files);
     public ContainerSummary GetSetBasedSummary(List<BackupSet> sets) => _real.GetSetBasedSummary(sets);
+    /// <summary>The time zone the last grouping was handed - pins WHOSE zone was used (#286).</summary>
+    public string? LastGroupTimeZoneId { get; private set; }
+
     public List<BackupSet> GroupIntoBackupSets(List<BackupFileInfo> files, string? backupServerTimeZoneId = null)
-        => _real.GroupIntoBackupSets(files, backupServerTimeZoneId);
+    {
+        LastGroupTimeZoneId = backupServerTimeZoneId;
+        return _real.GroupIntoBackupSets(files, backupServerTimeZoneId);
+    }
     public List<string> GetDiscoveredDatabases(List<BackupFileInfo> files) => _real.GetDiscoveredDatabases(files);
     public List<string> GetDiscoveredServers(List<BackupFileInfo> files) => _real.GetDiscoveredServers(files);
 }

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -136,11 +136,18 @@ public partial class BlobBrowserViewModel : ViewModelBase
     [ObservableProperty]
     private ServerConnection? _sourceServer;
 
-    partial void OnSourceServerChanged(ServerConnection? value) => Clear();
+    partial void OnSourceServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
+    {
+        // RefreshContainers rebuilds the list with fresh instances on every visit to this
+        // screen; the same saved server under a new reference is not a change of source, and
+        // clearing on it emptied the listing on every round trip away and back (#286).
+        if (oldValue?.Id == newValue?.Id) return;
+        Clear();
+    }
 
     public void RefreshContainers()
     {
-        var previous = SelectedContainer?.Name;
+        var previous = SelectedContainer?.Id;
         var previousServer = SourceServer?.Id;
         var config = _credentialStore.LoadConfig();
         Containers = new ObservableCollection<BlobContainerConfig>(config.BlobContainers);
@@ -157,12 +164,16 @@ public partial class BlobBrowserViewModel : ViewModelBase
         }
 
         if (previous != null)
-            SelectedContainer = Containers.FirstOrDefault(c => c.Name == previous);
+            SelectedContainer = Containers.FirstOrDefault(c => c.Id == previous);
         if (SelectedContainer == null && Containers.Count > 0)
             SelectedContainer = Containers[0];
     }
 
-    partial void OnSelectedContainerChanged(BlobContainerConfig? value) => Clear();
+    partial void OnSelectedContainerChanged(BlobContainerConfig? oldValue, BlobContainerConfig? newValue)
+    {
+        if (oldValue?.Id == newValue?.Id) return;
+        Clear();
+    }
 
     /// <summary>
     /// Empties the screen. Called whenever the SOURCE changes, whichever part of it changed.
@@ -172,6 +183,12 @@ public partial class BlobBrowserViewModel : ViewModelBase
     /// </summary>
     private void Clear()
     {
+        // What is loading belongs to the source that was asked. Without this, changing the
+        // container mid-listing let the stale result land under the new selection - and the
+        // grouping then ran with the new container's time zone, skewing every filename-less
+        // timestamp by the zone difference.
+        _loadCancellation.Cancel();
+
         _allFiles.Clear();
         _allSets.Clear();
         FilteredFiles.Clear();
@@ -205,9 +222,16 @@ public partial class BlobBrowserViewModel : ViewModelBase
     }
 
     [RelayCommand]
-    private void Refresh()
+    private async Task RefreshAsync()
     {
         RefreshContainers();
+
+        // Reload whatever is listed, which is F5's documented contract. The identity-aware
+        // change hooks above keep the refresh from clearing first, so this is a reload rather
+        // than a wipe-then-load.
+        if ((MediumIsBlob && SelectedContainer != null) ||
+            (MediumIsSharedPath && SourceServer != null))
+            await LoadBackupsAsync();
     }
 
     [RelayCommand]
@@ -237,9 +261,15 @@ public partial class BlobBrowserViewModel : ViewModelBase
                 return;
             }
 
-            _allFiles = await _blobService.ListBackupFilesAsync(SelectedContainer!, ct);
-            _allSets = _blobService.GroupIntoBackupSets(
-                _allFiles, SelectedContainer?.BackupServerTimeZoneId);
+            // Captured before the await: the answer belongs to the container that was asked.
+            // Re-reading the selection after the await grouped container A's files with
+            // container B's time zone when the selection changed mid-listing.
+            var container = SelectedContainer!;
+            var files = await _blobService.ListBackupFilesAsync(container, ct);
+            ct.ThrowIfCancellationRequested();
+
+            _allFiles = files;
+            _allSets = _blobService.GroupIntoBackupSets(files, container.BackupServerTimeZoneId);
             HasFiles = _allFiles.Count > 0;
 
             var servers = _blobService.GetDiscoveredServers(_allFiles);
@@ -259,14 +289,17 @@ public partial class BlobBrowserViewModel : ViewModelBase
         }
         catch (OperationCanceledException)
         {
-            // Listing is read-only, so there is nothing to undo or explain - just say it stopped.
+            // Listing is read-only, so there is nothing to undo or explain - just say it
+            // stopped. The rows still on screen are the previous complete answer for this same
+            // source (a source change would have cleared them), so HasFiles reflects THEM -
+            // half old rows with the restore button gone was neither truth.
             SetStatus("Loading cancelled.");
-            HasFiles = false;
+            HasFiles = _allFiles.Count > 0;
         }
         catch (Exception ex)
         {
             SetError($"Failed to load backups: {ex.Message}");
-            HasFiles = false;
+            HasFiles = _allFiles.Count > 0;
         }
         finally
         {
@@ -287,6 +320,7 @@ public partial class BlobBrowserViewModel : ViewModelBase
     {
         var source = SourceServer!;
         var history = await _sqlService.ReadBackupHistoryAsync(source, null, ct);
+        ct.ThrowIfCancellationRequested();
         var sets = BackupHistoryInventory.ToSets(history, BackupPathMapping.None);
 
         _allSets = sets;
@@ -307,6 +341,10 @@ public partial class BlobBrowserViewModel : ViewModelBase
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)!);
 
+        // The total before the server auto-pick narrows the visible list - the blob path
+        // reports the container's total, so the history path reports the instance's.
+        var totalDatabases = DiscoveredDatabases.Count;
+
         if (DiscoveredServers.Count > 0)
             SelectedServer = DiscoveredServers[0];
         else if (DiscoveredDatabases.Count > 0)
@@ -318,7 +356,7 @@ public partial class BlobBrowserViewModel : ViewModelBase
         SetStatus(sets.Count == 0
             ? $"{source.ServerName} has no backup history."
             : $"Read {_allFiles.Count} file(s) in {sets.Count} backup set(s) from "
-              + $"{source.ServerName} across {DiscoveredDatabases.Count} database(s).");
+              + $"{source.ServerName} across {totalDatabases} database(s).");
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -512,7 +512,9 @@ public partial class MainViewModel : ViewModelBase
                 if (Restore.LoadBackupsCommand.CanExecute(null)) Restore.LoadBackupsCommand.Execute(null);
                 break;
             case Nav.BrowseBackups:
-                BlobBrowser.RefreshContainers();
+                // The full contract, not just the source lists: RefreshContainers alone left
+                // the screen to be emptied, which made F5 a wipe instead of a reload (#286).
+                if (BlobBrowser.RefreshCommand.CanExecute(null)) BlobBrowser.RefreshCommand.Execute(null);
                 break;
             case Nav.History:
                 History.Refresh();


### PR DESCRIPTION
Closes #286.

The Browse screen's one job is answering "what do I actually have?", and each defect here was a way of answering with two sources' truths at once:

- **A stale listing cannot land under a new source's name.** Clear() - the on-any-source-change wipe - now cancels the in-flight load too, and the load re-checks its token after the await. The set grouping is handed the container that was ASKED (captured before the await) rather than re-reading the selection, which could group container A's files with container B's `BackupServerTimeZoneId` and skew every filename-less timestamp by the zone difference.
- **A round trip keeps the listing.** The container/server change hooks compare identity (Id) before clearing, so RefreshContainers reassigning reference-fresh selections on navigation no longer wipes a 4,400-blob listing. F5 routes through the browse refresh command, which refreshes the source lists and then RELOADS - its documented contract - instead of emptying the screen.
- **A cancelled reload keeps the previous answer whole.** HasFiles now reflects the rows actually on screen (the previous complete listing for this same source), so cancelling a reload no longer showed old rows with the restore button missing.
- **Selection by identity.** The remembered container is re-matched by Id as the server always was - a rename keeps the selection, duplicate names cannot pick the wrong one.
- **The two media agree what the count means.** Both status lines report the source's total databases; the history path used to report the count after the server auto-pick had narrowed the list.

The fake listing grew an awaitable `BeforeListReturns` gate (honouring cancellation on release, as the real paged enumeration does) and records `LastGroupTimeZoneId`. Seven pins in `BrowserStateDisciplineTests` hold the behaviours. Suite 1,693 + 10 integration, Release `-warnaserror` clean.