### PR TITLE
The handoff tells the truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The handoff tells the truth** (#288). Clicking "Open in Restore" while a restore is
+  RUNNING is refused with an explanation instead of wiping the run's chain and timeline off
+  the screen - the handoff may not do what the regenerate button already refuses. What
+  arrives is exactly what the browser showed: extra containers ticked on an earlier visit
+  are unticked, so the chain cannot assemble from backups nobody looked at. And the instance
+  filter matches by identity the way every other server comparison does - a case or naming
+  difference between msdb's name and a path-inferred one no longer silently drops the
+  filter, and a filter that genuinely cannot apply is SAID on the status line rather than
+  quietly answering a different question
 - **The exposure sweep answers to the user** (#287). It can be STOPPED - a Stop button while
   it runs, and Esc reaches it - where a dozen servers with several unreachable used to mean
   minutes of timeouts with no exit; stopping keeps the previous sweep's rows, and is never

--- a/src/NineLives.Tests/HandoffHonestyTests.cs
+++ b/src/NineLives.Tests/HandoffHonestyTests.cs
@@ -1,0 +1,131 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The browse/exposure handoff tells the truth (#288): it refuses to wipe a running restore's
+/// record, it loads exactly what the browser showed, and a filter it cannot apply is SAID
+/// rather than silently dropped.
+/// </summary>
+public class HandoffHonestyTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 7, 22, 0, 0);
+
+    private static BlobContainerConfig Container(string id = "c1", string name = "backups") => new()
+    {
+        Id = id,
+        Name = name,
+        ContainerUrl = $"https://acct.blob.core.windows.net/{name}"
+    };
+
+    private static BackupFileInfo File_(string database, string server = "SRV01") => new()
+    {
+        BlobName = $"FULL/{server}/{database}/20260807_220000.bak",
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/FULL/{server}/{database}/20260807_220000.bak",
+        Type = BackupType.Full,
+        InferredDatabaseName = database,
+        InferredServerName = server,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    private static RestoreViewModel Restore(FakeCredentialStore store, FakeBlobStorageService blob) => new(
+        blob, new FakeSqlServerService(), new BackupChainBuilder(),
+        new RestoreScriptGenerator(), store, TestLogs.Temp(),
+        new FakeRestoreHistoryStore(), TestAuditStores.Temp())
+    { Mode = AppMode.Pro };
+
+    private static FakeCredentialStore Store(params BlobContainerConfig[] containers)
+    {
+        var store = new FakeCredentialStore();
+        foreach (var c in containers) store.Config.BlobContainers.Add(c);
+        return store;
+    }
+
+    /// <summary>
+    /// The screen already refuses to regenerate the script mid-restore because it is the record
+    /// of the run; the handoff may not do what the regenerate button may not.
+    /// </summary>
+    [Fact]
+    public async Task AHandoffIsRefusedWhileARestoreRuns()
+    {
+        var blob = new FakeBlobStorageService { Files = [File_("Sales"), File_("Payroll")] };
+        var vm = Restore(Store(Container()), blob);
+        vm.RefreshContainers();
+        await vm.AcceptHandoffAsync(new BrowseHandoff(
+            BackupMedium.AzureBlob, Container(), null, null, "Sales"));
+        Assert.Equal("Sales", vm.Inventory.SelectedDatabaseName);
+
+        vm.Execution.IsExecuting = true;
+        await vm.AcceptHandoffAsync(new BrowseHandoff(
+            BackupMedium.AzureBlob, Container(), null, null, "Payroll"));
+
+        // The record of the run is untouched, and the refusal is explained.
+        Assert.Equal("Sales", vm.Inventory.SelectedDatabaseName);
+        Assert.Contains("restore is running", vm.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Extra containers ticked on an earlier visit would make the load see MORE than the
+    /// browser showed - a chain could assemble from backups the user never looked at.
+    /// </summary>
+    [Fact]
+    public async Task ExtraTickedContainersDoNotSurviveTheHandoff()
+    {
+        var blob = new FakeBlobStorageService();
+        blob.FilesByContainer["backups"] = [File_("Sales")];
+        blob.FilesByContainer["archive"] = [File_("Sales")];
+        var vm = Restore(Store(Container(), Container("c2", "archive")), blob);
+        vm.RefreshContainers();
+
+        var extra = Assert.Single(vm.AdditionalContainers);
+        extra.IsSelected = true;
+        Assert.Equal(2, vm.ContainersToRead.Count);
+
+        await vm.AcceptHandoffAsync(new BrowseHandoff(
+            BackupMedium.AzureBlob, Container(), null, null, "Sales"));
+
+        Assert.All(vm.AdditionalContainers, c => Assert.False(c.IsSelected));
+        Assert.Single(vm.ContainersToRead);
+        Assert.Equal("c1", vm.ContainersToRead[0].Id);
+    }
+
+    /// <summary>The filter matches the way every other server comparison does - by identity.</summary>
+    [Fact]
+    public async Task TheInstanceFilterLandsAcrossACaseDifference()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            Files = [File_("Sales", "SRV01"), File_("Sales", "SRV02")]
+        };
+        var vm = Restore(Store(Container()), blob);
+        vm.RefreshContainers();
+
+        await vm.AcceptHandoffAsync(new BrowseHandoff(
+            BackupMedium.AzureBlob, Container(), null, "srv01", "Sales"));
+
+        Assert.Equal("SRV01", vm.Inventory.SelectedServerName);
+        Assert.Equal("Sales", vm.Inventory.SelectedDatabaseName);
+    }
+
+    /// <summary>
+    /// A filter that cannot be applied is a different question than the one clicked - the
+    /// screen says so instead of silently answering it.
+    /// </summary>
+    [Fact]
+    public async Task ADroppedInstanceFilterIsSaidOutLoud()
+    {
+        var blob = new FakeBlobStorageService { Files = [File_("Sales")] };
+        var vm = Restore(Store(Container()), blob);
+        vm.RefreshContainers();
+
+        // The dashboard hands over msdb's name for the machine; the blob paths inferred another.
+        await vm.AcceptHandoffAsync(new BrowseHandoff(
+            BackupMedium.AzureBlob, Container(), null, "localhost", "Sales"));
+
+        Assert.Contains("not among this source's instances", vm.StatusMessage);
+        Assert.Equal("Sales", vm.Inventory.SelectedDatabaseName);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -554,6 +554,17 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     public async Task AcceptHandoffAsync(BrowseHandoff handoff)
     {
+        // This screen already refuses to regenerate the script mid-restore because it is the
+        // record of what is actually running - the handoff cannot be allowed to do what the
+        // regenerate button may not (#288). Clicking a red dashboard row must not wipe the
+        // chain and timeline out from under a 40-minute restore.
+        if (IsExecuting)
+        {
+            SetError("A restore is running on this screen. Wait for it to finish (or stop it) " +
+                     "and hand over again - jumping sources now would wipe the record of the run.");
+            return;
+        }
+
         SelectedMedium = handoff.Medium == BackupMedium.SharedPath
             ? BackupMedium.SharedPath
             : BackupMedium.AzureBlob;
@@ -567,6 +578,12 @@ public partial class RestoreViewModel : ViewModelBase
         }
         else if (handoff.Container != null)
         {
+            // What arrives is what the browser showed. Extra containers ticked on an earlier
+            // visit would make the load see MORE than was looked at - a chain assembling from
+            // backups the user never saw (#288).
+            foreach (var choice in AdditionalContainers)
+                choice.IsSelected = false;
+
             SelectedContainer = Containers.FirstOrDefault(c => c.Id == handoff.Container.Id)
                                 ?? handoff.Container;
         }
@@ -575,14 +592,36 @@ public partial class RestoreViewModel : ViewModelBase
 
         // The filters land only when the load found them - a database the load did not see would
         // put the working set into a state the screen cannot have reached by hand.
-        if (handoff.ServerFilter != null && Inventory.DiscoveredServers.Contains(handoff.ServerFilter))
-            Inventory.SelectedServerName = handoff.ServerFilter;
+        string? droppedFilter = null;
+        if (handoff.ServerFilter != null)
+        {
+            // The way every other server comparison works (#288): identity, not ordinal. The
+            // dashboard hands over the name msdb records while a blob listing infers from
+            // paths - a case difference must not silently drop the instance filter.
+            var match = Inventory.DiscoveredServers.FirstOrDefault(d =>
+            {
+                var (server, instance) = ServerIdentity.Split(d);
+                return ServerIdentity.Matches(server, instance, handoff.ServerFilter);
+            });
+
+            if (match != null)
+                Inventory.SelectedServerName = match;
+            else
+                droppedFilter = handoff.ServerFilter;
+        }
 
         if (handoff.Database != null &&
             Inventory.DiscoveredDatabases.Contains(handoff.Database, StringComparer.OrdinalIgnoreCase))
             Inventory.SelectedDatabaseName =
                 Inventory.DiscoveredDatabases.First(d =>
                     string.Equals(d, handoff.Database, StringComparison.OrdinalIgnoreCase));
+
+        // Said last, so nothing the filters trigger can clear it: applying only the database
+        // filter is a DIFFERENT question than the one clicked, and silence would present its
+        // answer as the clicked one's.
+        if (droppedFilter != null)
+            SetStatus($"The instance filter '{droppedFilter}' is not among this source's " +
+                      "instances, so every instance's backups are shown.");
     }
 
     /// <summary>The saved connections, for choosing whose backup history to read.</summary>


### PR DESCRIPTION
Closes #288.

- **A running restore's record is safe.** `AcceptHandoffAsync` now refuses while `IsExecuting`, with the reason on the error line - the screen already refuses to regenerate the script mid-restore because it is the record of the run; the handoff could do what the regenerate button may not, wiping the chain and timeline out from under a 40-minute restore.
- **What arrives is what the browser showed.** Extra `AdditionalContainers` ticks from an earlier visit are cleared before the load, so the restore screen cannot assemble a chain from backups the user never looked at.
- **The instance filter is applied by identity, or its absence is said.** The filter now matches through `ServerIdentity` (as every other server comparison does) instead of ordinal equality, so a case difference between msdb's recorded name and a path-inferred one lands the filter. When it genuinely cannot apply - "localhost" vs the real machine name - the status line says so, emitted last so nothing the filters trigger can clear it, instead of silently answering a different question than the row that was clicked.

Four pins in `HandoffHonestyTests`. Suite 1,704 + 10 integration, Release `-warnaserror` clean.