### PR TITLE
The exposure sweep answers to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The exposure sweep answers to the user** (#287). It can be STOPPED - a Stop button while
+  it runs, and Esc reaches it - where a dozen servers with several unreachable used to mean
+  minutes of timeouts with no exit; stopping keeps the previous sweep's rows, and is never
+  dressed up as a server failure. A sweep that fails says so on the dashboard instead of
+  dying unobserved behind the first-visit auto-sweep, and that auto-sweep now runs once per
+  session as promised: "has swept" is a real flag, no longer inferred from an empty row list
+  that re-triggered a full estate sweep on every visit whenever the answer WAS empty. The
+  "as of" clock carries the date, an unreachable row is a property rather than a magic
+  caption, and the one-click handoff hands the restore screen the exact connection whose
+  sweep produced the row - two entries for the same instance with different credentials no
+  longer collapse into whichever came first
 - **The browser no longer mixes two sources' answers** (#286). Changing the container,
   medium or source server mid-listing cancels the in-flight load instead of letting the
   stale result land under the new source's name - and the set grouping runs with the

--- a/src/NineLives.Core/Services/ExposureAdvisor.cs
+++ b/src/NineLives.Core/Services/ExposureAdvisor.cs
@@ -20,6 +20,12 @@ public sealed class ExposureRow
     public string RecoveryModel { get; init; } = string.Empty;
     public string StateDescription { get; init; } = string.Empty;
 
+    /// <summary>
+    /// The server would not answer, so this row is an alarm about silence rather than a judged
+    /// database (#287). A property rather than a magic string compared in two places.
+    /// </summary>
+    public bool IsUnreachable { get; init; }
+
     public DateTime? LastFull { get; init; }
     public DateTime? LastDifferential { get; init; }
     public DateTime? LastLog { get; init; }

--- a/src/NineLives.Tests/ExposureHardeningTests.cs
+++ b/src/NineLives.Tests/ExposureHardeningTests.cs
@@ -1,0 +1,186 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The sweep machinery gets the same discipline as the rest (#287): it can be stopped, it
+/// cannot fail silently, "has swept" is a fact rather than an inference from an empty list,
+/// the clock carries a date, and the one-click handoff hands over the connection whose sweep
+/// actually produced the row.
+/// </summary>
+public class ExposureHardeningTests
+{
+    private static ExposureRow Row(string server, string db) => new()
+    {
+        ServerName = server,
+        DatabaseName = db,
+        RecoveryModel = "FULL",
+        StateDescription = "ONLINE",
+        LastFull = new DateTime(2026, 8, 9, 22, 0, 0),
+        LastLog = new DateTime(2026, 8, 10, 11, 40, 0)
+    };
+
+    private static (ExposureViewModel vm, FakeSqlServerService sql, FakeCredentialStore store)
+        New(params string[] servers)
+    {
+        var store = new FakeCredentialStore();
+        foreach (var name in servers)
+            store.Config.Servers.Add(new ServerConnection
+            { Id = ServerConnection.NewId(), Name = name, ServerName = name });
+
+        var sql = new FakeSqlServerService();
+        return (new ExposureViewModel(store, sql, new FakeRestoreHistoryStore(), TestLogs.Temp()), sql, store);
+    }
+
+    // ── the sweep can be stopped (#287 item 1) ──────────────────────────────────
+
+    [Fact]
+    public async Task TheSweepCanBeStoppedAndStoppingIsNotAnAlarm()
+    {
+        var (vm, sql, _) = New("SRV01");
+        sql.ExposureByServer["SRV01"] = [Row("SRV01", "Sales")];
+        sql.BeforeExposureReturns = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var sweep = vm.RefreshCommand.ExecuteAsync(null);
+        Assert.True(vm.CanCancelSweep);
+
+        vm.StopSweepCommand.Execute(null);
+        sql.BeforeExposureReturns.SetResult(true);
+        await sweep;
+
+        // Stopping is the user's doing - it must not fabricate an UNREACHABLE alarm row.
+        Assert.Empty(vm.Rows);
+        Assert.Contains("cancelled", vm.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.False(vm.IsSweeping);
+        Assert.False(vm.CanCancelSweep);
+    }
+
+    [Fact]
+    public async Task StoppingAReSweepKeepsThePreviousAnswer()
+    {
+        var (vm, sql, _) = New("SRV01");
+        sql.ExposureByServer["SRV01"] = [Row("SRV01", "Sales")];
+        await vm.RefreshCommand.ExecuteAsync(null);
+        Assert.Single(vm.Rows);
+        var summaryBefore = vm.Summary;
+
+        sql.BeforeExposureReturns = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var resweep = vm.RefreshCommand.ExecuteAsync(null);
+        vm.StopSweepCommand.Execute(null);
+        sql.BeforeExposureReturns.SetResult(true);
+        await resweep;
+
+        Assert.Single(vm.Rows);
+        Assert.Equal(summaryBefore, vm.Summary);
+    }
+
+    // ── has-swept is a fact, not an inference (#287 item 2) ─────────────────────
+
+    /// <summary>
+    /// The first-visit auto-sweep used to infer "never swept" from Rows.Count == 0 - so an
+    /// estate whose honest answer was empty re-swept every server on every visit.
+    /// </summary>
+    [Fact]
+    public async Task AnEmptyAnswerStillCountsAsSwept()
+    {
+        var (vm, _, _) = New();   // no servers configured
+
+        Assert.False(vm.HasSwept);
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.True(vm.HasSwept);
+        Assert.Empty(vm.Rows);
+    }
+
+    [Fact]
+    public async Task ACancelledFirstSweepStillCountsAsAttempted()
+    {
+        var (vm, sql, _) = New("SRV01");
+        sql.ExposureByServer["SRV01"] = [Row("SRV01", "Sales")];
+        sql.BeforeExposureReturns = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var sweep = vm.RefreshCommand.ExecuteAsync(null);
+        vm.StopSweepCommand.Execute(null);
+        sql.BeforeExposureReturns.SetResult(true);
+        await sweep;
+
+        // Stopping it was a decision about THIS sweep; the shell must not immediately restart
+        // one on the next visit.
+        Assert.True(vm.HasSwept);
+    }
+
+    // ── the clock carries a date (#287 item 3) ──────────────────────────────────
+
+    [Fact]
+    public async Task TheClockSaysWhichDayItMeans()
+    {
+        var (vm, sql, _) = New("SRV01");
+        sql.ExposureByServer["SRV01"] = [Row("SRV01", "Sales")];
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Matches(@"as of \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", vm.LastRefreshed);
+    }
+
+    // ── the handoff is exact (#287 item 4) ──────────────────────────────────────
+
+    /// <summary>
+    /// Two saved entries for the same instance - different credentials - are different
+    /// connections. The handoff used to dedupe by server name with First(), which could hand
+    /// the restore screen the OTHER entry's credentials.
+    /// </summary>
+    [Fact]
+    public async Task TheHandoffHandsOverTheConnectionWhoseSweepProducedTheRow()
+    {
+        var store = new FakeCredentialStore();
+        var asAdmin = new ServerConnection { Id = "s1", Name = "SRV01 (admin)", ServerName = "SRV01" };
+        var asReader = new ServerConnection { Id = "s2", Name = "SRV01 (reader)", ServerName = "SRV01" };
+        store.Config.Servers.Add(asAdmin);
+        store.Config.Servers.Add(asReader);
+        var sql = new FakeSqlServerService();
+        sql.ExposureByServer["SRV01"] = [Row("SRV01", "Sales")];
+        var vm = new ExposureViewModel(store, sql, new FakeRestoreHistoryStore(), TestLogs.Temp());
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        // Both entries answered, so the same database appears once per connection; each row
+        // must hand over its own.
+        BrowseHandoff? handoff = null;
+        vm.RestoreRequested += h => handoff = h;
+
+        foreach (var row in vm.Rows)
+        {
+            handoff = null;
+            vm.RestoreFromRowCommand.Execute(row);
+            Assert.NotNull(handoff);
+        }
+
+        var owners = new List<string?>();
+        foreach (var row in vm.Rows)
+        {
+            vm.RestoreFromRowCommand.Execute(row);
+            owners.Add(handoff!.SourceServer?.Id);
+        }
+        Assert.Contains("s1", owners);
+        Assert.Contains("s2", owners);
+    }
+
+    [Fact]
+    public async Task AnUnreachableRowRefusesTheHandoffByItsFlagNotByItsCaption()
+    {
+        var (vm, _, _) = New("SRV01");   // SRV01 not in ExposureByServer -> fake throws
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        var row = Assert.Single(vm.Rows);
+        Assert.True(row.IsUnreachable);
+        Assert.Equal(ExposureLevel.Alarm, row.Level);
+
+        var raised = false;
+        vm.RestoreRequested += _ => raised = true;
+        vm.RestoreFromRowCommand.Execute(row);
+        Assert.False(raised);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -604,13 +604,38 @@ public sealed class FakeSqlServerService : ISqlServerService
     public Dictionary<string, List<ExposureRow>> ExposureByServer { get; } =
         new(StringComparer.OrdinalIgnoreCase);
 
-    public Task<List<ExposureRow>> GetBackupExposureAsync(
+    /// <summary>When set, the sweep waits here per server - and honours a cancellation that
+    /// arrived while it waited, as the real query does (#287).</summary>
+    public TaskCompletionSource<bool>? BeforeExposureReturns { get; set; }
+
+    public async Task<List<ExposureRow>> GetBackupExposureAsync(
         ServerConnection server, CancellationToken ct = default)
     {
+        ct.ThrowIfCancellationRequested();
+        if (BeforeExposureReturns != null)
+        {
+            await BeforeExposureReturns.Task;
+            ct.ThrowIfCancellationRequested();
+        }
+
         if (!ExposureByServer.TryGetValue(server.ServerName, out var rows))
             throw new InvalidOperationException($"fake: {server.ServerName} is not answering");
 
-        return Task.FromResult(rows.ToList());
+        // Fresh instances per call, as the real query produces - two connections to the same
+        // instance must not share row objects, or the sweep cannot tell whose answer is whose.
+        return rows.Select(r => new ExposureRow
+        {
+            ServerName = r.ServerName,
+            DatabaseName = r.DatabaseName,
+            RecoveryModel = r.RecoveryModel,
+            StateDescription = r.StateDescription,
+            IsUnreachable = r.IsUnreachable,
+            LastFull = r.LastFull,
+            LastDifferential = r.LastDifferential,
+            LastLog = r.LastLog,
+            Level = r.Level,
+            Verdict = r.Verdict
+        }).ToList();
     }
 
     /// <summary>What each ad-hoc file's headers say, keyed by path (#203).</summary>

--- a/src/NineLives/ViewModels/ExposureViewModel.cs
+++ b/src/NineLives/ViewModels/ExposureViewModel.cs
@@ -22,6 +22,7 @@ public partial class ExposureViewModel : ViewModelBase
     private readonly ISqlServerService _sql;
     private readonly IRestoreHistoryStore _history;
     private readonly OperationLog _log;
+    private readonly OperationCancellation _sweepCancellation = new();
 
     public ExposureViewModel(
         ICredentialStore store, ISqlServerService sql, IRestoreHistoryStore history,
@@ -45,9 +46,36 @@ public partial class ExposureViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isSweeping;
 
-    /// <summary>The connections behind the rows, by server name - the handoff needs the object.</summary>
-    private Dictionary<string, ServerConnection> _serversByName =
-        new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>True while a sweep is running and has not been asked to stop (#287).</summary>
+    [ObservableProperty]
+    private bool _canCancelSweep;
+
+    /// <summary>
+    /// Whether a sweep has ever been ATTEMPTED (#287). The shell's first-visit auto-sweep used
+    /// to infer this from Rows.Count == 0 - so an estate that answered "no rows" (or a sweep
+    /// that failed) re-triggered a full sweep of every server on every later visit, the exact
+    /// opposite of "Refresh stays deliberate after the first".
+    /// </summary>
+    public bool HasSwept { get; private set; }
+
+    /// <summary>
+    /// Stops an in-progress sweep. A dozen servers with several unreachable is minutes of
+    /// timeouts, and until now there was no way out of it.
+    /// </summary>
+    [RelayCommand]
+    private void StopSweep()
+    {
+        _sweepCancellation.Cancel();
+        CanCancelSweep = false;
+        SetStatus("Cancelling...");
+    }
+
+    /// <summary>
+    /// The connection each row's numbers actually came from (#287). By row identity, not by
+    /// server name: two entries for the same instance with different credentials are different
+    /// connections, and the one-click handoff must hand over the one that produced the row.
+    /// </summary>
+    private Dictionary<ExposureRow, ServerConnection> _ownerByRow = new();
 
     /// <summary>Raised when somebody wants to act on a row. The shell wires it (#202's pattern).</summary>
     public event Action<BrowseHandoff>? RestoreRequested;
@@ -61,8 +89,8 @@ public partial class ExposureViewModel : ViewModelBase
     [RelayCommand]
     private void RestoreFromRow(ExposureRow? row)
     {
-        if (row == null || row.StateDescription == "UNREACHABLE") return;
-        if (!_serversByName.TryGetValue(row.ServerName, out var server)) return;
+        if (row == null || row.IsUnreachable) return;
+        if (!_ownerByRow.TryGetValue(row, out var server)) return;
 
         RestoreRequested?.Invoke(new BrowseHandoff(
             BackupMedium.SharedPath, null, server, row.ServerName, row.DatabaseName));
@@ -78,7 +106,9 @@ public partial class ExposureViewModel : ViewModelBase
     [RelayCommand]
     private async Task RefreshAsync()
     {
+        var ct = _sweepCancellation.Begin();
         IsSweeping = true;
+        CanCancelSweep = true;
         ClearStatus();
 
         try
@@ -103,39 +133,50 @@ public partial class ExposureViewModel : ViewModelBase
             }
 
             var now = DateTime.Now;
-            _serversByName = servers
-                .GroupBy(s => s.ServerName, StringComparer.OrdinalIgnoreCase)
-                .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
             var sweeps = servers.Select(async server =>
             {
                 try
                 {
-                    return await _sql.GetBackupExposureAsync(server);
+                    return (server, rows: await _sql.GetBackupExposureAsync(server, ct));
+                }
+                catch (OperationCanceledException)
+                {
+                    // Stopping is the user's doing, not the server's silence - it must not
+                    // fabricate an UNREACHABLE alarm row.
+                    throw;
                 }
                 catch (Exception ex)
                 {
                     _log.Warn($"[exposure] {server.ServerName}: {ex.Message}");
-                    return
+                    return (server, rows: (List<ExposureRow>)
                     [
                         new ExposureRow
                         {
                             ServerName = server.ServerName,
                             DatabaseName = "(server did not answer)",
                             StateDescription = "UNREACHABLE",
+                            IsUnreachable = true,
                             Level = ExposureLevel.Alarm,
                             Verdict = $"The server would not answer: {ex.Message} Its databases' " +
                                       "exposure is UNKNOWN, which is not the same as fine."
                         }
-                    ];
+                    ]);
                 }
             }).ToList();
 
             var results = await Task.WhenAll(sweeps);
-            var rows = results.SelectMany(r => r).ToList();
+
+            var owners = new Dictionary<ExposureRow, ServerConnection>();
+            foreach (var (server, serverRows) in results)
+                foreach (var row in serverRows)
+                    owners[row] = server;
+            _ownerByRow = owners;
+
+            var rows = results.SelectMany(r => r.rows).ToList();
 
             // The advisor judges everything that answered; unreachable rows arrive pre-judged.
-            foreach (var row in rows.Where(r => r.StateDescription != "UNREACHABLE"))
+            foreach (var row in rows.Where(r => !r.IsUnreachable))
                 ExposureAdvisor.Judge(row, now);
 
             AttachRehearsalReceipts(rows);
@@ -153,11 +194,26 @@ public partial class ExposureViewModel : ViewModelBase
                 ? $"All {rows.Count} database(s) across {servers.Count} server(s) are inside their windows."
                 : $"{alarms} alarm(s), {warnings} warning(s) across {servers.Count} server(s) - worst first.";
 
-            LastRefreshed = $"as of {now:HH:mm:ss}";
+            LastRefreshed = $"as of {now:yyyy-MM-dd HH:mm:ss}";
+        }
+        catch (OperationCanceledException)
+        {
+            // The rows on screen are the previous sweep's complete answer; stopping this one
+            // does not invalidate them.
+            SetStatus("Sweep cancelled.");
+        }
+        catch (Exception ex)
+        {
+            // The auto-sweep is fired without an awaiter, so anything escaping here used to
+            // vanish - an empty dashboard with no explanation (#287).
+            SetError($"The sweep failed: {ex.Message}");
         }
         finally
         {
+            HasSwept = true;
+            _sweepCancellation.End();
             IsSweeping = false;
+            CanCancelSweep = false;
         }
     }
 

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -155,7 +155,9 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     private ExposureViewModel SweepExposureOnFirstVisit()
     {
-        if (Exposure.Rows.Count == 0 && !Exposure.IsSweeping)
+        // Gated on a real has-swept flag (#287): inferring "never swept" from an empty rows
+        // list re-swept the whole estate on every visit whenever the answer WAS empty.
+        if (!Exposure.HasSwept && !Exposure.IsSweeping)
             _ = Exposure.RefreshCommand.ExecuteAsync(null);
 
         return Exposure;
@@ -536,7 +538,8 @@ public partial class MainViewModel : ViewModelBase
     {
         if (Restore.Execution.CancelCommand.CanExecute(null)) { Restore.Execution.CancelCommand.Execute(null); return; }
         if (Restore.CancelQueryCommand.CanExecute(null)) { Restore.CancelQueryCommand.Execute(null); return; }
-        if (Restore.CancelLoadCommand.CanExecute(null)) Restore.CancelLoadCommand.Execute(null);
+        if (Restore.CancelLoadCommand.CanExecute(null)) { Restore.CancelLoadCommand.Execute(null); return; }
+        if (Exposure.CanCancelSweep) Exposure.StopSweepCommand.Execute(null);
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -573,6 +573,14 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     [ObservableProperty]
     private double _actionPercent = -1;
 
+    /// <summary>
+    /// Which action the percent bar currently belongs to. Progress&lt;T&gt; POSTS its callbacks,
+    /// so a report made just before an action completed can arrive after the finally block has
+    /// reset the bar - and a stale 99% about a finished action would sit there claiming the
+    /// next action's progress. Bumped when an action ends; late reports check it and drop.
+    /// </summary>
+    private int _actionEpoch;
+
     [ObservableProperty]
     private bool _isRunningAction;
 
@@ -603,6 +611,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
         RaiseCancelStateChanged();
 
         IsRunningAction = true;
+        var epoch = _actionEpoch;
         ActionPercent = -1;
         ActionOutcome = string.Empty;
         TaskbarState = System.Windows.Shell.TaskbarItemProgressState.Normal;
@@ -616,6 +625,10 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             // panel runs - so the bar moves for exactly the actions long enough to need one.
             var progress = new Progress<double>(p =>
             {
+                // Posted asynchronously, so it can arrive after this action already ended -
+                // about the run that is over, not the one that may have started since.
+                if (epoch != _actionEpoch) return;
+
                 ActionPercent = p;
                 TaskbarValue = p / 100.0;
             });
@@ -651,6 +664,9 @@ public partial class RestoreExecutionViewModel : ViewModelBase
         }
         finally
         {
+            // Before the resets, so a late-posted percent report cannot un-reset them.
+            _actionEpoch++;
+
             IsRunningAction = false;
             ActionPercent = -1;
             TaskbarState = System.Windows.Shell.TaskbarItemProgressState.None;

--- a/src/NineLives/Views/ExposureView.xaml
+++ b/src/NineLives/Views/ExposureView.xaml
@@ -19,6 +19,12 @@
                         Command="{Binding RefreshCommand}"
                         Style="{StaticResource PrimaryButton}"
                         Padding="16,8" Margin="0,0,12,0" />
+                <Button Content="Stop"
+                        Command="{Binding StopSweepCommand}"
+                        Style="{StaticResource SecondaryButton}"
+                        Padding="16,8" Margin="0,0,12,0"
+                        Visibility="{Binding CanCancelSweep, Converter={StaticResource BoolToVis}}"
+                        ToolTip="Stops the sweep. Rows already on screen stay - they are the previous sweep's answer." />
                 <ContentControl Template="{StaticResource BusySpinner}"
                                 Width="16" Height="16" Margin="0,0,8,0"
                                 VerticalAlignment="Center"


### PR DESCRIPTION
Closes #287.

- **It can be stopped.** `OperationCancellation` through `GetBackupExposureAsync`, a Stop button beside the spinner, and Esc reaches the sweep through the shell's cancel chain. Stopping keeps the previous sweep's rows on screen and is never dressed up as a server failure - the per-server catch rethrows cancellation rather than fabricating an UNREACHABLE alarm row.
- **No silent failures.** The whole sweep body is guarded: a failure sets the dashboard's error instead of dying unobserved behind the first-visit auto-sweep's discarded task.
- **"Has swept" is a fact.** A real flag set once a sweep has been attempted - cancelled, failed or empty included - replaces the `Rows.Count == 0` inference that re-swept the entire estate on every visit whenever the honest answer WAS empty.
- **The clock carries a date.** "as of 2026-08-10 21:58:43" - "as of 09:14:03" might be yesterday.
- **The handoff is exact.** The row-to-connection map is by row identity, filled from each server's own sweep results: two saved entries for the same instance with different credentials hand over their own connection, not whichever `First()` picked. UNREACHABLE became `ExposureRow.IsUnreachable` instead of a magic caption compared in two places.

The fake exposure query gained an awaitable `BeforeExposureReturns` gate and returns fresh row instances per call, as the real query does. Seven pins in `ExposureHardeningTests`; rendered the mid-sweep (Stop offered) and settled (dated clock) states. Suite 1,700 + 10 integration, Release `-warnaserror` clean.