### PR TITLE
A front door (#343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **A front door** (#343). Choosing a mode now lands on Home: what Nine Lives is in a
+  paragraph, the three get-going steps - add your storage, add a SQL Server, restore -
+  as buttons that go to the right screens, and pointers to the rest of what the chosen
+  mode offers, mirroring the sidebar exactly. Reachable any time from the sidebar
+  (Ctrl+0). The launch-time carry-on still goes to wherever work was left - the front
+  door greets arrivals, it does not toll returns - and only somebody with no recorded
+  screen at all lands there by default, which is exactly who the introduction is for.
+
 - **The Add Container form asks the provider question up front** (#51). A Storage
   Provider choice - Azure Blob Storage or S3-compatible - sits above the URL, so the
   key-pair and region fields are on screen before any URL has been typed; the

--- a/src/NineLives.Tests/AppModeTests.cs
+++ b/src/NineLives.Tests/AppModeTests.cs
@@ -154,10 +154,10 @@ public class AppModeTests
 
         Assert.False(main.IsChoosingMode);
 
-        // Restore, specifically - the same place choosing a mode lands. "Not the settings page"
-        // was too weak a pin: it let the container list through, which is the landing the cards
-        // exist to get away from (#209).
-        Assert.Same(main.Restore, main.CurrentView);
+        // The front door, specifically - the same place choosing a mode lands (#343, which
+        // moved this from Restore). "Not the settings page" was too weak a pin: it let the
+        // container list through, which is the landing the cards exist to get away from (#209).
+        Assert.Same(main.Home, main.CurrentView);
     }
 
     /// <summary>The choice is remembered, or it would be asked again next time.</summary>
@@ -242,7 +242,9 @@ public class AppModeTests
         main.Mode = AppMode.Basic;
 
         Assert.NotSame(main.CopyDatabase, main.CurrentView);
-        Assert.Same(main.Restore, main.CurrentView);
+        // The front door (#343, which moved this from Restore): it exists in every
+        // mode, and its pointers show the new shape that just hid the old screen.
+        Assert.Same(main.Home, main.CurrentView);
     }
 
     [Fact]

--- a/src/NineLives.Tests/HomeScreenTests.cs
+++ b/src/NineLives.Tests/HomeScreenTests.cs
@@ -1,0 +1,103 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The front door (#343). The mode cards say how MUCH of the app you get; this screen is the
+/// only one that says what the app IS - so choosing a mode lands here, its buttons must
+/// genuinely go where they claim, and its feature pointers must show exactly the shape the
+/// sidebar shows, or the introduction lies about the thing it introduces.
+/// </summary>
+public class HomeScreenTests
+{
+    private static MainViewModel FirstRun(out FakeCredentialStore store)
+    {
+        store = new FakeCredentialStore();
+        return new MainViewModel(store);
+    }
+
+    [Fact]
+    public void ChoosingAModeLandsOnTheFrontDoor()
+    {
+        var main = FirstRun(out _);
+        Assert.True(main.IsChoosingMode);
+
+        main.ModeSelection.ChooseCommand.Execute(
+            main.ModeSelection.Cards.Single(c => c.Mode == AppMode.Standard));
+
+        Assert.False(main.IsChoosingMode);
+        Assert.Same(main.Home, main.CurrentView);
+        Assert.Equal(MainViewModel.Nav.Home, main.CurrentViewName);
+    }
+
+    [Fact]
+    public void TheFrontDoorsButtonsGoWhereTheyClaim()
+    {
+        var main = FirstRun(out _);
+        main.ModeSelection.ChooseCommand.Execute(
+            main.ModeSelection.Cards.Single(c => c.Mode == AppMode.Pro));
+
+        main.Home.GoCommand.Execute(MainViewModel.Nav.BlobStorage);
+        Assert.Same(main.BlobConfig, main.CurrentView);
+
+        main.Home.GoCommand.Execute(MainViewModel.Nav.Restore);
+        Assert.Same(main.Restore, main.CurrentView);
+
+        // And back: the sidebar offers Home like any other screen.
+        main.NavigateToCommand.Execute(MainViewModel.Nav.Home);
+        Assert.Same(main.Home, main.CurrentView);
+    }
+
+    [Theory]
+    [InlineData(AppMode.Basic)]
+    [InlineData(AppMode.Standard)]
+    [InlineData(AppMode.Pro)]
+    public void TheFrontDoorExistsInEveryMode(AppMode mode)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = mode;
+
+        Assert.True(new MainViewModel(store).IsViewAvailable(MainViewModel.Nav.Home));
+    }
+
+    /// <summary>
+    /// The feature pointers mirror the sidebar. A Basic user shown a "Back Up" card whose
+    /// screen the sidebar does not offer would be introduced to an app they do not have.
+    /// </summary>
+    [Fact]
+    public void TheFeaturePointersShowTheModesActualShape()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Basic;
+        var main = new MainViewModel(store);
+
+        Assert.False(main.Home.ShowBackup);
+        Assert.False(main.Home.ShowBrowseBackups);
+        Assert.False(main.Home.ShowCopyDatabase);
+
+        // Changing the mode from Settings reshapes the pointers with the sidebar.
+        main.Mode = AppMode.Pro;
+        Assert.True(main.Home.ShowBackup);
+        Assert.True(main.Home.ShowBrowseBackups);
+        Assert.True(main.Home.ShowCopyDatabase);
+    }
+
+    /// <summary>
+    /// Home is a screen like any other for the carry-on memory (#211): left there, landed
+    /// there next launch.
+    /// </summary>
+    [Fact]
+    public void TheFrontDoorIsRememberedLikeAnyOtherScreen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = AppMode.Pro;
+        store.Config.LastScreen = MainViewModel.Nav.Home;
+        var main = new MainViewModel(store);
+
+        main.ModeSelection.CancelCommand.Execute(null);
+
+        Assert.Same(main.Home, main.CurrentView);
+    }
+}

--- a/src/NineLives.Tests/RememberedWindowTests.cs
+++ b/src/NineLives.Tests/RememberedWindowTests.cs
@@ -78,35 +78,39 @@ public class RememberedWindowTests
         Assert.Same(main.History, main.CurrentView);
     }
 
-    /// <summary>Nothing recorded still lands on Restore, the app's centre (#209).</summary>
+    /// <summary>
+    /// Nothing recorded lands on the front door (#343). It used to be Restore, the app's
+    /// centre (#209) - but the only people with nothing recorded are the ones who have never
+    /// been anywhere, and they are exactly who the introduction exists for.
+    /// </summary>
     [Fact]
-    public void NothingRecordedLandsOnRestore()
+    public void NothingRecordedLandsOnTheFrontDoor()
     {
         var main = Shell();
 
         main.ModeSelection.CancelCommand.Execute(null);
 
-        Assert.Same(main.Restore, main.CurrentView);
+        Assert.Same(main.Home, main.CurrentView);
     }
 
     /// <summary>
-    /// A screen the current mode no longer offers falls back to Restore - a guess at the nearest
-    /// cousin would be worse than the app's centre.
+    /// A screen the current mode no longer offers falls back to the front door - a guess at
+    /// the nearest cousin would be worse than the screen that shows the mode's actual shape.
     /// </summary>
     [Fact]
-    public void AScreenTheModeDoesNotOfferFallsBackToRestore()
+    public void AScreenTheModeDoesNotOfferFallsBackToTheFrontDoor()
     {
         var main = Shell(AppMode.Basic, MainViewModel.Nav.CopyDatabase);
 
         main.ModeSelection.CancelCommand.Execute(null);
 
-        Assert.Same(main.Restore, main.CurrentView);
+        Assert.Same(main.Home, main.CurrentView);
     }
 
     [Fact]
-    public void GarbageInTheConfigFallsBackToRestore()
+    public void GarbageInTheConfigFallsBackToTheFrontDoor()
     {
-        Assert.Equal(MainViewModel.Nav.Restore, Shell().LandingScreen("No Such Screen"));
+        Assert.Equal(MainViewModel.Nav.Home, Shell().LandingScreen("No Such Screen"));
     }
 
     // ── saving at shutdown ──────────────────────────────────────────────────────

--- a/src/NineLives/MainWindow.xaml
+++ b/src/NineLives/MainWindow.xaml
@@ -31,6 +31,7 @@
          What each one does is decided on MainViewModel, not bound straight to a screen's command -
          see the comment there. -->
     <Window.InputBindings>
+        <KeyBinding Modifiers="Ctrl" Key="D0" Command="{Binding NavigateToCommand}" CommandParameter="Home" />
         <KeyBinding Modifiers="Ctrl" Key="D1" Command="{Binding NavigateToCommand}" CommandParameter="Blob Storage" />
         <KeyBinding Modifiers="Ctrl" Key="D2" Command="{Binding NavigateToCommand}" CommandParameter="SQL Servers" />
         <KeyBinding Modifiers="Ctrl" Key="D3" Command="{Binding NavigateToCommand}" CommandParameter="Browse Backups" />
@@ -49,6 +50,9 @@
         <converters:NullToVisibilityConverter x:Key="NullToVis" />
         <converters:EnumToBoolConverter x:Key="EnumToBool" />
 
+        <DataTemplate DataType="{x:Type vm:HomeViewModel}">
+            <views:HomeView />
+        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:BlobConfigViewModel}">
             <views:BlobConfigView />
         </DataTemplate>
@@ -265,6 +269,17 @@
 
                     <!-- Navigation -->
                     <StackPanel DockPanel.Dock="Top" Margin="0,8,0,0">
+                        <!-- Above the section headers: the front door belongs to no section (#343). -->
+                        <RadioButton Style="{StaticResource SidebarButton}"
+                                     IsChecked="{Binding CurrentViewName, Converter={StaticResource EnumToBool}, ConverterParameter='Home'}"
+                                     Command="{Binding NavigateToCommand}"
+                                     CommandParameter="Home">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#x2302;" FontSize="15" VerticalAlignment="Center" Width="24" />
+                                <TextBlock Text="Home" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </RadioButton>
+
                         <TextBlock Text="CONFIGURATION"
                                    FontSize="10" FontWeight="Bold"
                                    Foreground="{DynamicResource DisabledTextBrush}"

--- a/src/NineLives/ViewModels/HomeViewModel.cs
+++ b/src/NineLives/ViewModels/HomeViewModel.cs
@@ -1,0 +1,44 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>
+/// The front door (#343): where choosing a mode lands, and where a launch with nothing
+/// remembered begins. Says what the app is, walks the three get-going steps, and points at
+/// the rest of what the chosen mode offers - because the mode cards say how MUCH of the app
+/// you get, and nothing else ever said what the app IS.
+///
+/// Deliberately almost stateless: the screen is prose and buttons. Navigation stays
+/// MainViewModel's job - this only raises the request, the same one-way wiring the browser's
+/// restore handoff uses - and the mode arrives from above like every other screen's, so the
+/// feature pointers show exactly what the sidebar shows.
+/// </summary>
+public partial class HomeViewModel : ViewModelBase
+{
+    /// <summary>Raised with a <see cref="MainViewModel.Nav"/> name. MainViewModel owns the switch.</summary>
+    public event Action<string>? NavigateRequested;
+
+    [RelayCommand]
+    private void Go(string viewName) => NavigateRequested?.Invoke(viewName);
+
+    /// <summary>Set by MainViewModel whenever the mode changes, like the other screens.</summary>
+    [ObservableProperty]
+    private AppMode _mode = AppMode.Pro;
+
+    public bool ShowBackup => AppModeCapabilities.CanBackUp(Mode);
+    public bool ShowCopyDatabase => AppModeCapabilities.CanCopyBetweenServers(Mode);
+    public bool ShowBrowseBackups => AppModeCapabilities.CanBrowseBackups(Mode);
+
+    partial void OnModeChanged(AppMode value)
+    {
+        OnPropertyChanged(nameof(ShowBackup));
+        OnPropertyChanged(nameof(ShowCopyDatabase));
+        OnPropertyChanged(nameof(ShowBrowseBackups));
+    }
+
+    /// <summary>Read from the assembly so it cannot go stale. Instance rather than static
+    /// because a Binding path only sees the DataContext's own properties.</summary>
+    public string VersionText => Services.AppVersion.Display;
+}

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -58,11 +58,13 @@ public partial class MainViewModel : ViewModelBase
 
         Restore.Mode = value;
         Backup.Mode = value;
+        Home.Mode = value;
         Settings.CurrentMode = value;
 
         // A screen that has just been hidden must not stay on display underneath a sidebar that no
-        // longer offers it - which is what changing mode from Settings would otherwise do.
-        if (!IsViewAvailable(CurrentViewName)) NavigateTo(Nav.Restore);
+        // longer offers it - which is what changing mode from Settings would otherwise do. Home,
+        // because it exists in every mode and its feature pointers SHOW the new shape (#343).
+        if (!IsViewAvailable(CurrentViewName)) NavigateTo(Nav.Home);
     }
 
     private void OnModeChosen(AppMode mode)
@@ -70,9 +72,10 @@ public partial class MainViewModel : ViewModelBase
         Mode = mode;
         IsChoosingMode = false;
 
-        // Restore rather than back to Settings, deliberately: the point of changing the mode is the
-        // shape of the app, and landing on the settings page you came from shows none of it.
-        NavigateTo(Nav.Restore);
+        // The front door, deliberately (#343): choosing a mode is choosing the shape of the app,
+        // and Home is the one screen that says what that shape contains - landing on Restore
+        // showed one room of it, and landing back on Settings showed none.
+        NavigateTo(Nav.Home);
     }
 
     /// <summary>
@@ -98,7 +101,7 @@ public partial class MainViewModel : ViewModelBase
     /// app. Sending somebody who has just started the app to the settings page would be a stranger
     /// place to land than the one they were heading for.
     /// </summary>
-    private string _modeCardsReturnTo = Nav.Restore;
+    private string _modeCardsReturnTo = Nav.Home;
 
     private void OnModeCardsCancelled()
     {
@@ -108,13 +111,15 @@ public partial class MainViewModel : ViewModelBase
 
     /// <summary>
     /// Where carrying on from the launch cards lands (#211): the last session's screen when it is
-    /// still a screen this mode offers, Restore otherwise. Restore rather than the recorded
-    /// screen's nearest cousin, because a guess about intent is worse than the app's centre.
+    /// still a screen this mode offers, the front door otherwise (#343). Home rather than the
+    /// recorded screen's nearest cousin, because a guess about intent is worse than the one
+    /// screen that introduces all the others - and the only people who reach the fallback are
+    /// the ones with no recorded intent to guess at.
     /// </summary>
     internal string LandingScreen(string? lastScreen) =>
         lastScreen != null && Nav.Views.Contains(lastScreen) && IsViewAvailable(lastScreen)
             ? lastScreen
-            : Nav.Restore;
+            : Nav.Home;
 
     /// <summary>
     /// Files everything the next launch wants back: where the window was, and which screen was in
@@ -198,6 +203,7 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     public string VersionText => Services.AppVersion.Display;
 
+    public HomeViewModel Home { get; }
     public BlobConfigViewModel BlobConfig { get; }
     public ServerManagerViewModel ServerManager { get; }
     public BlobBrowserViewModel BlobBrowser { get; }
@@ -240,6 +246,10 @@ public partial class MainViewModel : ViewModelBase
         _sqlService = new SqlServerService(_credentialStore);
         _chainBuilder = new BackupChainBuilder();
         _scriptGenerator = new RestoreScriptGenerator();
+
+        // The front door (#343). Navigation stays here; the screen only asks.
+        Home = new HomeViewModel();
+        Home.NavigateRequested += NavigateTo;
 
         BlobConfig = new BlobConfigViewModel(_credentialStore, _blobService);
         ServerManager = new ServerManagerViewModel(_credentialStore, _sqlService);
@@ -557,6 +567,7 @@ public partial class MainViewModel : ViewModelBase
     /// </summary>
     public static class Nav
     {
+        public const string Home = "Home";
         public const string BlobStorage = "Blob Storage";
         public const string SqlServers = "SQL Servers";
         public const string BrowseBackups = "Browse Backups";
@@ -569,7 +580,7 @@ public partial class MainViewModel : ViewModelBase
         public const string About = "About";
 
         public static IReadOnlyList<string> Views =>
-            [BlobStorage, SqlServers, BrowseBackups, Exposure, Backup, Restore, CopyDatabase, History, Settings, About];
+            [Home, BlobStorage, SqlServers, BrowseBackups, Exposure, Backup, Restore, CopyDatabase, History, Settings, About];
     }
 
     [RelayCommand]
@@ -578,6 +589,7 @@ public partial class MainViewModel : ViewModelBase
         CurrentViewName = viewName;
         CurrentView = viewName switch
         {
+            Nav.Home => Home,
             Nav.BlobStorage => BlobConfig,
             Nav.SqlServers => ServerManager,
             Nav.BrowseBackups => BlobBrowser,

--- a/src/NineLives/Views/HomeView.xaml
+++ b/src/NineLives/Views/HomeView.xaml
@@ -1,0 +1,179 @@
+<UserControl x:Class="Blackcat.NineLives.Views.HomeView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:converters="clr-namespace:Blackcat.NineLives.Converters">
+
+    <UserControl.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
+
+        <!-- The get-going step cards. -->
+        <Style x:Key="StepCard" TargetType="Border" BasedOn="{StaticResource CardBorder}">
+            <Setter Property="Padding" Value="20" />
+            <Setter Property="Margin" Value="0,0,12,0" />
+        </Style>
+
+        <Style x:Key="StepNumber" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="22" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+            <Setter Property="Margin" Value="0,0,0,6" />
+        </Style>
+
+        <Style x:Key="StepTitle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="15" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+            <Setter Property="Margin" Value="0,0,0,6" />
+        </Style>
+
+        <Style x:Key="StepText" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="Margin" Value="0,0,0,14" />
+        </Style>
+
+        <!-- The everything-else pointers: smaller, quieter. -->
+        <Style x:Key="FeatureCard" TargetType="Border" BasedOn="{StaticResource CardBorder}">
+            <Setter Property="Padding" Value="14" />
+            <Setter Property="Margin" Value="0,0,12,12" />
+            <Setter Property="Width" Value="292" />
+        </Style>
+    </UserControl.Resources>
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel MaxWidth="940" Margin="32,24,32,32" HorizontalAlignment="Center">
+
+            <!-- Who this is -->
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                <ContentControl Template="{StaticResource NineLivesLogo}" Height="52" Margin="0,0,16,0" />
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Style="{StaticResource LogoWordmark}" FontSize="24">
+                        <Run Text="N I N E" Foreground="{DynamicResource PrimaryTextBrush}" />
+                        <Run Text=" " />
+                        <Run Text="L I V E S" Foreground="{DynamicResource AccentBrush}" />
+                    </TextBlock>
+                    <TextBlock Text="RESTORE | RECOVER | RESUME"
+                               FontSize="11"
+                               Foreground="{DynamicResource SecondaryTextBrush}" />
+                </StackPanel>
+            </StackPanel>
+
+            <TextBlock Style="{StaticResource StepText}" FontSize="13" Margin="0,10,0,24"
+                       Text="Nine Lives finds the SQL Server backups in your storage - an Azure Blob container or any S3-compatible bucket - works out the restore chains, and turns any moment you pick into a script you can read, run from here with live progress, or hand to an agent job. Everything it executes is receipted in History, and nothing destructive runs without being asked twice." />
+
+            <!-- Get going -->
+            <TextBlock Text="GET GOING" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+            <UniformGrid Columns="3" Margin="0,0,-12,20">
+                <Border Style="{StaticResource StepCard}">
+                    <StackPanel>
+                        <TextBlock Text="1" Style="{StaticResource StepNumber}" />
+                        <TextBlock Text="Add your storage" Style="{StaticResource StepTitle}" />
+                        <TextBlock Style="{StaticResource StepText}"
+                                   Text="Point the app at where the backups live. The credential - a SAS token or an S3 access key pair - is proven against the container and stored in Windows Credential Manager." />
+                        <Button Content="Open Blob Storage"
+                                Style="{StaticResource PrimaryButton}"
+                                HorizontalAlignment="Left"
+                                Command="{Binding GoCommand}"
+                                CommandParameter="Blob Storage" />
+                    </StackPanel>
+                </Border>
+                <Border Style="{StaticResource StepCard}">
+                    <StackPanel>
+                        <TextBlock Text="2" Style="{StaticResource StepNumber}" />
+                        <TextBlock Text="Add a SQL Server" Style="{StaticResource StepTitle}" />
+                        <TextBlock Style="{StaticResource StepText}"
+                                   Text="The instance restores will land on. Windows or SQL authentication; the connection and its permissions are proven in one round trip when it is saved." />
+                        <Button Content="Open SQL Servers"
+                                Style="{StaticResource PrimaryButton}"
+                                HorizontalAlignment="Left"
+                                Command="{Binding GoCommand}"
+                                CommandParameter="SQL Servers" />
+                    </StackPanel>
+                </Border>
+                <Border Style="{StaticResource StepCard}">
+                    <StackPanel>
+                        <TextBlock Text="3" Style="{StaticResource StepNumber}" />
+                        <TextBlock Text="Restore" Style="{StaticResource StepTitle}" />
+                        <TextBlock Style="{StaticResource StepText}"
+                                   Text="Pick a database, pick a moment - the app builds the full-diff-log chain, writes the script, and shows it before anything runs. Execute from here, or take the script away." />
+                        <Button Content="Open Restore"
+                                Style="{StaticResource SuccessButton}"
+                                HorizontalAlignment="Left"
+                                Command="{Binding GoCommand}"
+                                CommandParameter="Restore" />
+                    </StackPanel>
+                </Border>
+            </UniformGrid>
+
+            <!-- What else the chosen mode offers -->
+            <TextBlock Text="ALSO HERE" Style="{StaticResource LabelText}" Margin="0,0,0,8" />
+            <WrapPanel Margin="0,0,-12,8">
+                <Border Style="{StaticResource FeatureCard}"
+                        Visibility="{Binding ShowBrowseBackups, Converter={StaticResource BoolToVis}}">
+                    <StackPanel>
+                        <TextBlock Text="Browse Backups" Style="{StaticResource StepTitle}" />
+                        <TextBlock Style="{StaticResource StepText}" Margin="0,0,0,10"
+                                   Text="Look inside a container - or at what a server has recorded backing up - without restoring anything." />
+                        <Button Content="Open" Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"
+                                Command="{Binding GoCommand}" CommandParameter="Browse Backups" />
+                    </StackPanel>
+                </Border>
+                <Border Style="{StaticResource FeatureCard}"
+                        Visibility="{Binding ShowBrowseBackups, Converter={StaticResource BoolToVis}}">
+                    <StackPanel>
+                        <TextBlock Text="Exposure" Style="{StaticResource StepTitle}" />
+                        <TextBlock Style="{StaticResource StepText}" Margin="0,0,0,10"
+                                   Text="How exposed is the estate right now? Every server's most recent restorable moment, worst first." />
+                        <Button Content="Open" Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"
+                                Command="{Binding GoCommand}" CommandParameter="Exposure" />
+                    </StackPanel>
+                </Border>
+                <Border Style="{StaticResource FeatureCard}"
+                        Visibility="{Binding ShowBackup, Converter={StaticResource BoolToVis}}">
+                    <StackPanel>
+                        <TextBlock Text="Back Up" Style="{StaticResource StepTitle}" />
+                        <TextBlock Style="{StaticResource StepText}" Margin="0,0,0,10"
+                                   Text="To cloud storage or a path the server can write to. COPY_ONLY by default, so production schedules are left alone." />
+                        <Button Content="Open" Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"
+                                Command="{Binding GoCommand}" CommandParameter="Back Up" />
+                    </StackPanel>
+                </Border>
+                <Border Style="{StaticResource FeatureCard}"
+                        Visibility="{Binding ShowCopyDatabase, Converter={StaticResource BoolToVis}}">
+                    <StackPanel>
+                        <TextBlock Text="Copy Database" Style="{StaticResource StepTitle}" />
+                        <TextBlock Style="{StaticResource StepText}" Margin="0,0,0,10"
+                                   Text="Source to target in one move, through cloud storage or a shared path - backup, chain and restore handled as one action." />
+                        <Button Content="Open" Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"
+                                Command="{Binding GoCommand}" CommandParameter="Copy Database" />
+                    </StackPanel>
+                </Border>
+                <Border Style="{StaticResource FeatureCard}">
+                    <StackPanel>
+                        <TextBlock Text="History" Style="{StaticResource StepTitle}" />
+                        <TextBlock Style="{StaticResource StepText}" Margin="0,0,0,10"
+                                   Text="Every executed run, receipted: what ran, where, how long it took, and whether it worked - from the app or the CLI." />
+                        <Button Content="Open" Style="{StaticResource SecondaryButton}" HorizontalAlignment="Left"
+                                Command="{Binding GoCommand}" CommandParameter="History" />
+                    </StackPanel>
+                </Border>
+                <Border Style="{StaticResource FeatureCard}">
+                    <StackPanel>
+                        <TextBlock Text="The CLI: 9lives.exe" Style="{StaticResource StepTitle}" />
+                        <TextBlock Style="{StaticResource StepText}" Margin="0,0,0,10"
+                                   Text="The same engine from a terminal, against the same configuration - scripted restores, rehearsals and provisioning. Start with: 9lives help" />
+                        <TextBlock Text="Ships next to this app's exe."
+                                   FontSize="11" Foreground="{DynamicResource DisabledTextBrush}" />
+                    </StackPanel>
+                </Border>
+            </WrapPanel>
+
+            <TextBlock FontSize="11" Foreground="{DynamicResource DisabledTextBrush}" TextWrapping="Wrap">
+                <Run Text="{Binding VersionText, Mode=OneWay}" />
+                <Run Text=" - this page is under Home in the sidebar. How much of the app is shown is a mode, changed any time from Settings." />
+            </TextBlock>
+
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/NineLives/Views/HomeView.xaml.cs
+++ b/src/NineLives/Views/HomeView.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows.Controls;
+
+namespace Blackcat.NineLives.Views;
+
+public partial class HomeView : UserControl
+{
+    public HomeView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
Closes #343. Choosing a mode dropped straight onto the Restore screen; a fresh install's first sight of the app proper was a form asking for a backup source it did not have yet.

## What this adds

**A Home screen** - what Nine Lives is in a paragraph, the three get-going steps (add your storage → add a SQL Server → restore) as buttons that navigate, and pointers to the rest of what the chosen mode offers. The pointers mirror the sidebar exactly (same `AppModeCapabilities` answers): a Basic user sees History and the CLI, not screens their mode hides. Sidebar entry above the section headers, `Ctrl+0`.

**Where it lands** - three deliberate moves, pinned:
- Choosing a mode → Home (the choice is about the app's shape; Home shows it).
- Narrowing the mode off a hidden screen → Home (exists in every mode, shows the new shape).
- A launch with nothing recorded → Home (the only people with no recorded screen have never been anywhere - exactly who an introduction is for).
- **Untouched:** the launch carry-on still goes to wherever work was left. The front door greets arrivals; it does not toll returns.

The screen is nearly stateless: prose and buttons. Navigation stays MainViewModel's job - Home raises a request, the same one-way wiring the browse screen's restore handoff uses.

## Verification

1,871 unit tests passing (7 new: landing, routing, availability in every mode, pointer shape, carry-on memory; 4 existing landing pins deliberately moved Restore→Home with the reasoning updated). Release `-warnaserror` clean. Rendered in Pro and Basic and eyeballed.