### PR TITLE
9lives backup: the other half of the orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **9lives backup: the other half of the orchestrator** (#300). The CLI could restore,
+  rehearse and judge but not take a backup - and the scriptable case is everywhere: the
+  pre-change safety snapshot with the restore in the same tool, the copy-away before risky
+  maintenance, the nightly extra full to a second container. Full, differential and log
+  (`--type`), striping (`--stripes`), blob container or share, and the app's rules travel:
+  COPY_ONLY by default and LOUD in stderr AND the script header when disabled, destinations
+  from the same layout rules every browser reads, the blob credential preflight before the
+  first statement, generate-only without `--execute`, and the same history receipts and
+  webhooks as every other execution verb
 - **The CLI restore relocates** (#299): `--relocate` moves every file to the target's own
   default data and log directories keeping its original name, and `--data-path` /
   `--log-path` place them explicitly - mirroring the app's WITH MOVE control. The freshly

--- a/src/NineLives.Cli/Program.cs
+++ b/src/NineLives.Cli/Program.cs
@@ -104,6 +104,7 @@ internal static class Program
                 "script" => await ScriptVerb.RunAsync(args, services, Console.Out, Console.Error),
                 "validate" => await ValidateVerb.RunAsync(args, services, Console.Out, Console.Error),
                 "exposure" => await ExposureVerb.RunAsync(args, services, Console.Out, Console.Error),
+                "backup" => await BackupVerb.RunAsync(args, services, Console.Out, Console.Error, interrupt.Token),
                 "restore" => await RestoreVerb.RunAsync(args, services, Console.Out, Console.Error, interrupt.Token),
                 "rehearse" => await RehearseVerb.RunAsync(args, services, Console.Out, Console.Error, interrupt.Token),
                 _ => ExitCodes.Usage

--- a/src/NineLives.Cli/VerbCatalogue.cs
+++ b/src/NineLives.Cli/VerbCatalogue.cs
@@ -13,7 +13,7 @@ internal static class VerbCatalogue
     [
         AddServerVerb.Spec, AddContainerVerb.Spec,
         ListVerb.Spec, PointsVerb.Spec, ScriptVerb.Spec, ValidateVerb.Spec, ExposureVerb.Spec,
-        RestoreVerb.Spec, RehearseVerb.Spec
+        BackupVerb.Spec, RestoreVerb.Spec, RehearseVerb.Spec
     ];
 
     public static VerbSpec? Find(string name) => All.FirstOrDefault(

--- a/src/NineLives.Cli/Verbs/BackupVerb.cs
+++ b/src/NineLives.Cli/Verbs/BackupVerb.cs
@@ -1,0 +1,302 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Cli.Verbs;
+
+/// <summary>
+/// The other half of the orchestrator (#300). The CLI could restore, rehearse and judge but
+/// not take a backup - and the scriptable case is everywhere: the pre-change safety snapshot
+/// ("backup before the deploy; restore if the smoke test fails" - the full loop in one tool),
+/// the copy-away before risky maintenance, the nightly extra full to a second container.
+///
+/// The app's rules travel: COPY_ONLY by default and LOUD when disabled, destinations built by
+/// the same BackupDestinationBuilder so what this writes is what every browser and restore
+/// can find, generate-only without --execute, a history receipt and webhooks like the other
+/// execution verbs.
+/// </summary>
+internal static class BackupVerb
+{
+    public static readonly VerbSpec Spec = new(
+        "backup",
+        "Generate, and with --execute run, a backup of a database",
+        "9lives backup (--container NAME | --path DIR) --server NAME --database DB " +
+        "[--type full|diff|log] [--stripes N] [--not-copy-only] [--execute]",
+        Valued: ["container", "path", "server", "database", "type", "stripes"],
+        Switches: ["execute", "not-copy-only"],
+        Options:
+        [
+            ("--container NAME", "A blob container configured in the app, as the destination. " +
+                "The blob layout follows the container's own path pattern, so every browser " +
+                "and restore finds what this writes."),
+            ("--path DIR", "A directory (usually a share) as the destination - one folder " +
+                "per database, timestamped names, exactly as the app writes them."),
+            ("--server NAME", "The configured server that TAKES the backup. Required."),
+            ("--database DB", "The database to back up. Required."),
+            ("--type TYPE", "full (the default), diff or log. A log backup requires FULL " +
+                "recovery and an existing base; a differential requires a full to be based on."),
+            ("--stripes N", "Write N striped files, 1-64. Faster on large databases, and the " +
+                "only way past Azure's per-blob size limit."),
+            ("--not-copy-only", "Take a PLAIN full instead of the default COPY_ONLY. A plain " +
+                "full RESETS THE DIFFERENTIAL BASE on the source: every differential the " +
+                "schedule takes afterwards depends on this file. A real choice, said loudly."),
+            ("--execute", "Actually run it. Without this, the script prints and nothing is " +
+                "touched.")
+        ],
+        Notes:
+        [
+            "COPY_ONLY is the default, exactly as it is in the app: a plain full backup " +
+            "resets the differential base on the source, silently re-basing every " +
+            "differential a schedule takes afterwards onto a file that lives in this " +
+            "container and that whoever runs the restore has never heard of. Disabling it " +
+            "with --not-copy-only prints the warning to stderr AND into the generated " +
+            "script's header, so the person reading the script sees what the person running " +
+            "the command was told.",
+            "Destinations are built by the same layout rules the app uses - the container's " +
+            "path pattern for blob, one folder per database on a share - so what this " +
+            "writes is exactly what 9lives list, the app's browser and every restore can " +
+            "find and classify, copy-only marked in the file name included.",
+            "BACKUP TO URL needs the container's credential on the SOURCE instance; the " +
+            "same preflight the app runs asks before the first statement, so the run cannot " +
+            "die of Msg 3201 after consent.",
+            "An executed run leaves the same receipts as the other execution verbs: a " +
+            "history entry the app's History screen lists, and notifications to the " +
+            "configured webhooks."
+        ],
+        ExitCodes:
+        [
+            "0   backed up - or, without --execute, generated with nothing refused",
+            "2   refused by the credential preflight, or the backup itself failed",
+            "3   the server could not be reached at all",
+            "64  usage",
+            "130 cancelled with Ctrl+C - the receipt says Cancelled, the channel was told"
+        ],
+        Examples:
+        [
+            ("9lives backup --container backups --server SRV01 --database Sales --execute",
+                "a copy-only full into the container, found by every browser afterwards"),
+            ("9lives backup --path \\\\nas01\\sql --server SRV01 --database Sales --type log --execute",
+                "a log backup onto the share - the pre-change tail of the safety loop"),
+            ("9lives backup --container backups --server SRV01 --database Sales --stripes 4 --execute",
+                "four stripes, for the database too large for one blob")
+        ]);
+
+    public static async Task<int> RunAsync(
+        CliArguments args, CliServices services, TextWriter output, TextWriter errors,
+        CancellationToken ct = default)
+    {
+        if (args.Get("server") == null || args.Get("database") == null)
+        {
+            errors.WriteLine("backup needs --server (the instance that takes it) and --database.");
+            return ExitCodes.Usage;
+        }
+
+        var containerName = args.Get("container");
+        var path = args.Get("path");
+        if ((containerName == null) == (path == null))
+        {
+            errors.WriteLine("Give exactly one destination: --container NAME or --path DIR.");
+            return ExitCodes.Usage;
+        }
+
+        var type = (args.Get("type") ?? "full").ToLowerInvariant() switch
+        {
+            "full" => BackupType.Full,
+            "diff" or "differential" => BackupType.Differential,
+            "log" => BackupType.TransactionLog,
+            _ => (BackupType?)null
+        };
+        if (type == null)
+        {
+            errors.WriteLine($"Unknown --type '{args.Get("type")}'. One of: full, diff, log.");
+            return ExitCodes.Usage;
+        }
+
+        var stripes = 1;
+        if (args.Get("stripes") is { } stripesText)
+        {
+            if (!int.TryParse(stripesText, out stripes) || stripes < 1 || stripes > 64)
+            {
+                errors.WriteLine("--stripes takes a number from 1 to 64 - SQL Server's own " +
+                                 "device limit.");
+                return ExitCodes.Usage;
+            }
+        }
+
+        var (server, serverError) = services.FindServer(args.Get("server")!);
+        if (server == null)
+        {
+            errors.WriteLine(serverError);
+            return ExitCodes.Usage;
+        }
+
+        BlobContainerConfig? container = null;
+        if (containerName != null)
+        {
+            var (found, containerError) = services.FindContainer(containerName);
+            if (found == null)
+            {
+                errors.WriteLine(containerError);
+                return ExitCodes.Usage;
+            }
+            container = found;
+        }
+
+        var database = args.Get("database")!;
+
+        // COPY_ONLY is the default and turning it off is LOUD (#300): the consequence lands
+        // on the SOURCE's differential schedule, not on this run.
+        var copyOnly = !args.Has("not-copy-only");
+        if (!copyOnly && type == BackupType.Full)
+            errors.WriteLine("WARNING: NOT copy-only. This full RESETS THE DIFFERENTIAL BASE " +
+                             $"on {server.ServerName} - every differential the schedule takes " +
+                             "afterwards will be based on this file. The script's header says " +
+                             "the same.");
+
+        var takenAt = DateTime.Now;
+        var destinations = container != null
+            ? BackupDestinationBuilder.ForContainer(
+                container, server.ServerName, database, type.Value, takenAt, stripes, copyOnly)
+            : BackupDestinationBuilder.ForSharedPath(
+                path!, database, type.Value, takenAt, stripes, copyOnly);
+
+        var script = new BackupScriptGenerator().Generate(new BackupOptions
+        {
+            DatabaseName = database,
+            Medium = container != null ? BackupMedium.AzureBlob : BackupMedium.SharedPath,
+            Destinations = destinations,
+            Type = type.Value,
+            CopyOnly = copyOnly
+        });
+
+        // BACKUP TO URL needs the credential on the SOURCE instance (#284's preflight, the
+        // same one the app runs) - asked before the first statement, so the run cannot die
+        // of Msg 3201 after consent.
+        if (container != null)
+        {
+            var preflight = await BlobCredentialPreflight.EnsureAsync(
+                services.Store, services.Sql, null, container, server, line => errors.WriteLine(line));
+            if (!preflight.CanProceed)
+            {
+                errors.WriteLine($"REFUSED: {preflight.Refusal}");
+                if (!args.Has("execute")) output.WriteLine(script);
+                return ExitCodes.Failed;
+            }
+        }
+
+        errors.WriteLine($"Backup: {type.Value} of '{database}' on {server.ServerName}, " +
+                         $"{destinations.Count} file(s), " +
+                         (copyOnly && type != BackupType.Differential ? "copy-only." : "plain."));
+
+        if (!args.Has("execute"))
+        {
+            output.WriteLine(script);
+            errors.WriteLine("Nothing was executed. Add --execute to run this.");
+            return ExitCodes.Ok;
+        }
+
+        return await ExecuteAsync(services, server, script, database, type.Value, errors, ct);
+    }
+
+    private static async Task<int> ExecuteAsync(
+        CliServices services, ServerConnection server, string script, string database,
+        BackupType type, TextWriter errors, CancellationToken ct)
+    {
+        var startedAt = DateTime.Now;
+        var log = new System.Text.StringBuilder();
+
+        void Progress(string message)
+        {
+            log.AppendLine(message);
+            errors.WriteLine(message);
+        }
+
+        services.Notifier.Notify(new RunNotification(
+            RunPhase.Started, "Backup", database, server.ServerName, $"{type} backup.", null));
+
+        try
+        {
+            await services.Sql.ExecuteWithProgressAsync(server, script, Progress, ct);
+
+            var completedAt = DateTime.Now;
+            services.History.Append(new RestoreHistoryEntry
+            {
+                Kind = "Backup",
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                ServerName = server.ServerName,
+                TargetDatabase = database,
+                SourceDatabase = database,
+                ChainSummary = $"{type} backup",
+                Outcome = RestoreOutcome.Succeeded,
+                Script = script,
+                Log = log.ToString()
+            });
+
+            services.Notifier.Notify(new RunNotification(
+                RunPhase.Succeeded, "Backup", database, server.ServerName,
+                $"{type} backup complete.", completedAt - startedAt));
+
+            errors.WriteLine($"Done: {type} backup of '{database}' on {server.ServerName} in " +
+                             $"{(completedAt - startedAt).TotalSeconds:0}s.");
+            await services.Notifier.DrainAsync(NotificationDrain);
+            return ExitCodes.Ok;
+        }
+        catch (OperationCanceledException)
+        {
+            var completedAt = DateTime.Now;
+            log.AppendLine("Cancelled from the terminal.");
+            services.History.Append(new RestoreHistoryEntry
+            {
+                Kind = "Backup",
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                ServerName = server.ServerName,
+                TargetDatabase = database,
+                SourceDatabase = database,
+                ChainSummary = $"{type} backup",
+                Outcome = RestoreOutcome.Cancelled,
+                ErrorMessage = "Cancelled from the terminal.",
+                Script = script,
+                Log = log.ToString()
+            });
+            services.Notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Backup", database, server.ServerName,
+                "Cancelled - any file already written is incomplete and cannot be restored " +
+                "from.", completedAt - startedAt));
+            await services.Notifier.DrainAsync(NotificationDrain);
+            errors.WriteLine("CANCELLED. Any file already written is incomplete and cannot be " +
+                             "restored from.");
+            return ExitCodes.Interrupted;
+        }
+        catch (Exception ex)
+        {
+            var completedAt = DateTime.Now;
+            log.AppendLine(ex.Message);
+            services.History.Append(new RestoreHistoryEntry
+            {
+                Kind = "Backup",
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                ServerName = server.ServerName,
+                TargetDatabase = database,
+                SourceDatabase = database,
+                ChainSummary = $"{type} backup",
+                Outcome = RestoreOutcome.Failed,
+                ErrorMessage = ex.Message,
+                Script = script,
+                Log = log.ToString()
+            });
+
+            services.Notifier.Notify(new RunNotification(
+                RunPhase.Problem, "Backup", database, server.ServerName,
+                ex.Message, completedAt - startedAt));
+
+            errors.WriteLine($"FAILED: {ex.Message}");
+            await services.Notifier.DrainAsync(NotificationDrain);
+            return ExitCodes.Failed;
+        }
+    }
+
+    /// <summary>Long enough for a slow webhook, short enough that a dead one cannot hold the exit.</summary>
+    private static readonly TimeSpan NotificationDrain = TimeSpan.FromSeconds(10);
+}

--- a/src/NineLives.Core/Models/BackupOptions.cs
+++ b/src/NineLives.Core/Models/BackupOptions.cs
@@ -13,6 +13,13 @@ public class BackupOptions
     /// <summary>The database to back up, as it is named on the source instance.</summary>
     public string DatabaseName { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Full, differential or log (#300). COPY_ONLY applies to full and log backups;
+    /// a differential has no copy-only form and the generator ignores the flag for one -
+    /// a differential does not move the base anyway, which is what COPY_ONLY protects.
+    /// </summary>
+    public BackupType Type { get; set; } = BackupType.Full;
+
     /// <summary>Where it is written. The medium decides TO URL or TO DISK.</summary>
     public BackupMedium Medium { get; set; } = BackupMedium.AzureBlob;
 

--- a/src/NineLives.Core/Services/BackupScriptGenerator.cs
+++ b/src/NineLives.Core/Services/BackupScriptGenerator.cs
@@ -55,8 +55,12 @@ public class BackupScriptGenerator
 
     private static void AppendBackup(StringBuilder sb, BackupOptions options)
     {
+        // BACKUP LOG for a log backup; BACKUP DATABASE for full and differential, the
+        // differential distinguished in the WITH list (#300).
+        var statement = options.Type == BackupType.TransactionLog ? "BACKUP LOG" : "BACKUP DATABASE";
+
         // Exact, not unwrapped (#294): this name came from the server's own database list.
-        sb.AppendLine($"BACKUP DATABASE {TSql.QuoteNameExact(options.DatabaseName)}");
+        sb.AppendLine($"{statement} {TSql.QuoteNameExact(options.DatabaseName)}");
         sb.AppendLine($"    TO {DeviceClause(options)}");
         sb.AppendLine($"    WITH {string.Join(", ", WithOptions(options))};");
         sb.AppendLine("GO");
@@ -85,8 +89,14 @@ public class BackupScriptGenerator
     {
         var with = new List<string>();
 
-        // First, because it is the one that changes what happens to the SOURCE.
-        if (options.CopyOnly) with.Add("COPY_ONLY");
+        // DIFFERENTIAL first when it applies - it is what makes this statement a different
+        // kind of backup, not an option on one (#300).
+        if (options.Type == BackupType.Differential) with.Add("DIFFERENTIAL");
+
+        // First of the options proper, because it is the one that changes what happens to
+        // the SOURCE. A differential has no copy-only form - and does not move the base
+        // anyway, which is what COPY_ONLY protects - so the flag is ignored for one.
+        if (options.CopyOnly && options.Type != BackupType.Differential) with.Add("COPY_ONLY");
 
         if (options.Compression) with.Add("COMPRESSION");
         if (options.Checksum) with.Add("CHECKSUM");

--- a/src/NineLives.Tests/CliBackupVerbTests.cs
+++ b/src/NineLives.Tests/CliBackupVerbTests.cs
@@ -1,0 +1,187 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The other half of the orchestrator (#300): 9lives backup, with the app's rules travelling -
+/// COPY_ONLY by default and loud when disabled, destinations from the same layout rules every
+/// browser reads, generate-only without --execute, receipts and webhooks like the other
+/// execution verbs.
+/// </summary>
+public class CliBackupVerbTests
+{
+    private static (CliServices services, FakeSqlServerService sql,
+                    FakeRestoreHistoryStore history, FakeRunNotifier notifier) Stage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService();
+        var history = new FakeRestoreHistoryStore();
+        var notifier = new FakeRunNotifier();
+        var services = new CliServices(
+            store, sql, new FakeBlobStorageService(), history, notifier);
+        return (services, sql, history, notifier);
+    }
+
+    private static async Task<(int exit, string output, string errors)> Run(
+        string[] args, CliServices services)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await BackupVerb.RunAsync(
+            CliArguments.Parse(args, BackupVerb.Spec), services, output, errors);
+        return (exit, output.ToString(), errors.ToString());
+    }
+
+    [Fact]
+    public async Task WithoutExecuteTheScriptPrintsAndNothingRuns()
+    {
+        var (services, sql, history, notifier) = Stage();
+
+        var (exit, output, errors) = await Run(
+            ["--container", "backups", "--server", "SRV01", "--database", "Sales"], services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("BACKUP DATABASE [Sales]", output);
+        Assert.Contains("COPY_ONLY", output);
+        Assert.Contains("Nothing was executed", errors);
+        Assert.Empty(sql.ExecutedScripts);
+        Assert.Empty(history.Entries);
+        Assert.Empty(notifier.Sent);
+    }
+
+    /// <summary>The blob layout is the container's own pattern - what every browser reads.</summary>
+    [Fact]
+    public async Task TheBlobDestinationFollowsTheContainersLayout()
+    {
+        var (services, _, _, _) = Stage();
+
+        var (_, output, _) = await Run(
+            ["--container", "backups", "--server", "SRV01", "--database", "Sales"], services);
+
+        Assert.Contains("FULL/SRV01/Sales/", output);
+        Assert.Contains("_COPY_ONLY_", output);
+        Assert.Contains(".bak", output);
+    }
+
+    [Fact]
+    public async Task DisablingCopyOnlyIsLoudInBothPlaces()
+    {
+        var (services, _, _, _) = Stage();
+
+        var (_, output, errors) = await Run(
+            ["--container", "backups", "--server", "SRV01", "--database", "Sales",
+             "--not-copy-only"], services);
+
+        Assert.Contains("RESETS THE DIFFERENTIAL BASE", errors);
+        Assert.Contains("RESETS THE DIFFERENTIAL", output);   // the script's own header warning
+        Assert.DoesNotContain("COPY_ONLY", output.Split("WITH")[1].Split(';')[0]);
+    }
+
+    [Fact]
+    public async Task ALogBackupSaysBackupLogAndLandsAsTrn()
+    {
+        var (services, _, _, _) = Stage();
+
+        var (exit, output, _) = await Run(
+            ["--container", "backups", "--server", "SRV01", "--database", "Sales",
+             "--type", "log"], services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("BACKUP LOG [Sales]", output);
+        Assert.Contains(".trn", output);
+    }
+
+    /// <summary>A differential has no copy-only form - the flag is ignored, not emitted.</summary>
+    [Fact]
+    public async Task ADifferentialIsDifferentialAndNeverCopyOnly()
+    {
+        var (services, _, _, _) = Stage();
+
+        var (_, output, _) = await Run(
+            ["--container", "backups", "--server", "SRV01", "--database", "Sales",
+             "--type", "diff"], services);
+
+        Assert.Contains("DIFFERENTIAL", output);
+        Assert.DoesNotContain("COPY_ONLY", output.Split("WITH")[1].Split(';')[0]);
+    }
+
+    [Fact]
+    public async Task StripesOutsideTheDeviceRangeAreRefused()
+    {
+        var (services, _, _, _) = Stage();
+
+        var (exit, _, errors) = await Run(
+            ["--container", "backups", "--server", "SRV01", "--database", "Sales",
+             "--stripes", "640"], services);
+
+        Assert.Equal(64, exit);
+        Assert.Contains("1 to 64", errors);
+    }
+
+    [Fact]
+    public async Task AnExecutedBackupLeavesTheReceiptsTheOtherVerbsLeave()
+    {
+        var (services, sql, history, notifier) = Stage();
+
+        var (exit, _, _) = await Run(
+            ["--path", @"\\nas01\sql", "--server", "SRV01", "--database", "Sales",
+             "--execute"], services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(sql.ExecutedScripts, s => s.Contains("BACKUP DATABASE [Sales]"));
+
+        var receipt = Assert.Single(history.Entries);
+        Assert.Equal("Backup", receipt.Kind);
+        Assert.Equal(RestoreOutcome.Succeeded, receipt.Outcome);
+
+        Assert.Equal(RunPhase.Started, notifier.Sent[0].Phase);
+        Assert.Equal(RunPhase.Succeeded, notifier.Sent[^1].Phase);
+        Assert.True(notifier.DrainCalls > 0);
+    }
+
+    [Fact]
+    public async Task AFailedBackupClosesTheChannelAndTheReceiptSaysFailed()
+    {
+        var (services, sql, history, notifier) = Stage();
+        sql.FailOnExecuteNumber = 1;
+
+        var (exit, _, errors) = await Run(
+            ["--path", @"\\nas01\sql", "--server", "SRV01", "--database", "Sales",
+             "--execute"], services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("FAILED", errors);
+        Assert.Equal(RestoreOutcome.Failed, Assert.Single(history.Entries).Outcome);
+        Assert.Equal(RunPhase.Problem, notifier.Sent[^1].Phase);
+        Assert.NotNull(notifier.Sent[^1].Duration);
+    }
+
+    [Fact]
+    public async Task ExactlyOneDestinationIsRequired()
+    {
+        var (services, _, _, _) = Stage();
+
+        var (both, _, _) = await Run(
+            ["--container", "backups", "--path", @"\\nas01\sql",
+             "--server", "SRV01", "--database", "Sales"], services);
+        var (neither, _, _) = await Run(
+            ["--server", "SRV01", "--database", "Sales"], services);
+
+        Assert.Equal(64, both);
+        Assert.Equal(64, neither);
+    }
+}


### PR DESCRIPTION
Closes #300.

`9lives backup (--container NAME | --path DIR) --server NAME --database DB [--type full|diff|log] [--stripes N] [--not-copy-only] [--execute]`

- **The generator learned the other two types**: `BACKUP LOG` and `WITH DIFFERENTIAL` (`BackupOptions.Type`), with COPY_ONLY correctly ignored for a differential - it has no copy-only form and does not move the base anyway. The GUI is unchanged (defaults Full).
- **The app's rules travel.** COPY_ONLY by default; `--not-copy-only` warns on stderr AND the script's own header carries the generator's existing differential-base warning. Destinations come from the same `BackupDestinationBuilder` layout every browser and restore reads - container path pattern, one folder per database on a share, copy-only marked in the file name. BACKUP TO URL runs the same blob credential preflight the app runs, before the first statement.
- **Same contract as the other execution verbs**: generate-only without `--execute` (script to stdout, plan to stderr), history receipt with `Kind=Backup`, Started/Succeeded/Problem webhooks with durations, notification drain before exit, Ctrl+C = 130.
- Full help page in the exe; `--stripes` refused outside SQL Server's 1-64.

Nine pins in `CliBackupVerbTests`. Suite 1,758 + 10 integration, Release `-warnaserror` clean.