### PR TITLE
The screens stopped assuming Azure (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,13 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Changed
 
+- **The screens stopped assuming Azure** (#51). "Azure Blob Storage" as a backup
+  source, destination or browse medium now reads "Cloud storage" - a saved container,
+  whichever provider answers it - across Restore, Back Up, Copy Database and Browse
+  Backups, with labels, empty-states and the delete-container dialog following. The
+  genuinely Azure-specific texts (Entra guidance, SAS specifics) still say Azure,
+  because there they mean it.
+
 - The engine - every service and model - now lives in NineLives.Core, a library with no UI
   framework behind it. Nothing a user can see is different; this is the load-bearing wall for
   the command-line front end (#63), where the same chain calculation, the same preflights and

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -1424,7 +1424,7 @@ public class XamlLoadTests(WpfFixture wpf)
             var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
 
             Assert.Empty(vm.Containers);
-            Assert.DoesNotContain("No blob containers configured", shown);
+            Assert.DoesNotContain("No storage containers configured", shown);
         });
     }
 
@@ -1440,7 +1440,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
             var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
 
-            Assert.Contains("No blob containers configured", shown);
+            Assert.Contains("No storage containers configured", shown);
         });
     }
 

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -39,6 +39,6 @@ public partial class AboutViewModel : ViewModelBase
     public string Author => "Jake Morgan";
     public string Company => "Blackcat Data Solutions Ltd";
     public string Website => "https://blackcat.wales";
-    public string Description => "Every database deserves nine lives. A production-ready utility for restoring SQL Server databases from Azure Blob Storage backups with full support for point-in-time recovery using Full, Differential, and Transaction Log backup chains.";
+    public string Description => "Every database deserves nine lives. A production-ready utility for restoring SQL Server databases from Azure Blob Storage or S3-compatible object storage backups, with full support for point-in-time recovery using Full, Differential, and Transaction Log backup chains.";
 
 }

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -865,9 +865,10 @@ public partial class BlobConfigViewModel : ViewModelBase
         // question rather than a single click (#42).
         var confirm = MessageBox.Show(
             $"Remove the container \"{SelectedContainer.Name}\"?\n\n" +
-            "Its stored SAS token will be deleted from Windows Credential Manager. The app never " +
-            "displays stored tokens, so if this is the only copy you will need to obtain a new one.\n\n" +
-            "Nothing in Azure is affected - no backups are deleted.",
+            "Its stored credential - the SAS token or access key pair - will be deleted from " +
+            "Windows Credential Manager. The app never displays stored credentials, so if this " +
+            "is the only copy you will need to obtain a new one.\n\n" +
+            "Nothing in the container itself is affected - no backups are deleted.",
             "Nine Lives", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
 
         if (confirm != MessageBoxResult.Yes) return;

--- a/src/NineLives/Views/BackupView.xaml
+++ b/src/NineLives/Views/BackupView.xaml
@@ -14,7 +14,7 @@
             <!-- Header -->
             <StackPanel Margin="0,0,0,20">
                 <TextBlock Text="Back Up a Database" Style="{StaticResource HeaderText}" />
-                <TextBlock Text="Take a backup to Azure Blob Storage or to a path the server can write to. Copy-only by default, so a production differential schedule is left alone."
+                <TextBlock Text="Take a backup to cloud storage or to a path the server can write to. Copy-only by default, so a production differential schedule is left alone."
                            Style="{StaticResource SecondaryText}"
                            TextWrapping="Wrap"
                            Margin="0,4,0,0" />
@@ -127,12 +127,12 @@
 
                     <TextBlock Text="WRITE IT TO" Style="{StaticResource LabelText}" Margin="0,10,0,0" />
                     <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                        <RadioButton Content="Azure Blob Storage"
+                        <RadioButton Content="Cloud storage"
                                      GroupName="BackupMedium"
                                      Style="{StaticResource DarkRadioButton}"
                                      IsChecked="{Binding Medium, Converter={StaticResource EnumToBool}, ConverterParameter=AzureBlob}"
                                      Margin="0,0,20,0"
-                                     ToolTip="BACKUP TO URL. Needs a credential on the server, and needs no network path between hosts." />
+                                     ToolTip="A saved container - Azure Blob Storage or an S3-compatible bucket. BACKUP TO URL: needs a credential on the server, and no network path between hosts." />
                         <RadioButton Content="A path the server can write to"
                                      GroupName="BackupMedium"
                                      Style="{StaticResource DarkRadioButton}"

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -24,7 +24,7 @@
         <StackPanel Grid.Row="0" Margin="0,0,0,16">
             <TextBlock Text="Browse Backups"
                        Style="{StaticResource HeaderText}" />
-            <TextBlock Text="Look at what is in a blob container, or at what a SQL Server has recorded backing up."
+            <TextBlock Text="Look at what is in a storage container, or at what a SQL Server has recorded backing up."
                        Style="{StaticResource SecondaryText}"
                        Margin="0,4,0,0" />
         </StackPanel>
@@ -36,12 +36,12 @@
                      order and with the same radio pair, because it is the same choice. -->
                 <TextBlock Text="WHERE TO LOOK" Style="{StaticResource LabelText}" Margin="0,0,0,6" />
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
-                    <RadioButton Content="Azure Blob Storage"
+                    <RadioButton Content="Cloud storage"
                                  GroupName="BrowseMedium"
                                  Style="{StaticResource DarkRadioButton}"
                                  IsChecked="{Binding SelectedMedium, Converter={StaticResource EnumToBool}, ConverterParameter=AzureBlob}"
                                  Margin="0,0,20,0"
-                                 ToolTip="Lists the container. Everything about each backup is inferred from its path and filename." />
+                                 ToolTip="A saved container - Azure Blob Storage or an S3-compatible bucket. Everything about each backup is inferred from its path and filename." />
                     <!-- Not "a path both servers can see": nothing is being restored here, so there
                          is no second server. What is read is one instance's own record. -->
                     <RadioButton Content="A server's backup history"

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -100,7 +100,8 @@
                                Text="Where the backup is written and then read back from. Blob needs no network path between the two servers; a shared path is faster and costs no egress, where both can reach it." />
 
                     <StackPanel Orientation="Horizontal">
-                        <RadioButton Content="Azure Blob Storage"
+                        <RadioButton Content="Cloud storage"
+                                     ToolTip="A saved container - Azure Blob Storage or an S3-compatible bucket."
                                      GroupName="CopyMedium"
                                      Style="{StaticResource DarkRadioButton}"
                                      IsChecked="{Binding Medium, Converter={StaticResource EnumToBool}, ConverterParameter=AzureBlob}"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -75,7 +75,7 @@
                     </Style>
                 </Border.Style>
                 <StackPanel>
-                    <TextBlock Text="No blob containers configured"
+                    <TextBlock Text="No storage containers configured"
                                Style="{StaticResource SubHeaderText}"
                                Margin="0,0,0,6" />
                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap">
@@ -102,12 +102,12 @@
                                 Visibility="{Binding ShowMediumChoice, Converter={StaticResource BoolToVis}}">
                         <TextBlock Text="WHERE THE BACKUPS LIVE" Style="{StaticResource LabelText}" />
                         <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                            <RadioButton Content="Azure Blob Storage"
+                            <RadioButton Content="Cloud storage"
                                          GroupName="BackupMedium"
                                          Style="{StaticResource DarkRadioButton}"
                                          IsChecked="{Binding SelectedMedium, Converter={StaticResource EnumToBool}, ConverterParameter=AzureBlob}"
                                          Margin="0,0,20,0"
-                                         ToolTip="RESTORE FROM URL. Needs a server-side credential, and needs no network path between the two hosts." />
+                                         ToolTip="A saved container - Azure Blob Storage or an S3-compatible bucket. RESTORE FROM URL: needs a server-side credential, and no network path between the two hosts." />
                             <RadioButton Content="A path both servers can see"
                                          GroupName="BackupMedium"
                                          Style="{StaticResource DarkRadioButton}"
@@ -133,7 +133,7 @@
                         </Grid.ColumnDefinitions>
 
                         <StackPanel Grid.Column="0" Margin="0,0,12,0">
-                            <TextBlock Text="BLOB CONTAINER" Style="{StaticResource LabelText}" />
+                            <TextBlock Text="STORAGE CONTAINER" Style="{StaticResource LabelText}" />
                             <!-- Tag pills here too, not only on the containers screen. This is the
                                  dropdown where "which of these is production" actually gets
                                  decided, and it was the one place the tags did not follow (#117
@@ -1948,7 +1948,7 @@
                                                 Content="{Binding Credential.CreateButtonText}"
                                                 Margin="0,0,0,0" Padding="10,6"
                                                 Style="{StaticResource SecondaryButton}"
-                                                ToolTip="Creates the SQL Server credential for this blob container URL, or updates an existing one, so that RESTORE FROM URL can access the backups. An existing credential is altered in place, never dropped. No secret is ever included in the generated script."
+                                                ToolTip="Creates the SQL Server credential for this container URL, or updates an existing one, so that RESTORE FROM URL can access the backups. An existing credential is altered in place, never dropped. No secret is ever included in the generated script."
                                                 HorizontalAlignment="Left" />
                                     </StackPanel>
                                 </StackPanel>


### PR DESCRIPTION
Wording sweep after the S3 feature landed: every screen that said "Azure Blob Storage" where it now means "a saved container, whichever provider answers it".

- The medium radios on **Restore, Back Up, Copy Database and Browse Backups** now read **"Cloud storage"**, with tooltips that lead with what the option is - a saved container, Azure Blob Storage or an S3-compatible bucket - before the mechanics.
- Labels and empty states follow: **STORAGE CONTAINER**, "No storage containers configured", the Browse screen's blurb, the Back Up header blurb.
- The **delete-container dialog** stops naming Azure and names what actually happens: the stored credential (SAS token or access key pair) is destroyed; the container itself is untouched.
- The About text now says what the app restores from: Azure Blob Storage **or S3-compatible object storage**.
- Deliberately untouched: the Entra guidance, SAS specifics and managed-identity tooltips - there "Azure" is the meaning, not a leftover.

No behaviour changes; strings and two test pins only.

## Verification

1,864 unit tests passing, Release `-warnaserror` clean. The Restore source section rendered to PNG with an s3:// container selected and eyeballed: "Cloud storage" radio, STORAGE CONTAINER label.