### PR TITLE
Names cannot smuggle statements past the script's reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,14 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Names cannot smuggle statements past the person reading the script** (#294). sysname
+  permits control characters and line breaks, and the restore target is free text - a name
+  containing a newline used to terminate the generated script's header comment and hand the
+  remainder to the server as executable text. Header comments now flatten control
+  characters; everywhere else the name already travels as data. And names that came FROM
+  the server - the backup's database, the encryption certificate, an orphaned user - are
+  quoted exactly: a database genuinely named [Archive] stays [Archive] instead of
+  round-tripping through the typed-name unwrapping into a different database
 - **Three truths on the backup screen** (#293). The Agent-job handover names a backup job
   "NineLives backup ..." instead of introducing itself as a restore, and multi-select names
   all of it - "NineLives backup 3 databases" rather than an empty database in the

--- a/src/NineLives.Core/Services/BackupScriptGenerator.cs
+++ b/src/NineLives.Core/Services/BackupScriptGenerator.cs
@@ -34,7 +34,7 @@ public class BackupScriptGenerator
         sb.AppendLine("-- ============================================================");
         sb.AppendLine("-- Nine Lives - Generated Backup Script (Blackcat Data Solutions)");
         sb.AppendLine($"-- Generated: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
-        sb.AppendLine($"-- Database:  {options.DatabaseName}");
+        sb.AppendLine($"-- Database:  {TSql.CommentText(options.DatabaseName)}");
         sb.AppendLine($"-- Writing:   {options.Destinations.Count} file(s)");
         sb.AppendLine("-- ============================================================");
 
@@ -55,7 +55,8 @@ public class BackupScriptGenerator
 
     private static void AppendBackup(StringBuilder sb, BackupOptions options)
     {
-        sb.AppendLine($"BACKUP DATABASE {TSql.QuoteName(options.DatabaseName)}");
+        // Exact, not unwrapped (#294): this name came from the server's own database list.
+        sb.AppendLine($"BACKUP DATABASE {TSql.QuoteNameExact(options.DatabaseName)}");
         sb.AppendLine($"    TO {DeviceClause(options)}");
         sb.AppendLine($"    WITH {string.Join(", ", WithOptions(options))};");
         sb.AppendLine("GO");
@@ -92,7 +93,7 @@ public class BackupScriptGenerator
 
         if (!string.IsNullOrWhiteSpace(options.EncryptionCertificate))
             with.Add("ENCRYPTION (ALGORITHM = AES_256, " +
-                     $"SERVER CERTIFICATE = {TSql.QuoteName(options.EncryptionCertificate)})");
+                     $"SERVER CERTIFICATE = {TSql.QuoteNameExact(options.EncryptionCertificate)})");
 
         // FORMAT implies INIT, and naming both is noise at best. FORMAT also discards whatever the
         // media set already held, so it is never inferred - only ever asked for.

--- a/src/NineLives.Core/Services/PostRestoreAdvice.cs
+++ b/src/NineLives.Core/Services/PostRestoreAdvice.cs
@@ -56,10 +56,12 @@ public static class PostRestoreAdvice
     /// The fix for an orphaned user with a same-named login: remap the SID. This is the modern
     /// form of sp_change_users_login, which is deprecated and SQL-auth only.
     /// </summary>
+    // The user names came FROM the restored database (#294) - quoted exactly, or a user
+    // genuinely named [admin] would be re-attached as a different principal.
     public static RecoveryAction FixOrphan(string database, OrphanedUser user) => new(
         $"Re-attach user {user.Name} to the login of the same name",
         $"USE {TSql.QuoteName(database)}; " +
-        $"ALTER USER {TSql.QuoteName(user.Name)} WITH LOGIN = {TSql.QuoteName(user.Name)}",
+        $"ALTER USER {TSql.QuoteNameExact(user.Name)} WITH LOGIN = {TSql.QuoteNameExact(user.Name)}",
         "Points the database user at this server's login by rewriting its SID. The user keeps " +
         "every permission it had inside the database.");
 
@@ -70,9 +72,9 @@ public static class PostRestoreAdvice
     public static RecoveryAction ExplainUnmappableOrphan(string database, OrphanedUser user) => new(
         $"User {user.Name} has no matching login on this server",
         $"-- After creating the login:\n" +
-        $"-- CREATE LOGIN {TSql.QuoteName(user.Name)} WITH PASSWORD = '...';\n" +
+        $"-- CREATE LOGIN {TSql.CommentText(TSql.QuoteNameExact(user.Name))} WITH PASSWORD = '...';\n" +
         $"USE {TSql.QuoteName(database)}; " +
-        $"ALTER USER {TSql.QuoteName(user.Name)} WITH LOGIN = {TSql.QuoteName(user.Name)}",
+        $"ALTER USER {TSql.QuoteNameExact(user.Name)} WITH LOGIN = {TSql.QuoteNameExact(user.Name)}",
         "This server has no login of that name, so there is nothing to re-attach the user to. " +
         "Create the login first - with a password set by whoever owns that account, not invented " +
         "here - then the ALTER USER line maps the user onto it.",

--- a/src/NineLives.Core/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives.Core/Services/RestoreScriptGenerator.cs
@@ -46,8 +46,8 @@ public class RestoreScriptGenerator
         sb.AppendLine("-- ============================================================");
         sb.AppendLine("-- Nine Lives - Generated Restore Script (Blackcat Data Solutions)");
         sb.AppendLine($"-- Generated: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
-        sb.AppendLine($"-- Target Database: {options.TargetDatabaseName}");
-        sb.AppendLine($"-- Restore Chain: {chain.Summary}");
+        sb.AppendLine($"-- Target Database: {TSql.CommentText(options.TargetDatabaseName)}");
+        sb.AppendLine($"-- Restore Chain: {TSql.CommentText(chain.Summary)}");
         if (options.StopAt.HasValue)
             sb.AppendLine($"-- Point-in-Time: {options.StopAt.Value:yyyy-MM-dd HH:mm:ss}");
         sb.AppendLine("-- ============================================================");

--- a/src/NineLives.Core/Services/TSql.cs
+++ b/src/NineLives.Core/Services/TSql.cs
@@ -43,6 +43,32 @@ public static class TSql
     public static string UnquoteName(string? name) => Unwrap(name);
 
     /// <summary>
+    /// Quotes an identifier that came FROM the server exactly as it is (#294).
+    /// <see cref="QuoteName"/>'s bracket unwrapping is right for TYPED names - somebody typing
+    /// [My Db] means My Db - but a database genuinely named [Archive] (sys.databases says so)
+    /// must round-trip as [[Archive]]], not silently become a different database.
+    /// </summary>
+    public static string QuoteNameExact(string? name) =>
+        $"[{(name ?? string.Empty).Replace("]", "]]")}]";
+
+    /// <summary>
+    /// A value about to be interpolated into a <c>--</c> comment (#294). sysname permits
+    /// control characters and line breaks, and a name containing a newline would terminate
+    /// the comment and hand the rest of the line to the server as executable text - breaking
+    /// the read-the-script-before-it-runs property every screen rests on. Control characters
+    /// become spaces: the comment describes; the statements below quote properly.
+    /// </summary>
+    public static string CommentText(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return string.Empty;
+
+        var sb = new System.Text.StringBuilder(value.Length);
+        foreach (var c in value)
+            sb.Append(char.IsControl(c) ? ' ' : c);
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Rejects identifiers that cannot be safely quoted. Bracket doubling handles <c>]</c>, but
     /// control characters and line breaks have no business in a credential or database name and
     /// would let a value smuggle statement structure past a human reading the generated script.

--- a/src/NineLives.Tests/ScriptHygieneTests.cs
+++ b/src/NineLives.Tests/ScriptHygieneTests.cs
@@ -1,0 +1,105 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Names cannot smuggle statements past the person reading the script (#294). sysname permits
+/// control characters and line breaks, and the restore target is free text - so a name
+/// containing a newline used to terminate a header comment and hand the remainder to the
+/// server as executable text, breaking the read-the-script-before-it-runs property every
+/// screen rests on. And names that came FROM the server are quoted exactly: QuoteName's
+/// bracket unwrapping is for what people TYPE.
+/// </summary>
+public class ScriptHygieneTests
+{
+    // ── comments describe, they do not execute ──────────────────────────────────
+
+    [Fact]
+    public void CommentTextFlattensControlCharacters()
+    {
+        Assert.Equal("MyDb  DROP DATABASE x", TSql.CommentText("MyDb\r\nDROP DATABASE x"));
+        Assert.Equal("tab here", TSql.CommentText("tab\there"));
+        Assert.Equal(string.Empty, TSql.CommentText(null));
+    }
+
+    [Fact]
+    public void ANewlineInTheRestoreTargetCannotEscapeTheHeaderComment()
+    {
+        var chain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                DatabaseName = "MyDb",
+                Type = BackupType.Full,
+                Timestamp = new DateTime(2026, 8, 1, 22, 0, 0),
+                Files = [new BackupFileInfo
+                {
+                    BlobName = "FULL/SRV01/MyDb/20260801_220000.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/20260801_220000.bak",
+                    Type = BackupType.Full
+                }]
+            }
+        };
+        var script = new RestoreScriptGenerator().Generate(chain, new RestoreOptions
+        {
+            TargetDatabaseName = "MyDb\nDROP DATABASE [Payroll]--"
+        });
+
+        // The header names the target on ONE commented line - the newline became a space.
+        Assert.Contains("-- Target Database: MyDb DROP DATABASE [Payroll]--", script);
+
+        // Everywhere else the name travels as DATA: inside DB_ID's string literal and inside
+        // a bracketed identifier, where a newline is legal and inert. The hostile text never
+        // stands alone as a statement.
+        Assert.Contains("DB_ID('MyDb\nDROP DATABASE [Payroll]--')", script);
+        Assert.Contains("SET SINGLE_USER", script);
+    }
+
+    [Fact]
+    public void ANewlineInTheBackupDatabaseNameCannotEscapeTheHeaderComment()
+    {
+        var script = new BackupScriptGenerator().Generate(new BackupOptions
+        {
+            DatabaseName = "MyDb\nGO\nDROP DATABASE [Payroll]",
+            Destinations = [@"\\nas01\sql\MyDb.bak"],
+            Medium = BackupMedium.SharedPath
+        });
+
+        Assert.Contains("-- Database:  MyDb GO DROP DATABASE [Payroll]", script);
+    }
+
+    // ── server-sourced names are quoted exactly (#294) ──────────────────────────
+
+    [Fact]
+    public void QuoteNameExactRoundTripsANameThatLooksQuoted()
+    {
+        // Typed [My Db] means My Db - QuoteName unwraps. A database GENUINELY named
+        // [Archive] must not become a different database on the way through.
+        Assert.Equal("[My Db]", TSql.QuoteName("[My Db]"));
+        Assert.Equal("[[Archive]]]", TSql.QuoteNameExact("[Archive]"));
+        Assert.Equal("[Plain]", TSql.QuoteNameExact("Plain"));
+    }
+
+    [Fact]
+    public void ABackupOfABracketNamedDatabaseTargetsTheRightDatabase()
+    {
+        var script = new BackupScriptGenerator().Generate(new BackupOptions
+        {
+            DatabaseName = "[Archive]",
+            Destinations = [@"\\nas01\sql\Archive.bak"],
+            Medium = BackupMedium.SharedPath
+        });
+
+        Assert.Contains("BACKUP DATABASE [[Archive]]]", script);
+    }
+
+    [Fact]
+    public void TheOrphanFixQuotesTheDatabasesOwnUserExactly()
+    {
+        var action = PostRestoreAdvice.FixOrphan("MyDb", new OrphanedUser("[svc]", HasSameNamedLogin: true));
+
+        Assert.Contains("ALTER USER [[svc]]] WITH LOGIN = [[svc]]]", action.Sql);
+    }
+}


### PR DESCRIPTION
Closes #294.

- **Header comments flatten control characters.** `TSql.CommentText` turns control characters into spaces before a name is interpolated into a `--` header line - a restore target containing a newline used to terminate the comment and hand the rest of the name to the server as executable text, breaking the read-the-script-before-it-runs property. Everywhere else the name already travels as data (inside `DB_ID('...')` literals and bracketed identifiers, where a newline is legal and inert) - now pinned.
- **Server-sourced names are quoted exactly.** `TSql.QuoteNameExact` quotes without the typed-name bracket unwrapping: the backup's database (from the server's own list), the encryption certificate, and orphaned users (from the restored database) round-trip exactly - a database genuinely named `[Archive]` becomes `[[Archive]]]`, not a different database called `Archive`. `QuoteName` stays for what people type.

Six pins in `ScriptHygieneTests` covering the flattening, both generators' headers, the exact-quote round-trip, and the orphan fix. Suite 1,731 + 10 integration, Release `-warnaserror` clean.