### PR TITLE
Two Azure-shaped assumptions the S3 work left behind (#345, #346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,21 @@ more detail on the user-facing changes; this file is the short history.
   list meant guessing whose history the timeline would show. One instance answers its own
   filter automatically; the database choice itself always stays with the user
 
+### Fixed
+
+- **A bucket has an endpoint, not a storage account** (#345). The container details pane
+  read the first label of the host name into a row labelled STORAGE ACCOUNT - correct for
+  Azure, and "s3" for every AWS bucket. Both the label and the value now follow the
+  provider, and an endpoint given with a port keeps it.
+
+- **A backup destination too long for SQL Server is refused before the run, not during it**
+  (#346). The engine caps a backup device URL at 259 characters; past that BACKUP TO URL
+  fails on the server, mid-backup, with a message about devices rather than lengths. The
+  destination is now measured where it is built, so the Back Up screen, Copy Database and
+  the CLI's backup verb all refuse it up front - naming the offending URL and its length,
+  because the fix is always in one of its parts. Easy to reach with a long endpoint, a base
+  path and the default four-segment pattern; striping makes every stripe carry it.
+
 ### Changed
 
 - **The screens stopped assuming Azure** (#51). "Azure Blob Storage" as a backup

--- a/src/NineLives.Cli/Verbs/BackupVerb.cs
+++ b/src/NineLives.Cli/Verbs/BackupVerb.cs
@@ -162,6 +162,15 @@ internal static class BackupVerb
             : BackupDestinationBuilder.ForSharedPath(
                 path!, database, type.Value, takenAt, stripes, copyOnly);
 
+        // Before the script exists, let alone runs (#346). A URL SQL Server will refuse for its
+        // length is a problem with the container's settings, not a run to start and have fail
+        // on the server - so it exits as usage rather than as a failed backup.
+        if (BackupDestinationBuilder.DescribeTooLong(destinations) is { } tooLong)
+        {
+            errors.WriteLine($"REFUSED: {tooLong}");
+            return ExitCodes.Usage;
+        }
+
         var script = new BackupScriptGenerator().Generate(new BackupOptions
         {
             DatabaseName = database,

--- a/src/NineLives.Core/Models/BlobContainerConfig.cs
+++ b/src/NineLives.Core/Models/BlobContainerConfig.cs
@@ -266,6 +266,25 @@ public class BlobContainerConfig : INotifyPropertyChanged
         }
     }
 
+    /// <summary>
+    /// What to call the thing this container lives in (#345). Azure has a storage account -
+    /// the first label of the host name - and a bucket does not: an S3 URL's host is the
+    /// provider's endpoint, whole.
+    /// </summary>
+    [JsonIgnore]
+    public string LocationLabel => IsS3 ? "ENDPOINT" : "STORAGE ACCOUNT";
+
+    /// <summary>
+    /// The value for <see cref="LocationLabel"/>. Reported "s3" for every AWS bucket before
+    /// this existed, because <see cref="StorageAccountName"/> splits the host on its first dot
+    /// - which is the storage account for an Azure URL and the first label of an endpoint for
+    /// an S3 one. The authority rather than the bare host, so an endpoint given with a port
+    /// still describes itself completely.
+    /// </summary>
+    [JsonIgnore]
+    public string? LocationDisplay =>
+        IsS3 ? S3Url.TryParse(ContainerUrl)?.Authority : StorageAccountName;
+
     public string DisplayText
     {
         get

--- a/src/NineLives.Core/Services/BackupDestinationBuilder.cs
+++ b/src/NineLives.Core/Services/BackupDestinationBuilder.cs
@@ -90,6 +90,39 @@ public static class BackupDestinationBuilder
     }
 
     /// <summary>
+    /// How long a backup device URL may be before SQL Server refuses it (#346).
+    ///
+    /// The engine's own limit, not ours. Past it BACKUP TO URL fails on the server, with a
+    /// message about the device rather than about lengths - and by then the run is under way.
+    /// </summary>
+    public const int MaxDeviceUrlLength = 259;
+
+    /// <summary>
+    /// Why these destinations cannot be written, or null when they can.
+    ///
+    /// Checked where it can still be fixed. Every part that makes a URL long is a setting
+    /// somebody chose - the endpoint, the base prefix, the path pattern - so the refusal names
+    /// the longest offender and its length rather than saying "too long" and leaving the search
+    /// to whoever is standing there. Striping is the multiplier worth knowing about: every
+    /// stripe carries the same prefix, so one that does not fit means none of them do.
+    /// </summary>
+    public static string? DescribeTooLong(IReadOnlyList<string> destinations)
+    {
+        var worst = destinations
+            .Where(d => d.Length > MaxDeviceUrlLength)
+            .OrderByDescending(d => d.Length)
+            .FirstOrDefault();
+
+        if (worst == null) return null;
+
+        return $"This backup's destination is {worst.Length} characters and SQL Server refuses a " +
+               $"backup URL longer than {MaxDeviceUrlLength}:{Environment.NewLine}{Environment.NewLine}" +
+               $"{worst}{Environment.NewLine}{Environment.NewLine}" +
+               "Shorten the container's path pattern, or its base path, before running this - the " +
+               "server would refuse it mid-backup otherwise.";
+    }
+
+    /// <summary>
     /// The file paths to write on a share.
     ///
     /// A share has no configured pattern to follow, and it does not need one: backups written here

--- a/src/NineLives.Tests/BackupDestinationBuilderTests.cs
+++ b/src/NineLives.Tests/BackupDestinationBuilderTests.cs
@@ -186,6 +186,71 @@ public class BackupDestinationBuilderTests
         Assert.DoesNotContain(@"\", name);
     }
 
+    // ── the length SQL Server refuses (#346) ────────────────────────────────────
+
+    /// <summary>
+    /// An ordinary destination is not refused. The guard exists to catch a real engine limit,
+    /// and one that fired on normal work would be worse than the failure it prevents.
+    /// </summary>
+    [Fact]
+    public void AnOrdinaryDestinationIsNotRefused()
+    {
+        var destinations = BackupDestinationBuilder
+            .ForContainer(Container(), "SRV01", "MyDb", BackupType.Full, T0);
+
+        Assert.Null(BackupDestinationBuilder.DescribeTooLong(destinations));
+    }
+
+    /// <summary>
+    /// Past 259 characters SQL Server refuses the device mid-backup, so this is caught while
+    /// the settings that made it long can still be changed.
+    /// </summary>
+    [Fact]
+    public void ADestinationOverTheEngineLimitIsRefusedWithItsLengthAndTheUrl()
+    {
+        var deep = new BlobContainerConfig
+        {
+            Name = "long",
+            // A real shape: an endpoint, a bucket, and a base path somebody chose.
+            ContainerUrl = "s3://s3.eu-west-2.amazonaws.com/" + new string('b', 60) + "/" + new string('p', 60),
+            PathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}"
+        };
+
+        var destinations = BackupDestinationBuilder.ForContainer(
+            deep, new string('s', 40), new string('d', 60), BackupType.Full, T0);
+
+        var refusal = BackupDestinationBuilder.DescribeTooLong(destinations);
+
+        Assert.NotNull(refusal);
+        Assert.Contains(destinations[0].Length.ToString(), refusal);
+        Assert.Contains("259", refusal);
+        // The URL itself, because the fix is always in one of its parts.
+        Assert.Contains(destinations[0], refusal);
+    }
+
+    /// <summary>
+    /// Every stripe carries the same prefix, so one that does not fit means the set does not -
+    /// and the refusal names the longest rather than whichever came first.
+    /// </summary>
+    [Fact]
+    public void TheWorstStripeIsTheOneNamed()
+    {
+        var container = new BlobContainerConfig
+        {
+            Name = "long",
+            ContainerUrl = "https://acct.blob.core.windows.net/" + new string('c', 120),
+            PathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}"
+        };
+
+        var destinations = BackupDestinationBuilder.ForContainer(
+            container, new string('s', 40), new string('d', 40), BackupType.Full, T0, stripes: 3);
+
+        var refusal = BackupDestinationBuilder.DescribeTooLong(destinations);
+
+        Assert.NotNull(refusal);
+        Assert.Contains(destinations.OrderByDescending(d => d.Length).First(), refusal);
+    }
+
     // ── a share ─────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/src/NineLives.Tests/S3ConfigScreenTests.cs
+++ b/src/NineLives.Tests/S3ConfigScreenTests.cs
@@ -222,6 +222,38 @@ public class S3ConfigScreenTests
         Assert.False(vm.IsSasExpired);
     }
 
+    /// <summary>
+    /// A bucket has an endpoint, not a storage account (#345). The old row read the first label
+    /// of the host, which is the account for an Azure URL and reported "s3" for every AWS
+    /// bucket - a fact about nothing, in a row labelled as though it meant something.
+    /// </summary>
+    [Fact]
+    public void TheDetailsPaneCallsAnS3EndpointAnEndpoint()
+    {
+        var bucket = SavedS3Container();
+
+        Assert.Equal("ENDPOINT", bucket.LocationLabel);
+        Assert.Equal("s3.eu-west-2.amazonaws.com", bucket.LocationDisplay);
+
+        var azure = new BlobContainerConfig
+        {
+            ContainerUrl = "https://myaccount.blob.core.windows.net/backups"
+        };
+
+        Assert.Equal("STORAGE ACCOUNT", azure.LocationLabel);
+        Assert.Equal("myaccount", azure.LocationDisplay);
+    }
+
+    /// <summary>An endpoint given with a port describes itself completely.</summary>
+    [Fact]
+    public void AnEndpointWithAPortKeepsIt()
+    {
+        Assert.Equal("storage.example.com:9000", new BlobContainerConfig
+        {
+            ContainerUrl = "s3://storage.example.com:9000/backups"
+        }.LocationDisplay);
+    }
+
     [Fact]
     public void TheDetailsPaneNamesTheKeyPairNotTheSas()
     {

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -451,6 +451,14 @@ public partial class BackupViewModel : ViewModelBase
             _generated.Select(g => g.Script));
         Destinations = new ObservableCollection<string>(_generated.SelectMany(g => g.Destinations));
 
+        // Said at generate time, while the script is on screen and the settings that made it
+        // long are still to hand (#346). The server would refuse this mid-backup.
+        if (BackupDestinationBuilder.DescribeTooLong([.. Destinations]) is { } tooLong)
+        {
+            SetError(tooLong);
+            return;
+        }
+
         SetStatus(_generated.Count == 1
             ? "Script generated."
             : $"Script generated - {_generated.Count} databases, in order.");

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -342,6 +342,13 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
         Destinations = new ObservableCollection<string>(destinations);
 
+        // The same length the server will refuse, said while it can still be changed (#346).
+        if (BackupDestinationBuilder.DescribeTooLong(destinations) is { } tooLong)
+        {
+            SetError(tooLong);
+            return;
+        }
+
         BackupScript = _backupGenerator.Generate(new BackupOptions
         {
             DatabaseName = SourceDatabase!,

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -215,8 +215,11 @@
                                            TextWrapping="Wrap"
                                            Margin="0,0,0,12" />
 
-                                <TextBlock Text="STORAGE ACCOUNT" Style="{StaticResource LabelText}" />
-                                <TextBlock Text="{Binding SelectedContainer.StorageAccountName}"
+                                <!-- Label and value both from the container (#345): a bucket has
+                                     an endpoint, not a storage account, and the old value read
+                                     the first label of the host - "s3" for every AWS bucket. -->
+                                <TextBlock Text="{Binding SelectedContainer.LocationLabel}" Style="{StaticResource LabelText}" />
+                                <TextBlock Text="{Binding SelectedContainer.LocationDisplay}"
                                            Style="{StaticResource BodyText}"
                                            Margin="0,0,0,12" />
 
@@ -245,7 +248,7 @@
                                     </TextBlock.Text>
                                 </TextBlock>
 
-                                <TextBlock Text="BLOB PATH STRUCTURE" Style="{StaticResource LabelText}" />
+                                <TextBlock Text="PATH STRUCTURE" Style="{StaticResource LabelText}" />
                                 <TextBlock Text="{Binding SelectedContainer.PathPattern}"
                                            Style="{StaticResource BodyText}"
                                            Margin="0,0,0,12" />
@@ -569,7 +572,7 @@
                             <TextBlock>
                                 <TextBlock.Style>
                                     <Style TargetType="TextBlock" BasedOn="{StaticResource LabelText}">
-                                        <Setter Property="Text" Value="BLOB PATH STRUCTURE" />
+                                        <Setter Property="Text" Value="PATH STRUCTURE" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding IsMixedSourceType}" Value="True">
                                                 <Setter Property="Text" Value="STANDALONE PATH STRUCTURE" />
@@ -578,7 +581,7 @@
                                     </Style>
                                 </TextBlock.Style>
                             </TextBlock>
-                            <TextBlock Text="Drag the coloured elements below to define how blob paths are structured. Each colour represents a path component. Add or remove elements as needed. FileName must always be last."
+                            <TextBlock Text="Drag the coloured elements below to define how the paths in this container are structured. Each colour represents a path component. Add or remove elements as needed. FileName must always be last."
                                        Style="{StaticResource SecondaryText}"
                                        FontSize="11" Margin="0,0,0,8" TextWrapping="Wrap" />
 


### PR DESCRIPTION
Closes #345. Closes #346. Findings from a review pass over what shipped today: the wording sweep caught labels but not the values underneath them, and one guard from the original #51 plan never got written.

## A bucket has an endpoint, not a storage account (#345)

The details pane's STORAGE ACCOUNT row was built from `StorageAccountName`, which takes the first label of the host - correct for `https://myaccount.blob...`, and **"s3"** for every AWS bucket. Label and value now both follow the provider (`LocationLabel` / `LocationDisplay`), an endpoint keeps its port when one was given, and Azure renders exactly as before. PATH STRUCTURE also loses its "BLOB": it describes keys as well as blobs.

## A destination too long for SQL Server is refused before the run (#346)

The engine caps a backup device URL at 259 characters and enforces it *mid-backup*, with a message about devices rather than lengths. `BackupDestinationBuilder` now measures what it builds, and all three callers - Back Up, Copy Database, and the CLI's `backup` verb - refuse up front, naming the offending URL and its length because the fix is always in one of its parts (endpoint, base path, or pattern).

Not exotic to reach: a long endpoint + a base path + the default four-segment pattern + a long database name gets there, and every stripe carries the same prefix - so the longest is the one named. The CLI exits `64` (usage) rather than as a failed backup: a URL the engine will not accept is a configuration problem, not a run to start and have fail.

## Verification

1,876 unit tests passing (5 new: an ordinary destination is not refused, an over-long one is refused with its length and URL, striping names the worst, and the endpoint/account row both ways including a port). Release `-warnaserror` clean. Both details panes rendered and eyeballed.

## Note on how this review went

Six parallel reviewers were spawned across UX, the S3 code, the engine, the CLI, cross-cutting quality and docs; all of them died on a session usage limit before reporting. These two findings are from my own pass afterwards, so the review is **partial** - the engine, CLI and cross-cutting lanes are still unexamined.