### PR TITLE
The execution verbs end as data, and receipts know their origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **The execution verbs end as data, and receipts know their origin** (#303). `--json` on
+  restore, rehearse and backup puts the ending on stdout machine-shaped: outcome, chain,
+  point reached, measured duration - the rehearsal's proof carrying the real RTO number -
+  warnings, refusals and the history id, while the prose stays on stderr. A pipeline
+  archives the artefact instead of parsing sentences. And every receipt now records which
+  front end acted: History rows say "via CLI", because a 3am scripted restore reads
+  differently in an incident review than a clicked one
 - **Ephemeral mode: an estate defined only in the environment** (#302). `--ephemeral` on
   any verb resolves server and container names against zero-persistence definitions from
   NINELIVES_SERVER, NINELIVES_SQL_USER/PASSWORD, NINELIVES_CONTAINER_URL and NINELIVES_SAS -

--- a/src/NineLives.Cli/CliRunResult.cs
+++ b/src/NineLives.Cli/CliRunResult.cs
@@ -1,0 +1,15 @@
+using System.Text.Json;
+
+namespace Blackcat.NineLives.Cli;
+
+/// <summary>
+/// The execution verbs' --json ending (#303): one machine-shaped object on stdout - outcome,
+/// duration, chain, point reached, refusals, history id - where the prose ending goes to
+/// stderr as always. The read verbs were already composable; this makes the execution verbs
+/// composable too, and a rehearsal's proof becomes a JSON artefact a pipeline can archive.
+/// </summary>
+internal static class CliRunResult
+{
+    public static void Write(TextWriter output, object result) =>
+        output.WriteLine(JsonSerializer.Serialize(result, JsonOut.Options));
+}

--- a/src/NineLives.Cli/Verbs/BackupVerb.cs
+++ b/src/NineLives.Cli/Verbs/BackupVerb.cs
@@ -20,9 +20,9 @@ internal static class BackupVerb
         "backup",
         "Generate, and with --execute run, a backup of a database",
         "9lives backup (--container NAME | --path DIR) --server NAME --database DB " +
-        "[--type full|diff|log] [--stripes N] [--not-copy-only] [--execute]",
+        "[--type full|diff|log] [--stripes N] [--not-copy-only] [--execute] [--json]",
         Valued: ["container", "path", "server", "database", "type", "stripes"],
-        Switches: ["execute", "not-copy-only"],
+        Switches: ["execute", "not-copy-only", "json"],
         Options:
         [
             ("--container NAME", "A blob container configured in the app, as the destination. " +
@@ -40,7 +40,10 @@ internal static class BackupVerb
                 "full RESETS THE DIFFERENTIAL BASE on the source: every differential the " +
                 "schedule takes afterwards depends on this file. A real choice, said loudly."),
             ("--execute", "Actually run it. Without this, the script prints and nothing is " +
-                "touched.")
+                "touched."),
+            ("--json", "The ending as data on stdout - outcome, type, destinations, " +
+                "duration, history id - in place of the script or beside the prose, which " +
+                "stays on stderr.")
         ],
         Notes:
         [
@@ -187,22 +190,60 @@ internal static class BackupVerb
                          $"{destinations.Count} file(s), " +
                          (copyOnly && type != BackupType.Differential ? "copy-only." : "plain."));
 
+        var json = args.Has("json");
+
         if (!args.Has("execute"))
         {
-            output.WriteLine(script);
+            if (json)
+                CliRunResult.Write(output, new
+                {
+                    Verb = "backup",
+                    Outcome = "Generated",
+                    Server = server.ServerName,
+                    Database = database,
+                    Type = type.Value.ToString(),
+                    CopyOnly = copyOnly && type != BackupType.Differential,
+                    Destinations = destinations,
+                    Script = script
+                });
+            else
+                output.WriteLine(script);
             errors.WriteLine("Nothing was executed. Add --execute to run this.");
             return ExitCodes.Ok;
         }
 
-        return await ExecuteAsync(services, server, script, database, type.Value, errors, ct);
+        return await ExecuteAsync(
+            services, server, script, database, type.Value, destinations,
+            json ? output : null, errors, ct);
     }
 
     private static async Task<int> ExecuteAsync(
         CliServices services, ServerConnection server, string script, string database,
-        BackupType type, TextWriter errors, CancellationToken ct)
+        BackupType type, List<string> destinations, TextWriter? jsonOut, TextWriter errors,
+        CancellationToken ct)
     {
         var startedAt = DateTime.Now;
         var log = new System.Text.StringBuilder();
+
+        // The run's ending as data (#303), when asked for.
+        void EmitResult(string outcome, DateTime completedAt, string historyId, string? error = null)
+        {
+            if (jsonOut == null) return;
+            CliRunResult.Write(jsonOut, new
+            {
+                Verb = "backup",
+                Outcome = outcome,
+                Server = server.ServerName,
+                Database = database,
+                Type = type.ToString(),
+                Destinations = destinations,
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                DurationSeconds = Math.Round((completedAt - startedAt).TotalSeconds, 1),
+                HistoryId = historyId,
+                Error = error
+            });
+        }
 
         void Progress(string message)
         {
@@ -218,8 +259,9 @@ internal static class BackupVerb
             await services.Sql.ExecuteWithProgressAsync(server, script, Progress, ct);
 
             var completedAt = DateTime.Now;
-            services.History.Append(new RestoreHistoryEntry
+            var receipt = new RestoreHistoryEntry
             {
+                Origin = "CLI",
                 Kind = "Backup",
                 StartedAt = startedAt,
                 CompletedAt = completedAt,
@@ -230,7 +272,9 @@ internal static class BackupVerb
                 Outcome = RestoreOutcome.Succeeded,
                 Script = script,
                 Log = log.ToString()
-            });
+            };
+            services.History.Append(receipt);
+            EmitResult("Succeeded", completedAt, receipt.Id);
 
             services.Notifier.Notify(new RunNotification(
                 RunPhase.Succeeded, "Backup", database, server.ServerName,
@@ -245,8 +289,9 @@ internal static class BackupVerb
         {
             var completedAt = DateTime.Now;
             log.AppendLine("Cancelled from the terminal.");
-            services.History.Append(new RestoreHistoryEntry
+            var receipt = new RestoreHistoryEntry
             {
+                Origin = "CLI",
                 Kind = "Backup",
                 StartedAt = startedAt,
                 CompletedAt = completedAt,
@@ -258,7 +303,9 @@ internal static class BackupVerb
                 ErrorMessage = "Cancelled from the terminal.",
                 Script = script,
                 Log = log.ToString()
-            });
+            };
+            services.History.Append(receipt);
+            EmitResult("Cancelled", completedAt, receipt.Id, "Cancelled from the terminal.");
             services.Notifier.Notify(new RunNotification(
                 RunPhase.Problem, "Backup", database, server.ServerName,
                 "Cancelled - any file already written is incomplete and cannot be restored " +
@@ -272,8 +319,9 @@ internal static class BackupVerb
         {
             var completedAt = DateTime.Now;
             log.AppendLine(ex.Message);
-            services.History.Append(new RestoreHistoryEntry
+            var receipt = new RestoreHistoryEntry
             {
+                Origin = "CLI",
                 Kind = "Backup",
                 StartedAt = startedAt,
                 CompletedAt = completedAt,
@@ -285,7 +333,9 @@ internal static class BackupVerb
                 ErrorMessage = ex.Message,
                 Script = script,
                 Log = log.ToString()
-            });
+            };
+            services.History.Append(receipt);
+            EmitResult("Failed", completedAt, receipt.Id, ex.Message);
 
             services.Notifier.Notify(new RunNotification(
                 RunPhase.Problem, "Backup", database, server.ServerName,

--- a/src/NineLives.Cli/Verbs/RehearseVerb.cs
+++ b/src/NineLives.Cli/Verbs/RehearseVerb.cs
@@ -20,9 +20,9 @@ internal static class RehearseVerb
         "rehearse",
         "Prove a database restores: scratch restore + CHECKDB + drop, receipt in History",
         "9lives rehearse (--container NAME | --server NAME) --database DB --target SERVER " +
-        "[--at \"yyyy-MM-dd HH:mm:ss\"] [--execute]",
+        "[--at \"yyyy-MM-dd HH:mm:ss\"] [--execute] [--json]",
         Valued: ["container", "server", "database", "at", "target"],
-        Switches: ["execute"],
+        Switches: ["json", "execute"],
         Options:
         [
             ("--container NAME", "A blob container configured in the app, as the source."),
@@ -34,7 +34,10 @@ internal static class RehearseVerb
             ("--at TIME", "Prove the chain to this moment. Omitted, the newest reachable " +
                 "point - which is the honest answer to \"could I restore what I have NOW?\""),
             ("--execute", "Actually run it. Without this, the full rehearsal script prints " +
-                "and nothing is touched.")
+                "and nothing is touched."),
+            ("--json", "The proof as data on stdout: outcome, chain, point, the measured " +
+                "duration - the RTO number - and the history id. The artefact a pipeline " +
+                "archives.")
         ],
         Notes:
         [
@@ -154,9 +157,24 @@ internal static class RehearseVerb
                          $"{(stopAt ?? point.Timestamp):yyyy-MM-dd HH:mm:ss}, proving " +
                          $"'{sourceDatabase}' as scratch '{scratch}' on {target.ServerName}.");
 
+        var json = args.Has("json");
+
         if (!args.Has("execute"))
         {
-            output.WriteLine(script);
+            if (json)
+                CliRunResult.Write(output, new
+                {
+                    Verb = "rehearse",
+                    Outcome = "Generated",
+                    Server = target.ServerName,
+                    Database = sourceDatabase,
+                    Scratch = scratch,
+                    Chain = point.TypeDisplay,
+                    ProveTo = stopAt ?? point.Timestamp,
+                    Script = script
+                });
+            else
+                output.WriteLine(script);
             errors.WriteLine("Nothing was executed. Add --execute to run the rehearsal.");
             return ExitCodes.Ok;
         }
@@ -182,8 +200,9 @@ internal static class RehearseVerb
             await services.Sql.ExecuteWithProgressAsync(target, script, Progress, ct);
 
             var completedAt = DateTime.Now;
-            services.History.Append(new RestoreHistoryEntry
+            var receipt = new RestoreHistoryEntry
             {
+                Origin = "CLI",
                 StartedAt = startedAt,
                 CompletedAt = completedAt,
                 ServerName = target.ServerName,
@@ -196,7 +215,22 @@ internal static class RehearseVerb
                 Outcome = RestoreOutcome.Succeeded,
                 Script = script,
                 Log = log.ToString()
-            });
+            };
+            services.History.Append(receipt);
+            if (json)
+                CliRunResult.Write(output, new
+                {
+                    Verb = "rehearse",
+                    Outcome = "Proven",
+                    Server = target.ServerName,
+                    Database = sourceDatabase,
+                    Chain = point.TypeDisplay,
+                    ProvenTo = stopAt ?? point.Timestamp,
+                    StartedAt = startedAt,
+                    CompletedAt = completedAt,
+                    DurationSeconds = Math.Round((completedAt - startedAt).TotalSeconds, 1),
+                    HistoryId = receipt.Id
+                });
 
             services.Notifier.Notify(new RunNotification(
                 RunPhase.Succeeded, "Rehearsal", sourceDatabase, target.ServerName,
@@ -216,8 +250,9 @@ internal static class RehearseVerb
             // interruption may have landed after its restore began.
             var completedAt = DateTime.Now;
             log.AppendLine("Cancelled from the terminal.");
-            services.History.Append(new RestoreHistoryEntry
+            var receipt = new RestoreHistoryEntry
             {
+                Origin = "CLI",
                 StartedAt = startedAt,
                 CompletedAt = completedAt,
                 ServerName = target.ServerName,
@@ -231,7 +266,20 @@ internal static class RehearseVerb
                 ErrorMessage = "Cancelled from the terminal.",
                 Script = script,
                 Log = log.ToString()
-            });
+            };
+            services.History.Append(receipt);
+            if (json)
+                CliRunResult.Write(output, new
+                {
+                    Verb = "rehearse",
+                    Outcome = "Cancelled",
+                    Server = target.ServerName,
+                    Database = sourceDatabase,
+                    Scratch = scratch,
+                    ScratchRetained = true,
+                    HistoryId = receipt.Id,
+                    Error = "Cancelled from the terminal."
+                });
             services.Notifier.Notify(new RunNotification(
                 RunPhase.Problem, "Rehearsal", sourceDatabase, target.ServerName,
                 "Cancelled from the terminal.", completedAt - startedAt));
@@ -244,8 +292,9 @@ internal static class RehearseVerb
         {
             var completedAt = DateTime.Now;
             log.AppendLine(ex.Message);
-            services.History.Append(new RestoreHistoryEntry
+            var receipt = new RestoreHistoryEntry
             {
+                Origin = "CLI",
                 StartedAt = startedAt,
                 CompletedAt = completedAt,
                 ServerName = target.ServerName,
@@ -259,7 +308,20 @@ internal static class RehearseVerb
                 ErrorMessage = ex.Message,
                 Script = script,
                 Log = log.ToString()
-            });
+            };
+            services.History.Append(receipt);
+            if (json)
+                CliRunResult.Write(output, new
+                {
+                    Verb = "rehearse",
+                    Outcome = "NotProven",
+                    Server = target.ServerName,
+                    Database = sourceDatabase,
+                    Scratch = scratch,
+                    ScratchRetained = true,
+                    HistoryId = receipt.Id,
+                    Error = ex.Message
+                });
 
             services.Notifier.Notify(new RunNotification(
                 RunPhase.Problem, "Rehearsal", sourceDatabase, target.ServerName,

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -23,10 +23,10 @@ internal static class RestoreVerb
         "9lives restore (--container NAME | --server NAME) --database DB --target SERVER " +
         "[--at \"yyyy-MM-dd HH:mm:ss\"] [--target-database NAME] [--with-replace] [--norecovery] " +
         "[--relocate | --data-path DIR [--log-path DIR]] " +
-        "[--stop-before-mark NAME | --stop-at-mark NAME] [--execute] [--force]",
+        "[--stop-before-mark NAME | --stop-at-mark NAME] [--execute] [--force] [--json]",
         Valued: ["container", "server", "database", "at", "target", "target-database",
                  "stop-before-mark", "stop-at-mark", "data-path", "log-path"],
-        Switches: ["execute", "with-replace", "norecovery", "force", "relocate"],
+        Switches: ["execute", "with-replace", "norecovery", "force", "relocate", "json"],
         Options:
         [
             ("--container NAME", "A blob container configured in the app, as the source."),
@@ -54,7 +54,10 @@ internal static class RestoreVerb
                 "verdict print and nothing is touched."),
             ("--force", "Override what the EVIDENCE says - version direction, missing TDE " +
                 "certificate, unreadable files - loudly, as warnings. It cannot stand in " +
-                "for --with-replace: evidence is overridable, consent is not.")
+                "for --with-replace: evidence is overridable, consent is not."),
+            ("--json", "The ending as data on stdout - outcome, chain, point, duration, " +
+                "warnings, refusals, history id - in place of the script or beside the " +
+                "prose, which stays on stderr. The run's result as an artefact.")
         ],
         Notes:
         [
@@ -234,9 +237,27 @@ internal static class RestoreVerb
         foreach (var refusal in preflight.Refusals)
             errors.WriteLine($"REFUSED: {refusal}");
 
+        var json = args.Has("json");
+
         if (!args.Has("execute"))
         {
-            output.WriteLine(script);
+            if (json)
+                CliRunResult.Write(output, new
+                {
+                    Verb = "restore",
+                    Outcome = preflight.Refusals.Count > 0 ? "Refused" : "Generated",
+                    Server = target.ServerName,
+                    Database = sourceDatabase,
+                    TargetDatabase = targetDatabase,
+                    Chain = point.TypeDisplay,
+                    RestoreTo = stopAt ?? point.Timestamp,
+                    Warnings = preflight.Warnings,
+                    Refusals = preflight.Refusals,
+                    Script = script
+                });
+            else
+                output.WriteLine(script);
+
             errors.WriteLine(preflight.Refusals.Count > 0
                 ? "Nothing was executed - and --execute would be refused for the reasons above."
                 : "Nothing was executed. Add --execute to run this.");
@@ -245,6 +266,17 @@ internal static class RestoreVerb
 
         if (preflight.Refusals.Count > 0)
         {
+            if (json)
+                CliRunResult.Write(output, new
+                {
+                    Verb = "restore",
+                    Outcome = "Refused",
+                    Server = target.ServerName,
+                    Database = sourceDatabase,
+                    TargetDatabase = targetDatabase,
+                    Warnings = preflight.Warnings,
+                    Refusals = preflight.Refusals
+                });
             errors.WriteLine("Not run. Every refusal above must be resolved - or, for the " +
                              "evidence-based ones, deliberately overridden with --force.");
             return ExitCodes.Failed;
@@ -252,16 +284,37 @@ internal static class RestoreVerb
 
         return await ExecuteAsync(
             services, target, script, sourceDatabase, targetDatabase, point, stopAt,
-            chain, args.Get("container"), errors, ct);
+            chain, args.Get("container"), json ? output : null, errors, ct);
     }
 
     private static async Task<int> ExecuteAsync(
         CliServices services, ServerConnection target, string script, string sourceDatabase,
         string targetDatabase, RestorePoint point, DateTime? stopAt, BackupChain chain,
-        string? containerName, TextWriter errors, CancellationToken ct)
+        string? containerName, TextWriter? jsonOut, TextWriter errors, CancellationToken ct)
     {
         var startedAt = DateTime.Now;
         var log = new System.Text.StringBuilder();
+
+        // The run's ending as data (#303), when asked for - stdout carries only this.
+        void EmitResult(string outcome, DateTime completedAt, string historyId, string? error = null)
+        {
+            if (jsonOut == null) return;
+            CliRunResult.Write(jsonOut, new
+            {
+                Verb = "restore",
+                Outcome = outcome,
+                Server = target.ServerName,
+                Database = sourceDatabase,
+                TargetDatabase = targetDatabase,
+                Chain = point.TypeDisplay,
+                RestoredTo = stopAt ?? point.Timestamp,
+                StartedAt = startedAt,
+                CompletedAt = completedAt,
+                DurationSeconds = Math.Round((completedAt - startedAt).TotalSeconds, 1),
+                HistoryId = historyId,
+                Error = error
+            });
+        }
 
         void Progress(string message)
         {
@@ -279,8 +332,9 @@ internal static class RestoreVerb
             await services.Sql.ExecuteWithProgressAsync(target, script, Progress, ct);
 
             var completedAt = DateTime.Now;
-            services.History.Append(new RestoreHistoryEntry
+            var receipt = new RestoreHistoryEntry
             {
+                Origin = "CLI",
                 StartedAt = startedAt,
                 CompletedAt = completedAt,
                 ServerName = target.ServerName,
@@ -292,7 +346,9 @@ internal static class RestoreVerb
                 Outcome = RestoreOutcome.Succeeded,
                 Script = script,
                 Log = log.ToString()
-            });
+            };
+            services.History.Append(receipt);
+            EmitResult("Succeeded", completedAt, receipt.Id);
 
             services.Notifier.Notify(new RunNotification(
                 RunPhase.Succeeded, "Restore", sourceDatabase, target.ServerName,
@@ -310,8 +366,9 @@ internal static class RestoreVerb
             // conventional 128+SIGINT so a wrapping script can tell interruption from failure.
             var completedAt = DateTime.Now;
             log.AppendLine("Cancelled from the terminal.");
-            services.History.Append(new RestoreHistoryEntry
+            var receipt = new RestoreHistoryEntry
             {
+                Origin = "CLI",
                 StartedAt = startedAt,
                 CompletedAt = completedAt,
                 ServerName = target.ServerName,
@@ -324,7 +381,9 @@ internal static class RestoreVerb
                 ErrorMessage = "Cancelled from the terminal.",
                 Script = script,
                 Log = log.ToString()
-            });
+            };
+            services.History.Append(receipt);
+            EmitResult("Cancelled", completedAt, receipt.Id, "Cancelled from the terminal.");
             services.Notifier.Notify(new RunNotification(
                 RunPhase.Problem, "Restore", sourceDatabase, target.ServerName,
                 "Cancelled from the terminal - check the target database's state before " +
@@ -338,8 +397,9 @@ internal static class RestoreVerb
         {
             var completedAt = DateTime.Now;
             log.AppendLine(ex.Message);
-            services.History.Append(new RestoreHistoryEntry
+            var receipt = new RestoreHistoryEntry
             {
+                Origin = "CLI",
                 StartedAt = startedAt,
                 CompletedAt = completedAt,
                 ServerName = target.ServerName,
@@ -352,7 +412,9 @@ internal static class RestoreVerb
                 ErrorMessage = ex.Message,
                 Script = script,
                 Log = log.ToString()
-            });
+            };
+            services.History.Append(receipt);
+            EmitResult("Failed", completedAt, receipt.Id, ex.Message);
 
             services.Notifier.Notify(new RunNotification(
                 RunPhase.Problem, "Restore", sourceDatabase, target.ServerName,

--- a/src/NineLives.Core/Models/RestoreHistoryEntry.cs
+++ b/src/NineLives.Core/Models/RestoreHistoryEntry.cs
@@ -45,6 +45,13 @@ public sealed class RestoreHistoryEntry
     /// </summary>
     public string Kind { get; set; } = "Restore";
 
+    /// <summary>
+    /// "App" or "CLI" (#303) - which front end acted. A 3am CLI restore reads differently in
+    /// an incident review than a clicked one. A string for the same cross-version tolerance
+    /// as Kind; entries written before this field existed read as "App", which they were.
+    /// </summary>
+    public string Origin { get; set; } = "App";
+
     public RestoreOutcome Outcome { get; set; }
 
     /// <summary>What went wrong, when something did.</summary>
@@ -80,5 +87,6 @@ public sealed class RestoreHistoryEntry
     public string Summary => $"{TargetDatabase} on {ServerName} - {OutcomeDisplay}";
 
     public string Detail =>
-        $"{ChainSummary}{(RestorePointTimestamp.HasValue ? $"  |  point {RestorePointTimestamp:yyyy-MM-dd HH:mm:ss}" : "")}  |  {DurationDisplay}";
+        $"{ChainSummary}{(RestorePointTimestamp.HasValue ? $"  |  point {RestorePointTimestamp:yyyy-MM-dd HH:mm:ss}" : "")}  |  {DurationDisplay}" +
+        (Origin is "App" or "" ? string.Empty : $"  |  via {Origin}");
 }

--- a/src/NineLives.Tests/CliJsonResultTests.cs
+++ b/src/NineLives.Tests/CliJsonResultTests.cs
@@ -1,0 +1,205 @@
+using System.IO;
+using System.Text.Json;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The execution verbs end as data when asked (#303): --json puts outcome, duration, chain,
+/// point, refusals and the history id on stdout, machine-shaped - the rehearsal's proof
+/// becomes an artefact a pipeline can archive. And receipts carry their Origin, so the
+/// History screen can tell a 3am CLI restore from a clicked one.
+/// </summary>
+public class CliJsonResultTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static (CliServices services, FakeSqlServerService sql, FakeRestoreHistoryStore history)
+        Stage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "MyDb",
+                    Type = BackupType.Full,
+                    StartedAt = T0,
+                    FinishedAt = T0.AddMinutes(5),
+                    CheckpointLsn = 100,
+                    Position = 1,
+                    Files = [@"X:\backups\full.bak"]
+                }
+            ]
+        };
+        var history = new FakeRestoreHistoryStore();
+        var services = new CliServices(
+            store, sql, new FakeBlobStorageService(), history, new FakeRunNotifier());
+        return (services, sql, history);
+    }
+
+    private static async Task<(int exit, string output, string errors)> Run(
+        Func<CliArguments, CliServices, TextWriter, TextWriter, CancellationToken, Task<int>> verb,
+        VerbSpec spec, string[] args, CliServices services)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await verb(CliArguments.Parse(args, spec), services, output, errors, default);
+        return (exit, output.ToString(), errors.ToString());
+    }
+
+    private static JsonElement Parse(string output) =>
+        JsonDocument.Parse(output).RootElement;
+
+    // ── the restore ends as data ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AGenerateOnlyRestoreEmitsTheVerdictAndTheScript()
+    {
+        var (services, _, _) = Stage();
+
+        var (exit, output, _) = await Run(RestoreVerb.RunAsync, RestoreVerb.Spec,
+            ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02", "--json"], services);
+
+        Assert.Equal(0, exit);
+        var result = Parse(output);
+        Assert.Equal("restore", result.GetProperty("verb").GetString());
+        Assert.Equal("Generated", result.GetProperty("outcome").GetString());
+        Assert.Contains("RESTORE DATABASE", result.GetProperty("script").GetString());
+        Assert.Equal(0, result.GetProperty("refusals").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task ARefusedRestoreCarriesItsRefusalsAsData()
+    {
+        var (services, sql, _) = Stage();
+        sql.DatabaseList = ["MyDb"];   // exists without --with-replace: refused
+
+        var (exit, output, _) = await Run(RestoreVerb.RunAsync, RestoreVerb.Spec,
+            ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02", "--json"], services);
+
+        Assert.Equal(2, exit);
+        var result = Parse(output);
+        Assert.Equal("Refused", result.GetProperty("outcome").GetString());
+        Assert.Contains("--with-replace",
+            result.GetProperty("refusals")[0].GetString());
+    }
+
+    [Fact]
+    public async Task AnExecutedRestoreEmitsTheOutcomeDurationAndHistoryId()
+    {
+        var (services, _, history) = Stage();
+
+        var (exit, output, _) = await Run(RestoreVerb.RunAsync, RestoreVerb.Spec,
+            ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02",
+             "--execute", "--json"], services);
+
+        Assert.Equal(0, exit);
+        var result = Parse(output);
+        Assert.Equal("Succeeded", result.GetProperty("outcome").GetString());
+        Assert.True(result.GetProperty("durationSeconds").GetDouble() >= 0);
+        Assert.Equal(history.Entries.Single().Id, result.GetProperty("historyId").GetString());
+    }
+
+    // ── the rehearsal's proof is an artefact ────────────────────────────────────
+
+    private static FileMoveOption ScratchableFile() => new()
+    {
+        LogicalName = "MyDb",
+        PhysicalName = @"E:\Data\MyDb.mdf",
+        NewPhysicalName = @"E:\Data\MyDb.mdf",
+        Type = "D",
+        SizeBytes = 1024
+    };
+
+    [Fact]
+    public async Task AProvenRehearsalEmitsTheMeasuredRto()
+    {
+        var (services, sql, history) = Stage();
+        sql.FileList = [ScratchableFile()];
+
+        var (exit, output, _) = await Run(RehearseVerb.RunAsync, RehearseVerb.Spec,
+            ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02",
+             "--execute", "--json"], services);
+
+        Assert.Equal(0, exit);
+        var result = Parse(output);
+        Assert.Equal("rehearse", result.GetProperty("verb").GetString());
+        Assert.Equal("Proven", result.GetProperty("outcome").GetString());
+        Assert.True(result.TryGetProperty("durationSeconds", out _));
+        Assert.Equal(history.Entries.Single().Id, result.GetProperty("historyId").GetString());
+    }
+
+    [Fact]
+    public async Task AFailedRehearsalSaysNotProvenAndThatTheScratchRemains()
+    {
+        var (services, sql, _) = Stage();
+        sql.FileList = [ScratchableFile()];
+        sql.FailOnExecuteNumber = 1;
+
+        var (exit, output, _) = await Run(RehearseVerb.RunAsync, RehearseVerb.Spec,
+            ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02",
+             "--execute", "--json"], services);
+
+        Assert.Equal(2, exit);
+        var result = Parse(output);
+        Assert.Equal("NotProven", result.GetProperty("outcome").GetString());
+        Assert.True(result.GetProperty("scratchRetained").GetBoolean());
+        Assert.NotNull(result.GetProperty("error").GetString());
+    }
+
+    // ── the backup too, and stdout stays pure ───────────────────────────────────
+
+    [Fact]
+    public async Task AnExecutedBackupEmitsOneParseableObjectOnStdout()
+    {
+        var (services, _, _) = Stage();
+
+        var (exit, output, _) = await Run(BackupVerb.RunAsync, BackupVerb.Spec,
+            ["--path", @"\\nas01\sql", "--server", "SRV01", "--database", "MyDb",
+             "--execute", "--json"], services);
+
+        Assert.Equal(0, exit);
+        var result = Parse(output);   // parse of the WHOLE stdout: nothing else leaked in
+        Assert.Equal("backup", result.GetProperty("verb").GetString());
+        Assert.Equal("Succeeded", result.GetProperty("outcome").GetString());
+        Assert.True(result.GetProperty("destinations").GetArrayLength() > 0);
+    }
+
+    // ── receipts say which front end acted (#303) ───────────────────────────────
+
+    [Fact]
+    public async Task CliReceiptsCarryTheirOrigin()
+    {
+        var (services, _, history) = Stage();
+
+        await Run(RestoreVerb.RunAsync, RestoreVerb.Spec,
+            ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02", "--execute"],
+            services);
+
+        Assert.Equal("CLI", history.Entries.Single().Origin);
+    }
+
+    [Fact]
+    public void AppReceiptsReadAsAppAndTheRowSaysNothingExtra()
+    {
+        var entry = new RestoreHistoryEntry { TargetDatabase = "MyDb", ServerName = "SRV01" };
+
+        Assert.Equal("App", entry.Origin);
+        Assert.DoesNotContain("via", entry.Detail);
+
+        entry.Origin = "CLI";
+        Assert.Contains("via CLI", entry.Detail);
+    }
+}


### PR DESCRIPTION
Closes #303 - the review board's last item.

- **`--json` on restore, rehearse and backup.** One machine-shaped object on stdout: outcome (`Generated`/`Refused`/`Succeeded`/`Cancelled`/`Failed`, and the rehearsal's `Proven`/`NotProven`), server, database, chain, point reached, started/completed, `durationSeconds` (the rehearsal's measured RTO), warnings, refusals, and the history entry id. Generate-only carries the script inside the JSON so stdout stays one parseable object; prose remains on stderr. `CliRunResult` shares the writer.
- **Receipts carry `Origin`** ("App" | "CLI", string for cross-version tolerance like Kind; pre-field entries read as "App"). History rows append "via CLI" when it was - a 3am scripted restore reads differently in an incident review than a clicked one, and until now they were indistinguishable.

Eight pins in `CliJsonResultTests`: generate-only verdict+script, refusals as data, executed outcome with history id, the rehearsal's Proven RTO artefact and NotProven with scratch retention, backup's parseable stdout, CLI origin stamping, and the App default with the row suffix. Suite 1,778 + 10 integration, Release `-warnaserror` clean.