### PR TITLE
The CLI checks the restore fits before anything is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,13 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The CLI checks the restore fits before anything is dropped** (#297). The preflight
+  ladder's fifth rung: FILELISTONLY sizes against the target's own free space, per volume,
+  judged by the same check the app uses - including the volume the target does not have at
+  all, which is a MOVE problem rather than a free-space problem. Space is evidence, so
+  --force downgrades the refusal to a loud warning; the shortfall is named either way. The
+  CLI is the front end most often aimed at a freshly provisioned VM with small disks, and a
+  restore that runs out of disk fails AFTER WITH REPLACE has dropped what it was replacing
 - **Every run closes on the channel** (#295). A failed SINGLE-database backup now sends the
   close of the run with its duration, exactly as the multi-database path always has - the
   channel used to hear "Started" and then silence forever, which teaches people the channel

--- a/src/NineLives.Cli/Preflights.cs
+++ b/src/NineLives.Cli/Preflights.cs
@@ -67,6 +67,27 @@ internal static class Preflights
             .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
             .ToList();
 
+        // 5. Will it physically fit (#297)? The GUI checks before WITH REPLACE drops
+        // anything, and this front end is the one most often aimed at a freshly provisioned
+        // VM with small disks. FILELISTONLY says how big each file lands, the target says
+        // what each volume has, RestoreSpaceCheck judges - including the volume that does
+        // not exist on the target at all. Best effort both ways: not being able to check is
+        // not the same as not fitting.
+        try
+        {
+            var files = await services.Sql.RestoreFileListOnlyAsync(target, devices);
+            if (files.Count > 0)
+            {
+                var free = await services.Sql.GetVolumeFreeSpaceAsync(target);
+                foreach (var volume in RestoreSpaceCheck.Check(files, free).Where(v => !v.Fits))
+                    Verdict(volume.Describe);
+            }
+        }
+        catch
+        {
+            // No verdict from silence.
+        }
+
         BackupFileInfo? header;
         try
         {

--- a/src/NineLives.Tests/CliExecuteVerbTests.cs
+++ b/src/NineLives.Tests/CliExecuteVerbTests.cs
@@ -315,4 +315,82 @@ public class CliExecuteVerbTests
         Assert.Contains("retained", errors);
         Assert.Equal("Rehearsal", Assert.Single(history.Entries).Kind);
     }
+
+    // ── the restore must physically fit (#297) ──────────────────────────────────
+
+    private static FileMoveOption DataFile(string path, long size) => new()
+    {
+        LogicalName = "MyDb",
+        PhysicalName = path,
+        NewPhysicalName = path,
+        Type = "D",
+        SizeBytes = size
+    };
+
+    [Fact]
+    public async Task ARestoreThatCannotFitIsRefusedWithTheShortfallNamed()
+    {
+        var (services, sql, history, _) = Stage(Full(100, T0));
+        sql.FileList = [DataFile(@"D:\Data\MyDb.mdf", 100L * 1024 * 1024 * 1024)];
+        sql.VolumeFreeSpace = new() { [@"D:\"] = 10L * 1024 * 1024 * 1024 };
+
+        var (exit, _, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs("--execute"), services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("short by", errors);
+        Assert.Empty(sql.ExecutedScripts);
+        Assert.Empty(history.Entries);
+    }
+
+    /// <summary>Space is evidence, not consent - --force may override it, loudly.</summary>
+    [Fact]
+    public async Task ForceDowngradesTheSpaceRefusalToAWarningAndProceeds()
+    {
+        var (services, sql, history, _) = Stage(Full(100, T0));
+        sql.FileList = [DataFile(@"D:\Data\MyDb.mdf", 100L * 1024 * 1024 * 1024)];
+        sql.VolumeFreeSpace = new() { [@"D:\"] = 10L * 1024 * 1024 * 1024 };
+
+        var (exit, _, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs("--execute", "--force"), services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("--force: proceeding anyway", errors);
+        Assert.NotEmpty(sql.ExecutedScripts);
+        Assert.Single(history.Entries);
+    }
+
+    /// <summary>
+    /// dm_os_volume_stats only reports volumes that host database files, so an absent volume
+    /// usually means the drive does not exist there - a different fix than freeing space.
+    /// </summary>
+    [Fact]
+    public async Task AMissingVolumeIsRefusedAsAbsentNotAsFull()
+    {
+        var (services, sql, _, _) = Stage(Full(100, T0));
+        sql.FileList = [DataFile(@"D:\Data\MyDb.mdf", 1024)];
+        sql.VolumeFreeSpace = new() { [@"C:\"] = 500L * 1024 * 1024 * 1024 };
+
+        var (exit, _, errors) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs("--execute"), services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains(@"no D:\ volume", errors);
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    /// <summary>Not being able to check is not the same as not fitting.</summary>
+    [Fact]
+    public async Task AnUnanswerableSpaceQuestionRefusesNothing()
+    {
+        var (services, sql, history, _) = Stage(Full(100, T0));
+        sql.FileList = [DataFile(@"D:\Data\MyDb.mdf", 100L * 1024 * 1024 * 1024)];
+        sql.VolumeCheckThrows = new InvalidOperationException("VIEW SERVER STATE denied");
+
+        var (exit, _, _) = await Run(
+            RestoreVerb.RunAsync, RestoreVerb.Spec, RestoreArgs("--execute"), services);
+
+        Assert.Equal(0, exit);
+        Assert.Single(history.Entries);
+    }
 }


### PR DESCRIPTION
Closes #297.

The fifth rung of the CLI's preflight ladder, from the same Core machinery the app uses: `RestoreFileListOnlyAsync` sizes on the target, `GetVolumeFreeSpaceAsync` from the target's own `dm_os_volume_stats`, judged per volume by `RestoreSpaceCheck` - four 10 GB files on one drive are 40 GB there, and a volume the target never reported is surfaced as ABSENT (a MOVE-clause problem) rather than as full (a free-space problem).

Space is evidence, so `--force` downgrades the refusal to a loud warning with the shortfall still named - unlike WITH REPLACE consent, which no flag substitutes for. Not being able to check produces no verdict: an instance that refuses VIEW SERVER STATE must not block a restore that is probably fine.

Four pins: the shortfall-named refusal, the --force downgrade (run proceeds, warning loud), absent-volume-as-absent, and no-verdict-from-silence. Suite 1,740 + 10 integration, Release `-warnaserror` clean.