### PR TITLE
S3-compatible object storage, the screen half (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **S3-compatible object storage, the screen half** (#51). The Blob Storage screen reads the
+  URL's scheme the way everything else does: type an `s3://` URL and the SAS section becomes
+  the key-pair boxes - access key id and secret key, combined on save into the engine's own
+  `AccessKeyId:SecretKey` secret format, shape-checked at entry - plus a Region field for the
+  providers that need one said. The Entra choices vanish (a bucket has exactly one way in),
+  no SAS expiry line appears against a credential that has none, and Test Connection tests
+  exactly what is on screen - stored secret with the on-screen region, when the region is the
+  thing being fixed. A refused listing now explains itself: AccessDenied, InvalidAccessKeyId,
+  SignatureDoesNotMatch, RequestTimeTooSkewed, NoSuchBucket and wrong-region redirects each
+  turn into the next move, not just the provider's sentence.
+
 - **S3-compatible object storage, the listing half** (#51). The app can now browse an
   `s3://` container: a hand-rolled SigV4 signer and a minimal ListObjectsV2 client - one
   signed GET, paged, path-style over TLS - behind the same storage interface Azure listings

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Exit codes are the contract: `0` fine, `1` warnings, `2` broken or unreachable-b
 
 The full reference ships inside the exe: `9lives help` for the overview, `9lives help restore` (or any verb) for the complete page - every option, the behaviour, the exit codes, examples. Documentation that lives in the binary cannot drift from it, and a test holds every page to the parser's own option lists.
 
-**Provisioning from nothing.** A freshly built VM - a Terraform clone, a DR bubble, a scratch environment - has no app config and nobody at a screen. `add-server` and `add-container` create the configuration from the command line, validated by default: the server is asked its version (address, credentials and permissions proven in one round trip), the container is asked to answer with exactly the recorded SAS - because a SAS is a string that looks right for weeks after it expired. Both converge on re-run, secrets can ride in `NINELIVES_SQL_PASSWORD` / `NINELIVES_SAS` instead of flags, and a chained script stops at the first failed validation. The whole template is three lines, and the only variable is the moment:
+**Provisioning from nothing.** A freshly built VM - a Terraform clone, a DR bubble, a scratch environment - has no app config and nobody at a screen. `add-server` and `add-container` create the configuration from the command line, validated by default: the server is asked its version (address, credentials and permissions proven in one round trip), the container is asked to answer with exactly the recorded credential - because a SAS is a string that looks right for weeks after it expired. An `s3://` URL works here too: the credential is then the pair `AccessKeyId:SecretKey`, and `--region` says the bucket's region when the provider needs one said. Both converge on re-run, secrets can ride in `NINELIVES_SQL_PASSWORD` / `NINELIVES_SAS` instead of flags, and a chained script stops at the first failed validation. The whole template is three lines, and the only variable is the moment:
 
 ```
 9lives add-server --name target --address localhost --user svc_restore --password %SQL_PW%
@@ -131,6 +131,13 @@ Two verbs execute, and they are built out of refusals: `restore` and `rehearse` 
 - Support for striped backup sets (multiple files per backup)
 - Availability Group backups using Ola Hallengren's default AG naming (`Cluster$AG_Database_FULL_yyyymmdd_hhmmss_n.bak`)
 - Secure SAS token storage using Windows Credential Manager
+
+### S3-Compatible Object Storage
+- An `s3://` container is just another entry in the list: AWS S3, Wasabi, Backblaze B2, Cloudflare R2 and storage appliances speaking the S3 API
+- The URL's own scheme picks the provider - `s3://endpoint/bucket` - so nothing else to configure, and a base path after the bucket scopes everything
+- Authenticates with the access key pair, stored together in Windows Credential Manager; the region is only needed when the endpoint's host name does not carry it
+- Browsing uses a built-in SigV4 listing client (no SDK), pinned against AWS's published signature test vectors
+- Restoring from S3 needs SQL Server 2022+ (not Express) - the app refuses earlier, before anything is dropped, because the S3 connector simply is not there
 
 ### SQL Server Connectivity
 - Windows Authentication and SQL Server Authentication support

--- a/src/NineLives.Core/Models/BlobContainerConfig.cs
+++ b/src/NineLives.Core/Models/BlobContainerConfig.cs
@@ -275,6 +275,14 @@ public class BlobContainerConfig : INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// What to call the way this container authenticates. An s3:// container reuses
+    /// <see cref="BlobAuthMode.SasToken"/> as its storage slot (#51), but showing "SAS token"
+    /// for it would send someone reading Azure documentation for a bucket.
+    /// </summary>
+    [JsonIgnore]
+    public string AuthDisplay => IsS3 ? "S3 access key pair" : AuthMode.Describe();
+
     private string? _cachedSasTokenValue;
 
     public DateTime? GetSasExpiry(string? sasToken = null) => ReadSasExpiry(sasToken).ExpiresAt;

--- a/src/NineLives.Core/Services/BlobFailureExplainer.cs
+++ b/src/NineLives.Core/Services/BlobFailureExplainer.cs
@@ -17,11 +17,48 @@ namespace Blackcat.NineLives.Services;
 internal static class BlobFailureExplainer
 {
     /// <summary>
-    /// Guidance for a failure, or null when there is nothing useful to add and Azure's own message
-    /// should stand on its own.
+    /// Guidance for a failure, or null when there is nothing useful to add and the provider's own
+    /// message should stand on its own.
     /// </summary>
     internal static string? Explain(Exception exception, BlobContainerConfig config)
     {
+        // The S3 codes are part of the contract every compatible provider imitates, which makes
+        // them the reliable thing to switch on - the message text gets rephrased per provider,
+        // and it is already shown above this guidance anyway (#51).
+        if (exception is S3RequestFailedException s3)
+        {
+            return s3.Code switch
+            {
+                "InvalidAccessKeyId" =>
+                    "The endpoint does not recognise this access key id. Check it was pasted "
+                    + "whole, and that the key belongs to this provider and account - a key from "
+                    + "a different account looks identical.",
+                "SignatureDoesNotMatch" =>
+                    "The endpoint recognised the access key id, but the signature computed from "
+                    + "the secret key is wrong. Re-enter the pair. If the pair is definitely "
+                    + "right, check the Region field - some providers answer with this code when "
+                    + "the request is signed for the wrong region.",
+                "AccessDenied" =>
+                    "The key pair is valid but not allowed to list this bucket. The key needs "
+                    + "permission to list the bucket and read its objects (on AWS: s3:ListBucket "
+                    + "and s3:GetObject) - listing is how backups are discovered here, and "
+                    + "reading is how the engine restores them.",
+                "RequestTimeTooSkewed" =>
+                    "This machine's clock is too far from the provider's. Every signed request "
+                    + "carries a timestamp the provider checks - correct the clock (Windows time "
+                    + "synchronisation) and try again.",
+                "NoSuchBucket" =>
+                    "The endpoint answered, but the bucket does not exist there. The bucket is "
+                    + "the first path segment of the s3:// URL - check its spelling, and that "
+                    + "the endpoint host is the one serving the bucket's region.",
+                "PermanentRedirect" or "AuthorizationHeaderMalformed" =>
+                    "The bucket lives in a different region than the request was signed for. Set "
+                    + "the Region field to the bucket's real region - the provider's message "
+                    + "above usually names it.",
+                _ => null
+            };
+        }
+
         if (exception is not RequestFailedException failure) return null;
 
         return failure.ErrorCode switch

--- a/src/NineLives.Core/Services/S3ListingClient.cs
+++ b/src/NineLives.Core/Services/S3ListingClient.cs
@@ -94,7 +94,7 @@ public static class S3ListingClient
         var body = await response.Content.ReadAsStringAsync(ct);
 
         if (!response.IsSuccessStatusCode)
-            throw new InvalidOperationException(DescribeRefusal((int)response.StatusCode, body));
+            throw Refusal((int)response.StatusCode, body);
 
         return ParsePage(body);
     }
@@ -104,9 +104,10 @@ public static class S3ListingClient
     /// the single most useful sentence available - AccessDenied, RequestTimeTooSkewed and
     /// SignatureDoesNotMatch all explain themselves. Passed through rather than translated;
     /// when the body is not the expected XML (a proxy's error page, an empty 403) the status
-    /// line still stands on its own.
+    /// line still stands on its own. The code rides on the exception for the failure
+    /// explainer, which can turn it into the next move.
     /// </summary>
-    private static string DescribeRefusal(int status, string body)
+    private static S3RequestFailedException Refusal(int status, string body)
     {
         string? code = null, message = null;
         try
@@ -123,7 +124,8 @@ public static class S3ListingClient
         var head = string.IsNullOrEmpty(code)
             ? $"The S3 endpoint refused the listing (HTTP {status})."
             : $"The S3 endpoint refused the listing ({code}, HTTP {status}).";
-        return string.IsNullOrEmpty(message) ? head : $"{head} {message}";
+        return new S3RequestFailedException(
+            string.IsNullOrEmpty(message) ? head : $"{head} {message}", code, status);
     }
 
     /// <summary>

--- a/src/NineLives.Core/Services/S3RequestFailedException.cs
+++ b/src/NineLives.Core/Services/S3RequestFailedException.cs
@@ -1,0 +1,21 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// An S3 endpoint's refusal with the provider's own code attached (#51).
+///
+/// InvalidOperationException underneath, so every existing catch treats it as the ordinary
+/// operational failure it is. The code exists for BlobFailureExplainer: AccessDenied,
+/// SignatureDoesNotMatch and RequestTimeTooSkewed each have a different next move, and the
+/// code is the only reliable way to tell them apart - providers rephrase the message text,
+/// but the code is part of the S3 contract they are all imitating.
+/// </summary>
+public sealed class S3RequestFailedException(string message, string? code, int status)
+    : InvalidOperationException(message)
+{
+    /// <summary>The error code from the response body (AccessDenied, NoSuchBucket...), when
+    /// the body carried the expected XML. Null for a bare status line.</summary>
+    public string? Code { get; } = code;
+
+    /// <summary>The HTTP status the refusal arrived with.</summary>
+    public int Status { get; } = status;
+}

--- a/src/NineLives.Tests/S3ConfigScreenTests.cs
+++ b/src/NineLives.Tests/S3ConfigScreenTests.cs
@@ -1,0 +1,241 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The Blob Storage screen speaking S3 (#51). The scheme picks the provider everywhere else,
+/// so the form reads it the same way: typing an s3:// URL swaps the SAS section for the
+/// key-pair boxes with nothing to also select. What must hold: the two halves leave the form
+/// only as the combined AccessKeyId:SecretKey string (shape-checked at entry, not at restore
+/// time), the region rides the config, Test Connection tests what is on screen, and none of
+/// the SAS-isms - expiry lines especially - leak onto a container that has no SAS.
+/// </summary>
+public class S3ConfigScreenTests
+{
+    private readonly FakeCredentialStore _store = new();
+    private readonly FakeBlobStorageService _blobs = new();
+
+    private BlobConfigViewModel NewViewModel() => new(_store, _blobs);
+
+    private BlobContainerConfig SavedS3Container(string pair = "AKIDSTORED:stored-secret")
+    {
+        var container = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "bucket",
+            ContainerUrl = "s3://s3.eu-west-2.amazonaws.com/backups",
+            S3Region = "eu-west-2"
+        };
+        _store.Config.BlobContainers.Add(container);
+        _store.SaveSasToken(container, pair);
+        return container;
+    }
+
+    // ── the scheme drives the form ──────────────────────────────────────────────
+
+    [Fact]
+    public void TypingAnS3UrlSnapsTheAuthModeToTheKeyPair()
+    {
+        var vm = NewViewModel();
+        vm.AddNewCommand.Execute(null);
+        vm.EditAuthMode = BlobAuthMode.EntraInteractive;
+
+        vm.EditContainerUrl = "s3://storage.example.com/backups";
+
+        Assert.True(vm.IsS3Url);
+        // Entra cannot reach a bucket - the mode snaps back rather than riding along silently.
+        Assert.Equal(BlobAuthMode.SasToken, vm.EditAuthMode);
+    }
+
+    // ── saving ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SavingComposesThePairAndCarriesTheRegion()
+    {
+        var vm = NewViewModel();
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "bucket";
+        vm.EditContainerUrl = "s3://s3.eu-west-2.amazonaws.com/backups";
+        vm.EditS3KeyId = "  AKIDEXAMPLE ";
+        vm.EditS3SecretKey = "wJalrXUtnFEMIEXAMPLE";
+        vm.EditS3Region = "eu-west-2";
+
+        vm.SaveCommand.Execute(null);
+
+        var saved = Assert.Single(_store.Config.BlobContainers);
+        Assert.Equal("eu-west-2", saved.S3Region);
+        Assert.Equal(BlobAuthMode.SasToken, saved.AuthMode);
+        // One string, the engine's own secret format, clipboard whitespace trimmed away.
+        Assert.Equal("AKIDEXAMPLE:wJalrXUtnFEMIEXAMPLE", _store.GetSasToken(saved));
+        Assert.False(vm.IsEditing);
+    }
+
+    [Fact]
+    public void HalfAPairIsRefusedAtTheForm()
+    {
+        var vm = NewViewModel();
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "bucket";
+        vm.EditContainerUrl = "s3://storage.example.com/backups";
+        vm.EditS3KeyId = "AKIDEXAMPLE";
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.Contains("Both halves", vm.ErrorMessage);
+        Assert.Empty(_store.Config.BlobContainers);
+        Assert.True(vm.IsEditing);
+    }
+
+    [Fact]
+    public void AColonInTheSecretIsRefusedAtTheForm()
+    {
+        // The one shape the engine's credential format cannot carry - refused where it can be
+        // fixed, not discovered as an authentication failure at restore time.
+        var vm = NewViewModel();
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "bucket";
+        vm.EditContainerUrl = "s3://storage.example.com/backups";
+        vm.EditS3KeyId = "AKIDEXAMPLE";
+        vm.EditS3SecretKey = "se:cret";
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.Contains("colon", vm.ErrorMessage);
+        Assert.Empty(_store.Config.BlobContainers);
+    }
+
+    [Fact]
+    public void AUrlWithoutABucketIsRefusedAtTheForm()
+    {
+        var vm = NewViewModel();
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "bucket";
+        vm.EditContainerUrl = "s3://host-only.example.com";
+        vm.EditS3KeyId = "AKIDEXAMPLE";
+        vm.EditS3SecretKey = "secret";
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.Contains("s3://endpoint[:port]/bucket", vm.ErrorMessage);
+        Assert.Empty(_store.Config.BlobContainers);
+    }
+
+    [Fact]
+    public void EditingKeepsTheStoredPairWhenTheBoxesStayEmpty()
+    {
+        var container = SavedS3Container();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+
+        vm.EditCommand.Execute(null);
+        // The region is shown back (addressing, not a secret); the pair is not.
+        Assert.Equal("eu-west-2", vm.EditS3Region);
+        Assert.Equal(string.Empty, vm.EditS3KeyId);
+        Assert.True(vm.HasStoredSasToken);
+
+        vm.EditS3Region = "eu-west-1";
+        vm.SaveCommand.Execute(null);
+
+        Assert.Equal("eu-west-1", Assert.Single(_store.Config.BlobContainers).S3Region);
+        Assert.Equal("AKIDSTORED:stored-secret", _store.GetSasToken(container));
+    }
+
+    // ── the SAS-isms stay off it ────────────────────────────────────────────────
+
+    [Fact]
+    public void NoExpiryLineAppearsForAKeyPair()
+    {
+        // The stored pair has no se= to read. The old fallback said "SAS token states no
+        // expiry", which is an answer to a question nobody asked about a bucket.
+        SavedS3Container();
+        var vm = NewViewModel();
+
+        vm.SelectedContainer = vm.Containers.Single();
+
+        Assert.True(string.IsNullOrEmpty(vm.SasExpiryText));
+        Assert.False(vm.IsSasExpired);
+    }
+
+    [Fact]
+    public void TheDetailsPaneNamesTheKeyPairNotTheSas()
+    {
+        Assert.Equal("S3 access key pair", SavedS3Container().AuthDisplay);
+        Assert.Equal("SAS token", new BlobContainerConfig
+        {
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        }.AuthDisplay);
+    }
+
+    // ── test connection tests the screen ────────────────────────────────────────
+
+    [Fact]
+    public async Task TestConnectionCarriesThePairAndRegionFromTheForm()
+    {
+        var vm = NewViewModel();
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "bucket";
+        vm.EditContainerUrl = "s3://storage.example.com/backups";
+        vm.EditS3KeyId = "AKIDEXAMPLE";
+        vm.EditS3SecretKey = "secret";
+        vm.EditS3Region = "eu-central-2";
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        var tested = _blobs.LastConfig!;
+        Assert.Equal("AKIDEXAMPLE:secret", tested.UnsavedSasToken);
+        Assert.Equal("eu-central-2", tested.S3Region);
+        // In memory only - nothing was persisted by a test (#12).
+        Assert.Empty(_store.ListCredentialKeys("NineLives:Blob:"));
+    }
+
+    [Fact]
+    public async Task TestConnectionFallsBackToTheStoredPairWithTheScreensRegion()
+    {
+        SavedS3Container();
+        var vm = NewViewModel();
+        vm.SelectedContainer = vm.Containers.Single();
+        vm.EditCommand.Execute(null);
+
+        // Fixing the region is the likeliest reason to re-test an S3 container - the test
+        // must combine the stored secret with the region on screen, not the saved one.
+        vm.EditS3Region = "eu-west-1";
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        var tested = _blobs.LastConfig!;
+        Assert.Equal("AKIDSTORED:stored-secret", tested.UnsavedSasToken);
+        Assert.Equal("eu-west-1", tested.S3Region);
+    }
+
+    // ── the refusals explain themselves ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData("InvalidAccessKeyId", "does not recognise this access key id")]
+    [InlineData("SignatureDoesNotMatch", "Re-enter the pair")]
+    [InlineData("AccessDenied", "s3:ListBucket")]
+    [InlineData("RequestTimeTooSkewed", "clock")]
+    [InlineData("NoSuchBucket", "first path segment")]
+    [InlineData("PermanentRedirect", "different region")]
+    [InlineData("AuthorizationHeaderMalformed", "different region")]
+    public void TheExplainerTurnsTheCodeIntoTheNextMove(string code, string expectFragment)
+    {
+        var guidance = BlobFailureExplainer.Explain(
+            new S3RequestFailedException("refused", code, 403),
+            new BlobContainerConfig { ContainerUrl = "s3://storage.example.com/backups" });
+
+        Assert.NotNull(guidance);
+        Assert.Contains(expectFragment, guidance);
+    }
+
+    [Fact]
+    public void AnUnknownCodeAddsNothing()
+    {
+        // The provider's own message is already shown; guidance that merely rephrases it is
+        // noise. Null means "let it stand".
+        Assert.Null(BlobFailureExplainer.Explain(
+            new S3RequestFailedException("refused", "SlowDown", 503),
+            new BlobContainerConfig { ContainerUrl = "s3://storage.example.com/backups" }));
+    }
+}

--- a/src/NineLives.Tests/S3ListingTests.cs
+++ b/src/NineLives.Tests/S3ListingTests.cs
@@ -226,12 +226,14 @@ public class S3ListingTests : IDisposable
                     "<Message>Access Denied</Message></Error>")
             ]));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<S3RequestFailedException>(
             () => blobs.VerifyConnectionAsync(config));
 
         Assert.Contains("AccessDenied", ex.Message);
         Assert.Contains("HTTP 403", ex.Message);
         Assert.Contains("Access Denied", ex.Message);
+        Assert.Equal("AccessDenied", ex.Code);
+        Assert.Equal(403, ex.Status);
     }
 
     [Fact]
@@ -241,10 +243,11 @@ public class S3ListingTests : IDisposable
             new Queue<(HttpStatusCode, string)>(
                 [(HttpStatusCode.InternalServerError, "<html>proxy says no</html>")]));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<S3RequestFailedException>(
             () => blobs.VerifyConnectionAsync(config));
 
         Assert.Contains("HTTP 500", ex.Message);
+        Assert.Null(ex.Code);
     }
 
     [Fact]

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -50,6 +50,42 @@ public partial class BlobConfigViewModel : ViewModelBase
     [ObservableProperty]
     private string _editSasToken = string.Empty;
 
+    /// <summary>
+    /// True when the URL on the form is an s3:// endpoint (#51). The scheme is the provider
+    /// answer everywhere else in the app, so the form reads it the same way: typing an s3://
+    /// URL swaps the SAS section for the key-pair section, live, with nothing to also select.
+    /// </summary>
+    public bool IsS3Url =>
+        EditContainerUrl.TrimStart().StartsWith("s3://", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The two halves the form collects for an s3:// container. Combined on save into
+    /// the one AccessKeyId:SecretKey string the engine's credential and the vault slot both
+    /// want - the halves are never stored separately.</summary>
+    [ObservableProperty]
+    private string _editS3KeyId = string.Empty;
+
+    [ObservableProperty]
+    private string _editS3SecretKey = string.Empty;
+
+    /// <summary>
+    /// The bucket's region, when the provider needs one said (#51). Addressing, not a secret -
+    /// it rides in the config next to the URL.
+    /// </summary>
+    [ObservableProperty]
+    private string _editS3Region = string.Empty;
+
+    private string _originalS3Region = string.Empty;
+
+    /// <summary>
+    /// The pair as the one string everything downstream understands, or empty when the form
+    /// holds no complete pair. Trimmed halves: a pasted key id arrives with the clipboard's
+    /// whitespace often enough, and neither half legitimately contains any.
+    /// </summary>
+    private string ComposedS3Pair =>
+        string.IsNullOrWhiteSpace(EditS3KeyId) || string.IsNullOrWhiteSpace(EditS3SecretKey)
+            ? string.Empty
+            : $"{EditS3KeyId.Trim()}:{EditS3SecretKey.Trim()}";
+
     [ObservableProperty]
     private string _editPathPattern = BlobContainerConfig.DefaultPathPattern;
 
@@ -247,8 +283,23 @@ public partial class BlobConfigViewModel : ViewModelBase
     }
 
     partial void OnEditNameChanged(string value) => CheckForUnsavedChanges();
-    partial void OnEditContainerUrlChanged(string value) => CheckForUnsavedChanges();
+    partial void OnEditContainerUrlChanged(string value)
+    {
+        OnPropertyChanged(nameof(IsS3Url));
+
+        // An s3:// endpoint has exactly one way in - the key pair - so the Entra choices
+        // vanish from the form and the mode snaps back rather than silently riding along on
+        // a container that can never use it (#51).
+        if (IsS3Url && EditAuthMode != BlobAuthMode.SasToken)
+            EditAuthMode = BlobAuthMode.SasToken;
+
+        if (IsEditing) UpdateSasExpiryStatusForForm();
+        CheckForUnsavedChanges();
+    }
     partial void OnEditSasTokenChanged(string value) => CheckForUnsavedChanges();
+    partial void OnEditS3KeyIdChanged(string value) => CheckForUnsavedChanges();
+    partial void OnEditS3SecretKeyChanged(string value) => CheckForUnsavedChanges();
+    partial void OnEditS3RegionChanged(string value) => CheckForUnsavedChanges();
     partial void OnEditAuthModeChanged(BlobAuthMode value)
     {
         OnPropertyChanged(nameof(IsSasAuth));
@@ -273,14 +324,19 @@ public partial class BlobConfigViewModel : ViewModelBase
     private void CheckForUnsavedChanges()
     {
         if (!IsEditing) return;
+
+        // Whichever credential the form is collecting - the SAS box or the key-pair halves -
+        // counts the same way: against the stored sentinel, anything entered is a change.
+        var enteredSecret = IsS3Url ? ComposedS3Pair : EditSasToken;
         var sasChanged = _originalSas == StoredSasSentinel
-            ? !string.IsNullOrEmpty(EditSasToken)
-            : EditSasToken != _originalSas;
+            ? !string.IsNullOrEmpty(enteredSecret)
+            : enteredSecret != _originalSas;
         HasUnsavedChanges =
             EditName != _originalName ||
             EditContainerUrl != _originalUrl ||
             EditAuthMode != _originalAuthMode ||
             sasChanged ||
+            EditS3Region != _originalS3Region ||
             EditPathPattern != _originalPattern ||
             EditBackupSourceType != _originalBackupSourceType ||
             EditAgPathPattern != _originalAgPathPattern ||
@@ -297,6 +353,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         var name = container.Name;
         var url = container.ContainerUrl;
         var authMode = container.AuthMode;
+        var s3Region = container.S3Region;
         var pattern = container.PathPattern;
         var sourceType = container.BackupSourceType;
         var agPattern = container.AgPathPattern;
@@ -308,6 +365,7 @@ public partial class BlobConfigViewModel : ViewModelBase
             container.Name = name;
             container.ContainerUrl = url;
             container.AuthMode = authMode;
+            container.S3Region = s3Region;
             container.PathPattern = pattern;
             container.BackupSourceType = sourceType;
             container.AgPathPattern = agPattern;
@@ -322,6 +380,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         _originalUrl = EditContainerUrl;
         _originalAuthMode = EditAuthMode;
         _originalSas = HasStoredSasToken ? StoredSasSentinel : EditSasToken;
+        _originalS3Region = EditS3Region;
         _originalPattern = EditPathPattern;
         _originalBackupSourceType = EditBackupSourceType;
         _originalAgPathPattern = EditAgPathPattern;
@@ -330,8 +389,33 @@ public partial class BlobConfigViewModel : ViewModelBase
         HasUnsavedChanges = false;
     }
 
+    /// <summary>Re-reads the expiry line from what the form currently says, for the edits that
+    /// change what kind of credential is even in play.</summary>
+    private void UpdateSasExpiryStatusForForm()
+    {
+        if (IsS3Url)
+        {
+            SasExpiryText = string.Empty;
+            IsSasExpired = false;
+        }
+        else if (SelectedContainer != null)
+        {
+            UpdateSasExpiryStatus(SelectedContainer);
+        }
+    }
+
     private void UpdateSasExpiryStatus(BlobContainerConfig container)
     {
+        // A key pair has no se= to read: it does not expire on a schedule the app can see, and
+        // an expiry line against it would send someone hunting for a token that does not exist
+        // (#51). Same reasoning as Entra below.
+        if ((IsEditing && IsS3Url) || (!IsEditing && container.IsS3))
+        {
+            SasExpiryText = string.Empty;
+            IsSasExpired = false;
+            return;
+        }
+
         // Entra has no token of ours to expire. Reporting "expired" against a container that never
         // had a SAS would send someone hunting for a token that is not the problem.
         if (EditAuthMode.IsEntra() || (!IsEditing && container.AuthMode.IsEntra()))
@@ -498,6 +582,9 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditContainerUrl = string.Empty;
         EditAuthMode = BlobAuthMode.SasToken;
         EditSasToken = string.Empty;
+        EditS3KeyId = string.Empty;
+        EditS3SecretKey = string.Empty;
+        EditS3Region = string.Empty;
         EditPathPattern = BlobContainerConfig.DefaultPathPattern;
         EditBackupSourceType = BackupSourceType.Standalone;
         EditAgPathPattern = null;
@@ -524,6 +611,9 @@ public partial class BlobConfigViewModel : ViewModelBase
         var storedToken = _credentialStore.GetSasToken(SelectedContainer);
         HasStoredSasToken = !string.IsNullOrEmpty(storedToken);
         EditSasToken = string.Empty; // Never show stored token; user can only replace it
+        EditS3KeyId = string.Empty; // The pair is stored, never displayed - same rule as the SAS
+        EditS3SecretKey = string.Empty;
+        EditS3Region = SelectedContainer.S3Region ?? string.Empty;
         EditPathPattern = SelectedContainer.PathPattern;
         EditBackupSourceType = SelectedContainer.BackupSourceType;
         EditBackupServerTimeZone = TimeZoneOption.For(SelectedContainer.BackupServerTimeZoneId, TimeZones);
@@ -554,12 +644,52 @@ public partial class BlobConfigViewModel : ViewModelBase
             return;
         }
 
-        bool haveTokenToSave = IsSasAuth && !string.IsNullOrWhiteSpace(EditSasToken);
-        if (IsNew && IsSasAuth && !haveTokenToSave)
+        bool haveTokenToSave;
+        if (IsS3Url)
         {
-            SetError("SAS Token is required.");
-            return;
+            // The URL and the pair are both shape-checked here, at entry - a malformed one
+            // refused now is an authentication failure that never happens later (#51).
+            if (S3Url.TryParse(EditContainerUrl.TrimEnd('/')) == null)
+            {
+                SetError("An s3:// container URL is s3://endpoint[:port]/bucket - the endpoint "
+                    + "is the provider's host name, and the first path segment is the bucket.");
+                return;
+            }
+
+            var hasEither = !string.IsNullOrWhiteSpace(EditS3KeyId)
+                || !string.IsNullOrWhiteSpace(EditS3SecretKey);
+            haveTokenToSave = ComposedS3Pair.Length > 0;
+            if (hasEither && !haveTokenToSave)
+            {
+                SetError("Both halves of the key pair are needed - the access key id and the "
+                    + "secret key.");
+                return;
+            }
+            if (haveTokenToSave && S3Credentials.Validate(ComposedS3Pair) is { } why)
+            {
+                SetError(why);
+                return;
+            }
+            if (IsNew && !haveTokenToSave)
+            {
+                SetError("The access key pair is required.");
+                return;
+            }
         }
+        else
+        {
+            haveTokenToSave = IsSasAuth && !string.IsNullOrWhiteSpace(EditSasToken);
+            if (IsNew && IsSasAuth && !haveTokenToSave)
+            {
+                SetError("SAS Token is required.");
+                return;
+            }
+        }
+
+        // Addressing, not a secret - and null clears a stale region when the URL stops being s3.
+        var s3Region = IsS3Url && !string.IsNullOrWhiteSpace(EditS3Region)
+            ? EditS3Region.Trim()
+            : null;
 
         BlobContainerConfig container;
 
@@ -582,6 +712,7 @@ public partial class BlobConfigViewModel : ViewModelBase
                 Name = EditName,
                 ContainerUrl = EditContainerUrl.TrimEnd('/'),
                 AuthMode = EditAuthMode,
+                S3Region = s3Region,
                 PathPattern = EditPathPattern,
                 BackupSourceType = EditBackupSourceType,
                 AgPathPattern = string.IsNullOrWhiteSpace(agPattern) ? null : agPattern.Trim(),
@@ -604,6 +735,7 @@ public partial class BlobConfigViewModel : ViewModelBase
             ReplaceTags(container.Tags, TagPalette.ParseTags(EditTags));
             container.ContainerUrl = EditContainerUrl.TrimEnd('/');
             container.AuthMode = EditAuthMode;
+            container.S3Region = s3Region;
             container.PathPattern = EditPathPattern;
             container.BackupSourceType = EditBackupSourceType;
             container.BackupServerTimeZoneId = EditBackupServerTimeZone?.Id;
@@ -633,7 +765,9 @@ public partial class BlobConfigViewModel : ViewModelBase
         {
             try
             {
-                _credentialStore.SaveSasToken(container, EditSasToken);
+                // For an s3:// container the two halves leave the form as the one string the
+                // engine's CREATE CREDENTIAL wants - the same slot the SAS occupies (#51).
+                _credentialStore.SaveSasToken(container, IsS3Url ? ComposedS3Pair : EditSasToken);
             }
             catch (Exception ex)
             {
@@ -704,6 +838,9 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditContainerUrl = SelectedContainer.ContainerUrl;
         HasStoredSasToken = true; // Still have a token; user will replace it
         EditSasToken = string.Empty;
+        EditS3KeyId = string.Empty;
+        EditS3SecretKey = string.Empty;
+        EditS3Region = SelectedContainer.S3Region ?? string.Empty;
         EditPathPattern = SelectedContainer.PathPattern;
         EditBackupServerTimeZone = TimeZoneOption.For(SelectedContainer.BackupServerTimeZoneId, TimeZones);
         EditBackupSourceType = SelectedContainer.BackupSourceType;
@@ -729,7 +866,32 @@ public partial class BlobConfigViewModel : ViewModelBase
         BlobContainerConfig? config;
         if (IsEditing)
         {
-            if (IsEntraAuth)
+            if (IsS3Url)
+            {
+                // Built from the form, so what is tested is exactly what is on screen - the
+                // URL and region included, which matters when the region is the thing being
+                // fixed. The pair comes from the form when entered, else the stored one; in
+                // memory only either way, same rule as the SAS below (#12).
+                var pair = ComposedS3Pair.Length > 0
+                    ? ComposedS3Pair
+                    : SelectedContainer != null ? _credentialStore.GetSasToken(SelectedContainer) : null;
+
+                if (ComposedS3Pair.Length > 0 && S3Credentials.Validate(ComposedS3Pair) is { } why)
+                {
+                    TestSuccess = false;
+                    TestResult = why;
+                    return;
+                }
+
+                config = new BlobContainerConfig
+                {
+                    Name = EditName,
+                    ContainerUrl = EditContainerUrl,
+                    UnsavedSasToken = string.IsNullOrEmpty(pair) ? null : pair,
+                    S3Region = string.IsNullOrWhiteSpace(EditS3Region) ? null : EditS3Region.Trim()
+                };
+            }
+            else if (IsEntraAuth)
             {
                 // Nothing stored to fall back on, and nothing needed - the token comes from the
                 // signed-in account. Built from the form, so what is tested is the URL on screen.

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -12,6 +12,7 @@
         <converters:EnumToBoolConverter x:Key="EnumToBool" />
         <converters:BlobAuthModeToDisplayConverter x:Key="BlobAuthModeDisplay" />
         <converters:BlobAuthModeIsSasConverter x:Key="BlobAuthModeIsSas" />
+        <converters:StringToVisibilityConverter x:Key="StringToVis" />
     </UserControl.Resources>
 
     <Grid>
@@ -24,7 +25,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,0,20">
             <TextBlock Text="Blob Storage Configuration"
                        Style="{StaticResource HeaderText}" />
-            <TextBlock Text="Configure Azure Blob Storage containers and SAS tokens for backup access."
+            <TextBlock Text="Configure the containers holding your backups - Azure Blob Storage, or any S3-compatible bucket."
                        Style="{StaticResource SecondaryText}"
                        Margin="0,4,0,0" />
         </StackPanel>
@@ -220,17 +221,21 @@
                                            Margin="0,0,0,12" />
 
                                 <TextBlock Text="AUTHENTICATION" Style="{StaticResource LabelText}" />
-                                <TextBlock Text="{Binding SelectedContainer.AuthMode, Converter={StaticResource BlobAuthModeDisplay}}"
+                                <TextBlock Text="{Binding SelectedContainer.AuthDisplay}"
                                            Style="{StaticResource BodyText}"
                                            Margin="0,0,0,12" />
 
-                                <!-- Only under SAS. An expiry line against a container that has no
-                                     token of ours would send someone hunting for the wrong thing. -->
+                                <!-- Only under SAS, and only when there is something to say. An
+                                     expiry line against a container that has no token of ours -
+                                     Entra, or an S3 key pair, which has no readable expiry -
+                                     would send someone hunting for the wrong thing. -->
                                 <StackPanel Visibility="{Binding SelectedContainer.AuthMode, Converter={StaticResource BlobAuthModeIsSas}}">
-                                    <TextBlock Text="SAS TOKEN STATUS" Style="{StaticResource LabelText}" />
-                                    <TextBlock Text="{Binding SasExpiryText}"
-                                               Style="{StaticResource BodyText}"
-                                               Margin="0,0,0,12" />
+                                    <StackPanel Visibility="{Binding SasExpiryText, Converter={StaticResource StringToVis}}">
+                                        <TextBlock Text="SAS TOKEN STATUS" Style="{StaticResource LabelText}" />
+                                        <TextBlock Text="{Binding SasExpiryText}"
+                                                   Style="{StaticResource BodyText}"
+                                                   Margin="0,0,0,12" />
+                                    </StackPanel>
                                 </StackPanel>
 
                                 <TextBlock Text="BACKUPS AT THIS LOCATION" Style="{StaticResource LabelText}" />
@@ -366,13 +371,17 @@
                                           Margin="0,0,0,16" />
 
                             <TextBlock Text="CONTAINER URL" Style="{StaticResource LabelText}" />
-                            <TextBlock Text="e.g. https://myaccount.blob.core.windows.net/backups"
+                            <TextBlock Text="e.g. https://myaccount.blob.core.windows.net/backups - or s3://s3.eu-west-2.amazonaws.com/backups for S3-compatible storage"
                                        Style="{StaticResource SecondaryText}"
-                                       FontSize="11" Margin="0,0,0,4" />
+                                       FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap" />
                             <TextBox Text="{Binding EditContainerUrl, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,16" />
 
+                            <!-- The URL's scheme picks the provider (#51), so an s3:// container
+                                 has nothing to choose here: the pair is the one way in, and the
+                                 Entra options would be noise against a bucket. -->
+                            <StackPanel Visibility="{Binding IsS3Url, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                             <TextBlock Text="AUTHENTICATION" Style="{StaticResource LabelText}" />
                             <StackPanel Margin="0,4,0,16">
                                 <RadioButton Content="SAS token"
@@ -393,6 +402,7 @@
                                              GroupName="BlobAuthMode"
                                              ToolTip="Environment, then managed identity, then the Azure CLI or Visual Studio sign-in, then a prompt. The one to pick when this app runs on an Azure VM." />
                             </StackPanel>
+                            </StackPanel>
 
                             <!-- Untested against a real tenant - see the note in the README. Said
                                  here rather than only in the docs, because the person who finds out
@@ -410,6 +420,55 @@
                                 </StackPanel>
                             </Border>
 
+                            <!-- The key pair, two boxes combining into the one string the
+                                 engine's CREATE CREDENTIAL wants (#51). Stored together in the
+                                 SAS slot; like the SAS, never displayed once stored. -->
+                            <StackPanel Visibility="{Binding IsS3Url, Converter={StaticResource BoolToVis}}">
+                                <TextBlock Text="ACCESS KEY PAIR" Style="{StaticResource LabelText}" />
+                                <TextBlock Text="A key pair is stored securely and cannot be displayed. Enter a new pair below to replace it."
+                                           Style="{StaticResource SecondaryText}" FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap"
+                                           Visibility="{Binding HasStoredSasToken, Converter={StaticResource BoolToVis}}" />
+                                <TextBlock Text="The access key id and its secret key, as the provider issued them. Stored together in Windows Credential Manager."
+                                           Style="{StaticResource SecondaryText}" FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap"
+                                           Visibility="{Binding HasStoredSasToken, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+
+                                <TextBlock Text="Access key id" Style="{StaticResource SecondaryText}" FontSize="11" Margin="0,4,0,2" />
+                                <TextBox Text="{Binding EditS3KeyId, UpdateSourceTrigger=PropertyChanged}"
+                                         Style="{StaticResource DarkTextBox}"
+                                         Margin="0,0,0,8" />
+
+                                <TextBlock Text="Secret key" Style="{StaticResource SecondaryText}" FontSize="11" Margin="0,0,0,2" />
+                                <Grid Margin="0,0,0,8">
+                                    <TextBox Text="{Binding EditS3SecretKey, UpdateSourceTrigger=PropertyChanged}"
+                                             Style="{StaticResource DarkTextBox}"
+                                             Visibility="{Binding ShowSasToken, Converter={StaticResource BoolToVis}}" />
+                                    <Border Background="{DynamicResource InputBackgroundBrush}"
+                                            CornerRadius="4" Padding="10,8"
+                                            BorderBrush="{DynamicResource CardBorderBrush}"
+                                            BorderThickness="1" MinHeight="36"
+                                            Visibility="{Binding ShowSasToken, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
+                                        <TextBlock Text="••••••••••••••••••••••••••••••••"
+                                                   Foreground="{DynamicResource SecondaryTextBrush}"
+                                                   VerticalAlignment="Center" FontSize="14" />
+                                    </Border>
+                                    <Button Content="{Binding ShowSasToken, Converter={StaticResource BoolToEyeIcon}}"
+                                            Command="{Binding ToggleShowSasTokenCommand}"
+                                            HorizontalAlignment="Right" VerticalAlignment="Top"
+                                            Margin="0,4,4,0" Padding="6,2" FontSize="14"
+                                            Background="Transparent" BorderThickness="0"
+                                            Foreground="{DynamicResource SecondaryTextBrush}"
+                                            Cursor="Hand" ToolTip="Show/hide secret key" />
+                                </Grid>
+
+                                <TextBlock Text="REGION" Style="{StaticResource LabelText}" />
+                                <TextBlock Text="Only when the provider needs one said - AWS-style endpoints carry it in the host name, and the engine assumes us-east-1 otherwise."
+                                           Style="{StaticResource SecondaryText}" FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap" />
+                                <TextBox Text="{Binding EditS3Region, UpdateSourceTrigger=PropertyChanged}"
+                                         Style="{StaticResource DarkTextBox}"
+                                         Margin="0,0,0,16" />
+                            </StackPanel>
+
+                            <StackPanel Visibility="{Binding IsS3Url, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                             <StackPanel Visibility="{Binding IsSasAuth, Converter={StaticResource BoolToVis}}">
                             <TextBlock Text="SAS TOKEN" Style="{StaticResource LabelText}" />
                             <TextBlock Text="Token is stored securely and cannot be displayed. Enter a new token below to replace it."
@@ -450,6 +509,7 @@
                                             Cursor="Hand" ToolTip="Show/hide SAS token" />
                                 </Grid>
                             </Grid>
+                            </StackPanel>
                             </StackPanel>
 
                             <TextBlock Text="BACKUPS AT THIS LOCATION" Style="{StaticResource LabelText}" />


### PR DESCRIPTION
Third of the three PRs on #51, after the engine half (#338) and the listing half (#339). The Blob Storage screen now reads the URL's scheme the way everything else in the app does.

## What changes on screen

- **Type an `s3://` URL and the form follows.** The SAS section becomes the key-pair boxes - access key id, and a secret key behind the same show/hide treatment the SAS gets - plus a Region field for the providers that need one said. The Entra radio buttons vanish: a bucket has exactly one way in, so there is nothing to also select, and the auth mode snaps back rather than riding along meaninglessly.
- **The pair leaves the form only as `AccessKeyId:SecretKey`** - the engine's own secret format, into the same vault slot the SAS uses. Shape-checked at entry: half a pair, or a colon in the secret, is refused where it can be fixed rather than discovered as an authentication failure at restore time. The URL's own shape is validated the same way.
- **The SAS-isms stay off it.** No expiry line against a credential that has no `se=` to read (the old fallback said "SAS token states no expiry" about a bucket), and the details pane says "S3 access key pair" instead of "SAS token" - the wrong label sends someone reading Azure documentation for a bucket problem.
- **Test Connection tests the screen.** The pair from the form when entered, else the stored one, combined with the on-screen URL and region - fixing the region being the likeliest reason to re-test. In memory only either way (#12's rule).
- **A refused listing explains itself.** The listing client's refusal now carries the provider's code on a typed `S3RequestFailedException`, and `BlobFailureExplainer` turns the six that matter - `InvalidAccessKeyId`, `SignatureDoesNotMatch`, `AccessDenied`, `RequestTimeTooSkewed`, `NoSuchBucket`, and the wrong-region pair `PermanentRedirect`/`AuthorizationHeaderMalformed` - into the next move. Codes, not message text: providers rephrase the sentence, the code is the contract.

## Docs

README gains the S3 features section and the provisioning template's container line now covers both URL shapes. The screen's own subtitle stops claiming Azure-only.

## Verification

1,861 unit tests passing (18 new: scheme-driven form behaviour, pair composition and refusals, region round-trip, Test Connection payloads, explainer cases). Release `-warnaserror` clean. Both edit states rendered to PNG under all three themes and eyeballed - key-pair/region sections present and SAS-free for s3, Azure state pixel-identical to before.