### PR TITLE
The Add Container form asks the provider question up front (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **The Add Container form asks the provider question up front** (#51). A Storage
+  Provider choice - Azure Blob Storage or S3-compatible - sits above the URL, so the
+  key-pair and region fields are on screen before any URL has been typed; the
+  scheme-driven swap alone left S3 invisible on an empty form. Nothing new is stored:
+  the URL's scheme stays the truth, a typed scheme still snaps the choice to match,
+  and a mismatch left standing is refused at save with the fix named.
+
 - **S3-compatible object storage, the screen half** (#51). The Blob Storage screen reads the
   URL's scheme the way everything else does: type an `s3://` URL and the SAS section becomes
   the key-pair boxes - access key id and secret key, combined on save into the engine's own

--- a/src/NineLives.Tests/S3ConfigScreenTests.cs
+++ b/src/NineLives.Tests/S3ConfigScreenTests.cs
@@ -34,10 +34,10 @@ public class S3ConfigScreenTests
         return container;
     }
 
-    // ── the scheme drives the form ──────────────────────────────────────────────
+    // ── the provider choice and the scheme agree ────────────────────────────────
 
     [Fact]
-    public void TypingAnS3UrlSnapsTheAuthModeToTheKeyPair()
+    public void TypingAnS3UrlSelectsTheProviderAndSnapsTheAuthMode()
     {
         var vm = NewViewModel();
         vm.AddNewCommand.Execute(null);
@@ -46,8 +46,69 @@ public class S3ConfigScreenTests
         vm.EditContainerUrl = "s3://storage.example.com/backups";
 
         Assert.True(vm.IsS3Url);
+        Assert.True(vm.EditIsS3);
         // Entra cannot reach a bucket - the mode snaps back rather than riding along silently.
         Assert.Equal(BlobAuthMode.SasToken, vm.EditAuthMode);
+    }
+
+    /// <summary>
+    /// The reason the choice exists at all: on an empty Add Container form the scheme has not
+    /// been typed yet, so without an explicit selection every section defaulted to its Azure
+    /// shape and nothing said a bucket was even possible.
+    /// </summary>
+    [Fact]
+    public void ChoosingS3ShowsTheKeyPairFormBeforeAnyUrlExists()
+    {
+        var vm = NewViewModel();
+        vm.AddNewCommand.Execute(null);
+        Assert.False(vm.EditIsS3);
+
+        vm.EditProvider = StorageProviderChoice.S3;
+
+        Assert.Equal(BlobAuthMode.SasToken, vm.EditAuthMode);
+        // Typing the s3 URL afterwards leaves the choice standing.
+        vm.EditContainerUrl = "s3://storage.example.com/backups";
+        Assert.True(vm.EditIsS3);
+    }
+
+    [Fact]
+    public void AnAzureUrlSnapsTheChoiceBack()
+    {
+        var vm = NewViewModel();
+        vm.AddNewCommand.Execute(null);
+        vm.EditProvider = StorageProviderChoice.S3;
+
+        // The URL is what gets saved, so a typed scheme outranks the earlier selection.
+        vm.EditContainerUrl = "https://acct.blob.core.windows.net/backups";
+
+        Assert.False(vm.EditIsS3);
+    }
+
+    [Fact]
+    public void AProviderUrlMismatchIsRefusedBothWays()
+    {
+        // Paste an Azure URL, then click back to S3: the mismatch the save must not guess at.
+        var vm = NewViewModel();
+        vm.AddNewCommand.Execute(null);
+        vm.EditName = "bucket";
+        vm.EditContainerUrl = "https://acct.blob.core.windows.net/backups";
+        vm.EditProvider = StorageProviderChoice.S3;
+        vm.EditS3KeyId = "AKIDEXAMPLE";
+        vm.EditS3SecretKey = "secret";
+        vm.SaveCommand.Execute(null);
+        Assert.Contains("not an s3://", vm.ErrorMessage);
+        Assert.Empty(_store.Config.BlobContainers);
+
+        // The mirror: an s3:// URL with Azure re-selected over it.
+        var vm2 = NewViewModel();
+        vm2.AddNewCommand.Execute(null);
+        vm2.EditName = "bucket";
+        vm2.EditContainerUrl = "s3://storage.example.com/backups";
+        vm2.EditProvider = StorageProviderChoice.Azure;
+        vm2.EditSasToken = "sv=2026&sig=x";
+        vm2.SaveCommand.Execute(null);
+        Assert.Contains("S3-compatible", vm2.ErrorMessage);
+        Assert.Empty(_store.Config.BlobContainers);
     }
 
     // ── saving ──────────────────────────────────────────────────────────────────
@@ -131,6 +192,8 @@ public class S3ConfigScreenTests
         vm.SelectedContainer = vm.Containers.Single();
 
         vm.EditCommand.Execute(null);
+        // Editing an s3 container opens with the provider already selected.
+        Assert.True(vm.EditIsS3);
         // The region is shown back (addressing, not a secret); the pair is not.
         Assert.Equal("eu-west-2", vm.EditS3Region);
         Assert.Equal(string.Empty, vm.EditS3KeyId);

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -8,6 +8,16 @@ using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.ViewModels;
 
+/// <summary>
+/// The Blob Storage form's provider choice (#51). UI state only - what persists is the
+/// container URL, whose scheme is the provider truth everywhere else in the app.
+/// </summary>
+public enum StorageProviderChoice
+{
+    Azure,
+    S3
+}
+
 public partial class BlobConfigViewModel : ViewModelBase
 {
     private readonly ICredentialStore _credentialStore;
@@ -51,12 +61,31 @@ public partial class BlobConfigViewModel : ViewModelBase
     private string _editSasToken = string.Empty;
 
     /// <summary>
-    /// True when the URL on the form is an s3:// endpoint (#51). The scheme is the provider
-    /// answer everywhere else in the app, so the form reads it the same way: typing an s3://
-    /// URL swaps the SAS section for the key-pair section, live, with nothing to also select.
+    /// True when the URL on the form is an s3:// endpoint (#51). What is SAVED never carries a
+    /// provider field - the URL's scheme is the answer - so this is the truth the form's
+    /// provider choice below has to agree with by the time Save runs.
     /// </summary>
     public bool IsS3Url =>
         EditContainerUrl.TrimStart().StartsWith("s3://", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Which provider the form is collecting for. UI state, not a persisted field: the saved
+    /// truth stays the URL's own scheme. This exists because the scheme alone made S3
+    /// invisible on an empty Add Container form - every section defaulted to its Azure shape
+    /// and nothing said a bucket was even possible until an s3:// URL had been typed. The
+    /// choice shows the right sections immediately; typing a URL with a scheme snaps the
+    /// choice to match it (the URL wins - it is what will be saved); a mismatch left standing
+    /// is refused at Save with the fix named.
+    ///
+    /// An enum bound through EnumToBool, exactly like the authentication radios above it: that
+    /// converter answers an uncheck with Binding.DoNothing, which is what keeps the radio
+    /// group's own unchecking from writing junk back through the binding.
+    /// </summary>
+    [ObservableProperty]
+    private StorageProviderChoice _editProvider = StorageProviderChoice.Azure;
+
+    /// <summary>The provider choice as the yes/no every section gate and code branch asks.</summary>
+    public bool EditIsS3 => EditProvider == StorageProviderChoice.S3;
 
     /// <summary>The two halves the form collects for an s3:// container. Combined on save into
     /// the one AccessKeyId:SecretKey string the engine's credential and the vault slot both
@@ -287,10 +316,24 @@ public partial class BlobConfigViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(IsS3Url));
 
+        // A typed scheme decides: the URL is what gets saved, so the provider choice follows
+        // it rather than arguing with it. A URL with no scheme yet moves nothing, so the
+        // choice made on an empty form survives the typing that comes after it.
+        if (IsS3Url) EditProvider = StorageProviderChoice.S3;
+        else if (value.TrimStart().StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            EditProvider = StorageProviderChoice.Azure;
+
+        CheckForUnsavedChanges();
+    }
+
+    partial void OnEditProviderChanged(StorageProviderChoice value)
+    {
+        OnPropertyChanged(nameof(EditIsS3));
+
         // An s3:// endpoint has exactly one way in - the key pair - so the Entra choices
         // vanish from the form and the mode snaps back rather than silently riding along on
         // a container that can never use it (#51).
-        if (IsS3Url && EditAuthMode != BlobAuthMode.SasToken)
+        if (value == StorageProviderChoice.S3 && EditAuthMode != BlobAuthMode.SasToken)
             EditAuthMode = BlobAuthMode.SasToken;
 
         if (IsEditing) UpdateSasExpiryStatusForForm();
@@ -327,7 +370,7 @@ public partial class BlobConfigViewModel : ViewModelBase
 
         // Whichever credential the form is collecting - the SAS box or the key-pair halves -
         // counts the same way: against the stored sentinel, anything entered is a change.
-        var enteredSecret = IsS3Url ? ComposedS3Pair : EditSasToken;
+        var enteredSecret = EditIsS3 ? ComposedS3Pair : EditSasToken;
         var sasChanged = _originalSas == StoredSasSentinel
             ? !string.IsNullOrEmpty(enteredSecret)
             : enteredSecret != _originalSas;
@@ -393,7 +436,7 @@ public partial class BlobConfigViewModel : ViewModelBase
     /// change what kind of credential is even in play.</summary>
     private void UpdateSasExpiryStatusForForm()
     {
-        if (IsS3Url)
+        if (EditIsS3)
         {
             SasExpiryText = string.Empty;
             IsSasExpired = false;
@@ -409,7 +452,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         // A key pair has no se= to read: it does not expire on a schedule the app can see, and
         // an expiry line against it would send someone hunting for a token that does not exist
         // (#51). Same reasoning as Entra below.
-        if ((IsEditing && IsS3Url) || (!IsEditing && container.IsS3))
+        if ((IsEditing && EditIsS3) || (!IsEditing && container.IsS3))
         {
             SasExpiryText = string.Empty;
             IsSasExpired = false;
@@ -580,6 +623,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditName = string.Empty;
         EditTags = string.Empty;
         EditContainerUrl = string.Empty;
+        EditProvider = StorageProviderChoice.Azure;
         EditAuthMode = BlobAuthMode.SasToken;
         EditSasToken = string.Empty;
         EditS3KeyId = string.Empty;
@@ -607,6 +651,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         EditName = SelectedContainer.Name;
         EditTags = TagPalette.FormatTags(SelectedContainer.Tags);
         EditContainerUrl = SelectedContainer.ContainerUrl;
+        EditProvider = SelectedContainer.IsS3 ? StorageProviderChoice.S3 : StorageProviderChoice.Azure;
         EditAuthMode = SelectedContainer.AuthMode;
         var storedToken = _credentialStore.GetSasToken(SelectedContainer);
         HasStoredSasToken = !string.IsNullOrEmpty(storedToken);
@@ -645,10 +690,18 @@ public partial class BlobConfigViewModel : ViewModelBase
         }
 
         bool haveTokenToSave;
-        if (IsS3Url)
+        if (EditIsS3)
         {
             // The URL and the pair are both shape-checked here, at entry - a malformed one
-            // refused now is an authentication failure that never happens later (#51).
+            // refused now is an authentication failure that never happens later (#51). The
+            // saved truth is the URL's scheme, so the provider choice and the URL must agree
+            // before anything persists.
+            if (!IsS3Url)
+            {
+                SetError("S3-compatible storage is selected, but the URL is not an s3:// one. "
+                    + "An S3 container URL is s3://endpoint[:port]/bucket.");
+                return;
+            }
             if (S3Url.TryParse(EditContainerUrl.TrimEnd('/')) == null)
             {
                 SetError("An s3:// container URL is s3://endpoint[:port]/bucket - the endpoint "
@@ -678,6 +731,14 @@ public partial class BlobConfigViewModel : ViewModelBase
         }
         else
         {
+            // The mirror of the check above: an s3:// URL with Azure selected is a mismatch
+            // someone should resolve, not a guess the save should make.
+            if (IsS3Url)
+            {
+                SetError("This URL is s3:// - S3-compatible storage. Select that above, or "
+                    + "paste an https:// Azure container URL.");
+                return;
+            }
             haveTokenToSave = IsSasAuth && !string.IsNullOrWhiteSpace(EditSasToken);
             if (IsNew && IsSasAuth && !haveTokenToSave)
             {
@@ -687,7 +748,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         }
 
         // Addressing, not a secret - and null clears a stale region when the URL stops being s3.
-        var s3Region = IsS3Url && !string.IsNullOrWhiteSpace(EditS3Region)
+        var s3Region = EditIsS3 && !string.IsNullOrWhiteSpace(EditS3Region)
             ? EditS3Region.Trim()
             : null;
 
@@ -767,7 +828,7 @@ public partial class BlobConfigViewModel : ViewModelBase
             {
                 // For an s3:// container the two halves leave the form as the one string the
                 // engine's CREATE CREDENTIAL wants - the same slot the SAS occupies (#51).
-                _credentialStore.SaveSasToken(container, IsS3Url ? ComposedS3Pair : EditSasToken);
+                _credentialStore.SaveSasToken(container, EditIsS3 ? ComposedS3Pair : EditSasToken);
             }
             catch (Exception ex)
             {
@@ -836,6 +897,7 @@ public partial class BlobConfigViewModel : ViewModelBase
         if (SelectedContainer == null) return;
         EditName = SelectedContainer.Name;
         EditContainerUrl = SelectedContainer.ContainerUrl;
+        EditProvider = SelectedContainer.IsS3 ? StorageProviderChoice.S3 : StorageProviderChoice.Azure;
         HasStoredSasToken = true; // Still have a token; user will replace it
         EditSasToken = string.Empty;
         EditS3KeyId = string.Empty;
@@ -866,12 +928,20 @@ public partial class BlobConfigViewModel : ViewModelBase
         BlobContainerConfig? config;
         if (IsEditing)
         {
-            if (IsS3Url)
+            if (EditIsS3)
             {
                 // Built from the form, so what is tested is exactly what is on screen - the
                 // URL and region included, which matters when the region is the thing being
                 // fixed. The pair comes from the form when entered, else the stored one; in
                 // memory only either way, same rule as the SAS below (#12).
+                if (S3Url.TryParse(EditContainerUrl.TrimEnd('/')) == null)
+                {
+                    TestSuccess = false;
+                    TestResult = "An s3:// container URL is s3://endpoint[:port]/bucket - "
+                        + "fix the URL and test again.";
+                    return;
+                }
+
                 var pair = ComposedS3Pair.Length > 0
                     ? ComposedS3Pair
                     : SelectedContainer != null ? _credentialStore.GetSasToken(SelectedContainer) : null;

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -370,18 +370,43 @@
                                           Style="{StaticResource TagPillList}"
                                           Margin="0,0,0,16" />
 
+                            <!-- Asked up front so the right sections show before a URL exists -
+                                 the scheme alone made S3 invisible on an empty form. What is
+                                 SAVED still carries no provider field: the URL's scheme is the
+                                 truth, a typed scheme snaps this choice, and Save refuses a
+                                 mismatch left standing. -->
+                            <TextBlock Text="STORAGE PROVIDER" Style="{StaticResource LabelText}" />
+                            <StackPanel Orientation="Horizontal" Margin="0,4,0,16">
+                                <RadioButton Content="Azure Blob Storage"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditProvider, Converter={StaticResource EnumToBool}, ConverterParameter=Azure}"
+                                             GroupName="StorageProvider"
+                                             Margin="0,0,24,0"
+                                             ToolTip="An https:// container URL, reached with a SAS token or an Entra ID sign-in." />
+                                <RadioButton Content="S3-compatible"
+                                             Style="{StaticResource DarkRadioButton}"
+                                             IsChecked="{Binding EditProvider, Converter={StaticResource EnumToBool}, ConverterParameter=S3}"
+                                             GroupName="StorageProvider"
+                                             ToolTip="AWS S3, Wasabi, Backblaze B2, Cloudflare R2 or a storage appliance speaking the S3 API. An s3:// URL, reached with an access key pair. Restoring from it needs SQL Server 2022+ (not Express)." />
+                            </StackPanel>
+
                             <TextBlock Text="CONTAINER URL" Style="{StaticResource LabelText}" />
-                            <TextBlock Text="e.g. https://myaccount.blob.core.windows.net/backups - or s3://s3.eu-west-2.amazonaws.com/backups for S3-compatible storage"
+                            <TextBlock Text="e.g. https://myaccount.blob.core.windows.net/backups"
                                        Style="{StaticResource SecondaryText}"
-                                       FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap" />
+                                       FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap"
+                                       Visibility="{Binding EditIsS3, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+                            <TextBlock Text="s3://endpoint[:port]/bucket - e.g. s3://s3.eu-west-2.amazonaws.com/backups"
+                                       Style="{StaticResource SecondaryText}"
+                                       FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap"
+                                       Visibility="{Binding EditIsS3, Converter={StaticResource BoolToVis}}" />
                             <TextBox Text="{Binding EditContainerUrl, UpdateSourceTrigger=PropertyChanged}"
                                      Style="{StaticResource DarkTextBox}"
                                      Margin="0,0,0,16" />
 
-                            <!-- The URL's scheme picks the provider (#51), so an s3:// container
-                                 has nothing to choose here: the pair is the one way in, and the
-                                 Entra options would be noise against a bucket. -->
-                            <StackPanel Visibility="{Binding IsS3Url, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
+                            <!-- An s3:// container has nothing to choose here: the pair is the
+                                 one way in, and the Entra options would be noise against a
+                                 bucket (#51). -->
+                            <StackPanel Visibility="{Binding EditIsS3, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                             <TextBlock Text="AUTHENTICATION" Style="{StaticResource LabelText}" />
                             <StackPanel Margin="0,4,0,16">
                                 <RadioButton Content="SAS token"
@@ -423,7 +448,7 @@
                             <!-- The key pair, two boxes combining into the one string the
                                  engine's CREATE CREDENTIAL wants (#51). Stored together in the
                                  SAS slot; like the SAS, never displayed once stored. -->
-                            <StackPanel Visibility="{Binding IsS3Url, Converter={StaticResource BoolToVis}}">
+                            <StackPanel Visibility="{Binding EditIsS3, Converter={StaticResource BoolToVis}}">
                                 <TextBlock Text="ACCESS KEY PAIR" Style="{StaticResource LabelText}" />
                                 <TextBlock Text="A key pair is stored securely and cannot be displayed. Enter a new pair below to replace it."
                                            Style="{StaticResource SecondaryText}" FontSize="11" Margin="0,0,0,4" TextWrapping="Wrap"
@@ -468,7 +493,7 @@
                                          Margin="0,0,0,16" />
                             </StackPanel>
 
-                            <StackPanel Visibility="{Binding IsS3Url, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
+                            <StackPanel Visibility="{Binding EditIsS3, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}">
                             <StackPanel Visibility="{Binding IsSasAuth, Converter={StaticResource BoolToVis}}">
                             <TextBlock Text="SAS TOKEN" Style="{StaticResource LabelText}" />
                             <TextBlock Text="Token is stored securely and cannot be displayed. Enter a new token below to replace it."


### PR DESCRIPTION
Follow-up to the screen half (#340), from using it: on an empty Add Container form nothing said S3 was even possible - the scheme-driven section swap only reveals itself after an `s3://` URL has been typed, and every section defaulted to its Azure shape.

## What changes

- A **Storage Provider** choice (Azure Blob Storage / S3-compatible) sits above the URL. Choosing S3 shows the key-pair and region fields immediately and switches the URL hint to the `s3://endpoint[:port]/bucket` shape.
- **Nothing new is stored.** The saved truth stays the URL's own scheme. A typed scheme snaps the choice to match (the URL is what gets saved, so it outranks the earlier click), and a mismatch left standing - S3 selected over an `https://` URL, or Azure re-selected over an `s3://` one - is refused at Save in both directions with the fix named.
- The radios bind through the same `EnumToBool` pattern as the authentication radios, whose `ConvertBack` answers an uncheck with `Binding.DoNothing` - the property that keeps the radio group's own unchecking from writing junk back through the binding. (The first cut bound one bool through an inverse converter; the group manager left both radios unchecked. Caught by rendering the form, not by the suite - the tests see the ViewModel, not the pixels.)

## Verification

1,864 unit tests passing (3 new: choice-before-URL, scheme-snaps-choice, both mismatch refusals). Release `-warnaserror` clean. Fresh Add form rendered both ways and eyeballed: correct radio filled, correct sections, correct URL hint in each.