### PR TITLE
The CLI restore relocates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **The CLI restore relocates** (#299): `--relocate` moves every file to the target's own
+  default data and log directories keeping its original name, and `--data-path` /
+  `--log-path` place them explicitly - mirroring the app's WITH MOVE control. The freshly
+  provisioned VM rarely has the source server's drive layout, and the recorded paths used
+  to fail with directory-not-found mid-run, after WITH REPLACE had already dropped the
+  target. With relocation in play the disk-space preflight judges the volumes the files
+  actually LAND on. The three-line Terraform template now survives any VM shape
+
 - Rehearsal notifications now name the database being PROVEN rather than the scratch copy it
   was proven on - "Rehearsal MyDb", not "Rehearsal MyDb_rehearsal_20260810_0930"
 - The Exposure dashboard sweeps itself on first visit - arriving at an empty screen that needs a

--- a/src/NineLives.Cli/Preflights.cs
+++ b/src/NineLives.Cli/Preflights.cs
@@ -24,7 +24,8 @@ internal static class Preflights
     /// </summary>
     public static async Task<Result> RunAsync(
         CliServices services, ServerConnection target, BackupChain chain,
-        string targetDatabase, bool withReplace, bool force)
+        string targetDatabase, bool withReplace, bool force,
+        IReadOnlyList<FileMoveOption>? fileMoves = null)
     {
         var refusals = new List<string>();
         var warnings = new List<string>();
@@ -75,7 +76,10 @@ internal static class Preflights
         // not the same as not fitting.
         try
         {
-            var files = await services.Sql.RestoreFileListOnlyAsync(target, devices);
+            // With relocation in play the caller already knows where each file LANDS - the
+            // moves are the truth to check, not the recorded paths (#299).
+            var files = (IReadOnlyList<FileMoveOption>?)fileMoves
+                        ?? await services.Sql.RestoreFileListOnlyAsync(target, devices);
             if (files.Count > 0)
             {
                 var free = await services.Sql.GetVolumeFreeSpaceAsync(target);

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -22,10 +22,11 @@ internal static class RestoreVerb
         "Generate, and with --execute run, a restore against a target server",
         "9lives restore (--container NAME | --server NAME) --database DB --target SERVER " +
         "[--at \"yyyy-MM-dd HH:mm:ss\"] [--target-database NAME] [--with-replace] [--norecovery] " +
+        "[--relocate | --data-path DIR [--log-path DIR]] " +
         "[--stop-before-mark NAME | --stop-at-mark NAME] [--execute] [--force]",
         Valued: ["container", "server", "database", "at", "target", "target-database",
-                 "stop-before-mark", "stop-at-mark"],
-        Switches: ["execute", "with-replace", "norecovery", "force"],
+                 "stop-before-mark", "stop-at-mark", "data-path", "log-path"],
+        Switches: ["execute", "with-replace", "norecovery", "force", "relocate"],
         Options:
         [
             ("--container NAME", "A blob container configured in the app, as the source."),
@@ -40,6 +41,13 @@ internal static class RestoreVerb
                 "from anywhere, never implied by --force - this flag is the only way to " +
                 "mean it."),
             ("--norecovery", "Leave the database restoring, ready for more log."),
+            ("--relocate", "MOVE every file to the target's default data and log " +
+                "directories, keeping the original file names. The freshly provisioned VM " +
+                "rarely has the source server's drive layout."),
+            ("--data-path DIR", "MOVE data files into this directory (log files follow " +
+                "--log-path, or the target's default log directory). Implies relocation."),
+            ("--log-path DIR", "MOVE log files into this directory. Implies relocation; " +
+                "data files follow --data-path, or the target's default data directory."),
             ("--stop-before-mark NAME", "Stop just before the named marked transaction."),
             ("--stop-at-mark NAME", "Stop at the mark, inclusive."),
             ("--execute", "Actually run it. Without this, the script and every preflight " +
@@ -67,9 +75,13 @@ internal static class RestoreVerb
             "the app's History screen lists - script, console log, outcome, duration - and " +
             "notifications to the same webhooks. A 3am restore from a runbook step looks " +
             "exactly like a clicked one afterwards.",
-            "Files restore to the paths recorded in the backup. Relocation flags are not " +
-            "built yet - the rehearse verb relocates automatically, and the app's restore " +
-            "screen has full WITH MOVE control."
+            "Files restore to the paths recorded in the backup unless relocation is " +
+            "asked for. --relocate moves every file to the target's default data and log " +
+            "directories keeping its original name; --data-path and --log-path place them " +
+            "explicitly, mirroring the app's WITH MOVE control. Either way the disk-space " +
+            "preflight judges the volumes the files actually LAND on - and a freshly " +
+            "provisioned VM whose drives differ from the source server's is exactly where " +
+            "the recorded paths would have failed mid-run."
         ],
         ExitCodes:
         [
@@ -86,7 +98,10 @@ internal static class RestoreVerb
             ("9lives restore --container backups --database Sales --target SRV02 --with-replace --execute",
                 "the real thing, consented to explicitly"),
             ("9lives restore --server SRV01 --database Sales --target SRV02 --at \"2026-08-02 19:00\" --execute",
-                "a moment mid-log, STOPAT stamped on every log restore")
+                "a moment mid-log, STOPAT stamped on every log restore"),
+            ("9lives restore --container backups --database Sales --target SRV02 --relocate --with-replace --execute",
+                "the provisioning shape: files land in the new VM's own data and log " +
+                "directories, whatever its drives are")
         ]);
 
     public static async Task<int> RunAsync(
@@ -156,6 +171,44 @@ internal static class RestoreVerb
         var targetDatabase = args.Get("target-database") ?? sourceDatabase;
         var withReplace = args.Has("with-replace");
 
+        // Relocation (#299): the Terraform case. A freshly provisioned VM rarely has the
+        // source server's drive layout, and the recorded paths fail mid-run with
+        // directory-not-found - after WITH REPLACE has already dropped the target. The
+        // rehearse verb has always relocated; the restore verb, the one the template
+        // actually ends with, now can. Explicit directories win; either side not given
+        // falls back to the target's own defaults.
+        List<FileMoveOption>? moves = null;
+        if (args.Has("relocate") || args.Get("data-path") != null || args.Get("log-path") != null)
+        {
+            var moveDevices = chain.FullSet.Files
+                .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+                .ToList();
+
+            List<FileMoveOption> logicalFiles;
+            try
+            {
+                logicalFiles = await services.Sql.RestoreFileListOnlyAsync(target, moveDevices, ct);
+            }
+            catch (Exception ex)
+            {
+                errors.WriteLine($"Could not read the backup's file list from " +
+                                 $"{target.ServerName}, which relocation needs: {ex.Message}");
+                return ExitCodes.CouldNotAnswer;
+            }
+
+            var dataDir = args.Get("data-path");
+            var logDir = args.Get("log-path");
+            if (dataDir == null || logDir == null)
+            {
+                var (defaultData, defaultLog) = await services.Sql.GetDefaultPathsAsync(target, ct);
+                dataDir ??= defaultData;
+                logDir ??= defaultLog;
+            }
+
+            moves = RestoreRelocation.ToDirectories(logicalFiles, dataDir, logDir);
+            errors.WriteLine($"Relocating {moves.Count} file(s): data to {dataDir}, log to {logDir}.");
+        }
+
         var script = new RestoreScriptGenerator().Generate(chain, new RestoreOptions
         {
             TargetDatabaseName = targetDatabase,
@@ -163,13 +216,15 @@ internal static class RestoreVerb
             RecoveryMode = args.Has("norecovery") ? RecoveryMode.NoRecovery : RecoveryMode.Recovery,
             StopAt = stopAt,
             StopAtMark = mark,
-            StopBeforeMark = markAt == null
+            StopBeforeMark = markAt == null,
+            FileMoves = moves ?? []
         });
 
         // The preflights run whether or not this is an --execute: a generate-only invocation
         // that says "this WOULD be refused" is the pipeline's cheap rehearsal of its own DR step.
+        // With relocation, the space check judges the volumes the files actually LAND on.
         var preflight = await Preflights.RunAsync(
-            services, target, chain, targetDatabase, withReplace, args.Has("force"));
+            services, target, chain, targetDatabase, withReplace, args.Has("force"), moves);
 
         errors.WriteLine($"Chain: {point.TypeDisplay} reaching " +
                          $"{(stopAt ?? point.Timestamp):yyyy-MM-dd HH:mm:ss}, restoring " +

--- a/src/NineLives.Core/Services/RestoreRelocation.cs
+++ b/src/NineLives.Core/Services/RestoreRelocation.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Moves a restore's files into chosen directories while keeping their names (#299).
+///
+/// The Terraform case: a freshly provisioned VM's drive layout routinely differs from the
+/// source server's, and a restore aimed at the recorded paths fails with directory-not-found
+/// mid-run. The rehearsal already relocates - to scratch NAMES, because its copy is
+/// disposable. A real restore keeps the original file names; only the directories change.
+/// </summary>
+public static class RestoreRelocation
+{
+    /// <summary>
+    /// One MOVE per logical file: rows into <paramref name="dataPath"/>, log into
+    /// <paramref name="logPath"/>, each keeping its original file name. Two source files
+    /// that share a name (different source directories) are disambiguated with a numeric
+    /// suffix rather than silently landing on one another.
+    /// </summary>
+    public static List<FileMoveOption> ToDirectories(
+        IReadOnlyList<FileMoveOption> logicalFiles, string dataPath, string logPath)
+    {
+        var moves = new List<FileMoveOption>();
+        var taken = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in logicalFiles)
+        {
+            var isLog = string.Equals(file.Type, "L", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(file.Type, "LOG", StringComparison.OrdinalIgnoreCase);
+            var directory = isLog ? logPath : dataPath;
+
+            var name = Path.GetFileName(file.PhysicalName);
+            if (string.IsNullOrWhiteSpace(name))
+                name = file.LogicalName + (isLog ? ".ldf" : ".mdf");
+
+            var candidate = Path.Combine(directory, name);
+            for (var n = 2; !taken.Add(candidate); n++)
+                candidate = Path.Combine(directory,
+                    $"{Path.GetFileNameWithoutExtension(name)}_{n}{Path.GetExtension(name)}");
+
+            moves.Add(new FileMoveOption
+            {
+                LogicalName = file.LogicalName,
+                PhysicalName = file.PhysicalName,
+                Type = file.Type,
+                SizeBytes = file.SizeBytes,
+                NewPhysicalName = candidate
+            });
+        }
+
+        return moves;
+    }
+}

--- a/src/NineLives.Tests/CliRelocationTests.cs
+++ b/src/NineLives.Tests/CliRelocationTests.cs
@@ -1,0 +1,150 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Relocation: the Terraform case (#299). A freshly provisioned VM rarely has the source
+/// server's drive layout, and a restore aimed at the recorded paths fails with
+/// directory-not-found mid-run - after WITH REPLACE has dropped what it was replacing. The
+/// rehearse verb has always relocated; the restore verb, the one the template actually ends
+/// with, now can - and with relocation in play the space preflight judges the volumes the
+/// files actually LAND on.
+/// </summary>
+public class CliRelocationTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static (CliServices services, FakeSqlServerService sql) Stage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "MyDb",
+                    Type = BackupType.Full,
+                    StartedAt = T0,
+                    FinishedAt = T0.AddMinutes(5),
+                    CheckpointLsn = 100,
+                    Position = 1,
+                    Files = [@"X:\backups\full.bak"]
+                }
+            ]
+        };
+        var services = new CliServices(
+            store, sql, new FakeBlobStorageService(), new FakeRestoreHistoryStore(),
+            new FakeRunNotifier());
+        return (services, sql);
+    }
+
+    private static FileMoveOption LogicalFile(string logical, string path, string type, long size = 1024) => new()
+    {
+        LogicalName = logical,
+        PhysicalName = path,
+        NewPhysicalName = path,
+        Type = type,
+        SizeBytes = size
+    };
+
+    private static async Task<(int exit, string output, string errors)> Run(
+        string[] args, CliServices services)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await RestoreVerb.RunAsync(
+            CliArguments.Parse(args, RestoreVerb.Spec), services, output, errors);
+        return (exit, output.ToString(), errors.ToString());
+    }
+
+    private static string[] Args(params string[] extra) =>
+        [.. new[] { "--server", "SRV01", "--database", "MyDb", "--target", "SRV02" }, .. extra];
+
+    [Fact]
+    public async Task RelocateMovesEveryFileToTheTargetsDefaultsKeepingItsName()
+    {
+        var (services, sql) = Stage();
+        sql.FileList =
+        [
+            LogicalFile("MyDb", @"E:\SourceData\MyDb.mdf", "D"),
+            LogicalFile("MyDb_log", @"F:\SourceLogs\MyDb_log.ldf", "L")
+        ];
+        sql.VolumeFreeSpace = new() { [@"D:\"] = 500L * 1024 * 1024 * 1024 };
+
+        var (exit, output, errors) = await Run(Args("--relocate"), services);
+
+        // The fake target's defaults are D:\Data and D:\Logs; the names travel unchanged.
+        Assert.Equal(0, exit);
+        Assert.Contains(@"MOVE N'MyDb' TO N'D:\Data\MyDb.mdf'", output);
+        Assert.Contains(@"MOVE N'MyDb_log' TO N'D:\Logs\MyDb_log.ldf'", output);
+        Assert.Contains("Relocating 2 file(s)", errors);
+    }
+
+    [Fact]
+    public async Task ExplicitDataAndLogPathsPlaceTheFilesExactly()
+    {
+        var (services, sql) = Stage();
+        sql.FileList =
+        [
+            LogicalFile("MyDb", @"E:\SourceData\MyDb.mdf", "D"),
+            LogicalFile("MyDb_log", @"F:\SourceLogs\MyDb_log.ldf", "L")
+        ];
+        sql.VolumeFreeSpace = new()
+        {
+            [@"X:\"] = 500L * 1024 * 1024 * 1024,
+            [@"Y:\"] = 500L * 1024 * 1024 * 1024
+        };
+
+        var (exit, output, _) = await Run(
+            Args("--data-path", @"X:\NewData", "--log-path", @"Y:\NewLogs"), services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(@"MOVE N'MyDb' TO N'X:\NewData\MyDb.mdf'", output);
+        Assert.Contains(@"MOVE N'MyDb_log' TO N'Y:\NewLogs\MyDb_log.ldf'", output);
+    }
+
+    /// <summary>
+    /// With relocation in play the space check judges the volumes the files LAND on - the
+    /// destination being too small matters; the recorded source volume no longer does.
+    /// </summary>
+    [Fact]
+    public async Task TheSpaceCheckFollowsTheRelocation()
+    {
+        var (services, sql) = Stage();
+        sql.FileList = [LogicalFile("MyDb", @"E:\SourceData\MyDb.mdf", "D", 100L * 1024 * 1024 * 1024)];
+        sql.VolumeFreeSpace = new() { [@"D:\"] = 10L * 1024 * 1024 * 1024 };
+
+        var (exit, _, errors) = await Run(Args("--relocate", "--execute"), services);
+
+        // The file would land on D:\ (the fake default), which cannot fit it.
+        Assert.Equal(2, exit);
+        Assert.Contains(@"D:\ needs", errors);
+        Assert.Contains("short by", errors);
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    /// <summary>Two source files sharing a name land side by side, not on one another.</summary>
+    [Fact]
+    public void RelocationDisambiguatesCollidingFileNames()
+    {
+        var moves = RestoreRelocation.ToDirectories(
+        [
+            LogicalFile("Rows1", @"E:\a\MyDb.ndf", "D"),
+            LogicalFile("Rows2", @"F:\b\MyDb.ndf", "D")
+        ], @"D:\Data", @"D:\Logs");
+
+        Assert.Equal(@"D:\Data\MyDb.ndf", moves[0].NewPhysicalName);
+        Assert.Equal(@"D:\Data\MyDb_2.ndf", moves[1].NewPhysicalName);
+    }
+}


### PR DESCRIPTION
Closes #299 - the last piece of the Terraform template.

**Two levels of relocation on `9lives restore`:**
- `--relocate` - every file MOVEs to the target's own default data/log directories (from `GetDefaultPathsAsync`), keeping its original file name. `RestoreRelocation.ToDirectories` in Core is the rehearsal's move-builder generalised to names that stay; colliding names disambiguate with a numeric suffix instead of landing on each other.
- `--data-path DIR` / `--log-path DIR` - explicit placement mirroring the app's WITH MOVE control. Either side not given falls back to the target's default.

**Preflight interplay:** with relocation in play, `Preflights.RunAsync` takes the moves and the disk-space rung judges the volumes the files actually LAND on - the destination being too small refuses (`--force` still downgrades); the recorded source volume no longer matters.

Help text rolled into the exe per the docs-live-in-the-exe rule, with the provisioning example: `9lives restore --container backups --database Sales --target SRV02 --relocate --with-replace --execute` - the template now survives any VM shape.

Four pins in `CliRelocationTests`. Suite 1,746 + 10 integration, Release `-warnaserror` clean.