### PR TITLE
The webhook settings tell the truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,14 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The webhook settings tell the truth** (#292). The Test button on an endpoint with all
+  three moments unticked - the natural way to pause one - now says it is subscribed to
+  nothing and will never fire during a run, instead of promising a channel that stays
+  silent forever. A URL typo is refused at Save with the reason on the row - it used to be
+  accepted and then fail on every run, with the failures visible only in the operation log.
+  And every delivery attempt, test or real, stamps the endpoint with when and how it went:
+  "Last delivery 2026-08-10 21:14: FAILED - 404" on the row is the difference between a
+  webhook that works and one that broke weeks ago and looked identical
 - **The connected server survives its own lifecycle honestly** (#291). Deleting it is
   recognised by identity, not by a caption captured at connect time - renaming the connected
   server and then deleting it used to leave the status bar claiming "Connected to X" while

--- a/src/NineLives.Core/Models/WebhookEndpoint.cs
+++ b/src/NineLives.Core/Models/WebhookEndpoint.cs
@@ -54,6 +54,16 @@ public class WebhookEndpoint
     /// <summary>It failed, was cancelled, or hit a problem mid-run.</summary>
     public bool NotifyProblems { get; set; } = true;
 
+    /// <summary>When the last delivery attempt happened - a test or a real run alike.</summary>
+    public DateTime? LastDeliveryAt { get; set; }
+
+    /// <summary>
+    /// "delivered", or the error text (#292). Delivery failures land only in the operation
+    /// log by design, so without this a webhook broken for weeks looked identical in
+    /// Settings to one that works.
+    /// </summary>
+    public string? LastDeliveryOutcome { get; set; }
+
     [JsonIgnore]
     public bool IsUsable => !string.IsNullOrWhiteSpace(Url);
 

--- a/src/NineLives.Core/Services/WebhookNotifier.cs
+++ b/src/NineLives.Core/Services/WebhookNotifier.cs
@@ -208,13 +208,18 @@ public class WebhookNotifier
     /// a measurable moment, and the only honest slow delivery in a test is a substituted one.
     /// </summary>
     public virtual async Task NotifyAsync(
-        IReadOnlyList<WebhookEndpoint> endpoints, RunNotification notification, Action<string>? log = null)
+        IReadOnlyList<WebhookEndpoint> endpoints, RunNotification notification,
+        Action<string>? log = null, Action<WebhookEndpoint, string?>? outcome = null)
     {
         foreach (var endpoint in endpoints)
         {
             if (!endpoint.IsUsable || !Wants(endpoint, notification.Phase)) continue;
 
             var error = await PostAsync(endpoint.Url, BuildPayload(endpoint.Format, notification));
+
+            // Per-endpoint, not per-batch (#292): the caller stamps each endpoint's last
+            // delivery, which is what makes a silently broken webhook visible in Settings.
+            outcome?.Invoke(endpoint, error);
 
             log?.Invoke(error == null
                 ? $"[notify] {endpoint.Name}: {notification.Phase} {notification.Operation} {notification.Subject}"

--- a/src/NineLives.Core/Services/WebhookRunNotifier.cs
+++ b/src/NineLives.Core/Services/WebhookRunNotifier.cs
@@ -63,15 +63,20 @@ public sealed class WebhookRunNotifier : IRunNotifier
                 // The injected notifier (tests) is used as-is; the real one is built per
                 // delivery with the configured transport (#316), so a proxy change in
                 // Settings applies to the very next send.
+                // The stamp makes silent breakage visible in Settings (#292): every
+                // attempt records when and how it went, per endpoint, test and run alike.
+                Action<WebhookEndpoint, string?> stamp =
+                    (endpoint, error) => WebhookTransport.RecordDelivery(_store, endpoint.Id, error);
+
                 if (_injected != null)
                 {
-                    await _injected.NotifyAsync(endpoints, notification, line => _log.Info(line));
+                    await _injected.NotifyAsync(endpoints, notification, line => _log.Info(line), stamp);
                 }
                 else
                 {
                     using var handler = WebhookTransport.BuildHandler(proxy, _store);
                     var notifier = new WebhookNotifier(handler);
-                    await notifier.NotifyAsync(endpoints, notification, line => _log.Info(line));
+                    await notifier.NotifyAsync(endpoints, notification, line => _log.Info(line), stamp);
                 }
             }
             catch (Exception ex)

--- a/src/NineLives.Core/Services/WebhookTransport.cs
+++ b/src/NineLives.Core/Services/WebhookTransport.cs
@@ -85,6 +85,29 @@ public static class WebhookTransport
         => ResolveUrl(endpoint, store) != null;
 
     /// <summary>
+    /// Records a delivery attempt's outcome against the endpoint (#292). Loaded fresh and
+    /// saved immediately, so the stamp lands on whatever the config has become since the
+    /// delivery started; a failed stamp is not a failed delivery, so it swallows.
+    /// </summary>
+    public static void RecordDelivery(ICredentialStore store, string endpointId, string? error)
+    {
+        try
+        {
+            var config = store.LoadConfig();
+            var target = config.Webhooks.FirstOrDefault(w => w.Id == endpointId);
+            if (target == null) return;
+
+            target.LastDeliveryAt = DateTime.Now;
+            target.LastDeliveryOutcome = error ?? "delivered";
+            store.SaveConfig(config);
+        }
+        catch
+        {
+            // The delivery already happened and is already logged; the stamp is bookkeeping.
+        }
+    }
+
+    /// <summary>
     /// Commits a URL as a secret (#317): into the vault, out of the file. After this the app
     /// never displays it again - replacing it means saving a new one, not reading this one.
     /// </summary>

--- a/src/NineLives.Tests/CliEndingsTests.cs
+++ b/src/NineLives.Tests/CliEndingsTests.cs
@@ -144,7 +144,7 @@ public class CliEndingsTests
 
         public override async Task NotifyAsync(
             IReadOnlyList<WebhookEndpoint> endpoints, RunNotification notification,
-            Action<string>? log = null)
+            Action<string>? log = null, Action<WebhookEndpoint, string?>? outcome = null)
         {
             await Task.Delay(250);
             Delivered = true;
@@ -155,7 +155,7 @@ public class CliEndingsTests
     {
         public override Task NotifyAsync(
             IReadOnlyList<WebhookEndpoint> endpoints, RunNotification notification,
-            Action<string>? log = null)
+            Action<string>? log = null, Action<WebhookEndpoint, string?>? outcome = null)
             => Task.Delay(Timeout.InfiniteTimeSpan);
     }
 }

--- a/src/NineLives.Tests/WebhookHonestyTests.cs
+++ b/src/NineLives.Tests/WebhookHonestyTests.cs
@@ -1,0 +1,195 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The webhook settings tell the truth (#292): a test against an endpoint subscribed to
+/// nothing says so instead of promising a channel that will stay silent forever; a URL typo
+/// is refused at save rather than accepted and failed on every run; and every delivery
+/// attempt stamps the endpoint, so silent breakage is visible on the row.
+/// </summary>
+public class WebhookHonestyTests
+{
+    private static WebhookEndpoint Endpoint(bool started = true, bool finished = true, bool problems = true) => new()
+    {
+        Name = "DBA channel",
+        NotifyStarted = started,
+        NotifyFinished = finished,
+        NotifyProblems = problems
+    };
+
+    // ── the test says when nothing is subscribed ────────────────────────────────
+
+    [Fact]
+    public void ATestAgainstASubscribedEndpointPromisesTheChannel()
+    {
+        var text = SettingsViewModel.DescribeTestOutcome("DBA channel", null, Endpoint());
+
+        Assert.Contains("check the channel", text);
+    }
+
+    /// <summary>
+    /// Unticking all three moments is the natural way to pause an endpoint - there is no
+    /// Enabled flag - and the plain "test sent" then promised a channel that would stay
+    /// silent forever.
+    /// </summary>
+    [Fact]
+    public void ATestAgainstAMutedEndpointSaysItWillNeverFire()
+    {
+        var text = SettingsViewModel.DescribeTestOutcome(
+            "DBA channel", null, Endpoint(started: false, finished: false, problems: false));
+
+        Assert.Contains("subscribed to nothing", text);
+        Assert.Contains("never fire", text);
+    }
+
+    [Fact]
+    public void AFailedTestReportsTheErrorNotTheSubscription()
+    {
+        var text = SettingsViewModel.DescribeTestOutcome(
+            "DBA channel", "404 NotFound", Endpoint(started: false, finished: false, problems: false));
+
+        Assert.Contains("404", text);
+        Assert.DoesNotContain("subscribed", text);
+    }
+
+    // ── the URL is validated at save (#292) ─────────────────────────────────────
+
+    private static WebhookEndpointViewModel Row(FakeCredentialStore store, WebhookEndpoint? model = null) =>
+        new(model ?? Endpoint(), store, () => { }, _ => Task.CompletedTask);
+
+    [Fact]
+    public void ATypoIsRefusedAtSaveWithTheReasonOnTheRow()
+    {
+        var store = new FakeCredentialStore();
+        var row = Row(store);
+
+        row.UrlInput = "htps://hooks.example/x";
+        row.SaveUrlCommand.Execute(null);
+
+        Assert.Contains("https://", row.UrlFeedback);
+        Assert.False(row.HasStoredUrl);
+        Assert.Equal("htps://hooks.example/x", row.UrlInput);   // still there to correct
+    }
+
+    [Fact]
+    public void PlainHttpIsRefusedTheSecretTravelsEncryptedOrNotAtAll()
+    {
+        var store = new FakeCredentialStore();
+        var row = Row(store);
+
+        row.UrlInput = "http://hooks.example/x";
+        row.SaveUrlCommand.Execute(null);
+
+        Assert.False(row.HasStoredUrl);
+        Assert.NotEmpty(row.UrlFeedback);
+    }
+
+    [Fact]
+    public void AValidUrlSavesAndClearsTheRefusal()
+    {
+        var store = new FakeCredentialStore();
+        var model = Endpoint();
+        var row = Row(store, model);
+
+        row.UrlInput = "htp://wrong";
+        row.SaveUrlCommand.Execute(null);
+        Assert.NotEmpty(row.UrlFeedback);
+
+        row.UrlInput = "https://hooks.example/services/T000/B000";
+        row.SaveUrlCommand.Execute(null);
+
+        Assert.True(row.HasStoredUrl);
+        Assert.Empty(row.UrlFeedback);
+        Assert.Empty(row.UrlInput);
+        Assert.Equal("https://hooks.example/services/T000/B000",
+            WebhookTransport.ResolveUrl(model, store));
+    }
+
+    // ── every attempt stamps the endpoint (#292) ────────────────────────────────
+
+    [Fact]
+    public void RecordDeliveryStampsTheEndpointInTheStore()
+    {
+        var store = new FakeCredentialStore();
+        var model = Endpoint();
+        store.Config.Webhooks.Add(model);
+
+        WebhookTransport.RecordDelivery(store, model.Id, null);
+
+        Assert.NotNull(model.LastDeliveryAt);
+        Assert.Equal("delivered", model.LastDeliveryOutcome);
+
+        WebhookTransport.RecordDelivery(store, model.Id, "410 Gone");
+        Assert.Equal("410 Gone", model.LastDeliveryOutcome);
+    }
+
+    [Fact]
+    public void AStampForAnUnknownEndpointIsANoOp()
+    {
+        var store = new FakeCredentialStore();
+
+        WebhookTransport.RecordDelivery(store, "gone", "whatever");
+
+        Assert.Empty(store.Config.Webhooks);
+    }
+
+    /// <summary>
+    /// The run notifier hands the notifier a stamp callback, and what the callback stamps is
+    /// the store - so real runs mark their endpoints exactly as the test button does.
+    /// </summary>
+    [Fact]
+    public async Task ARealRunsDeliveryStampsTheEndpoint()
+    {
+        var store = new FakeCredentialStore();
+        var model = Endpoint();
+        store.Config.Webhooks.Add(model);
+        WebhookTransport.SaveUrl(model, store, "https://hooks.example/x");
+
+        var notifier = new WebhookRunNotifier(store, TestLogs.Temp(), new StampingNotifier());
+        notifier.Notify(new RunNotification(RunPhase.Succeeded, "Restore", "MyDb", "SRV01"));
+        await notifier.DrainAsync(TimeSpan.FromSeconds(5));
+
+        Assert.NotNull(model.LastDeliveryAt);
+        Assert.Equal("delivered", model.LastDeliveryOutcome);
+    }
+
+    /// <summary>Invokes the outcome callback the way the real notifier does after a post.</summary>
+    private sealed class StampingNotifier : WebhookNotifier
+    {
+        public override Task NotifyAsync(
+            IReadOnlyList<WebhookEndpoint> endpoints, RunNotification notification,
+            Action<string>? log = null, Action<WebhookEndpoint, string?>? outcome = null)
+        {
+            foreach (var endpoint in endpoints)
+                outcome?.Invoke(endpoint, null);
+            return Task.CompletedTask;
+        }
+    }
+
+    // ── the row reads the stamp (#292) ──────────────────────────────────────────
+
+    [Fact]
+    public void TheRowSaysWhenNothingHasBeenDelivered()
+    {
+        var row = Row(new FakeCredentialStore());
+
+        Assert.Equal("No deliveries yet", row.LastDeliveryDisplay);
+    }
+
+    [Fact]
+    public void TheRowNamesTheLastOutcomeBothWays()
+    {
+        var store = new FakeCredentialStore();
+        var row = Row(store);
+
+        row.NoteDelivery(null);
+        Assert.Contains("delivered", row.LastDeliveryDisplay);
+
+        row.NoteDelivery("timed out");
+        Assert.Contains("FAILED - timed out", row.LastDeliveryDisplay);
+    }
+}

--- a/src/NineLives/Converters/ValueConverters.cs
+++ b/src/NineLives/Converters/ValueConverters.cs
@@ -73,6 +73,17 @@ public class BoolToVisibilityConverter : IValueConverter
         => value is Visibility v && v == Visibility.Visible;
 }
 
+/// <summary>Visible when the string has content - for feedback lines that appear only when
+/// there is something to say (#292).</summary>
+public class StringToVisibilityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => string.IsNullOrEmpty(value as string) ? Visibility.Collapsed : Visibility.Visible;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}
+
 public class InverseBoolConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -7,6 +7,7 @@
          was added to it. Views that still declare their own simply shadow this with an identical
          instance, so both work. -->
     <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+    <converters:StringToVisibilityConverter x:Key="StringToVis" />
     <converters:NullToVisibilityConverter x:Key="NullToVis" />
     <converters:ContrastingTextConverter x:Key="ContrastingText" />
 

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -136,9 +136,25 @@ public partial class SettingsViewModel : ViewModelBase
         using var handler = WebhookTransport.BuildHandler(
             _credentialStore.LoadConfig().WebhookProxy, _credentialStore);
         var error = await new WebhookNotifier(handler).SendTestAsync(hydrated);
-        WebhookTestResult = error == null
-            ? $"Test sent to {row.Name} - check the channel."
-            : $"{row.Name}: {error}";
+        WebhookTransport.RecordDelivery(_credentialStore, row.Model.Id, error);
+        row.NoteDelivery(error);
+        WebhookTestResult = DescribeTestOutcome(row.Name, error, row.Model);
+    }
+
+    /// <summary>
+    /// The sentence the test button produces (#292). The natural way to pause an endpoint is
+    /// unticking all three moments - there is no Enabled flag - and a plain "test sent" then
+    /// promised a channel that would stay silent forever.
+    /// </summary>
+    internal static string DescribeTestOutcome(string name, string? error, WebhookEndpoint model)
+    {
+        if (error != null) return $"{name}: {error}";
+
+        var listens = model.NotifyStarted || model.NotifyFinished || model.NotifyProblems;
+        return listens
+            ? $"Test sent to {name} - check the channel."
+            : $"Test sent to {name} - but it is subscribed to nothing (Started, Finished and " +
+              "Problems are all off), so it will never fire during a run.";
     }
 
     // ── moving machines (#213) ──────────────────────────────────────────────────

--- a/src/NineLives/ViewModels/WebhookEndpointViewModel.cs
+++ b/src/NineLives/ViewModels/WebhookEndpointViewModel.cs
@@ -41,6 +41,25 @@ public partial class WebhookEndpointViewModel : ObservableObject
 
     public WebhookEndpoint Model { get; }
 
+    /// <summary>
+    /// The last delivery attempt, on the row (#292). Failures land only in the operation log
+    /// by design, so without this a webhook broken for weeks looked identical to one that
+    /// works.
+    /// </summary>
+    public string LastDeliveryDisplay => Model.LastDeliveryAt is not { } at
+        ? "No deliveries yet"
+        : Model.LastDeliveryOutcome == "delivered"
+            ? $"Last delivery {at:yyyy-MM-dd HH:mm}: delivered"
+            : $"Last delivery {at:yyyy-MM-dd HH:mm}: FAILED - {Model.LastDeliveryOutcome}";
+
+    /// <summary>A delivery just happened on this screen - the row updates without a reload.</summary>
+    public void NoteDelivery(string? error)
+    {
+        Model.LastDeliveryAt = DateTime.Now;
+        Model.LastDeliveryOutcome = error ?? "delivered";
+        OnPropertyChanged(nameof(LastDeliveryDisplay));
+    }
+
     public IReadOnlyList<WebhookFormat> Formats { get; } =
         [WebhookFormat.Teams, WebhookFormat.Slack, WebhookFormat.Generic];
 
@@ -67,15 +86,31 @@ public partial class WebhookEndpointViewModel : ObservableObject
 
     public bool CanSaveUrl => !string.IsNullOrWhiteSpace(UrlInput);
 
+    /// <summary>Why the last URL save was refused - empty when it was not (#292).</summary>
+    [ObservableProperty]
+    private string _urlFeedback = string.Empty;
+
     /// <summary>
     /// The explicit commit (#317): into the vault, out of the file, off the screen. Also the
     /// migration path for URLs that predate the vault - saving a replacement moves the
     /// endpoint onto the new arrangement.
+    ///
+    /// Validated first (#292): a typo used to be accepted, saved, and then fail on every
+    /// run - with the failures landing only in the operation log.
     /// </summary>
     [RelayCommand(CanExecute = nameof(CanSaveUrl))]
     private void SaveUrl()
     {
-        WebhookTransport.SaveUrl(Model, _store, UrlInput);
+        var candidate = UrlInput.Trim();
+        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri) ||
+            uri.Scheme != Uri.UriSchemeHttps)
+        {
+            UrlFeedback = "Not saved: a webhook URL is an absolute https:// address.";
+            return;
+        }
+
+        UrlFeedback = string.Empty;
+        WebhookTransport.SaveUrl(Model, _store, candidate);
         UrlInput = string.Empty;
         HasStoredUrl = true;
         _save();

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -169,6 +169,16 @@
                                                             Style="{StaticResource SecondaryButton}"
                                                             Padding="10,5" Margin="6,0,0,0" />
                                                 </Grid>
+                                                <TextBlock Text="{Binding UrlFeedback}"
+                                                           Foreground="{StaticResource ErrorBrush}"
+                                                           FontSize="11"
+                                                           TextWrapping="Wrap"
+                                                           Margin="0,4,0,0"
+                                                           Visibility="{Binding UrlFeedback, Converter={StaticResource StringToVis}}" />
+                                                <TextBlock Text="{Binding LastDeliveryDisplay}"
+                                                           Style="{StaticResource SecondaryText}"
+                                                           FontSize="11"
+                                                           Margin="0,4,0,0" />
                                             </StackPanel>
                                             <Button Grid.Column="3" Content="Test"
                                                     Command="{Binding TestCommand}"


### PR DESCRIPTION
Closes #292.

- **The test names a muted endpoint.** `SendTestAsync` ignores the Wants flags by design (a test is a test), so an endpoint with all three moments unticked tested green and then stayed silent forever. The result line now says: sent, but subscribed to nothing - it will never fire during a run.
- **The URL is validated at Save.** `Uri.TryCreate` + https, refused with the reason beside the row (and the input kept for correcting). A typo used to be accepted into the vault and fail on every delivery, visibly only in the operation log.
- **Every delivery attempt stamps its endpoint.** `WebhookNotifier.NotifyAsync` reports per-endpoint outcomes to a callback; real runs (through `WebhookRunNotifier`) and the Settings test button both record via `WebhookTransport.RecordDelivery` - fresh-loaded, stamped by Id, saved - and the row shows "Last delivery 2026-08-10 21:14: delivered" or "FAILED - 404". Silent breakage is now a visible row state, not an operation-log archaeology exercise.

New `StringToVisibilityConverter` for the feedback line. Eleven pins in `WebhookHonestyTests`; rendered the refused-save and delivery-stamp row states. Suite 1,723 + 10 integration, Release `-warnaserror` clean.