### PR TITLE
The busy strip and the taskbar flash treat all three runs alike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,12 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The busy strip and the taskbar flash treat all three runs alike** (#289). The global
+  busy indicator - which exists so "is it doing something?" does not depend on scroll
+  position - now lights for backups and copies, the two longest-running screens it ignored.
+  And the taskbar attention flash on finishing behind another window, written for exactly
+  the alt-tabbed-away case, now fires for a finished backup and a finished copy as it always
+  did for a restore
 - **The handoff tells the truth** (#288). Clicking "Open in Restore" while a restore is
   RUNNING is refused with an explanation instead of wiping the run's chain and timeline off
   the screen - the handoff may not do what the regenerate button already refuses. What

--- a/src/NineLives.Tests/BusyFeedbackTests.cs
+++ b/src/NineLives.Tests/BusyFeedbackTests.cs
@@ -249,4 +249,40 @@ public class GlobalBusyTests
 
         Assert.Contains("Restoring", vm.BusyText);
     }
+
+    /// <summary>The two longest-running screens were the ones the indicator ignored (#289).</summary>
+    [Fact]
+    public void ABackupRunReachesTheWindow()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.Backup.IsRunning = true;
+        Assert.True(vm.IsBusy);
+        Assert.Equal("Running the backup...", vm.BusyText);
+
+        vm.Backup.IsRunning = false;
+        Assert.False(vm.IsBusy);
+    }
+
+    [Fact]
+    public void ACopyRunReachesTheWindow()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.CopyDatabase.IsRunning = true;
+        Assert.True(vm.IsBusy);
+        Assert.Equal("Copying the database...", vm.BusyText);
+    }
+
+    [Fact]
+    public void ARestoreOutranksABackupRun()
+    {
+        var vm = new MainViewModel(new FakeCredentialStore());
+
+        vm.Backup.IsRunning = true;
+        vm.Restore.TargetDatabaseName = "MyDb_Restored";
+        vm.Restore.Execution.IsExecuting = true;
+
+        Assert.Contains("Restoring", vm.BusyText);
+    }
 }

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -645,6 +645,10 @@ public partial class BackupViewModel : ViewModelBase
         {
             _runCancellation.End();
             IsRunning = false;
+
+            // Told, not interrupted (#289): the restore already flashes the taskbar when it
+            // finishes behind another window, and a backup is exactly as worth coming back to.
+            WindowAttention.FlashIfInBackground();
         }
     }
 

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -720,6 +720,10 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             IsRunning = false;
             OutcomeText = CopyOutcomeText.Describe(Outcome, run.Destinations.FirstOrDefault());
 
+            // Told, not interrupted (#289): same taskbar flash as the restore and the backup
+            // when the copy finishes while the app is behind another window.
+            WindowAttention.FlashIfInBackground();
+
             if (Outcome == CopyOutcome.Copied)
                 SetStatus($"Copied {SourceDatabase} to {TargetServer.ServerName} as {TargetDatabaseName}.");
             else if (Outcome != CopyOutcome.NotStarted)

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -366,8 +366,13 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     private void RefreshBusy()
     {
+        // Backup and copy are the two other screens that RUN something long (#289) - the
+        // indicator exists so "is it doing something?" does not depend on scroll position,
+        // and the two longest-running screens were the ones it ignored.
         var text =
             Restore.IsBusyWithAnything ? Restore.BusyDescription
+            : Backup.IsRunning ? "Running the backup..."
+            : CopyDatabase.IsRunning ? "Copying the database..."
             : BlobConfig.IsBusy ? "Testing the container connection..."
             : BlobBrowser.IsBusy ? "Listing the container..."
             : ServerManager.IsBusy ? "Connecting to SQL Server..."


### PR DESCRIPTION
Closes #289.

- **Global busy parity.** `RefreshBusy` now names backup runs ("Running the backup...") and copy runs ("Copying the database...") - both screens were already watched for property changes, but the text chain ignored their `IsRunning`. A restore still outranks everything, because it is the one writing to a database.
- **Taskbar flash parity.** `WindowAttention.FlashIfInBackground()` now fires from the backup's and the copy's completion paths - the same told-not-interrupted contract the restore has had, for the same alt-tabbed-away case it was written for.

Three pins extend `GlobalBusyTests`. Suite 1,707 + 10 integration, Release `-warnaserror` clean.