### PR TITLE
The connected server survives its own lifecycle honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,14 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The connected server survives its own lifecycle honestly** (#291). Deleting it is
+  recognised by identity, not by a caption captured at connect time - renaming the connected
+  server and then deleting it used to leave the status bar claiming "Connected to X" while
+  the restore screen still held the deleted object as its target. Editing the connected
+  entry's address, auth mode, login, encryption or password now DROPS the connection with an
+  explanation - the old settings were proven, the new ones are not - while a rename alone
+  keeps it. And renaming onto an existing name is refused, exactly as creating one is, so no
+  two entries can share a caption
 - **The busy strip and the taskbar flash treat all three runs alike** (#289). The global
   busy indicator - which exists so "is it doing something?" does not depend on scroll
   position - now lights for backups and copies, the two longest-running screens it ignored.

--- a/src/NineLives.Tests/IdentifyUnclassifiedTests.cs
+++ b/src/NineLives.Tests/IdentifyUnclassifiedTests.cs
@@ -199,15 +199,21 @@ public class IdentifyUnclassifiedTests
         var sql = new FakeSqlServerService { Header = Header() };
         var seen = new List<int>();
 
+        // A synchronous IProgress, not Progress<T>: Progress POSTS its reports through the
+        // synchronisation context, and a test that waits an arbitrary delay for them to land
+        // fails exactly when the machine is busiest. The identifier's contract - one report
+        // per file, cumulative - is what this pins, not the marshalling.
         await new BackupHeaderIdentifier(sql).IdentifyAsync(
             Server(),
             [Unplaceable("a.bak"), Unplaceable("b.bak"), Unplaceable("c.bak")],
-            new Progress<int>(seen.Add));
+            new InlineProgress(seen));
 
-        // Progress<T> marshals through the synchronisation context, so what matters is that it
-        // reaches the last count rather than exactly how the intermediate ones interleave.
-        await Task.Delay(50);
-        Assert.Contains(3, seen);
+        Assert.Equal([1, 2, 3], seen);
+    }
+
+    private sealed class InlineProgress(List<int> seen) : IProgress<int>
+    {
+        public void Report(int value) => seen.Add(value);
     }
 
     private static ServerConnection Server() =>

--- a/src/NineLives.Tests/ServerLifecycleTests.cs
+++ b/src/NineLives.Tests/ServerLifecycleTests.cs
@@ -1,0 +1,132 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The connected server survives its own lifecycle honestly (#291). Delete recognised the
+/// connected entry by display TEXT captured at connect time, and Save mutates the name in
+/// place - so renaming then deleting the connected server left the status bar claiming a
+/// connection to an object that no longer existed in config. Editing the connected entry's
+/// address silently repointed the SAME object at untested settings; renaming onto an existing
+/// name was allowed, making every text comparison ambiguous.
+/// </summary>
+public class ServerLifecycleTests
+{
+    private static (ServerManagerViewModel vm, FakeCredentialStore store) New(params string[] names)
+    {
+        var store = new FakeCredentialStore();
+        foreach (var name in names)
+            store.Config.Servers.Add(new ServerConnection
+            {
+                Id = ServerConnection.NewId(),
+                Name = name,
+                ServerName = name,
+                AuthMode = AuthMode.WindowsAuth
+            });
+
+        var vm = new ServerManagerViewModel(store, new FakeSqlServerService())
+        {
+            ConfirmDelete = _ => true
+        };
+        return (vm, store);
+    }
+
+    private static void Rename(ServerManagerViewModel vm, string to)
+    {
+        vm.EditCommand.Execute(null);
+        vm.EditName = to;
+        vm.SaveCommand.Execute(null);
+    }
+
+    [Fact]
+    public async Task DeletingTheRenamedConnectedServerStillDropsTheConnection()
+    {
+        var (vm, _) = New("SRV01");
+        vm.SelectedServer = vm.Servers.Single();
+        await vm.ConnectCommand.ExecuteAsync(null);
+        Assert.True(vm.IsConnected);
+
+        var dropped = false;
+        vm.ConnectionChanged += (_, e) => dropped = !e.IsConnected;
+
+        Rename(vm, "SRV01 (primary)");
+        Assert.True(vm.IsConnected);   // a rename alone does not unprove the connection
+
+        vm.DeleteCommand.Execute(null);
+
+        Assert.False(vm.IsConnected);
+        Assert.True(dropped);
+        Assert.Empty(vm.ConnectedServerDisplay);
+    }
+
+    /// <summary>The caption names the ADDRESS, which a rename does not change - so the
+    /// proven connection and its caption both stand.</summary>
+    [Fact]
+    public async Task ARenameAloneKeepsTheProvenConnection()
+    {
+        var (vm, _) = New("SRV01");
+        vm.SelectedServer = vm.Servers.Single();
+        await vm.ConnectCommand.ExecuteAsync(null);
+        var captionBefore = vm.ConnectedServerDisplay;
+
+        Rename(vm, "Production");
+
+        Assert.True(vm.IsConnected);
+        Assert.Equal(captionBefore, vm.ConnectedServerDisplay);
+        Assert.True(vm.Servers.Single().IsConnectedServer);
+    }
+
+    /// <summary>
+    /// The old settings were proven; the new ones are not. A connection that survives an
+    /// address change is a claim nobody tested.
+    /// </summary>
+    [Fact]
+    public async Task ChangingTheConnectedServersAddressDropsTheConnection()
+    {
+        var (vm, _) = New("SRV01");
+        vm.SelectedServer = vm.Servers.Single();
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        var dropped = false;
+        vm.ConnectionChanged += (_, e) => dropped = !e.IsConnected;
+
+        vm.EditCommand.Execute(null);
+        vm.EditServerName = "SRV01.other.example";
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.IsConnected);
+        Assert.True(dropped);
+        Assert.Contains("connect again", vm.StatusMessage);
+    }
+
+    [Fact]
+    public async Task EditingAnUnconnectedServerLeavesTheConnectionAlone()
+    {
+        var (vm, _) = New("SRV01", "SRV02");
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV01");
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV02");
+        vm.EditCommand.Execute(null);
+        vm.EditServerName = "SRV02.other.example";
+        vm.SaveCommand.Execute(null);
+
+        Assert.True(vm.IsConnected);
+        Assert.Contains("SRV01", vm.ConnectedServerDisplay);
+    }
+
+    [Fact]
+    public void ARenameOntoAnExistingNameIsRefused()
+    {
+        var (vm, store) = New("SRV01", "SRV02");
+        vm.SelectedServer = vm.Servers.Single(s => s.Name == "SRV02");
+
+        Rename(vm, "srv01");
+
+        Assert.Contains("already exists", vm.ErrorMessage);
+        Assert.Equal("SRV02", store.Config.Servers[1].Name);
+    }
+}

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -314,10 +314,27 @@ public partial class ServerManagerViewModel : ViewModelBase
         {
             server = SelectedServer!;
 
+            // The same rule the new path enforces, excluding self (#291): a rename onto an
+            // existing name was allowed, after which every display-text comparison anywhere
+            // in the app was ambiguous between the two.
+            if (Servers.Any(x => !ReferenceEquals(x, server) &&
+                                 x.Name.Equals(EditName, StringComparison.OrdinalIgnoreCase)))
+            {
+                SetError("A server with this name already exists.");
+                return;
+            }
+
             // Snapshot before mutating, so a refused save can put the model back rather than
             // leaving it showing values that were never persisted.
             restore = Snapshot(server);
         }
+
+        // What the connection was proven against, before the mutation below (#291). A changed
+        // address, auth mode, login, or encryption setting makes the proven connection a claim
+        // about settings that no longer exist.
+        var editingConnected = !IsNew && _connected != null && ReferenceEquals(server, _connected);
+        var beforeConnection = (server.ServerName, server.AuthMode, server.Username,
+                                server.Encrypt, server.TrustServerCertificate);
 
         server.Name = EditName;
         // Mutate in place - assigning a new collection raises no notification on a POCO, so the
@@ -377,8 +394,46 @@ public partial class ServerManagerViewModel : ViewModelBase
 
         SelectedServer = server;
         IsEditing = false;
+
+        if (editingConnected)
+        {
+            var afterConnection = (server.ServerName, server.AuthMode, server.Username,
+                                   server.Encrypt, server.TrustServerCertificate);
+            var passwordReplaced = server.AuthMode.NeedsStoredPassword() &&
+                                   !string.IsNullOrWhiteSpace(EditPassword);
+
+            if (beforeConnection != afterConnection || passwordReplaced)
+            {
+                // The old settings were proven; these are not. Silently repointing the SAME
+                // object at untested settings left every screen reporting a connection nobody
+                // had tested (#291).
+                IsConnected = false;
+                MarkConnected(null);
+                ConnectedServerDisplay = string.Empty;
+                ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs
+                {
+                    IsConnected = false,
+                    ServerName = string.Empty
+                });
+                SetStatus("Server saved. Its connection settings changed, so the previous " +
+                          "connection no longer stands - connect again to prove the new ones.");
+                return;
+            }
+
+            // A rename keeps the proven connection - the caption follows the new name.
+            ConnectedServerDisplay = server.DisplayText;
+        }
+
         SetStatus("Server saved successfully.");
     }
+
+    /// <summary>
+    /// The delete confirmation, injectable because the dialog is the one step a headless
+    /// test cannot click - the lifecycle around it is what needs the pins (#291).
+    /// </summary>
+    internal Func<string, bool> ConfirmDelete { get; set; } = message =>
+        MessageBox.Show(message, "Nine Lives", MessageBoxButton.YesNo, MessageBoxImage.Warning,
+            MessageBoxResult.No) == MessageBoxResult.Yes;
 
     [RelayCommand]
     private void Delete()
@@ -391,12 +446,9 @@ public partial class ServerManagerViewModel : ViewModelBase
             ? "\n\nIts stored SQL password will be deleted from Windows Credential Manager."
             : string.Empty;
 
-        var confirm = MessageBox.Show(
+        if (!ConfirmDelete(
             $"Remove the server \"{SelectedServer.Name}\"?{secretNote}\n\n" +
-            "Nothing on the SQL Server itself is affected.",
-            "Nine Lives", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
-
-        if (confirm != MessageBoxResult.Yes) return;
+            "Nothing on the SQL Server itself is affected.")) return;
 
         // Take the server out of the config first and only destroy its stored password once that
         // write has landed. The other order threw the password away and then, if the save failed,
@@ -416,7 +468,11 @@ public partial class ServerManagerViewModel : ViewModelBase
         if (removed.AuthMode.NeedsStoredPassword())
             _credentialStore.DeleteSecret(removed.CredentialKey);
 
-        if (IsConnected && ConnectedServerDisplay == removed.DisplayText)
+        // By identity, not caption (#291): Save mutates Name in place, so after a rename the
+        // display text never matched - the status bar kept saying "Connected to X" while the
+        // restore screen still held the deleted object as its target.
+        if (IsConnected && _connected != null &&
+            (ReferenceEquals(removed, _connected) || removed.Id == _connected.Id))
         {
             IsConnected = false;
             MarkConnected(null);
@@ -528,11 +584,15 @@ public partial class ServerManagerViewModel : ViewModelBase
         }
     }
 
+    /// <summary>The entry the live connection was proven against - by object, not by caption.</summary>
+    private ServerConnection? _connected;
+
     /// <summary>
     /// Exactly one server carries the connected marker, so the list can never show two.
     /// </summary>
     private void MarkConnected(ServerConnection? connected)
     {
+        _connected = connected;
         foreach (var server in Servers)
             server.IsConnectedServer = ReferenceEquals(server, connected);
     }


### PR DESCRIPTION
Closes #291.

- **Delete compares identity, not caption.** The live connection is tracked as the object it was proven against; deleting it - renamed or not - drops the connection and tells every listener. Display text captured at connect time stopped matching the moment a rename saved.
- **Editing the connected entry's connection settings drops the connection.** Address, auth mode, login, encryption, or a replaced password - the proven connection was against the OLD settings, and silently repointing the same object left every screen reporting a connection nobody tested. The status line says why and asks for a fresh connect. A rename alone keeps the connection: the caption names the address, which did not change.
- **The duplicate-name check runs on the edit path too**, excluding self - a rename onto an existing name made every display-text comparison in the app ambiguous between the two entries.
- The delete confirmation became an injectable seam (`ConfirmDelete`), because the dialog is the one step a headless test cannot click - which is what lets the lifecycle around it be pinned at all.

Five pins in `ServerLifecycleTests`. Suite 1,712 + 10 integration, Release `-warnaserror` clean.