### PR TITLE
Two processes cannot lose each other's receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,13 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Two processes cannot lose each other's receipts** (#298). The restore history's
+  read-modify-write was serialised in-process only - and the CLI made it two processes: a
+  scheduled 9lives rehearse writing its receipt while the app is open was a race where the
+  last writer silently dropped the other's entry, and the receipt that vanished is the
+  proof the rehearsal existed - the exact thing the Proven column reads. Writers now hold a
+  sidecar lock file across the read-modify-write, queueing in a short retry loop instead of
+  clobbering; the lock deletes itself on close, so a crash cannot orphan it
 - **The CLI checks the restore fits before anything is dropped** (#297). The preflight
   ladder's fifth rung: FILELISTONLY sizes against the target's own free space, per volume,
   judged by the same check the app uses - including the volume the target does not have at

--- a/src/NineLives.Core/Services/RestoreHistoryStore.cs
+++ b/src/NineLives.Core/Services/RestoreHistoryStore.cs
@@ -40,6 +40,45 @@ public sealed class RestoreHistoryStore : IRestoreHistoryStore
     private readonly string _path;
     private readonly object _gate = new();
 
+    /// <summary>
+    /// Serialises writers ACROSS processes (#298). The in-process gate was correct for one
+    /// process, but the CLI made it two: a scheduled 9lives rehearse writing its receipt
+    /// while the app is open is a read-modify-write race where the last writer silently
+    /// drops the other's entry - and the receipt that vanishes is the proof the rehearsal
+    /// existed, the exact thing the exposure dashboard's Proven column reads.
+    ///
+    /// A sidecar .lock file held with FileShare.None; DeleteOnClose so a crash cannot
+    /// orphan it. Writers queue in a short retry loop. After the timeout the write proceeds
+    /// WITHOUT the lock: the overlap window is milliseconds, and losing this entry for
+    /// certain is worse than the small chance of the race the lock exists to close.
+    /// </summary>
+    private FileStream? AcquireCrossProcessLock()
+    {
+        var directory = Path.GetDirectoryName(_path)!;
+        Directory.CreateDirectory(directory);
+        var lockPath = _path + ".lock";
+
+        for (var attempt = 0; attempt < 40; attempt++)
+        {
+            try
+            {
+                return new FileStream(
+                    lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None,
+                    bufferSize: 1, FileOptions.DeleteOnClose);
+            }
+            catch (IOException)
+            {
+                Thread.Sleep(50);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Thread.Sleep(50);
+            }
+        }
+
+        return null;
+    }
+
     public RestoreHistoryStore() : this(Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "NineLives"))
@@ -65,6 +104,8 @@ public sealed class RestoreHistoryStore : IRestoreHistoryStore
         {
             lock (_gate)
             {
+                using var crossProcess = AcquireCrossProcessLock();
+
                 var existing = ReadUnlocked();
 
                 // Null means the file is there and could not be read. Appending to an empty list
@@ -96,7 +137,11 @@ public sealed class RestoreHistoryStore : IRestoreHistoryStore
     {
         try
         {
-            lock (_gate) { WriteUnlocked([]); }
+            lock (_gate)
+            {
+                using var crossProcess = AcquireCrossProcessLock();
+                WriteUnlocked([]);
+            }
         }
         catch
         {

--- a/src/NineLives.Tests/RestoreHistoryTests.cs
+++ b/src/NineLives.Tests/RestoreHistoryTests.cs
@@ -229,6 +229,64 @@ public class RestoreHistoryTests : IDisposable
         Assert.False(vm.IsClearArmed);
         Assert.Single(store.Load());
     }
+
+    // ── two processes, one file (#298) ──────────────────────────────────────────
+
+    /// <summary>
+    /// The CLI made this two-process: a scheduled 9lives rehearse writes its receipt while
+    /// the app is open. Two stores on one path are two processes in miniature - separate
+    /// in-process gates, same file - and last-writer-wins used to silently drop entries.
+    /// </summary>
+    [Fact]
+    public async Task TwoWritersOnOnePathLoseNothing()
+    {
+        var a = Store();
+        var b = Store();
+
+        var writes = new List<Task>();
+        for (var i = 0; i < 25; i++)
+        {
+            var n = i;
+            writes.Add(Task.Run(() => a.Append(Entry($"FromA_{n}"))));
+            writes.Add(Task.Run(() => b.Append(Entry($"FromB_{n}"))));
+        }
+        await Task.WhenAll(writes);
+
+        var all = Store().Load();
+        Assert.Equal(50, all.Count);
+        for (var i = 0; i < 25; i++)
+        {
+            Assert.Contains(all, e => e.TargetDatabase == $"FromA_{i}");
+            Assert.Contains(all, e => e.TargetDatabase == $"FromB_{i}");
+        }
+    }
+
+    /// <summary>A writer waits for the holder instead of clobbering - and then lands.</summary>
+    [Fact]
+    public async Task AWriterQueuesBehindTheLockHolderAndStillLands()
+    {
+        var store = Store();
+        store.Append(Entry("First"));
+
+        var lockPath = Path.Combine(_dir, "restore-history.json.lock");
+
+        // Another process, in miniature: hold the sidecar exclusively, release shortly after.
+        var holder = new FileStream(
+            lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+
+        var append = Task.Run(() => store.Append(Entry("Second")));
+
+        // The append is retrying against the held lock - not lost, not clobbering.
+        await Task.Delay(200);
+        Assert.False(append.IsCompleted);
+
+        holder.Dispose();
+        await append;
+
+        var all = Store().Load();
+        Assert.Equal(2, all.Count);
+        Assert.Contains(all, e => e.TargetDatabase == "Second");
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #298.

`RestoreHistoryStore`'s read-modify-write was serialised in-process only; the CLI made it two processes, and a scheduled `9lives rehearse` writing its receipt while the app is open (or two CLI runs overlapping) was last-writer-wins - the dropped receipt being the proof the rehearsal existed, exactly what the exposure dashboard's Proven column reads.

Writers now acquire a sidecar `.lock` file with `FileShare.None` around the load-modify-save (Append and Clear), retrying every 50ms for 2s so concurrent writers queue instead of clobbering. `DeleteOnClose` means a crash cannot orphan the lock. If the lock cannot be had after the window, the write proceeds without it - losing the entry for certain is worse than the millisecond-wide race the lock exists to close.

Two pins: fifty concurrent appends from two independent stores on one path lose nothing; a writer visibly queues behind an externally held lock and still lands. Suite 1,742 + 10 integration, Release `-warnaserror` clean.