### PR TITLE
S3-compatible object storage, the listing half (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,28 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
-- **S3-compatible object storage, the engine half** (#51). An \`s3://\` container is just
+- **S3-compatible object storage, the listing half** (#51). The app can now browse an
+  `s3://` container: a hand-rolled SigV4 signer and a minimal ListObjectsV2 client - one
+  signed GET, paged, path-style over TLS - behind the same storage interface Azure listings
+  use, so discovery, set grouping, chain building and the restore screens neither know nor
+  care which provider answered. No SDK: the signer is pinned stage by stage against AWS's
+  published test vectors. The region resolves configured, then host name, then us-east-1
+  (the engine's own default); Test Connection and `add-container` validation now genuinely
+  prove an S3 key pair reaches its bucket; and a refusal surfaces the provider's own error
+  sentence (AccessDenied and friends explain themselves). The storage-screen surfaces
+  follow next.
+
+- **S3-compatible object storage, the engine half** (#51). An `s3://` container is just
   another entry in the list - the URL's own scheme picks the provider, so existing configs
-  migrate by doing nothing. The credential is the pair \`AccessKeyId:SecretKey\`, which is the
+  migrate by doing nothing. The credential is the pair `AccessKeyId:SecretKey`, which is the
   engine's own secret format, so it rides the whole existing SAS pipeline unchanged (vault
   slot, in-memory member, export-strips-secrets, environment variable) with a shape check at
-  entry. The server-side credential branches to \`IDENTITY = 'S3 Access Key'\`; backups
-  overwrite with \`FORMAT\` (the S3 connector has no append), and both generators emit the
-  optional region as \`BACKUP_OPTIONS\`/\`RESTORE_OPTIONS\` JSON on every statement. A hard
-  preflight refuses an S3 restore below SQL Server 2022 or on Express - a capability \`--force\`
-  cannot conjure - before \`WITH REPLACE\` drops anything. \`add-container\` and \`--ephemeral\`
-  take S3 endpoints. Browsing an S3 bucket (the listing client) and the storage-screen
-  surfaces follow next.
+  entry. The server-side credential branches to `IDENTITY = 'S3 Access Key'`; backups
+  overwrite with `FORMAT` (the S3 connector has no append), and both generators emit the
+  optional region as `BACKUP_OPTIONS`/`RESTORE_OPTIONS` JSON on every statement. A hard
+  preflight refuses an S3 restore below SQL Server 2022 or on Express - a capability `--force`
+  cannot conjure - before `WITH REPLACE` drops anything. `add-container` and `--ephemeral`
+  take S3 endpoints.
 
 - **The execution verbs end as data, and receipts know their origin** (#303). `--json` on
   restore, rehearse and backup puts the ending on stdout machine-shaped: outcome, chain,

--- a/src/NineLives.Core/Services/BlobStorageService.cs
+++ b/src/NineLives.Core/Services/BlobStorageService.cs
@@ -150,6 +150,18 @@ public class BlobStorageService : IBlobStorageService
 
     public async Task<bool> VerifyConnectionAsync(BlobContainerConfig config, CancellationToken ct = default)
     {
+        if (config.IsS3)
+        {
+            // The smallest page the provider can answer proves everything the Azure probe
+            // proves: reachability, the bucket, the key pair and its List permission (#51).
+            var (url, keyId, secret, region) = S3Context(config);
+            await S3ListingClient.ListPageAsync(
+                url, keyId, secret, region,
+                prefix: url.BasePrefix.Length > 0 ? url.BasePrefix : null,
+                delimiter: null, maxKeys: 1, continuationToken: null, ct);
+            return true;
+        }
+
         await EnsureSignedInAsync(config, ct);
         var client = CreateClient(config);
         await foreach (var _ in client.GetBlobsAsync(
@@ -165,6 +177,23 @@ public class BlobStorageService : IBlobStorageService
     public async Task<List<string>> ListTopLevelFoldersAsync(
         BlobContainerConfig config, CancellationToken ct = default)
     {
+        if (config.IsS3)
+        {
+            var (url, keyId, secret, region) = S3Context(config);
+            var s3Folders = new List<string>();
+            string? token = null;
+            do
+            {
+                var page = await S3ListingClient.ListPageAsync(
+                    url, keyId, secret, region,
+                    prefix: url.BasePrefix.Length > 0 ? url.BasePrefix : null,
+                    delimiter: "/", maxKeys: null, continuationToken: token, ct);
+                s3Folders.AddRange(page.CommonPrefixes.Select(p => url.Relative(p).TrimEnd('/')));
+                token = page.NextContinuationToken;
+            } while (token != null);
+            return s3Folders;
+        }
+
         await EnsureSignedInAsync(config, ct);
         var client = CreateClient(config);
         var folders = new List<string>();
@@ -198,6 +227,8 @@ public class BlobStorageService : IBlobStorageService
         IProgress<int>? progress,
         CancellationToken ct = default)
     {
+        if (config.IsS3) return await ListS3BackupFilesAsync(config, scope, progress, ct);
+
         await EnsureSignedInAsync(config, ct);
         var client = CreateClient(config);
         var files = new List<BackupFileInfo>();
@@ -216,6 +247,80 @@ public class BlobStorageService : IBlobStorageService
 
         progress?.Report(files.Count);
         return files.OrderBy(f => f.LastModified).ToList();
+    }
+
+    /// <summary>
+    /// The S3 shape of the listing above, and nothing more than the shape (#51): the same
+    /// prefix push-down (ResolvePrefixesAsync is pure string work, and its folder-discovery
+    /// call routes back through the S3 branch), the same inference (ReadBlob neither knows nor
+    /// cares what listed the name), the same progress cadence, the same ordering. BlobUrl comes
+    /// out as s3://endpoint/bucket/key because that is what ContainerUrl is - which is exactly
+    /// the device string the engine half already generates RESTORE ... FROM URL with.
+    /// </summary>
+    private async Task<List<BackupFileInfo>> ListS3BackupFilesAsync(
+        BlobContainerConfig config,
+        BlobListingScope? scope,
+        IProgress<int>? progress,
+        CancellationToken ct)
+    {
+        var (url, keyId, secret, region) = S3Context(config);
+        var files = new List<BackupFileInfo>();
+
+        var prefixes = await ResolvePrefixesAsync(config, scope, ct);
+
+        foreach (var prefix in prefixes)
+        {
+            var listPrefix = url.BasePrefix + (prefix ?? string.Empty);
+            string? token = null;
+            do
+            {
+                var page = await S3ListingClient.ListPageAsync(
+                    url, keyId, secret, region,
+                    prefix: listPrefix.Length > 0 ? listPrefix : null,
+                    delimiter: null, maxKeys: null, continuationToken: token, ct);
+
+                foreach (var obj in page.Objects)
+                {
+                    // A console-made "folder" is a zero-byte object whose key ends in '/'.
+                    // Azure's hierarchy listing never surfaces these; a flat S3 listing does,
+                    // and one is not a backup.
+                    if (obj.Key.EndsWith('/')) continue;
+
+                    ReadBlob(config, url.Relative(obj.Key), obj.SizeBytes, obj.LastModified,
+                        files, obj.ETag);
+                    if (files.Count % 250 == 0) progress?.Report(files.Count);
+                }
+                token = page.NextContinuationToken;
+            } while (token != null);
+        }
+
+        progress?.Report(files.Count);
+        return files.OrderBy(f => f.LastModified).ToList();
+    }
+
+    /// <summary>
+    /// Everything an S3 request needs, resolved once per operation. The key pair lives in the
+    /// SAS slot - same vault entry, same unsaved-token override for Test Connection (#12) -
+    /// as the one string the engine's CREATE CREDENTIAL wants, split here because the listing
+    /// signs with the halves individually (#51).
+    /// </summary>
+    private (S3Url Url, string KeyId, string Secret, string Region) S3Context(
+        BlobContainerConfig config)
+    {
+        var url = S3Url.Parse(config.ContainerUrl);
+
+        var pair = config.UnsavedSasToken ?? _credentialStore.GetSasToken(config);
+        if (string.IsNullOrEmpty(pair))
+            throw new InvalidOperationException(
+                "No S3 credential found. Store the pair AccessKeyId:SecretKey for this " +
+                "container - it lives where the SAS token would.");
+
+        var split = S3Credentials.Split(pair)
+            ?? throw new InvalidOperationException(
+                "The stored S3 credential is not usable: " + S3Credentials.Validate(pair));
+
+        return (url, split.KeyId, split.Secret,
+            config.S3Region ?? url.RegionFromHost ?? "us-east-1");
     }
 
     /// <summary>

--- a/src/NineLives.Core/Services/S3ListingClient.cs
+++ b/src/NineLives.Core/Services/S3ListingClient.cs
@@ -1,0 +1,176 @@
+using System.Globalization;
+using System.Net.Http;
+using System.Xml.Linq;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>One listed object, exactly what a page of ListObjectsV2 says about it.</summary>
+public sealed record S3Object(string Key, long SizeBytes, DateTimeOffset LastModified, string? ETag);
+
+/// <summary>
+/// One page of results. NextContinuationToken is null on the last page - it is the loop
+/// condition, straight from the response.
+/// </summary>
+public sealed record S3ListPage(
+    IReadOnlyList<S3Object> Objects,
+    IReadOnlyList<string> CommonPrefixes,
+    string? NextContinuationToken);
+
+/// <summary>
+/// ListObjectsV2 against any S3-compatible endpoint, signed with SigV4 and nothing else (#51).
+///
+/// This is the whole of the app's S3 wire surface: the engine does the restores itself, so the
+/// only thing the app ever needs from the provider is "what is in the bucket" - one GET,
+/// repeated per page. That is why this is a client and not an SDK reference: the AWS SDK would
+/// be the biggest package in the application, brought in to make one request whose every byte
+/// is pinned in tests anyway.
+///
+/// Requests are path-style (https://endpoint/bucket?list-type=2...) because that is what SQL
+/// Server's own S3 connector speaks and the one form every compatible provider accepts without
+/// per-bucket DNS. TLS is assumed for the same reason: the engine itself refuses s3:// over
+/// plain HTTP, so a provider the engine can restore from is a provider this can list.
+/// </summary>
+public static class S3ListingClient
+{
+    private static readonly HttpClient Http = new();
+
+    /// <summary>
+    /// Test seam. A signature can be pinned offline (S3SignerTests) but the request choreography
+    /// - paging, prefixes, what a 403 turns into - needs the whole client to run, and it must
+    /// run without a bucket. Checked on every send so a test observes exactly what would have
+    /// gone on the wire, Authorization header included.
+    /// </summary>
+    internal static Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? SenderForTests;
+
+    /// <summary>
+    /// One page of listing. The caller owns the paging loop and the prefix strategy; this owns
+    /// the request shape, the signature and the parse.
+    /// </summary>
+    /// <param name="prefix">The raw key prefix, unencoded - encoding is the signer's job.</param>
+    /// <param name="delimiter">"/" to read folders (CommonPrefixes) instead of walking keys.</param>
+    /// <param name="maxKeys">Smaller first page for a connection probe; null takes the provider default.</param>
+    public static async Task<S3ListPage> ListPageAsync(
+        S3Url url,
+        string keyId,
+        string secret,
+        string region,
+        string? prefix,
+        string? delimiter,
+        int? maxKeys,
+        string? continuationToken,
+        CancellationToken ct = default)
+    {
+        // Raw values; CanonicalQuery encodes and orders them, and the URI carries that exact
+        // canonical string - the server re-derives it from what arrives, so the two must match.
+        var query = new List<(string Name, string Value)> { ("list-type", "2") };
+        if (!string.IsNullOrEmpty(continuationToken)) query.Add(("continuation-token", continuationToken));
+        if (!string.IsNullOrEmpty(delimiter)) query.Add(("delimiter", delimiter));
+        if (maxKeys is { } mk) query.Add(("max-keys", mk.ToString(CultureInfo.InvariantCulture)));
+        if (!string.IsNullOrEmpty(prefix)) query.Add(("prefix", prefix));
+
+        var encodedPath = "/" + S3RequestSigner.UriEncode(url.Bucket, keepSlash: true);
+        var canonicalQuery = S3RequestSigner.CanonicalQuery(query);
+        var amzDate = DateTime.UtcNow.ToString("yyyyMMdd'T'HHmmss'Z'", CultureInfo.InvariantCulture);
+
+        var headers = new List<(string Name, string Value)>
+        {
+            ("host", url.Authority),
+            ("x-amz-content-sha256", S3RequestSigner.EmptyPayloadHash),
+            ("x-amz-date", amzDate)
+        };
+
+        var authorization = S3RequestSigner.Authorization(
+            "GET", encodedPath, query, headers, S3RequestSigner.EmptyPayloadHash,
+            keyId, secret, region, "s3", amzDate);
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get, $"{url.HttpsBase}{encodedPath}?{canonicalQuery}");
+        request.Headers.TryAddWithoutValidation("x-amz-date", amzDate);
+        request.Headers.TryAddWithoutValidation("x-amz-content-sha256", S3RequestSigner.EmptyPayloadHash);
+        request.Headers.TryAddWithoutValidation("Authorization", authorization);
+
+        var send = SenderForTests ?? ((r, c) => Http.SendAsync(r, c));
+        using var response = await send(request, ct);
+        var body = await response.Content.ReadAsStringAsync(ct);
+
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException(DescribeRefusal((int)response.StatusCode, body));
+
+        return ParsePage(body);
+    }
+
+    /// <summary>
+    /// An S3 refusal comes back as XML with a Code and a Message, and the Message is usually
+    /// the single most useful sentence available - AccessDenied, RequestTimeTooSkewed and
+    /// SignatureDoesNotMatch all explain themselves. Passed through rather than translated;
+    /// when the body is not the expected XML (a proxy's error page, an empty 403) the status
+    /// line still stands on its own.
+    /// </summary>
+    private static string DescribeRefusal(int status, string body)
+    {
+        string? code = null, message = null;
+        try
+        {
+            var root = XDocument.Parse(body).Root;
+            code = Element(root, "Code");
+            message = Element(root, "Message");
+        }
+        catch
+        {
+            // Not XML - the status alone will have to say it.
+        }
+
+        var head = string.IsNullOrEmpty(code)
+            ? $"The S3 endpoint refused the listing (HTTP {status})."
+            : $"The S3 endpoint refused the listing ({code}, HTTP {status}).";
+        return string.IsNullOrEmpty(message) ? head : $"{head} {message}";
+    }
+
+    /// <summary>
+    /// Reads a ListBucketResult. By local name, ignoring the namespace: AWS stamps
+    /// http://s3.amazonaws.com/doc/2006-03-01/ on the document, and some compatible providers
+    /// omit it - the same parse has to accept both, because "S3-compatible" is the product
+    /// promise here.
+    /// </summary>
+    internal static S3ListPage ParsePage(string xml)
+    {
+        var root = XDocument.Parse(xml).Root
+            ?? throw new InvalidOperationException("The S3 listing response was empty.");
+
+        var objects = new List<S3Object>();
+        var prefixes = new List<string>();
+
+        foreach (var element in root.Elements())
+        {
+            switch (element.Name.LocalName)
+            {
+                case "Contents":
+                    var key = Element(element, "Key");
+                    if (string.IsNullOrEmpty(key)) break;
+
+                    long.TryParse(Element(element, "Size"), NumberStyles.None,
+                        CultureInfo.InvariantCulture, out var size);
+
+                    // ISO-8601 with a Z. Invariant and pinned to UTC for the same reason as
+                    // the SAS expiry parse (#21): the ambient culture has no business here.
+                    DateTimeOffset.TryParse(Element(element, "LastModified"),
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                        out var modified);
+
+                    objects.Add(new S3Object(key, size, modified, Element(element, "ETag")));
+                    break;
+
+                case "CommonPrefixes":
+                    var prefix = Element(element, "Prefix");
+                    if (!string.IsNullOrEmpty(prefix)) prefixes.Add(prefix);
+                    break;
+            }
+        }
+
+        return new S3ListPage(objects, prefixes, Element(root, "NextContinuationToken"));
+    }
+
+    private static string? Element(XElement? parent, string localName)
+        => parent?.Elements().FirstOrDefault(e => e.Name.LocalName == localName)?.Value;
+}

--- a/src/NineLives.Core/Services/S3RequestSigner.cs
+++ b/src/NineLives.Core/Services/S3RequestSigner.cs
@@ -1,0 +1,157 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// AWS Signature Version 4 - the hundred lines of it a signed GET needs, and nothing else.
+///
+/// Hand-rolled deliberately (#51): the alternative is the AWS SDK, which would be the largest
+/// dependency in the application in exchange for one HMAC chain and some canonicalisation
+/// rules. The risk of hand-rolling is quiet divergence from the specification, and the answer
+/// to that is not reading the code harder - it is S3SignerTests, which pins every stage
+/// (canonical request, derived key, final signature, whole header) against the worked example
+/// in AWS's own documentation and its published test suite. A refactor that changes any byte
+/// of the output fails those pins.
+///
+/// Everything here is pure string-and-bytes work: no clock, no network, no state. The caller
+/// supplies the timestamp so that requests sign what they send and tests sign what the vectors
+/// signed.
+/// </summary>
+internal static class S3RequestSigner
+{
+    /// <summary>
+    /// SHA-256 of an empty body. Every request the listing client makes is a GET, so this is
+    /// the only payload hash it ever sends - but S3 still requires it said explicitly, both as
+    /// the x-amz-content-sha256 header and as the canonical request's last line.
+    /// </summary>
+    internal const string EmptyPayloadHash =
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    /// <summary>
+    /// RFC 3986 percent-encoding, the strict form SigV4 canonicalisation requires: unreserved
+    /// characters bare, everything else %XX with uppercase hex, UTF-8 bytes underneath.
+    /// Deliberately not Uri.EscapeDataString - .NET's set of "safe" characters has shifted
+    /// between releases, and a signature is a place where the encoding drifting means every
+    /// request starts failing with SignatureDoesNotMatch.
+    /// </summary>
+    /// <param name="keepSlash">True when encoding a URI path, where '/' separates segments
+    /// and stays bare. Query names and values encode it.</param>
+    internal static string UriEncode(string value, bool keepSlash = false)
+    {
+        var sb = new StringBuilder(value.Length + 16);
+        foreach (var b in Encoding.UTF8.GetBytes(value))
+        {
+            var c = (char)b;
+            if (c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z') or (>= '0' and <= '9')
+                or '-' or '.' or '_' or '~'
+                || (keepSlash && c == '/'))
+            {
+                sb.Append(c);
+            }
+            else
+            {
+                sb.Append('%').Append(((int)b).ToString("X2"));
+            }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The canonical query string: every name and value encoded, then sorted by encoded name
+    /// (ordinal, which is the byte order the specification asks for). This exact string is
+    /// also what goes on the request URI - the server re-derives the canonical form from what
+    /// arrives, so sending anything that canonicalises differently breaks the signature.
+    /// </summary>
+    internal static string CanonicalQuery(IEnumerable<(string Name, string Value)> query)
+        => string.Join('&',
+            query
+                .Select(q => (Name: UriEncode(q.Name), Value: UriEncode(q.Value)))
+                .OrderBy(q => q.Name, StringComparer.Ordinal)
+                .ThenBy(q => q.Value, StringComparer.Ordinal)
+                .Select(q => $"{q.Name}={q.Value}"));
+
+    /// <summary>
+    /// The canonical request. Header names lower-case and sorted; the signed-headers line is
+    /// derived from the same list, so the two can never disagree about what was signed.
+    /// </summary>
+    internal static string CanonicalRequest(
+        string method,
+        string encodedPath,
+        string canonicalQuery,
+        IReadOnlyList<(string Name, string Value)> headers,
+        string payloadHash)
+    {
+        var canonical = headers
+            .Select(h => (Name: h.Name.ToLowerInvariant(), Value: h.Value.Trim()))
+            .OrderBy(h => h.Name, StringComparer.Ordinal)
+            .ToList();
+
+        var sb = new StringBuilder();
+        sb.Append(method).Append('\n');
+        sb.Append(encodedPath.Length == 0 ? "/" : encodedPath).Append('\n');
+        sb.Append(canonicalQuery).Append('\n');
+        foreach (var (name, value) in canonical)
+            sb.Append(name).Append(':').Append(value).Append('\n');
+        sb.Append('\n');
+        sb.Append(string.Join(';', canonical.Select(h => h.Name))).Append('\n');
+        sb.Append(payloadHash);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The signing key: HMAC chained through date, region and service from "AWS4" + secret.
+    /// Derived per request rather than cached - the chain is four HMACs, and a cache keyed on
+    /// day/region/service is complexity with nothing measurable to show for it.
+    /// </summary>
+    internal static byte[] SigningKey(string secret, string dateStamp, string region, string service)
+    {
+        var kDate = Hmac(Encoding.UTF8.GetBytes("AWS4" + secret), dateStamp);
+        var kRegion = Hmac(kDate, region);
+        var kService = Hmac(kRegion, service);
+        return Hmac(kService, "aws4_request");
+    }
+
+    /// <summary>
+    /// The complete Authorization header value for a request whose parts are given. The
+    /// timestamp arrives as the already-formatted x-amz-date value (yyyyMMddTHHmmssZ) so that
+    /// the header on the wire and the one signed here are the same string by construction.
+    /// </summary>
+    internal static string Authorization(
+        string method,
+        string encodedPath,
+        IEnumerable<(string Name, string Value)> query,
+        IReadOnlyList<(string Name, string Value)> headers,
+        string payloadHash,
+        string keyId,
+        string secret,
+        string region,
+        string service,
+        string amzDate)
+    {
+        var dateStamp = amzDate[..8];
+        var scope = $"{dateStamp}/{region}/{service}/aws4_request";
+
+        var canonicalRequest = CanonicalRequest(
+            method, encodedPath, CanonicalQuery(query), headers, payloadHash);
+
+        var stringToSign =
+            $"AWS4-HMAC-SHA256\n{amzDate}\n{scope}\n{HexSha256(canonicalRequest)}";
+
+        var signature = Convert.ToHexStringLower(
+            Hmac(SigningKey(secret, dateStamp, region, service), stringToSign));
+
+        var signedHeaders = string.Join(';', headers
+            .Select(h => h.Name.ToLowerInvariant())
+            .OrderBy(n => n, StringComparer.Ordinal));
+
+        return $"AWS4-HMAC-SHA256 Credential={keyId}/{scope}, " +
+               $"SignedHeaders={signedHeaders}, Signature={signature}";
+    }
+
+    internal static string HexSha256(string value)
+        => Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+    private static byte[] Hmac(byte[] key, string data)
+        => HMACSHA256.HashData(key, Encoding.UTF8.GetBytes(data));
+}

--- a/src/NineLives.Core/Services/S3Url.cs
+++ b/src/NineLives.Core/Services/S3Url.cs
@@ -1,0 +1,100 @@
+using System.Text.RegularExpressions;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// The parts of an s3:// container URL (#51): <c>s3://endpoint[:port]/bucket[/base-prefix]</c>.
+///
+/// The exact string the engine restores from is also the string the app lists with - one URL,
+/// two readers - so this is the one place the app's idea of what an s3:// URL means lives. The
+/// listing requests themselves go over HTTPS path-style (<c>https://endpoint/bucket</c>): that
+/// is the form SQL Server's own S3 connector speaks, and the one every S3-compatible provider
+/// accepts regardless of how its bucket DNS is set up.
+/// </summary>
+/// <param name="Authority">Host, plus the port when the URL named one. Signed as-is into every
+/// request's host header, so it must match what the HTTP client sends byte for byte.</param>
+/// <param name="Bucket">The first path segment. Path-style requests put it back on the path.</param>
+/// <param name="BasePrefix">Anything after the bucket, normalised to end in '/' (or empty).
+/// Prepended to every listing prefix and stripped from every returned key, so blob names stay
+/// relative to the container URL - the same contract the Azure side has always had.</param>
+/// <param name="RegionFromHost">The region the host name itself states, when it does. AWS-style
+/// endpoints (<c>s3.eu-west-2.amazonaws.com</c>, and the compatibles that copy the shape) carry
+/// it; anything else answers null and the caller falls back to the configured region or the
+/// engine's own default of us-east-1.</param>
+public sealed record S3Url(string Authority, string Bucket, string BasePrefix, string? RegionFromHost)
+{
+    public string HttpsBase => $"https://{Authority}";
+
+    /// <summary>A listed key made relative to the container URL, base prefix stripped.</summary>
+    public string Relative(string key)
+        => BasePrefix.Length > 0 && key.StartsWith(BasePrefix, StringComparison.Ordinal)
+            ? key[BasePrefix.Length..]
+            : key;
+
+    public static S3Url Parse(string containerUrl)
+        => TryParse(containerUrl)
+           ?? throw new InvalidOperationException(
+               $"'{containerUrl}' is not an s3:// container URL. The shape is " +
+               "s3://endpoint[:port]/bucket - the endpoint is the provider's host name, and " +
+               "the first path segment is the bucket.");
+
+    public static S3Url? TryParse(string? containerUrl)
+    {
+        if (string.IsNullOrWhiteSpace(containerUrl)) return null;
+        if (!Uri.TryCreate(containerUrl, UriKind.Absolute, out var uri)) return null;
+        if (!uri.Scheme.Equals("s3", StringComparison.OrdinalIgnoreCase)) return null;
+        if (string.IsNullOrEmpty(uri.Host)) return null;
+
+        // AbsolutePath arrives percent-encoded; the prefix has to be the RAW key text because
+        // the request signer encodes exactly once. Unescape-then-use, same rule as
+        // BlobUrlEncoder, and idempotent for input that was never encoded.
+        var segments = uri.AbsolutePath
+            .Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Select(Uri.UnescapeDataString)
+            .ToArray();
+        if (segments.Length == 0) return null;
+
+        var basePrefix = segments.Length > 1 ? string.Join('/', segments.Skip(1)) + "/" : string.Empty;
+
+        // SQL Server's URL shape is s3://endpoint:port, and the port people write is 443.
+        // HTTPS elides the default port from the Host header it sends, so signing "host:443"
+        // while the wire says "host" would fail every request with SignatureDoesNotMatch -
+        // normalise it away here, once, for both the signature and the request URI.
+        var authority = uri.Port == 443 ? uri.Host : uri.Authority;
+
+        return new S3Url(authority, segments[0], basePrefix, SniffRegion(uri.Host));
+    }
+
+    /// <summary>
+    /// AWS regions all look like <c>xx-yyyy-N</c> and every S3-compatible that puts a region in
+    /// its host copies the shape, digits at the end included. Requiring the full shape is what
+    /// keeps ordinary host labels - "amazonaws", a company name - from being read as one.
+    /// </summary>
+    private static readonly Regex RegionShape = new(
+        "^[a-z]{2,}(?:-[a-z0-9]+)+$", RegexOptions.Compiled);
+
+    private static bool LooksLikeRegion(string label)
+        => RegionShape.IsMatch(label) && char.IsAsciiDigit(label[^1]);
+
+    private static string? SniffRegion(string host)
+    {
+        var labels = host.ToLowerInvariant().Split('.');
+        for (var i = 0; i < labels.Length - 1; i++)
+        {
+            // s3.eu-west-2.amazonaws.com, s3.dualstack.eu-west-2.amazonaws.com - and the
+            // compatibles that follow the pattern (Wasabi, Backblaze B2).
+            if (labels[i] == "s3")
+            {
+                var j = labels[i + 1] == "dualstack" && i + 2 < labels.Length ? i + 2 : i + 1;
+                if (LooksLikeRegion(labels[j])) return labels[j];
+            }
+            // The legacy AWS dash form: s3-eu-west-1.amazonaws.com.
+            else if (labels[i].StartsWith("s3-", StringComparison.Ordinal)
+                     && LooksLikeRegion(labels[i][3..]))
+            {
+                return labels[i][3..];
+            }
+        }
+        return null;
+    }
+}

--- a/src/NineLives.Tests/S3ListingTests.cs
+++ b/src/NineLives.Tests/S3ListingTests.cs
@@ -1,0 +1,288 @@
+using System.Net;
+using System.Net.Http;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The listing choreography (#51): what actually goes on the wire for an s3:// container, and
+/// what comes back into the app. The signature's bytes are pinned in S3SignerTests against
+/// AWS's published vectors; here the whole client runs against a scripted endpoint, so the
+/// pins are about behaviour - paging follows the continuation token, prefixes push down, a
+/// base prefix scopes and strips, folder markers are not backups, keys flow through the same
+/// inference Azure listings do, and a refusal surfaces the provider's own sentence.
+/// </summary>
+public class S3ListingTests : IDisposable
+{
+    public void Dispose() => S3ListingClient.SenderForTests = null;
+
+    // ── the scripted endpoint ───────────────────────────────────────────────────
+
+    /// <summary>What the client sent, captured before the request is disposed.</summary>
+    private sealed record Sent(string Uri, string? Authorization, string? AmzDate, string? ContentSha);
+
+    private static (List<Sent> sent, BlobStorageService blobs, BlobContainerConfig config) Stage(
+        string containerUrl,
+        Queue<(HttpStatusCode Status, string Body)> responses,
+        string pair = "AKIDEXAMPLE:test-secret",
+        string? region = null,
+        string pathPattern = BlobContainerConfig.DefaultPathPattern)
+    {
+        var config = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "s3",
+            ContainerUrl = containerUrl,
+            S3Region = region,
+            PathPattern = pathPattern
+        };
+
+        var store = new FakeCredentialStore();
+        if (pair.Length > 0) store.SaveSasToken(config, pair);
+
+        var sent = new List<Sent>();
+        S3ListingClient.SenderForTests = (request, _) =>
+        {
+            sent.Add(new Sent(
+                request.RequestUri!.ToString(),
+                request.Headers.TryGetValues("Authorization", out var auth) ? auth.First() : null,
+                request.Headers.TryGetValues("x-amz-date", out var date) ? date.First() : null,
+                request.Headers.TryGetValues("x-amz-content-sha256", out var sha) ? sha.First() : null));
+
+            var (status, body) = responses.Count > 0
+                ? responses.Dequeue()
+                : (HttpStatusCode.OK, EmptyPage);
+            return Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) });
+        };
+
+        return (sent, new BlobStorageService(store), config);
+    }
+
+    private const string EmptyPage =
+        """<?xml version="1.0"?><ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>""";
+
+    private static string Page(string? nextToken, params (string Key, long Size, string Modified)[] objects)
+    {
+        var contents = string.Join("", objects.Select(o =>
+            $"<Contents><Key>{o.Key}</Key><LastModified>{o.Modified}</LastModified>" +
+            $"<ETag>\"etag-{o.Size}\"</ETag><Size>{o.Size}</Size></Contents>"));
+        var token = nextToken == null
+            ? "<IsTruncated>false</IsTruncated>"
+            : $"<IsTruncated>true</IsTruncated><NextContinuationToken>{nextToken}</NextContinuationToken>";
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+               "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+               $"<Name>backups</Name>{token}{contents}</ListBucketResult>";
+    }
+
+    // ── listing behaviour ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PagesFollowTheContinuationTokenAndKeysFlowThroughTheInference()
+    {
+        var (sent, blobs, config) = Stage("s3://s3.eu-west-2.amazonaws.com/backups",
+            new Queue<(HttpStatusCode, string)>(
+            [
+                (HttpStatusCode.OK, Page("token-2",
+                    ("FULL/SRV01/SalesDb/SalesDb_backup_2026_01_05_010000.bak", 1048576, "2026-01-05T01:10:00Z"),
+                    ("LOG/SRV01/SalesDb/SalesDb_backup_2026_01_05_020000.trn", 2048, "2026-01-05T02:10:00Z"))),
+                (HttpStatusCode.OK, Page(null,
+                    ("FULL/", 0, "2026-01-01T00:00:00Z"),
+                    ("DIFF/SRV01/SalesDb/SalesDb_backup_2026_01_06_010000.bak", 4096, "2026-01-06T01:10:00Z")))
+            ]));
+
+        var files = await blobs.ListBackupFilesAsync(config);
+
+        // The zero-byte folder marker is not a backup; everything else inferred exactly as an
+        // Azure listing would have.
+        Assert.Equal(3, files.Count);
+        Assert.Equal(2, sent.Count);
+        Assert.Contains("continuation-token=token-2", sent[1].Uri);
+
+        var full = files.Single(f => f.Type == BackupType.Full);
+        Assert.Equal("SRV01", full.InferredServerName);
+        Assert.Equal("SalesDb", full.InferredDatabaseName);
+        Assert.Equal(
+            "s3://s3.eu-west-2.amazonaws.com/backups/FULL/SRV01/SalesDb/SalesDb_backup_2026_01_05_010000.bak",
+            full.BlobUrl);
+        Assert.Equal("\"etag-1048576\"", full.ETag);
+
+        // Ordered by LastModified, same as ever.
+        Assert.Equal(
+            files.OrderBy(f => f.LastModified).Select(f => f.BlobName).ToList(),
+            files.Select(f => f.BlobName).ToList());
+    }
+
+    [Fact]
+    public async Task TheRequestIsSignedPathStyleForTheHostsRegion()
+    {
+        var (sent, blobs, config) = Stage("s3://s3.eu-west-2.amazonaws.com/backups",
+            new Queue<(HttpStatusCode, string)>());
+
+        await blobs.ListBackupFilesAsync(config);
+
+        var request = Assert.Single(sent);
+        Assert.StartsWith("https://s3.eu-west-2.amazonaws.com/backups?list-type=2", request.Uri);
+        Assert.StartsWith("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/", request.Authorization);
+        Assert.Contains("/eu-west-2/s3/aws4_request", request.Authorization);
+        Assert.Contains("SignedHeaders=host;x-amz-content-sha256;x-amz-date", request.Authorization);
+        Assert.Equal(S3RequestSigner.EmptyPayloadHash, request.ContentSha);
+        Assert.NotNull(request.AmzDate);
+    }
+
+    [Fact]
+    public async Task TheConfiguredRegionOutranksTheHostAndSilenceMeansUsEast1()
+    {
+        var (sentConfigured, blobsConfigured, configConfigured) = Stage(
+            "s3://s3.eu-west-2.amazonaws.com/backups",
+            new Queue<(HttpStatusCode, string)>(), region: "us-gov-east-1");
+        await blobsConfigured.ListBackupFilesAsync(configConfigured);
+        Assert.Contains("/us-gov-east-1/s3/", Assert.Single(sentConfigured).Authorization);
+
+        var (sentPlain, blobsPlain, configPlain) = Stage(
+            "s3://storage.example.com/backups", new Queue<(HttpStatusCode, string)>());
+        await blobsPlain.ListBackupFilesAsync(configPlain);
+        Assert.Contains("/us-east-1/s3/", Assert.Single(sentPlain).Authorization);
+    }
+
+    [Fact]
+    public async Task AScopePushesThePrefixDown()
+    {
+        var (sent, blobs, config) = Stage("s3://storage.example.com/backups",
+            new Queue<(HttpStatusCode, string)>(),
+            pathPattern: "{ServerName}/{DatabaseName}/{FileName}");
+
+        await blobs.ListBackupFilesAsync(
+            config, new BlobListingScope("SRV01", "SalesDb"), progress: null);
+
+        Assert.Contains("prefix=SRV01%2FSalesDb", Assert.Single(sent).Uri);
+    }
+
+    [Fact]
+    public async Task ABasePrefixScopesTheListingAndStripsFromTheKeys()
+    {
+        var (sent, blobs, config) = Stage("s3://storage.example.com/backups/prod",
+            new Queue<(HttpStatusCode, string)>(
+            [
+                (HttpStatusCode.OK, Page(null,
+                    ("prod/FULL/SRV01/SalesDb/SalesDb_backup_2026_01_05_010000.bak", 100, "2026-01-05T01:10:00Z")))
+            ]));
+
+        var files = await blobs.ListBackupFilesAsync(config);
+
+        Assert.Contains("prefix=prod%2F", Assert.Single(sent).Uri);
+
+        var file = Assert.Single(files);
+        // Relative to the container URL, so the path inference still reads FULL/... - and the
+        // BlobUrl recomposes to the full engine-ready device string.
+        Assert.Equal("FULL/SRV01/SalesDb/SalesDb_backup_2026_01_05_010000.bak", file.BlobName);
+        Assert.Equal(BackupType.Full, file.Type);
+        Assert.Equal(
+            "s3://storage.example.com/backups/prod/FULL/SRV01/SalesDb/SalesDb_backup_2026_01_05_010000.bak",
+            file.BlobUrl);
+    }
+
+    [Fact]
+    public async Task VerifyConnectionProbesTheSmallestPage()
+    {
+        var (sent, blobs, config) = Stage("s3://storage.example.com/backups",
+            new Queue<(HttpStatusCode, string)>());
+
+        Assert.True(await blobs.VerifyConnectionAsync(config));
+        Assert.Contains("max-keys=1", Assert.Single(sent).Uri);
+    }
+
+    [Fact]
+    public async Task TopLevelFoldersComeFromCommonPrefixes()
+    {
+        var (sent, blobs, config) = Stage("s3://storage.example.com/backups",
+            new Queue<(HttpStatusCode, string)>(
+            [
+                (HttpStatusCode.OK,
+                    "<?xml version=\"1.0\"?><ListBucketResult>" +
+                    "<IsTruncated>false</IsTruncated>" +
+                    "<CommonPrefixes><Prefix>FULL/</Prefix></CommonPrefixes>" +
+                    "<CommonPrefixes><Prefix>LOG/</Prefix></CommonPrefixes>" +
+                    "</ListBucketResult>")
+            ]));
+
+        var folders = await blobs.ListTopLevelFoldersAsync(config);
+
+        Assert.Equal(["FULL", "LOG"], folders);
+        Assert.Contains("delimiter=%2F", Assert.Single(sent).Uri);
+    }
+
+    // ── refusals ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ARefusalSurfacesTheProvidersOwnSentence()
+    {
+        var (_, blobs, config) = Stage("s3://storage.example.com/backups",
+            new Queue<(HttpStatusCode, string)>(
+            [
+                (HttpStatusCode.Forbidden,
+                    "<?xml version=\"1.0\"?><Error><Code>AccessDenied</Code>" +
+                    "<Message>Access Denied</Message></Error>")
+            ]));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => blobs.VerifyConnectionAsync(config));
+
+        Assert.Contains("AccessDenied", ex.Message);
+        Assert.Contains("HTTP 403", ex.Message);
+        Assert.Contains("Access Denied", ex.Message);
+    }
+
+    [Fact]
+    public async Task ARefusalWithoutXmlStillNamesTheStatus()
+    {
+        var (_, blobs, config) = Stage("s3://storage.example.com/backups",
+            new Queue<(HttpStatusCode, string)>(
+                [(HttpStatusCode.InternalServerError, "<html>proxy says no</html>")]));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => blobs.VerifyConnectionAsync(config));
+
+        Assert.Contains("HTTP 500", ex.Message);
+    }
+
+    [Fact]
+    public async Task AMissingPairSaysWhereItLives()
+    {
+        var (sent, blobs, config) = Stage("s3://storage.example.com/backups",
+            new Queue<(HttpStatusCode, string)>(), pair: "");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => blobs.ListBackupFilesAsync(config));
+
+        Assert.Contains("AccessKeyId:SecretKey", ex.Message);
+        Assert.Empty(sent);
+    }
+
+    // ── the parse on its own ────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheParseAcceptsTheNamespacedAndTheBare()
+    {
+        // AWS stamps the 2006-03-01 namespace; some compatible providers answer without one.
+        // "S3-compatible" is the promise, so both shapes must read identically.
+        var namespaced = S3ListingClient.ParsePage(Page("next-token",
+            ("FULL/a.bak", 42, "2026-02-01T00:00:00Z")));
+        var bare = S3ListingClient.ParsePage(
+            "<?xml version=\"1.0\"?><ListBucketResult>" +
+            "<Contents><Key>FULL/a.bak</Key><LastModified>2026-02-01T00:00:00Z</LastModified>" +
+            "<Size>42</Size></Contents></ListBucketResult>");
+
+        foreach (var page in new[] { namespaced, bare })
+        {
+            var obj = Assert.Single(page.Objects);
+            Assert.Equal("FULL/a.bak", obj.Key);
+            Assert.Equal(42, obj.SizeBytes);
+            Assert.Equal(new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero), obj.LastModified);
+        }
+
+        Assert.Equal("next-token", namespaced.NextContinuationToken);
+        Assert.Null(bare.NextContinuationToken);
+    }
+}

--- a/src/NineLives.Tests/S3SignerTests.cs
+++ b/src/NineLives.Tests/S3SignerTests.cs
@@ -1,0 +1,121 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The signer against AWS's own published answers (#51). SigV4 is hand-rolled here instead of
+/// carried in by the SDK, and the entire safety case for that is these pins: the worked example
+/// in the Signature Version 4 documentation (the IAM ListUsers request, whose every
+/// intermediate value AWS publishes) and the get-vanilla case from the official
+/// aws-sig-v4-test-suite. Every stage is pinned separately - canonical request, derived key,
+/// final signature, whole header - so when a refactor drifts a byte, the failure names the
+/// stage that moved rather than just "signature wrong".
+/// </summary>
+public class S3SignerTests
+{
+    // The suite's shared credential scope. The secret is AWS's published test secret, not a
+    // real one.
+    private const string KeyId = "AKIDEXAMPLE";
+    private const string Secret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+    private const string AmzDate = "20150830T123600Z";
+
+    // ── the documented IAM example, stage by stage ──────────────────────────────
+
+    private static readonly (string, string)[] IamQuery =
+        [("Action", "ListUsers"), ("Version", "2010-05-08")];
+
+    private static readonly (string, string)[] IamHeaders =
+    [
+        ("content-type", "application/x-www-form-urlencoded; charset=utf-8"),
+        ("host", "iam.amazonaws.com"),
+        ("x-amz-date", AmzDate)
+    ];
+
+    [Fact]
+    public void TheCanonicalRequestHashesToTheDocumentedValue()
+    {
+        var canonical = S3RequestSigner.CanonicalRequest(
+            "GET", "/", S3RequestSigner.CanonicalQuery(IamQuery), IamHeaders,
+            S3RequestSigner.EmptyPayloadHash);
+
+        Assert.Equal(
+            "f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59",
+            S3RequestSigner.HexSha256(canonical));
+    }
+
+    [Fact]
+    public void TheSigningKeyDerivesToTheDocumentedValue()
+    {
+        Assert.Equal(
+            "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9",
+            Convert.ToHexStringLower(
+                S3RequestSigner.SigningKey(Secret, "20150830", "us-east-1", "iam")));
+    }
+
+    [Fact]
+    public void TheWholeHeaderMatchesTheDocumentedValue()
+    {
+        var authorization = S3RequestSigner.Authorization(
+            "GET", "/", IamQuery, IamHeaders, S3RequestSigner.EmptyPayloadHash,
+            KeyId, Secret, "us-east-1", "iam", AmzDate);
+
+        Assert.Equal(
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, " +
+            "SignedHeaders=content-type;host;x-amz-date, " +
+            "Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7",
+            authorization);
+    }
+
+    // ── the official test suite's plainest case ─────────────────────────────────
+
+    [Fact]
+    public void GetVanillaSignsToTheSuitesAnswer()
+    {
+        var authorization = S3RequestSigner.Authorization(
+            "GET", "/", [],
+            [("host", "example.amazonaws.com"), ("x-amz-date", AmzDate)],
+            S3RequestSigner.EmptyPayloadHash,
+            KeyId, Secret, "us-east-1", "service", AmzDate);
+
+        Assert.EndsWith(
+            "Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31",
+            authorization);
+    }
+
+    // ── the encoding rules the signature stands on ──────────────────────────────
+
+    [Theory]
+    [InlineData("FULL/SRV01 backups", false, "FULL%2FSRV01%20backups")]
+    [InlineData("FULL/SRV01 backups", true, "FULL/SRV01%20backups")]
+    [InlineData("A-b_c.d~e", false, "A-b_c.d~e")]
+    [InlineData("key:pair+x", false, "key%3Apair%2Bx")]
+    public void UriEncodingIsTheStrictRfcForm(string raw, bool keepSlash, string expected)
+    {
+        Assert.Equal(expected, S3RequestSigner.UriEncode(raw, keepSlash));
+    }
+
+    [Fact]
+    public void UriEncodingSpeaksUtf8PerByte()
+    {
+        // ü is 0xC3 0xBC in UTF-8: two escapes, uppercase hex - the form the server rebuilds
+        // before it re-derives the signature.
+        Assert.Equal("%C3%BC", S3RequestSigner.UriEncode("ü"));
+    }
+
+    [Fact]
+    public void TheCanonicalQuerySortsByEncodedName()
+    {
+        // prefix > list-type ordinally, and the value's slash encodes; the sort happens after
+        // encoding, which is the detail the specification is picky about.
+        Assert.Equal(
+            "list-type=2&prefix=FULL%2Fa%20b",
+            S3RequestSigner.CanonicalQuery([("prefix", "FULL/a b"), ("list-type", "2")]));
+    }
+
+    [Fact]
+    public void TheEmptyPayloadHashIsSha256OfNothing()
+    {
+        Assert.Equal(S3RequestSigner.EmptyPayloadHash, S3RequestSigner.HexSha256(""));
+    }
+}

--- a/src/NineLives.Tests/S3UrlTests.cs
+++ b/src/NineLives.Tests/S3UrlTests.cs
@@ -1,0 +1,95 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// One URL, two readers (#51): the engine restores from the s3:// string and the app lists
+/// with it, so what the app thinks the string means has to be pinned. The parts that carry
+/// consequences: the authority is signed into every request, the bucket goes back on the
+/// path, a base prefix must scope the listing AND strip from the keys (or blob names stop
+/// being relative to the container), and the region falls back configured -> host -> the
+/// engine's own us-east-1 assumption.
+/// </summary>
+public class S3UrlTests
+{
+    [Fact]
+    public void TheThreePartsComeApart()
+    {
+        var url = S3Url.Parse("s3://storage.example.com:9000/backups/prod");
+
+        Assert.Equal("storage.example.com:9000", url.Authority);
+        Assert.Equal("https://storage.example.com:9000", url.HttpsBase);
+        Assert.Equal("backups", url.Bucket);
+        Assert.Equal("prod/", url.BasePrefix);
+        Assert.Null(url.RegionFromHost);
+    }
+
+    [Fact]
+    public void ABareBucketHasNoBasePrefix()
+    {
+        var url = S3Url.Parse("s3://s3.eu-west-2.amazonaws.com/backups");
+
+        Assert.Equal("backups", url.Bucket);
+        Assert.Equal(string.Empty, url.BasePrefix);
+    }
+
+    [Fact]
+    public void Port443VanishesBecauseHttpsWillElideIt()
+    {
+        // SQL Server's own URL shape is s3://endpoint:port and people write the 443 out.
+        // The Host header HTTPS actually sends has no :443 on it, and the signature must
+        // sign what the wire says.
+        Assert.Equal("storage.example.com", S3Url.Parse("s3://storage.example.com:443/b").Authority);
+    }
+
+    [Theory]
+    [InlineData("s3://s3.eu-west-2.amazonaws.com/b", "eu-west-2")]
+    [InlineData("s3://s3.dualstack.ap-south-1.amazonaws.com/b", "ap-south-1")]
+    [InlineData("s3://s3-eu-west-1.amazonaws.com/b", "eu-west-1")]
+    [InlineData("s3://s3.us-west-004.backblazeb2.com/b", "us-west-004")]
+    [InlineData("s3://s3.eu-central-2.wasabisys.com/b", "eu-central-2")]
+    [InlineData("s3://storage.example.com/b", null)]
+    [InlineData("s3://accountid.r2.cloudflarestorage.com/b", null)]
+    public void TheHostStatesItsRegionOrStaysSilent(string containerUrl, string? region)
+    {
+        Assert.Equal(region, S3Url.Parse(containerUrl).RegionFromHost);
+    }
+
+    [Fact]
+    public void AnEncodedBasePrefixComesBackAsRawKeyText()
+    {
+        // The prefix parameter is signed from the raw text and encoded exactly once by the
+        // signer - a pre-encoded prefix would go out double-encoded and match nothing.
+        Assert.Equal("my backups/", S3Url.Parse("s3://h.example.com/b/my%20backups").BasePrefix);
+    }
+
+    [Fact]
+    public void RelativeStripsTheBasePrefixAndOnlyTheBasePrefix()
+    {
+        var url = S3Url.Parse("s3://h.example.com/bucket/prod");
+
+        Assert.Equal("FULL/f.bak", url.Relative("prod/FULL/f.bak"));
+        Assert.Equal("elsewhere/f.bak", url.Relative("elsewhere/f.bak"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("https://acct.blob.core.windows.net/backups")]
+    [InlineData("s3://host-only.example.com")]
+    [InlineData("not a url")]
+    public void AnythingElseRefusesToParse(string? containerUrl)
+    {
+        Assert.Null(S3Url.TryParse(containerUrl));
+    }
+
+    [Fact]
+    public void TheRefusalSpellsTheShapeOut()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => S3Url.Parse("s3://host-only.example.com"));
+
+        Assert.Contains("s3://endpoint[:port]/bucket", ex.Message);
+    }
+}


### PR DESCRIPTION
The engine half (#338) made an `s3://` container mean something to the generators; this makes it mean something to the app's own eyes. Second of the three PRs on #51 - the storage-screen surfaces follow.

## What this is

- **A hand-rolled SigV4 signer** (`S3RequestSigner`) - the hundred lines a signed GET needs, no SDK. The safety case for hand-rolling is `S3SignerTests`: every stage (canonical request, derived key, final signature, whole header) is pinned against the worked example in AWS's own documentation and the published `aws-sig-v4-test-suite` vectors, so a drifted byte fails naming the stage that moved.
- **A minimal ListObjectsV2 client** (`S3ListingClient`) - one signed GET, paged by continuation token, path-style over TLS (what SQL Server's own connector speaks, and the one form every compatible provider accepts without per-bucket DNS). Namespace-tolerant XML parse, because some compatibles answer without the AWS namespace.
- **The URL parser** (`S3Url`) - `s3://endpoint[:port]/bucket[/base-prefix]`, one reader for the same string the engine restores from. An explicit `:443` is normalised away - HTTPS elides it from the Host header, and the signature must sign what the wire says. A base prefix scopes every listing and strips from every key, so blob names stay relative to the container URL and recompose into exactly the device strings the engine half generates.
- **The branch behind the interface** - `BlobStorageService` routes `config.IsS3` to the client in `VerifyConnectionAsync`, `ListTopLevelFoldersAsync` and `ListBackupFilesAsync`. The prefix push-down, the `ReadBlob` inference, set grouping and every screen above them run unchanged over whichever provider answered. `Test Connection` and `add-container` validation now genuinely prove an S3 key pair reaches its bucket.

## Decisions worth a look

- Region resolves configured → host name (`s3.eu-west-2.amazonaws.com` and the compatibles that copy the shape, dualstack and legacy-dash forms included) → `us-east-1`, the engine's own default.
- Zero-byte keys ending `/` - console-made "folders" - are skipped. Azure's hierarchy listing never surfaces those; a flat S3 listing does, and one is not a backup.
- A refusal surfaces the provider's own `Code` and `Message` (AccessDenied, RequestTimeTooSkewed, SignatureDoesNotMatch all explain themselves). The full failure-explainer treatment arrives with the UI half.
- Also unescapes the engine-half CHANGELOG entry, which had literal backslash-backticks from the way it was written in.

## Verification

1,843 unit tests passing (40 new: signer vectors, URL parse, listing choreography against a scripted endpoint - paging, push-down, base-prefix stripping, refusal texts). Release `-warnaserror` clean.