### PR TITLE
Ephemeral mode: an estate defined only in the environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **Ephemeral mode: an estate defined only in the environment** (#302). `--ephemeral` on
+  any verb resolves server and container names against zero-persistence definitions from
+  NINELIVES_SERVER, NINELIVES_SQL_USER/PASSWORD, NINELIVES_CONTAINER_URL and NINELIVES_SAS -
+  consulted before the profile's config and written nowhere, secrets held in process memory
+  only. For the locked-down service account that must not own vault state and the CI agent
+  where nothing may outlive the job. History receipts still write and webhooks still fire -
+  they are the point. Documented on the overview help page
 - **The exposure sweep can speak** (#301): `9lives exposure --notify` pushes the sweep's
   verdict through the configured webhooks - ONE message per sweep, the worst offenders
   named worst first, into the same channel the runs already report to. Warning level and

--- a/src/NineLives.Cli/CliServices.cs
+++ b/src/NineLives.Cli/CliServices.cs
@@ -16,8 +16,13 @@ namespace Blackcat.NineLives.Cli;
 /// </summary>
 internal sealed class CliServices(
     ICredentialStore store, ISqlServerService sql, IBlobStorageService blobs,
-    IRestoreHistoryStore history, IRunNotifier notifier)
+    IRestoreHistoryStore history, IRunNotifier notifier,
+    ServerConnection? ephemeralServer = null, BlobContainerConfig? ephemeralContainer = null)
 {
+    /// <summary>The --ephemeral definitions (#302), consulted before config, persisted nowhere.</summary>
+    private readonly ServerConnection? _ephemeralServer = ephemeralServer;
+    private readonly BlobContainerConfig? _ephemeralContainer = ephemeralContainer;
+
     public ICredentialStore Store { get; } = store;
     public ISqlServerService Sql { get; } = sql;
     public IBlobStorageService Blobs { get; } = blobs;
@@ -33,26 +38,40 @@ internal sealed class CliServices(
     /// </summary>
     public (BlobContainerConfig? container, string? error) FindContainer(string name)
     {
+        // Ephemeral first (#302): a name defined for this invocation outranks the profile's.
+        if (_ephemeralContainer != null &&
+            string.Equals(_ephemeralContainer.Name, name, StringComparison.OrdinalIgnoreCase))
+            return (_ephemeralContainer, null);
+
         var match = Config.BlobContainers
             .FirstOrDefault(c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
         if (match != null) return (match, null);
 
-        var known = Config.BlobContainers.Count == 0
+        var names = Config.BlobContainers.Select(c => c.Name).ToList();
+        if (_ephemeralContainer != null) names.Insert(0, _ephemeralContainer.Name + " (ephemeral)");
+        var known = names.Count == 0
             ? "none are configured - add one in the app first"
-            : string.Join(", ", Config.BlobContainers.Select(c => c.Name));
+            : string.Join(", ", names);
         return (null, $"No container called '{name}'. Configured containers: {known}.");
     }
 
     /// <summary>A server by its configured name, same contract as <see cref="FindContainer"/>.</summary>
     public (ServerConnection? server, string? error) FindServer(string name)
     {
+        // Ephemeral first (#302): a name defined for this invocation outranks the profile's.
+        if (_ephemeralServer != null &&
+            string.Equals(_ephemeralServer.Name, name, StringComparison.OrdinalIgnoreCase))
+            return (_ephemeralServer, null);
+
         var match = Config.Servers
             .FirstOrDefault(s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
         if (match != null) return (match, null);
 
-        var known = Config.Servers.Count == 0
+        var names = Config.Servers.Select(s => s.Name).ToList();
+        if (_ephemeralServer != null) names.Insert(0, _ephemeralServer.Name + " (ephemeral)");
+        var known = names.Count == 0
             ? "none are configured - add one in the app first"
-            : string.Join(", ", Config.Servers.Select(s => s.Name));
+            : string.Join(", ", names);
         return (null, $"No server called '{name}'. Configured servers: {known}.");
     }
 }

--- a/src/NineLives.Cli/EnvironmentCredentials.cs
+++ b/src/NineLives.Cli/EnvironmentCredentials.cs
@@ -1,0 +1,57 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Cli;
+
+/// <summary>
+/// Zero-persistence definitions from environment variables (#302), activated by --ephemeral.
+///
+/// add-server and add-container closed most of the service-account gap, but they PERSIST:
+/// config in the profile, secrets in that user's Credential Manager. Two cases want neither -
+/// locked-down service accounts that must not own vault state, and CI agents where the
+/// machine is shared and nothing should outlive the job. The secrets ride on the objects
+/// (UnsavedPassword, UnsavedSasToken), which every service already prefers over the vault,
+/// so nothing is written anywhere. History receipts still write - they are the point - and
+/// the configured webhooks still fire.
+/// </summary>
+internal static class EnvironmentCredentials
+{
+    /// <summary>
+    /// The ephemeral server, or null when NINELIVES_SERVER is not set. SQL auth when
+    /// NINELIVES_SQL_USER is present (password from NINELIVES_SQL_PASSWORD, in memory only);
+    /// Windows auth otherwise. Resolvable by the name NINELIVES_SERVER_NAME, default "env".
+    /// </summary>
+    public static ServerConnection? Server(Func<string, string?> env)
+    {
+        var address = env("NINELIVES_SERVER");
+        if (string.IsNullOrWhiteSpace(address)) return null;
+
+        var user = env("NINELIVES_SQL_USER");
+        return new ServerConnection
+        {
+            Id = "env-server",
+            Name = env("NINELIVES_SERVER_NAME") ?? "env",
+            ServerName = address,
+            AuthMode = string.IsNullOrWhiteSpace(user) ? AuthMode.WindowsAuth : AuthMode.SqlAuth,
+            Username = string.IsNullOrWhiteSpace(user) ? null : user,
+            UnsavedPassword = env("NINELIVES_SQL_PASSWORD")
+        };
+    }
+
+    /// <summary>
+    /// The ephemeral container, or null when NINELIVES_CONTAINER_URL is not set. The SAS from
+    /// NINELIVES_SAS rides in memory only. Resolvable by NINELIVES_CONTAINER_NAME, default "env".
+    /// </summary>
+    public static BlobContainerConfig? Container(Func<string, string?> env)
+    {
+        var url = env("NINELIVES_CONTAINER_URL");
+        if (string.IsNullOrWhiteSpace(url)) return null;
+
+        return new BlobContainerConfig
+        {
+            Id = "env-container",
+            Name = env("NINELIVES_CONTAINER_NAME") ?? "env",
+            ContainerUrl = url,
+            UnsavedSasToken = string.IsNullOrWhiteSpace(env("NINELIVES_SAS")) ? null : env("NINELIVES_SAS")
+        };
+    }
+}

--- a/src/NineLives.Cli/HelpWriter.cs
+++ b/src/NineLives.Cli/HelpWriter.cs
@@ -32,6 +32,17 @@ internal static class HelpWriter
         output.WriteLine("refused; 3 the question could not be answered; 64 usage.");
         output.WriteLine();
         Wrapped(output,
+            "Ephemeral mode: pass --ephemeral on any verb to resolve names against " +
+            "zero-persistence definitions from environment variables, consulted before the " +
+            "profile's config and written nowhere - for locked-down service accounts and CI " +
+            "agents where nothing may outlive the job. NINELIVES_SERVER (address, resolvable " +
+            "as the name NINELIVES_SERVER_NAME or 'env'), NINELIVES_SQL_USER and " +
+            "NINELIVES_SQL_PASSWORD (SQL auth; omit both for Windows auth), " +
+            "NINELIVES_CONTAINER_URL (resolvable as NINELIVES_CONTAINER_NAME or 'env') and " +
+            "NINELIVES_SAS. Secrets stay in process memory; history receipts still write and " +
+            "webhooks still fire - they are the point.");
+        output.WriteLine();
+        Wrapped(output,
             "Two disciplines every verb keeps: data goes to stdout and everything human goes " +
             "to stderr, so output pipes and redirects cleanly; and timestamps parse exact " +
             "invariant formats only (yyyy-MM-dd HH:mm:ss, yyyy-MM-dd HH:mm, yyyy-MM-dd) - a " +

--- a/src/NineLives.Cli/Program.cs
+++ b/src/NineLives.Cli/Program.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Blackcat.NineLives.Cli.Verbs;
+using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.Cli;
@@ -76,7 +77,30 @@ internal static class Program
             return ExitCodes.Ok;
         }
 
-        var args = CliArguments.Parse(rawArgs.Skip(1).ToArray(), spec);
+        // --ephemeral (#302): resolve names against zero-persistence definitions from the
+        // NINELIVES_* environment variables, before config. Stripped here because it belongs
+        // to the invocation, not to any one verb - and it is an explicit switch so the
+        // command line SAYS it, rather than depending on invisible environment state.
+        var verbArgs = rawArgs.Skip(1).ToArray();
+        var ephemeral = verbArgs.Any(a => a is "--ephemeral");
+        ServerConnection? envServer = null;
+        BlobContainerConfig? envContainer = null;
+        if (ephemeral)
+        {
+            verbArgs = verbArgs.Where(a => a is not "--ephemeral").ToArray();
+            envServer = EnvironmentCredentials.Server(Environment.GetEnvironmentVariable);
+            envContainer = EnvironmentCredentials.Container(Environment.GetEnvironmentVariable);
+            if (envServer == null && envContainer == null)
+            {
+                Console.Error.WriteLine(
+                    "--ephemeral is set, but neither NINELIVES_SERVER nor " +
+                    "NINELIVES_CONTAINER_URL is defined. Set the NINELIVES_* variables " +
+                    "(see '9lives help') or drop the switch.");
+                return ExitCodes.Usage;
+            }
+        }
+
+        var args = CliArguments.Parse(verbArgs, spec);
         if (!args.Ok)
         {
             foreach (var error in args.Errors)
@@ -91,7 +115,8 @@ internal static class Program
         var store = new CredentialStore();
         var services = new CliServices(
             store, new SqlServerService(store), new BlobStorageService(store),
-            new RestoreHistoryStore(), new WebhookRunNotifier(store, new OperationLog()));
+            new RestoreHistoryStore(), new WebhookRunNotifier(store, new OperationLog()),
+            envServer, envContainer);
 
         try
         {

--- a/src/NineLives.Core/Services/BlobCredentialPreflight.cs
+++ b/src/NineLives.Core/Services/BlobCredentialPreflight.cs
@@ -35,8 +35,10 @@ public static class BlobCredentialPreflight
         var credentialName = container.ContainerUrl;
 
         // No stored token means nothing this app could write anyway - an Entra container has
-        // none by design. Whatever is on the server is what the run will use.
-        var sasToken = store.GetSasToken(container);
+        // none by design. Whatever is on the server is what the run will use. The in-memory
+        // copy wins over the vault, same rule as the blob service (#302): an unsaved or
+        // ephemeral container carries its secret on the object, never in a store.
+        var sasToken = container.UnsavedSasToken ?? store.GetSasToken(container);
         if (string.IsNullOrEmpty(sasToken)) return CredentialPreflight.Proceed;
 
         var credential = await sql.CredentialExistsAsync(server, credentialName);

--- a/src/NineLives.Tests/CliEphemeralTests.cs
+++ b/src/NineLives.Tests/CliEphemeralTests.cs
@@ -1,0 +1,145 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Zero persistence (#302): definitions from environment variables, consulted before config,
+/// written nowhere - for the locked-down service account that must not own vault state and
+/// the CI agent where nothing may outlive the job. Secrets ride on the objects
+/// (UnsavedPassword, UnsavedSasToken), which every service already prefers over the vault.
+/// </summary>
+public class CliEphemeralTests
+{
+    private static Func<string, string?> Env(params (string key, string value)[] vars) =>
+        key => vars.FirstOrDefault(v => v.key == key).value;
+
+    // ── the definitions parse ───────────────────────────────────────────────────
+
+    [Fact]
+    public void AServerDefinitionCarriesItsSecretInMemoryOnly()
+    {
+        var server = EnvironmentCredentials.Server(Env(
+            ("NINELIVES_SERVER", "10.0.0.4,1433"),
+            ("NINELIVES_SQL_USER", "restore_svc"),
+            ("NINELIVES_SQL_PASSWORD", "s3cret")));
+
+        Assert.NotNull(server);
+        Assert.Equal("env", server!.Name);
+        Assert.Equal("10.0.0.4,1433", server.ServerName);
+        Assert.Equal(AuthMode.SqlAuth, server.AuthMode);
+        Assert.Equal("restore_svc", server.Username);
+        Assert.Equal("s3cret", server.UnsavedPassword);
+    }
+
+    [Fact]
+    public void WithoutAUserTheServerIsWindowsAuth()
+    {
+        var server = EnvironmentCredentials.Server(Env(("NINELIVES_SERVER", "SRV01")));
+
+        Assert.Equal(AuthMode.WindowsAuth, server!.AuthMode);
+        Assert.Null(server.Username);
+    }
+
+    [Fact]
+    public void AContainerDefinitionCarriesItsSasInMemoryOnly()
+    {
+        var container = EnvironmentCredentials.Container(Env(
+            ("NINELIVES_CONTAINER_URL", "https://acct.blob.core.windows.net/backups"),
+            ("NINELIVES_SAS", "sv=2024&sig=abc")));
+
+        Assert.NotNull(container);
+        Assert.Equal("env", container!.Name);
+        Assert.Equal("sv=2024&sig=abc", container.UnsavedSasToken);
+    }
+
+    [Fact]
+    public void NothingSetMeansNothingDefined()
+    {
+        Assert.Null(EnvironmentCredentials.Server(Env()));
+        Assert.Null(EnvironmentCredentials.Container(Env()));
+    }
+
+    // ── the finders consult ephemerals first, config second ─────────────────────
+
+    private static CliServices Services(
+        ServerConnection? envServer = null, BlobContainerConfig? envContainer = null,
+        FakeCredentialStore? store = null)
+    {
+        store ??= new FakeCredentialStore();
+        return new CliServices(
+            store, new FakeSqlServerService(), new FakeBlobStorageService(),
+            new FakeRestoreHistoryStore(), new FakeRunNotifier(), envServer, envContainer);
+    }
+
+    [Fact]
+    public void TheEphemeralNameOutranksTheProfileAndConfigStaysSecond()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "cfg", Name = "SRV01", ServerName = "SRV01.corp" });
+
+        var envServer = new ServerConnection { Id = "env-server", Name = "env", ServerName = "10.0.0.4" };
+        var services = Services(envServer, store: store);
+
+        var (fromEnv, _) = services.FindServer("env");
+        Assert.Same(envServer, fromEnv);
+
+        var (fromConfig, _) = services.FindServer("SRV01");
+        Assert.Equal("cfg", fromConfig!.Id);
+    }
+
+    [Fact]
+    public void AMissLisTsTheEphemeralAmongTheChoices()
+    {
+        var services = Services(
+            new ServerConnection { Id = "env-server", Name = "env", ServerName = "10.0.0.4" });
+
+        var (server, error) = services.FindServer("nope");
+
+        Assert.Null(server);
+        Assert.Contains("env (ephemeral)", error);
+    }
+
+    // ── the whole loop: a verb runs against definitions that exist nowhere ──────
+
+    [Fact]
+    public async Task ABackupRunsAgainstAnEstateDefinedOnlyInTheEnvironment()
+    {
+        var envServer = new ServerConnection
+        {
+            Id = "env-server", Name = "env", ServerName = "10.0.0.4",
+            AuthMode = AuthMode.SqlAuth, Username = "svc", UnsavedPassword = "pw"
+        };
+        var envContainer = new BlobContainerConfig
+        {
+            Id = "env-container", Name = "env",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups",
+            UnsavedSasToken = "sv=2024&sig=abc"
+        };
+        var store = new FakeCredentialStore();   // deliberately EMPTY: no profile config at all
+        var sql = new FakeSqlServerService();
+        var history = new FakeRestoreHistoryStore();
+        var services = new CliServices(
+            store, sql, new FakeBlobStorageService(), history, new FakeRunNotifier(),
+            envServer, envContainer);
+
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await BackupVerb.RunAsync(
+            CliArguments.Parse(
+                ["--container", "env", "--server", "env", "--database", "Sales", "--execute"],
+                BackupVerb.Spec),
+            services, output, errors);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(sql.ExecutedScripts, s => s.Contains("BACKUP DATABASE [Sales]"));
+        Assert.Same(envServer, sql.ExecutedAgainst[^1]);      // the in-memory password travels
+        Assert.Single(history.Entries);                        // the receipt still writes
+        Assert.Equal(0, store.SaveConfigCalls);                // and nothing was persisted
+    }
+}


### PR DESCRIPTION
Closes #302.

`--ephemeral` on any verb resolves `--server`/`--target`/`--container` names against zero-persistence definitions from environment variables - consulted before the profile's config, persisted nowhere:

- `NINELIVES_SERVER` (+ optional `NINELIVES_SERVER_NAME`, default `env`; `NINELIVES_SQL_USER`/`NINELIVES_SQL_PASSWORD` for SQL auth, Windows auth otherwise)
- `NINELIVES_CONTAINER_URL` (+ optional `NINELIVES_CONTAINER_NAME`, default `env`; `NINELIVES_SAS`)

The secrets ride on the objects (`UnsavedPassword`, `UnsavedSasToken`), which every service already prefers over the vault - `BlobCredentialPreflight` now honours the same in-memory-first rule. The switch is explicit so the command line says it; set variables without `--ephemeral` change nothing, and `--ephemeral` with nothing set is a usage error naming the variables. History receipts still write and the configured webhooks still fire - they are the point of running the verb at all.

Composed in `Program` (switch stripped before verb parsing), resolved ephemeral-first in `CliServices.FindServer/FindContainer` with the ephemeral listed in miss messages. Documented on the overview help page. Eight pins in `CliEphemeralTests`, including the whole loop: a backup executing against an estate that exists nowhere but the environment, receipt written, nothing persisted. Suite 1,770 + 10 integration, Release `-warnaserror` clean.