### PR TITLE
S3-compatible object storage, the engine half (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **S3-compatible object storage, the engine half** (#51). An \`s3://\` container is just
+  another entry in the list - the URL's own scheme picks the provider, so existing configs
+  migrate by doing nothing. The credential is the pair \`AccessKeyId:SecretKey\`, which is the
+  engine's own secret format, so it rides the whole existing SAS pipeline unchanged (vault
+  slot, in-memory member, export-strips-secrets, environment variable) with a shape check at
+  entry. The server-side credential branches to \`IDENTITY = 'S3 Access Key'\`; backups
+  overwrite with \`FORMAT\` (the S3 connector has no append), and both generators emit the
+  optional region as \`BACKUP_OPTIONS\`/\`RESTORE_OPTIONS\` JSON on every statement. A hard
+  preflight refuses an S3 restore below SQL Server 2022 or on Express - a capability \`--force\`
+  cannot conjure - before \`WITH REPLACE\` drops anything. \`add-container\` and \`--ephemeral\`
+  take S3 endpoints. Browsing an S3 bucket (the listing client) and the storage-screen
+  surfaces follow next.
+
 - **The execution verbs end as data, and receipts know their origin** (#303). `--json` on
   restore, rehearse and backup puts the ending on stdout machine-shaped: outcome, chain,
   point reached, measured duration - the rehearsal's proof carrying the real RTO number -

--- a/src/NineLives.Cli/EnvironmentCredentials.cs
+++ b/src/NineLives.Cli/EnvironmentCredentials.cs
@@ -46,12 +46,19 @@ internal static class EnvironmentCredentials
         var url = env("NINELIVES_CONTAINER_URL");
         if (string.IsNullOrWhiteSpace(url)) return null;
 
+        // The credential comes from NINELIVES_SAS for either provider - it is one string
+        // in both cases (a SAS token, or the S3 AccessKeyId:SecretKey pair) and rides the
+        // same in-memory member (#51). No separate S3 variable is needed.
+        var secret = env("NINELIVES_SAS");
         return new BlobContainerConfig
         {
             Id = "env-container",
             Name = env("NINELIVES_CONTAINER_NAME") ?? "env",
             ContainerUrl = url,
-            UnsavedSasToken = string.IsNullOrWhiteSpace(env("NINELIVES_SAS")) ? null : env("NINELIVES_SAS")
+            S3Region = url.StartsWith("s3://", StringComparison.OrdinalIgnoreCase)
+                ? env("NINELIVES_S3_REGION")
+                : null,
+            UnsavedSasToken = string.IsNullOrWhiteSpace(secret) ? null : secret
         };
     }
 }

--- a/src/NineLives.Cli/Preflights.cs
+++ b/src/NineLives.Cli/Preflights.cs
@@ -68,6 +68,35 @@ internal static class Preflights
             .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
             .ToList();
 
+        // 0 (checked here, refused hard): can this engine speak S3 at all (#51)? The S3
+        // connector arrived in SQL Server 2022 and is not in Express - a capability, not
+        // evidence, so --force cannot override it: the engine would simply error after WITH
+        // REPLACE had already dropped the target. No verdict from silence, as ever.
+        if (devices.Any(d => d.StartsWith("s3://", StringComparison.OrdinalIgnoreCase)))
+        {
+            try
+            {
+                var s3Major = await services.Sql.GetProductMajorVersionAsync(target);
+                if (s3Major is { } m && m < 16)
+                    refusals.Add(
+                        $"This chain restores from S3-compatible storage, and {target.ServerName} " +
+                        $"is {VersionCompatibility.Describe(m)} - the S3 connector arrived in SQL " +
+                        "Server 2022. Restore onto a 2022+ instance, or from an Azure or shared-" +
+                        "path copy of the backups.");
+
+                var edition = await services.Sql.GetEngineEditionAsync(target);
+                if (edition == 4)
+                    refusals.Add(
+                        $"This chain restores from S3-compatible storage, and {target.ServerName} " +
+                        "is Express edition - the S3 connector is not available in Express, on " +
+                        "any version. Restore onto a Standard, Developer or Enterprise instance.");
+            }
+            catch
+            {
+                // The instance would not answer; the restore itself will say so properly.
+            }
+        }
+
         // 5. Will it physically fit (#297)? The GUI checks before WITH REPLACE drops
         // anything, and this front end is the one most often aimed at a freshly provisioned
         // VM with small disks. FILELISTONLY says how big each file lands, the target says

--- a/src/NineLives.Cli/Verbs/AddContainerVerb.cs
+++ b/src/NineLives.Cli/Verbs/AddContainerVerb.cs
@@ -1,4 +1,5 @@
 using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.Cli.Verbs;
 
@@ -12,8 +13,9 @@ internal static class AddContainerVerb
     public static readonly VerbSpec Spec = new(
         "add-container",
         "Add or update a blob container, and prove the SAS reaches it",
-        "9lives add-container --name NAME --url CONTAINER_URL [--sas TOKEN] [--no-validate]",
-        Valued: ["name", "url", "sas"],
+        "9lives add-container --name NAME --url CONTAINER_URL [--sas TOKEN] " +
+        "[--region REGION] [--no-validate]",
+        Valued: ["name", "url", "sas", "region"],
         Switches: ["no-validate"],
         Options:
         [
@@ -23,7 +25,12 @@ internal static class AddContainerVerb
                 "again with the new token."),
             ("--url CONTAINER_URL", "The container URL, no SAS in it: " +
                 "https://account.blob.core.windows.net/container"),
-            ("--sas TOKEN", "The SAS token, with or without its leading '?'. Stored in the " +
+            ("--region REGION", "For an s3:// container: the bucket's region, when the " +
+                "provider needs one said. The engine assumes us-east-1 otherwise; AWS-style " +
+                "endpoints usually carry the region in the host name and need nothing here."),
+            ("--sas TOKEN", "The credential. For an https:// Azure container: the SAS token, " +
+                "with or without its leading '?'. For an s3:// container: the pair " +
+                "AccessKeyId:SecretKey - the engine's own secret format. Stored in the " +
                 "Windows Credential Manager exactly as the app stores it. Prefer the " +
                 "NINELIVES_SAS environment variable in scripts - a variable stays out of " +
                 "shell history and process listings; a flag does not."),
@@ -73,9 +80,21 @@ internal static class AddContainerVerb
         var sas = args.Get("sas") ?? Environment.GetEnvironmentVariable("NINELIVES_SAS");
         if (string.IsNullOrEmpty(sas))
         {
-            errors.WriteLine("add-container needs the token: --sas, or the NINELIVES_SAS " +
+            errors.WriteLine("add-container needs the credential: --sas, or the NINELIVES_SAS " +
                              "environment variable (preferred in scripts - it stays out of " +
-                             "process listings).");
+                             "process listings). For an s3:// URL this is the pair " +
+                             "AccessKeyId:SecretKey; for https:// it is the SAS token.");
+            return ExitCodes.Usage;
+        }
+
+        var isS3 = url.StartsWith("s3://", StringComparison.OrdinalIgnoreCase);
+
+        // An s3:// endpoint's credential is the pair AccessKeyId:SecretKey (#51): the engine's
+        // own secret format, validated here so a malformed one is refused before it is stored
+        // rather than discovered as an authentication failure at restore time.
+        if (isS3 && S3Credentials.Validate(sas) is { } shapeError)
+        {
+            errors.WriteLine(shapeError);
             return ExitCodes.Usage;
         }
 
@@ -87,10 +106,13 @@ internal static class AddContainerVerb
         container.Name = name;
         container.ContainerUrl = url.TrimEnd('/');
         container.AuthMode = BlobAuthMode.SasToken;
+        // Region is addressing, stored on the container; null clears any stale value.
+        container.S3Region = isS3 ? args.Get("region") : null;
 
         if (existing == null) config.BlobContainers.Add(container);
         services.Store.SaveConfig(config);
-        services.Store.SaveSasToken(container, sas.TrimStart('?'));
+        // The pair goes in exactly as given; only a SAS carries a leading '?' to trim.
+        services.Store.SaveSasToken(container, isS3 ? sas : sas.TrimStart('?'));
 
         errors.WriteLine($"{(existing == null ? "Added" : "Updated")} container '{name}' -> " +
                          $"{container.ContainerUrl}.");

--- a/src/NineLives.Core/Models/BackupOptions.cs
+++ b/src/NineLives.Core/Models/BackupOptions.cs
@@ -90,4 +90,10 @@ public class BackupOptions
 
     /// <summary>A description written into the backup header, for whoever finds it later.</summary>
     public string? Description { get; set; }
+
+    /// <summary>
+    /// The bucket's region for an s3:// destination (#51), emitted as BACKUP_OPTIONS JSON.
+    /// Ignored - and cleared by the generator - when the destinations are not S3.
+    /// </summary>
+    public string? S3Region { get; set; }
 }

--- a/src/NineLives.Core/Models/BlobContainerConfig.cs
+++ b/src/NineLives.Core/Models/BlobContainerConfig.cs
@@ -93,6 +93,22 @@ public class BlobContainerConfig : INotifyPropertyChanged
     public string ContainerUrl { get; set; } = string.Empty;
 
     /// <summary>
+    /// Whether this container is S3-compatible object storage (#51). Derived from the URL's
+    /// own scheme - an s3:// endpoint IS the provider answer, there is no second field to
+    /// keep in sync, and every existing config migrates by doing nothing.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool IsS3 => ContainerUrl.StartsWith("s3://", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The bucket's region, for providers that need one (#51). Addressing, not a secret - it
+    /// rides in the config and in exports. Null means the provider's default (the engine
+    /// assumes us-east-1); AWS-style endpoints usually carry the region in the host name and
+    /// need nothing here.
+    /// </summary>
+    public string? S3Region { get; set; }
+
+    /// <summary>
     /// How the app signs in to this container (#29). Absent from config files written before this
     /// existed, which deserialise to <see cref="BlobAuthMode.SasToken"/> - the behaviour they
     /// already had, so no migration is needed.

--- a/src/NineLives.Core/Models/RestoreOptions.cs
+++ b/src/NineLives.Core/Models/RestoreOptions.cs
@@ -11,6 +11,13 @@ public enum RecoveryMode
 
 public class RestoreOptions
 {
+    /// <summary>
+    /// The bucket's region for an s3:// chain (#51), emitted as RESTORE_OPTIONS JSON on
+    /// every statement. Ignored - and cleared by the generator - when the chain's devices
+    /// are not S3.
+    /// </summary>
+    public string? S3Region { get; set; }
+
     public string TargetDatabaseName { get; set; } = string.Empty;
     public bool WithReplace { get; set; } = true;
     public RecoveryMode RecoveryMode { get; set; } = RecoveryMode.Recovery;

--- a/src/NineLives.Core/Services/BackupScriptGenerator.cs
+++ b/src/NineLives.Core/Services/BackupScriptGenerator.cs
@@ -23,6 +23,10 @@ public class BackupScriptGenerator
 
         var sb = new StringBuilder();
 
+        // Region is an S3 concept; a stale value on an Azure or share backup must not leak
+        // into the statement (#51).
+        if (!IsS3(options)) options.S3Region = null;
+
         AppendHeader(sb, options);
         AppendBackup(sb, options);
 
@@ -52,6 +56,11 @@ public class BackupScriptGenerator
 
         sb.AppendLine();
     }
+
+    /// <summary>An s3:// destination selects the S3 connector's rules (#51).</summary>
+    private static bool IsS3(BackupOptions options) =>
+        options.Destinations.Count > 0 &&
+        options.Destinations[0].StartsWith("s3://", StringComparison.OrdinalIgnoreCase);
 
     private static void AppendBackup(StringBuilder sb, BackupOptions options)
     {
@@ -106,12 +115,21 @@ public class BackupScriptGenerator
                      $"SERVER CERTIFICATE = {TSql.QuoteNameExact(options.EncryptionCertificate)})");
 
         // FORMAT implies INIT, and naming both is noise at best. FORMAT also discards whatever the
-        // media set already held, so it is never inferred - only ever asked for.
-        if (options.Format) with.Add("FORMAT");
+        // media set already held, so it is never inferred - only ever asked for. EXCEPT on S3
+        // (#51): the S3 connector has no append at all, INIT is rejected, and overwrite is
+        // spelled FORMAT - safe here precisely because every destination carries a fresh
+        // timestamped name, so there is never an existing backup for FORMAT to discard.
+        if (options.Format || IsS3(options)) with.Add("FORMAT");
         else if (options.Init) with.Add("INIT");
 
         if (!string.IsNullOrWhiteSpace(options.Description))
             with.Add($"DESCRIPTION = N'{TSql.EscapeLiteral(options.Description)}'");
+
+        // The engine assumes us-east-1 when unsaid; a provider that needs another region
+        // takes it as JSON (#51).
+        if (!string.IsNullOrWhiteSpace(options.S3Region))
+            with.Add("BACKUP_OPTIONS = '{\"s3\": {\"region\":\"" +
+                     TSql.EscapeLiteral(options.S3Region) + "\"}}'");
 
         with.Add($"STATS = {options.StatsPercent}");
 

--- a/src/NineLives.Core/Services/BlobCredentialIdentity.cs
+++ b/src/NineLives.Core/Services/BlobCredentialIdentity.cs
@@ -23,6 +23,13 @@ public enum BlobCredentialIdentity
     /// </summary>
     ManagedIdentity,
 
+    /// <summary>
+    /// WITH IDENTITY = 'S3 Access Key' - the S3 connector's identity (#51), SQL Server 2022+.
+    /// The secret is the literal pair 'AccessKeyId:SecretKey'. Only meaningful under an
+    /// s3:// credential name, which is the only place this app writes one.
+    /// </summary>
+    S3AccessKey,
+
     /// <summary>Anything else: a Windows account, a storage account key, a mistake. Not usable.</summary>
     Other
 }
@@ -42,7 +49,9 @@ public readonly record struct BlobCredentialStatus(BlobCredentialIdentity Kind, 
 
     /// <summary>Whether a RESTORE FROM URL can authenticate with it as it stands.</summary>
     public bool CanRestoreFromUrl =>
-        Kind is BlobCredentialIdentity.SharedAccessSignature or BlobCredentialIdentity.ManagedIdentity;
+        Kind is BlobCredentialIdentity.SharedAccessSignature
+             or BlobCredentialIdentity.ManagedIdentity
+             or BlobCredentialIdentity.S3AccessKey;
 
     /// <summary>Nothing of that name on the server.</summary>
     public static BlobCredentialStatus Missing => new(BlobCredentialIdentity.Missing, null);

--- a/src/NineLives.Core/Services/BlobCredentialPreflight.cs
+++ b/src/NineLives.Core/Services/BlobCredentialPreflight.cs
@@ -76,7 +76,10 @@ public static class BlobCredentialPreflight
                 "and the SAS token is sent over it.");
 
         var written = await sql.EnsureCredentialExistsAsync(
-            server, credentialName, container.ContainerUrl, sasToken);
+            server, credentialName, container.ContainerUrl, sasToken,
+            container.IsS3
+                ? BlobCredentialIdentity.S3AccessKey
+                : BlobCredentialIdentity.SharedAccessSignature);
 
         appendLog(written == CredentialChange.Created
             ? "Credential created on the server."

--- a/src/NineLives.Core/Services/BlobCredentialStatement.cs
+++ b/src/NineLives.Core/Services/BlobCredentialStatement.cs
@@ -52,6 +52,14 @@ public static class BlobCredentialStatement
                 $"WITH IDENTITY = 'SHARED ACCESS SIGNATURE',{Environment.NewLine}" +
                 $"SECRET = '{TSql.EscapeLiteral((sasToken ?? string.Empty).TrimStart('?'))}'",
 
+            // The S3 connector's identity (#51). The secret is the pair the app already
+            // stores as one string - 'AccessKeyId:SecretKey' is the engine's own format -
+            // and it goes in exactly as held: the '?' trim above is a SAS-ism.
+            BlobCredentialIdentity.S3AccessKey =>
+                $"{verb} CREDENTIAL {quotedName}{Environment.NewLine}" +
+                $"WITH IDENTITY = 'S3 Access Key',{Environment.NewLine}" +
+                $"SECRET = '{TSql.EscapeLiteral(sasToken ?? string.Empty)}'",
+
             _ => throw new ArgumentOutOfRangeException(
                 nameof(identity),
                 identity,

--- a/src/NineLives.Core/Services/ISqlServerService.cs
+++ b/src/NineLives.Core/Services/ISqlServerService.cs
@@ -65,6 +65,14 @@ public interface ISqlServerService
     Task<int?> GetProductMajorVersionAsync(ServerConnection server, CancellationToken ct = default);
 
     /// <summary>
+    /// SERVERPROPERTY('EngineEdition') as the engine reports it - 4 is Express (#51). Null
+    /// when the instance will not say. Asked by the S3 capability gate: the S3 connector
+    /// needs SQL Server 2022+ AND a non-Express edition, and refusing on a guess would block
+    /// legal restores, so silence produces no verdict.
+    /// </summary>
+    Task<int?> GetEngineEditionAsync(ServerConnection server, CancellationToken ct = default);
+
+    /// <summary>
     /// The marked transactions msdb knows for a database (#243) - name, description and when.
     /// Almost no tooling reads logmarkhistory, which is why almost nobody uses marks.
     /// </summary>

--- a/src/NineLives.Core/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives.Core/Services/RestoreScriptGenerator.cs
@@ -8,6 +8,14 @@ public class RestoreScriptGenerator
     public string Generate(BackupChain chain, RestoreOptions options)
     {
         var sb = new StringBuilder();
+
+        // Region is an S3 concept (#51): meaningful only when the chain's devices are s3://,
+        // and a stale value from a previous source must not leak into another provider's
+        // statements.
+        var s3 = chain.FullSet.Files.Any(f =>
+            !f.IsOnDisk && f.BlobUrl.StartsWith("s3://", StringComparison.OrdinalIgnoreCase));
+        if (!s3) options.S3Region = null;
+
         var dbName = EscapeName(options.TargetDatabaseName);
         var hasDiffs = chain.DiffSets.Count > 0;
         var hasLogs = chain.LogSets.Count > 0;
@@ -213,6 +221,13 @@ public class RestoreScriptGenerator
             sb.AppendLine("         CHECKSUM,");
         if (options.ContinueAfterError)
             sb.AppendLine("         CONTINUE_AFTER_ERROR,");
+
+        // On EVERY statement of the chain, the same rule as STOPAT: each RESTORE stands
+        // alone against the endpoint (#51).
+        if (!string.IsNullOrWhiteSpace(options.S3Region))
+            sb.AppendLine("         RESTORE_OPTIONS = '{\"s3\": {\"region\":\"" +
+                          TSql.EscapeLiteral(options.S3Region) + "\"}}',");
+
         sb.AppendLine($"         STATS = {options.StatsPercent};");
     }
 

--- a/src/NineLives.Core/Services/S3Credentials.cs
+++ b/src/NineLives.Core/Services/S3Credentials.cs
@@ -1,0 +1,44 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// The S3 key pair as one string (#51): <c>AccessKeyId:SecretKey</c> - which is literally the
+/// engine's CREATE CREDENTIAL secret format, so the pair rides the entire existing SAS
+/// pipeline unchanged: same vault slot, same in-memory-only member, same export-strips-secrets
+/// rule, same environment variable. The price of that reuse is a shape rule enforced at entry.
+/// </summary>
+public static class S3Credentials
+{
+    /// <summary>
+    /// Why the value cannot be used as an S3 credential secret - null when it can. The engine
+    /// requires exactly <c>AccessKeyId:SecretKey</c>, and a colon inside the secret key is
+    /// documented as unsupported, so a value with two colons is ambiguous and refused rather
+    /// than guessed at.
+    /// </summary>
+    public static string? Validate(string? pair)
+    {
+        if (string.IsNullOrWhiteSpace(pair))
+            return "An S3 credential is the pair AccessKeyId:SecretKey.";
+
+        var colon = pair.IndexOf(':');
+        if (colon <= 0)
+            return "An S3 credential is the pair AccessKeyId:SecretKey - the colon separates " +
+                   "the two, and both sides are required.";
+        if (colon == pair.Length - 1)
+            return "The secret key is missing after the colon.";
+        if (pair.IndexOf(':', colon + 1) >= 0)
+            return "The secret key cannot contain a colon - SQL Server's S3 credential format " +
+                   "does not support one.";
+
+        return null;
+    }
+
+    /// <summary>The two halves, for callers that need them separately (the listing client signs
+    /// requests with them individually). Null when the shape is wrong.</summary>
+    public static (string KeyId, string Secret)? Split(string? pair)
+    {
+        if (Validate(pair) != null) return null;
+
+        var colon = pair!.IndexOf(':');
+        return (pair[..colon], pair[(colon + 1)..]);
+    }
+}

--- a/src/NineLives.Core/Services/SqlServerService.cs
+++ b/src/NineLives.Core/Services/SqlServerService.cs
@@ -1144,6 +1144,8 @@ public class SqlServerService : ISqlServerService
             return BlobCredentialIdentity.SharedAccessSignature;
         if (identity.Equals("Managed Identity", StringComparison.OrdinalIgnoreCase))
             return BlobCredentialIdentity.ManagedIdentity;
+        if (identity.Equals("S3 Access Key", StringComparison.OrdinalIgnoreCase))
+            return BlobCredentialIdentity.S3AccessKey;
         return BlobCredentialIdentity.Other;
     }
 
@@ -1530,6 +1532,30 @@ public class SqlServerService : ISqlServerService
         }
 
         return orphans;
+    }
+
+    public async Task<int?> GetEngineEditionAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        try
+        {
+            await using var conn = CreateConnection(server);
+            await conn.OpenAsync(ct);
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT CAST(SERVERPROPERTY('EngineEdition') AS int)";
+            var result = await cmd.ExecuteScalarAsync(ct);
+            return result is int edition ? edition : null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            // No verdict from silence: an instance that will not answer must not be treated
+            // as any particular edition.
+            return null;
+        }
     }
 
     public async Task<Dictionary<string, long>> GetVolumeFreeSpaceAsync(

--- a/src/NineLives.Tests/CliProvisioningTests.cs
+++ b/src/NineLives.Tests/CliProvisioningTests.cs
@@ -154,6 +154,41 @@ public class CliProvisioningTests
         Assert.DoesNotContain("secret123", errors);
     }
 
+    /// <summary>An s3:// endpoint is just another container (#51): the key pair is stored as
+    /// the one string the engine wants, the region is kept, and validation runs the same way.</summary>
+    [Fact]
+    public async Task AddContainerAcceptsAnS3EndpointWithAKeyPairAndRegion()
+    {
+        var (services, store, _, _) = Stage();
+
+        var (exit, errors) = await Run(AddContainerVerb.RunAsync, AddContainerVerb.Spec,
+            ["--name", "s3backups", "--url", "s3://s3.eu-west-2.amazonaws.com/sqlbackups",
+             "--sas", "AKIAEXAMPLE:abc/def+secret", "--region", "eu-west-2"], services);
+
+        Assert.Equal(0, exit);
+        var container = Assert.Single(store.LoadConfig().BlobContainers);
+        Assert.True(container.IsS3);
+        Assert.Equal("eu-west-2", container.S3Region);
+        // The pair is stored verbatim - it IS the credential secret the engine will use.
+        Assert.Equal("AKIAEXAMPLE:abc/def+secret", store.GetSasToken(container));
+        Assert.DoesNotContain("secret", errors);
+    }
+
+    /// <summary>A malformed key pair is refused before storage, not discovered at restore.</summary>
+    [Fact]
+    public async Task AddContainerRefusesAMalformedS3KeyPair()
+    {
+        var (services, store, _, _) = Stage();
+
+        var (exit, errors) = await Run(AddContainerVerb.RunAsync, AddContainerVerb.Spec,
+            ["--name", "s3backups", "--url", "s3://s3.eu-west-2.amazonaws.com/sqlbackups",
+             "--sas", "no-colon-here"], services);
+
+        Assert.Equal(64, exit);
+        Assert.Contains("AccessKeyId:SecretKey", errors);
+        Assert.Empty(store.LoadConfig().BlobContainers);
+    }
+
     /// <summary>The SAS that looks right but is not: recorded, refused, exit 3, chain stops.</summary>
     [Fact]
     public async Task AddContainerWithASasTheContainerRefusesExitsThree()

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -333,6 +333,12 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>What GetProductMajorVersionAsync answers - 16 is SQL Server 2022 (#210).</summary>
     public int? ProductMajorVersion { get; set; } = 16;
 
+    /// <summary>What GetEngineEditionAsync answers - 4 is Express (#51). Default non-Express.</summary>
+    public int? EngineEdition { get; set; } = 3;
+
+    public Task<int?> GetEngineEditionAsync(ServerConnection server, CancellationToken ct = default)
+        => Task.FromResult(EngineEdition);
+
     /// <summary>Per-server overrides, for the checks that compare two servers' versions.</summary>
     public Dictionary<string, int?> MajorVersionByServer { get; } =
         new(StringComparer.OrdinalIgnoreCase);

--- a/src/NineLives.Tests/S3PreflightGateTests.cs
+++ b/src/NineLives.Tests/S3PreflightGateTests.cs
@@ -1,0 +1,131 @@
+using System.IO;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The S3 capability gate (#51): the S3 connector needs SQL Server 2022+ and a non-Express
+/// edition. That is a capability, not evidence - the engine would simply error after WITH
+/// REPLACE had dropped the target - so --force cannot override it. No verdict from silence.
+/// </summary>
+public class S3PreflightGateTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static (CliServices services, FakeSqlServerService sql) Stage(
+        string deviceUrl = "s3://s3.eu-west-2.amazonaws.com/backups/Sales_FULL.bak")
+    {
+        var store = new FakeCredentialStore();
+        // SRV01 is the source instance whose msdb history is read; SRV02 runs the restore.
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "Sales",
+                    Type = BackupType.Full,
+                    StartedAt = T0,
+                    FinishedAt = T0.AddMinutes(5),
+                    CheckpointLsn = 100,
+                    Position = 1,
+                    // The recorded device path is s3:// - not on-disk, so it reaches the target
+                    // as a blob device, which is exactly what the gate keys off.
+                    Files = [deviceUrl]
+                }
+            ]
+        };
+        var services = new CliServices(
+            store, sql, new FakeBlobStorageService(), new FakeRestoreHistoryStore(),
+            new FakeRunNotifier());
+        return (services, sql);
+    }
+
+    private static async Task<(int exit, string errors)> Run(string[] extra, CliServices services)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await RestoreVerb.RunAsync(
+            CliArguments.Parse(
+                [.. new[] { "--server", "SRV01", "--database", "Sales", "--target", "SRV02" }, .. extra],
+                RestoreVerb.Spec),
+            services, output, errors, default);
+        return (exit, errors.ToString());
+    }
+
+    [Fact]
+    public async Task Sql2019RefusesAnS3Restore()
+    {
+        var (services, sql) = Stage();
+        sql.ProductMajorVersion = 15;   // SQL Server 2019
+
+        var (exit, errors) = await Run(["--execute"], services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("S3 connector arrived in SQL Server 2022", errors);
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    [Fact]
+    public async Task ExpressEditionRefusesAnS3RestoreEvenOn2022()
+    {
+        var (services, sql) = Stage();
+        sql.ProductMajorVersion = 16;   // SQL Server 2022...
+        sql.EngineEdition = 4;          // ...but Express
+
+        var (exit, errors) = await Run(["--execute"], services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("Express edition", errors);
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    /// <summary>A capability the engine lacks cannot be forced into existence.</summary>
+    [Fact]
+    public async Task ForceDoesNotOverrideTheCapabilityGate()
+    {
+        var (services, sql) = Stage();
+        sql.ProductMajorVersion = 15;
+
+        var (exit, errors) = await Run(["--execute", "--force", "--with-replace"], services);
+
+        Assert.Equal(2, exit);
+        Assert.Contains("S3 connector arrived", errors);
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
+    [Fact]
+    public async Task A2022StandardInstanceRestoresFromS3()
+    {
+        var (services, sql) = Stage();
+        sql.ProductMajorVersion = 16;
+        sql.EngineEdition = 3;   // non-Express
+
+        var (exit, _) = await Run(["--execute"], services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(sql.ExecutedScripts, s => s.Contains("RESTORE DATABASE [Sales]"));
+    }
+
+    /// <summary>The gate is S3-only: an Azure restore is untouched by it.</summary>
+    [Fact]
+    public async Task AnAzureRestoreIsNotGatedOnVersion()
+    {
+        var (services, sql) = Stage("https://acct.blob.core.windows.net/backups/Sales_FULL.bak");
+        sql.ProductMajorVersion = 13;   // SQL Server 2016 - fine for Azure
+
+        var (exit, _) = await Run(["--execute"], services);
+
+        Assert.Equal(0, exit);
+        Assert.Contains(sql.ExecutedScripts, s => s.Contains("RESTORE DATABASE [Sales]"));
+    }
+}

--- a/src/NineLives.Tests/S3StatementTests.cs
+++ b/src/NineLives.Tests/S3StatementTests.cs
@@ -1,0 +1,204 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// An s3:// container is just another endpoint (#51): the URL's own scheme picks the
+/// provider, the key pair rides the SAS pipeline as one AccessKeyId:SecretKey string, the
+/// credential statement branches to the S3 identity, and the generators emit the S3
+/// connector's rules (FORMAT not INIT, optional region JSON).
+/// </summary>
+public class S3StatementTests
+{
+    // ── the container knows itself from its URL ─────────────────────────────────
+
+    [Theory]
+    [InlineData("s3://s3.eu-west-2.amazonaws.com/backups", true)]
+    [InlineData("S3://bucket.s3.amazonaws.com/x", true)]
+    [InlineData("https://acct.blob.core.windows.net/backups", false)]
+    public void TheSchemeDecidesTheProvider(string url, bool isS3)
+    {
+        Assert.Equal(isS3, new BlobContainerConfig { ContainerUrl = url }.IsS3);
+    }
+
+    // ── the key pair validation (#51) ───────────────────────────────────────────
+
+    [Theory]
+    [InlineData("AKIAEXAMPLE:abc/def+secret", null)]
+    [InlineData("", "AccessKeyId:SecretKey")]
+    [InlineData("nokeys", "colon separates")]
+    [InlineData(":secretonly", "AccessKeyId")]
+    [InlineData("keyonly:", "secret key is missing")]
+    [InlineData("key:sec:ret", "cannot contain a colon")]
+    public void TheKeyPairShapeIsEnforced(string pair, string? expectFragment)
+    {
+        var result = S3Credentials.Validate(pair);
+        if (expectFragment == null) Assert.Null(result);
+        else Assert.Contains(expectFragment, result);
+    }
+
+    [Fact]
+    public void SplitReturnsTheTwoHalvesOfAValidPair()
+    {
+        var split = S3Credentials.Split("AKIA123:the/secret+value");
+
+        Assert.NotNull(split);
+        Assert.Equal("AKIA123", split!.Value.KeyId);
+        Assert.Equal("the/secret+value", split.Value.Secret);
+        Assert.Null(S3Credentials.Split("nope"));
+    }
+
+    // ── the credential statement (#51) ──────────────────────────────────────────
+
+    [Fact]
+    public void TheS3CredentialUsesTheS3AccessKeyIdentityAndTheSecretAsIs()
+    {
+        var sql = BlobCredentialStatement.Build(
+            "s3://s3.eu-west-2.amazonaws.com/backups",
+            BlobCredentialIdentity.S3AccessKey, "AKIA123:se/cret+", exists: false);
+
+        Assert.Contains("CREATE CREDENTIAL [s3://s3.eu-west-2.amazonaws.com/backups]", sql);
+        Assert.Contains("IDENTITY = 'S3 Access Key'", sql);
+        Assert.Contains("SECRET = 'AKIA123:se/cret+'", sql);   // no '?' trimming, unlike SAS
+    }
+
+    [Fact]
+    public void AnExistingS3CredentialIsAltered()
+    {
+        var sql = BlobCredentialStatement.Build(
+            "s3://s3.amazonaws.com/b", BlobCredentialIdentity.S3AccessKey, "a:b", exists: true);
+
+        Assert.StartsWith("ALTER CREDENTIAL", sql);
+    }
+
+    [Fact]
+    public void AnS3CredentialCanAuthenticateARestore()
+    {
+        Assert.True(new BlobCredentialStatus(BlobCredentialIdentity.S3AccessKey, "S3 Access Key")
+            .CanRestoreFromUrl);
+    }
+
+    // ── the backup generator's S3 rules (#51) ───────────────────────────────────
+
+    private static BackupOptions S3Backup(string? region = null) => new()
+    {
+        DatabaseName = "Sales",
+        Medium = BackupMedium.AzureBlob,
+        Destinations = ["s3://s3.eu-west-2.amazonaws.com/backups/Sales_FULL_20260811.bak"],
+        Type = BackupType.Full,
+        S3Region = region
+    };
+
+    [Fact]
+    public void AnS3BackupOverwritesWithFormatBecauseAppendingDoesNotExist()
+    {
+        var script = new BackupScriptGenerator().Generate(S3Backup());
+
+        Assert.Contains("FORMAT", script);
+        // INIT would be rejected by the S3 connector - it must not be emitted.
+        Assert.DoesNotContain("INIT", script.Split("WITH")[1]);
+    }
+
+    [Fact]
+    public void AnAzureBackupStillUsesInit()
+    {
+        var script = new BackupScriptGenerator().Generate(new BackupOptions
+        {
+            DatabaseName = "Sales",
+            Medium = BackupMedium.AzureBlob,
+            Destinations = ["https://acct.blob.core.windows.net/backups/Sales.bak"],
+            Type = BackupType.Full
+        });
+
+        Assert.Contains("INIT", script);
+    }
+
+    [Fact]
+    public void TheBackupRegionRidesAsBackupOptionsJsonAndOnlyForS3()
+    {
+        var withRegion = new BackupScriptGenerator().Generate(S3Backup("eu-west-2"));
+        Assert.Contains("BACKUP_OPTIONS = '{\"s3\": {\"region\":\"eu-west-2\"}}'", withRegion);
+
+        // A region set on a non-S3 destination is cleared, never emitted.
+        var azure = new BackupScriptGenerator().Generate(new BackupOptions
+        {
+            DatabaseName = "Sales",
+            Destinations = ["https://acct.blob.core.windows.net/backups/Sales.bak"],
+            S3Region = "eu-west-2"
+        });
+        Assert.DoesNotContain("BACKUP_OPTIONS", azure);
+    }
+
+    // ── the restore generator's region, on every statement (#51) ────────────────
+
+    private static BackupChain S3Chain()
+    {
+        BackupFileInfo File(string name, BackupType type) => new()
+        {
+            BlobName = name,
+            BlobUrl = $"s3://s3.eu-west-2.amazonaws.com/backups/{name}",
+            Type = type
+        };
+        return new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                DatabaseName = "Sales", Type = BackupType.Full,
+                Timestamp = new DateTime(2026, 8, 1, 22, 0, 0),
+                Files = [File("Sales_FULL.bak", BackupType.Full)]
+            },
+            LogSets =
+            [
+                new BackupSet
+                {
+                    DatabaseName = "Sales", Type = BackupType.TransactionLog,
+                    Timestamp = new DateTime(2026, 8, 1, 23, 0, 0),
+                    Files = [File("Sales_LOG.trn", BackupType.TransactionLog)]
+                }
+            ]
+        };
+    }
+
+    [Fact]
+    public void TheRestoreRegionAppearsOnEveryStatementOfTheChain()
+    {
+        var script = new RestoreScriptGenerator().Generate(S3Chain(), new RestoreOptions
+        {
+            TargetDatabaseName = "Sales",
+            S3Region = "eu-west-2"
+        });
+
+        // One on the FULL, one on the LOG.
+        var count = script.Split("RESTORE_OPTIONS = '{\"s3\": {\"region\":\"eu-west-2\"}}'").Length - 1;
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void ANonS3ChainNeverEmitsARegionEvenIfOneIsSet()
+    {
+        var azureChain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                DatabaseName = "Sales", Type = BackupType.Full,
+                Timestamp = new DateTime(2026, 8, 1, 22, 0, 0),
+                Files = [new BackupFileInfo
+                {
+                    BlobName = "Sales.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/Sales.bak",
+                    Type = BackupType.Full
+                }]
+            }
+        };
+
+        var script = new RestoreScriptGenerator().Generate(azureChain, new RestoreOptions
+        {
+            TargetDatabaseName = "Sales",
+            S3Region = "eu-west-2"
+        });
+
+        Assert.DoesNotContain("RESTORE_OPTIONS", script);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1921,6 +1921,11 @@ public partial class RestoreViewModel : ViewModelBase
         options.StopAtMark = SelectedLogMark?.Name;
         options.StopBeforeMark = StopBeforeMark;
 
+        // The source container's region rides into the RESTORE_OPTIONS when the source is S3
+        // (#51). The generator ignores it - and clears it - for any non-S3 chain, so a stale
+        // value cannot leak between sources.
+        options.S3Region = SelectedContainer?.S3Region;
+
         GeneratedScript = _scriptGenerator.Generate(chain!, options);
         HasScript = true;
     }


### PR DESCRIPTION
First of the S3 support PRs (#51). This is everything the SQL Server *engine* touches - statement generation, credential, preflight gate - with the actual bucket-browsing listing client and the storage-screen surfaces to follow. Design is locked to Jake's framing: **an s3:// bucket is just another entry in the containers list**, the URL scheme decides the provider, no provider field.

- **`BlobContainerConfig.IsS3`** derives from the URL scheme; existing configs migrate untouched. New `S3Region` (addressing, travels in exports).
- **The key pair rides the SAS pipeline as one string** — `AccessKeyId:SecretKey` is the engine's own secret format, so vault slot, in-memory member, export-strips-secrets and `NINELIVES_SAS` all work unchanged. `S3Credentials.Validate` enforces the shape at entry.
- **`BlobCredentialStatement`** branches to `IDENTITY = 'S3 Access Key'`; `BlobCredentialIdentity` gains `S3AccessKey` (restore-capable), classified on read-back; the preflight writes the right identity for the container.
- **Backup generator**: `FORMAT` not `INIT` on s3 (no append exists), optional `BACKUP_OPTIONS` region JSON. **Restore generator**: `RESTORE_OPTIONS` region on every statement, cleared off non-S3 chains.
- **Hard capability gate** in `Preflights`: refuse S3 restore when target < SQL 2022 or Express edition (new `GetEngineEditionAsync`). Not evidence — `--force` can't override a feature the engine lacks — enforced *before* `WITH REPLACE`.
- **`add-container`** and **`--ephemeral`** accept s3:// endpoints + `--region`/`NINELIVES_S3_REGION`.

25 pins across `S3StatementTests`, `S3PreflightGateTests` and `CliProvisioningTests`. Suite 1,803 + 10 integration, Release `-warnaserror` clean. Nothing here changes existing Azure behaviour — every Azure pin is untouched and green.