### PR TITLE
The exposure sweep can speak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **The exposure sweep can speak** (#301): `9lives exposure --notify` pushes the sweep's
+  verdict through the configured webhooks - ONE message per sweep, the worst offenders
+  named worst first, into the same channel the runs already report to. Warning level and
+  above by default; `--notify-always` adds the all-clear heartbeat. Endpoint subscriptions
+  apply, the exit code is unaffected, and Task Scheduler plus this flag is backup
+  monitoring for an entire estate with no agent, no dashboard and no PowerShell module
 - **9lives backup: the other half of the orchestrator** (#300). The CLI could restore,
   rehearse and judge but not take a backup - and the scriptable case is everywhere: the
   pre-change safety snapshot with the restore in the same tool, the copy-away before risky

--- a/src/NineLives.Cli/Verbs/ExposureVerb.cs
+++ b/src/NineLives.Cli/Verbs/ExposureVerb.cs
@@ -16,15 +16,20 @@ internal static class ExposureVerb
     public static readonly VerbSpec Spec = new(
         "exposure",
         "Sweep every server: if it died now, what is lost? Exit code = worst level",
-        "9lives exposure [--server NAME] [--json]",
+        "9lives exposure [--server NAME] [--json] [--notify | --notify-always]",
         Valued: ["server"],
-        Switches: ["json"],
+        Switches: ["json", "notify", "notify-always"],
         Options:
         [
             ("--server NAME", "Sweep one configured server. Omitted, every configured server " +
                 "is swept in parallel - the estate, not a sample."),
             ("--json", "Rows as JSON on stdout: server, database, level, recoveryModel, " +
-                "lastFull, lastDifferential, lastLog, recoverableTo, verdict.")
+                "lastFull, lastDifferential, lastLog, recoverableTo, verdict."),
+            ("--notify", "Push the sweep's verdict through the configured webhooks - one " +
+                "message per sweep, worst offenders first, into the same channel the runs " +
+                "report to. Speaks only at warning level and above."),
+            ("--notify-always", "Like --notify, but a clean sweep also sends its all-clear - " +
+                "for the channel that wants the heartbeat, not just the bad news.")
         ],
         Notes:
         [
@@ -40,8 +45,13 @@ internal static class ExposureVerb
             "worst morning the servers that do answer still get judged.",
             "The worst level found IS the exit code, which makes this the scheduled-task " +
             "verb: wire it to a scheduler and a failing exit turns quiet log-backup silence " +
-            "into a red pipeline while attention is elsewhere. The app's webhooks cover the " +
-            "push side; this is the pull side any monitoring system can poll."
+            "into a red pipeline while attention is elsewhere - and --notify closes the " +
+            "loop with zero extra infrastructure, pushing the same verdict through the " +
+            "configured webhooks. One message per sweep, the worst offenders named worst " +
+            "first, never one per row: a channel flooded by forty rows is a channel " +
+            "somebody mutes. Endpoint subscriptions apply - a problem message honours " +
+            "Problems, the --notify-always all-clear honours Finished. Task Scheduler plus " +
+            "this flag is backup monitoring for an estate with no agent and no dashboard."
         ],
         ExitCodes:
         [
@@ -56,7 +66,9 @@ internal static class ExposureVerb
             ("9lives exposure",
                 "the whole estate, one exit code"),
             ("9lives exposure --server SRV01 --json",
-                "one server's rows for a dashboard or jq")
+                "one server's rows for a dashboard or jq"),
+            ("9lives exposure --notify",
+                "the scheduled shape: exit code for the scheduler, worst rows to the channel")
         ]);
 
     public static async Task<int> RunAsync(
@@ -167,6 +179,43 @@ internal static class ExposureVerb
         }
 
         var worst = rows.Count == 0 ? ExposureLevel.Ok : rows.Max(r => r.Level);
+
+        // --notify closes the loop (#301): the same verdict, through the configured
+        // webhooks. One message per sweep - a channel flooded by forty rows is a channel
+        // somebody mutes - speaking only at warning level and above unless --notify-always
+        // asks for the heartbeat. The exit code is unaffected either way.
+        if (args.Has("notify") || args.Has("notify-always"))
+        {
+            if (worst != ExposureLevel.Ok)
+            {
+                var alarms = rows.Count(r => r.Level == ExposureLevel.Alarm);
+                var warnings = rows.Count(r => r.Level == ExposureLevel.Warning);
+                var offenders = rows
+                    .Where(r => r.Level != ExposureLevel.Ok)
+                    .Take(5)
+                    .Select(r => $"{r.ServerName}/{r.DatabaseName} - {r.Verdict}");
+                var named = string.Join("  |  ", offenders);
+                var overflow = alarms + warnings > 5
+                    ? $"  |  ...and {alarms + warnings - 5} more"
+                    : string.Empty;
+
+                services.Notifier.Notify(new RunNotification(
+                    RunPhase.Problem, "Exposure",
+                    $"{alarms} alarm(s), {warnings} warning(s)",
+                    $"{servers.Count} server(s)",
+                    named + overflow));
+                await services.Notifier.DrainAsync(NotificationDrain);
+            }
+            else if (args.Has("notify-always"))
+            {
+                services.Notifier.Notify(new RunNotification(
+                    RunPhase.Succeeded, "Exposure",
+                    $"all {rows.Count} database(s) inside their windows",
+                    $"{servers.Count} server(s)"));
+                await services.Notifier.DrainAsync(NotificationDrain);
+            }
+        }
+
         return worst switch
         {
             ExposureLevel.Alarm => ExitCodes.Failed,
@@ -174,4 +223,7 @@ internal static class ExposureVerb
             _ => ExitCodes.Ok
         };
     }
+
+    /// <summary>Long enough for a slow webhook, short enough that a dead one cannot hold the exit.</summary>
+    private static readonly TimeSpan NotificationDrain = TimeSpan.FromSeconds(10);
 }

--- a/src/NineLives.Tests/CliExposureNotifyTests.cs
+++ b/src/NineLives.Tests/CliExposureNotifyTests.cs
@@ -1,0 +1,130 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// --notify closes the monitoring loop (#301): the sweep's verdict through the configured
+/// webhooks - ONE message per sweep, worst offenders first, warning level and above by
+/// default. Task Scheduler plus this flag is estate backup monitoring with no agent.
+/// </summary>
+public class CliExposureNotifyTests
+{
+    private static (CliServices services, FakeSqlServerService sql, FakeRunNotifier notifier)
+        Stage(params string[] servers)
+    {
+        var store = new FakeCredentialStore();
+        foreach (var name in servers)
+            store.Config.Servers.Add(new ServerConnection
+            { Id = ServerConnection.NewId(), Name = name, ServerName = name });
+
+        var sql = new FakeSqlServerService();
+        var notifier = new FakeRunNotifier();
+        var services = new CliServices(
+            store, sql, new FakeBlobStorageService(), new FakeRestoreHistoryStore(), notifier);
+        return (services, sql, notifier);
+    }
+
+    private static ExposureRow Row(string server, string db, DateTime? lastFull, DateTime? lastLog) => new()
+    {
+        ServerName = server,
+        DatabaseName = db,
+        RecoveryModel = "FULL",
+        StateDescription = "ONLINE",
+        LastFull = lastFull,
+        LastLog = lastLog
+    };
+
+    private static async Task<(int exit, string errors)> Run(string[] args, CliServices services)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await ExposureVerb.RunAsync(
+            CliArguments.Parse(args, ExposureVerb.Spec), services, output, errors);
+        return (exit, errors.ToString());
+    }
+
+    [Fact]
+    public async Task AHealthyEstateSaysNothingByDefault()
+    {
+        var now = DateTime.Now;
+        var (services, sql, notifier) = Stage("SRV01");
+        sql.ExposureByServer["SRV01"] = [Row("SRV01", "MyDb", now.AddHours(-20), now.AddMinutes(-10))];
+
+        var (exit, _) = await Run(["--notify"], services);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(notifier.Sent);
+    }
+
+    [Fact]
+    public async Task TroubleSendsOneMessageWorstFirstAndDrains()
+    {
+        var now = DateTime.Now;
+        var (services, sql, notifier) = Stage("SRV01", "SRV02");
+        sql.ExposureByServer["SRV01"] =
+        [
+            Row("SRV01", "Naked", null, null),                               // never backed up: alarm
+            Row("SRV01", "Stale", now.AddDays(-2), now.AddHours(-3))         // log silence: warning
+        ];
+        sql.ExposureByServer["SRV02"] =
+            [Row("SRV02", "Healthy", now.AddHours(-20), now.AddMinutes(-10))];
+
+        var (exit, _) = await Run(["--notify"], services);
+
+        Assert.Equal(2, exit);   // the exit code is unaffected by notifying
+
+        var sent = Assert.Single(notifier.Sent);
+        Assert.Equal(RunPhase.Problem, sent.Phase);
+        Assert.Equal("Exposure", sent.Operation);
+        Assert.Contains("1 alarm(s), 1 warning(s)", sent.Subject);
+        Assert.Contains("2 server(s)", sent.Target);
+        // Worst first: the alarm row leads the detail.
+        Assert.StartsWith("SRV01/Naked", sent.Detail);
+        Assert.DoesNotContain("Healthy", sent.Detail);
+        Assert.True(notifier.DrainCalls > 0);
+    }
+
+    /// <summary>An unreachable server is an alarm - and therefore a message.</summary>
+    [Fact]
+    public async Task AnUnreachableServerReachesTheChannel()
+    {
+        var (services, _, notifier) = Stage("SRV01");   // not in ExposureByServer: fake throws
+
+        var (exit, _) = await Run(["--notify"], services);
+
+        Assert.Equal(2, exit);
+        var sent = Assert.Single(notifier.Sent);
+        Assert.Contains("UNREACHABLE", sent.Detail);
+    }
+
+    [Fact]
+    public async Task NotifyAlwaysSendsTheAllClearHeartbeat()
+    {
+        var now = DateTime.Now;
+        var (services, sql, notifier) = Stage("SRV01");
+        sql.ExposureByServer["SRV01"] = [Row("SRV01", "MyDb", now.AddHours(-20), now.AddMinutes(-10))];
+
+        var (exit, _) = await Run(["--notify-always"], services);
+
+        Assert.Equal(0, exit);
+        var sent = Assert.Single(notifier.Sent);
+        Assert.Equal(RunPhase.Succeeded, sent.Phase);
+        Assert.Contains("inside their windows", sent.Subject);
+    }
+
+    [Fact]
+    public async Task WithoutTheFlagNothingIsEverSent()
+    {
+        var (services, _, notifier) = Stage("SRV01");   // unreachable, worst case
+
+        var (exit, _) = await Run([], services);
+
+        Assert.Equal(2, exit);
+        Assert.Empty(notifier.Sent);
+    }
+}


### PR DESCRIPTION
Closes #301.

`9lives exposure --notify` pushes the sweep's verdict through the configured webhooks - ONE message per sweep (never one per row: a flooded channel is a muted channel), the worst offenders named worst first with counts in the subject and the estate size in the target. Speaks at warning level and above by default; `--notify-always` adds the all-clear heartbeat.

Same `RunNotification` pipeline as every run, so endpoint subscriptions and formats just work - trouble honours the Problems subscription, the heartbeat honours Finished - and the per-endpoint delivery stamps from #292 apply. Deliveries drain (bounded) before exit per #296's rule; the exit code is unaffected by notifying.

Five pins in `CliExposureNotifyTests`: silent-when-healthy, one-message-worst-first with drain, unreachable-reaches-the-channel, the heartbeat, and never-without-the-flag. Suite 1,763 + 10 integration, Release `-warnaserror` clean.