### PR TITLE
The app refuses an S3 restore its engine cannot run (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,16 @@ more detail on the user-facing changes; this file is the short history.
   receipts out of fifty on a loaded runner. A writer that cannot take the lock now writes
   nothing, and the backoff starts short and jitters so it very rarely comes to that.
 
+- **The app refuses an S3 restore its engine cannot run** (#349). The SQL Server 2022+
+  and non-Express check shipped in the CLI's preflights alone, so the app - which is what
+  most restores are run from - promised a safety net in the README that only the other
+  front end provided. The gate now lives in the engine library and both front ends call
+  it, so a 2019 or Express target is refused before anything runs rather than erroring on
+  the server afterwards. It reads the whole chain rather than just the full backup - a
+  full on Azure carried forward by logs in a bucket still needs the connector - and it
+  asks the device the RESTORE will actually name, so a set read back from an instance's
+  own history is judged the same as one discovered by listing.
+
 - **A bucket has an endpoint, not a storage account** (#345). The container details pane
   read the first label of the host name into a row labelled STORAGE ACCOUNT - correct for
   Azure, and "s3" for every AWS bucket. Both the label and the value now follow the

--- a/src/NineLives.Cli/Preflights.cs
+++ b/src/NineLives.Cli/Preflights.cs
@@ -68,34 +68,13 @@ internal static class Preflights
             .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
             .ToList();
 
-        // 0 (checked here, refused hard): can this engine speak S3 at all (#51)? The S3
-        // connector arrived in SQL Server 2022 and is not in Express - a capability, not
-        // evidence, so --force cannot override it: the engine would simply error after WITH
-        // REPLACE had already dropped the target. No verdict from silence, as ever.
-        if (devices.Any(d => d.StartsWith("s3://", StringComparison.OrdinalIgnoreCase)))
-        {
-            try
-            {
-                var s3Major = await services.Sql.GetProductMajorVersionAsync(target);
-                if (s3Major is { } m && m < 16)
-                    refusals.Add(
-                        $"This chain restores from S3-compatible storage, and {target.ServerName} " +
-                        $"is {VersionCompatibility.Describe(m)} - the S3 connector arrived in SQL " +
-                        "Server 2022. Restore onto a 2022+ instance, or from an Azure or shared-" +
-                        "path copy of the backups.");
-
-                var edition = await services.Sql.GetEngineEditionAsync(target);
-                if (edition == 4)
-                    refusals.Add(
-                        $"This chain restores from S3-compatible storage, and {target.ServerName} " +
-                        "is Express edition - the S3 connector is not available in Express, on " +
-                        "any version. Restore onto a Standard, Developer or Enterprise instance.");
-            }
-            catch
-            {
-                // The instance would not answer; the restore itself will say so properly.
-            }
-        }
+        // 0 (checked here, refused hard): can this engine speak S3 at all (#51)? A capability,
+        // not evidence, so --force cannot override it: the engine would simply error after WITH
+        // REPLACE had already dropped the target. Shared with the app rather than written twice,
+        // and asked of the WHOLE chain - a full on Azure carried forward by logs in a bucket
+        // still needs the connector.
+        if (await S3CapabilityPreflight.RefusalAsync(services.Sql, target, chain) is { } s3Refusal)
+            refusals.Add(s3Refusal);
 
         // 5. Will it physically fit (#297)? The GUI checks before WITH REPLACE drops
         // anything, and this front end is the one most often aimed at a freshly provisioned

--- a/src/NineLives.Core/Services/S3CapabilityPreflight.cs
+++ b/src/NineLives.Core/Services/S3CapabilityPreflight.cs
@@ -1,0 +1,80 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Whether the target instance can speak S3 at all (#51, #349).
+///
+/// The S3 connector arrived in SQL Server 2022 and is absent from Express on every version.
+/// That is a CAPABILITY rather than evidence, which is why the refusal is hard: --force exists
+/// to override a judgement made on evidence, and no amount of insistence puts a connector into
+/// an engine that does not have one. The restore would fail on the server, after consent, with
+/// an error about the device rather than about the version.
+///
+/// Shared rather than written per front end. It shipped in the CLI's preflights alone, which
+/// left the app - the thing most people actually restore with - promising a check in the README
+/// that only the other front end performed.
+///
+/// Best effort by the same rule as every other preflight here: an instance that will not answer
+/// produces no refusal, because refusing on a guess blocks legal restores.
+/// </summary>
+public static class S3CapabilityPreflight
+{
+    /// <summary>
+    /// True when any device in the chain is an s3:// URL.
+    ///
+    /// The WHOLE chain, not just the full backup: containers are per-source and a chain can span
+    /// several, so a full on Azure carried forward by logs in a bucket is an ordinary shape - and
+    /// one the engine still has to be able to read.
+    /// </summary>
+    public static bool UsesS3(BackupChain? chain) =>
+        chain != null && chain.AllSets.Any(set => set.Files.Any(IsS3Device));
+
+    /// <summary>
+    /// Read from <see cref="BackupFileInfo.RestoreDevice"/> rather than from BlobUrl, because
+    /// that is the string the RESTORE will actually name - and it is the only one that is right
+    /// in both directions. A set discovered by listing a bucket carries its s3:// URL in BlobUrl;
+    /// one read back from an instance's own history carries the same URL in LocalPath, which
+    /// makes IsOnDisk true for something that was never on a disk. RestoreDevice resolves to
+    /// whichever is populated, so the question is asked once instead of twice.
+    /// </summary>
+    private static bool IsS3Device(BackupFileInfo file) =>
+        file.RestoreDevice.StartsWith("s3://", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Why this instance cannot restore the chain from S3, or null when it can - including when
+    /// the chain does not touch S3 at all, and when the instance would not say.
+    /// </summary>
+    public static async Task<string?> RefusalAsync(
+        ISqlServerService sql, ServerConnection target, BackupChain? chain,
+        CancellationToken ct = default)
+    {
+        if (!UsesS3(chain)) return null;
+
+        try
+        {
+            var major = await sql.GetProductMajorVersionAsync(target, ct);
+            if (major is { } m && m < 16)
+                return $"This chain restores from S3-compatible storage, and {target.ServerName} " +
+                       $"is {VersionCompatibility.Describe(m)} - the S3 connector arrived in SQL " +
+                       "Server 2022. Restore onto a 2022+ instance, or from an Azure or shared-" +
+                       "path copy of the backups.";
+
+            var edition = await sql.GetEngineEditionAsync(target, ct);
+            if (edition == ExpressEngineEdition)
+                return $"This chain restores from S3-compatible storage, and {target.ServerName} " +
+                       "is Express edition - the S3 connector is not available in Express, on " +
+                       "any version. Restore onto a Standard, Developer or Enterprise instance.";
+        }
+        catch
+        {
+            // The instance would not answer; no verdict from silence. The restore itself will
+            // say so properly if it comes to that.
+        }
+
+        return null;
+    }
+
+    /// <summary>What <c>SERVERPROPERTY('EngineEdition')</c> answers for Express.</summary>
+    private const int ExpressEngineEdition = 4;
+}

--- a/src/NineLives.Tests/S3GuiPreflightTests.cs
+++ b/src/NineLives.Tests/S3GuiPreflightTests.cs
@@ -1,0 +1,162 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The S3 capability gate on the APP's restore path (#51).
+///
+/// It shipped in the CLI's preflights alone, which left the README promising - under "Safety
+/// nets", the section whose whole claim is that these fire before WITH REPLACE drops anything -
+/// a check that only the other front end performed. The app is what most people restore with.
+///
+/// The engine either has the S3 connector or it does not, so this is a capability rather than
+/// evidence: there is no override, and no amount of insistence puts a connector into SQL 2019.
+/// </summary>
+public class S3GuiPreflightTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 11, 21, 0, 0);
+
+    private const string S3Device =
+        "s3://s3.eu-west-2.amazonaws.com/backups/FULL/VendorDb_FULL_20260811_210000.bak";
+
+    private static ServerConnection Server() =>
+        new() { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };
+
+    /// <summary>
+    /// A loaded chain whose one device is an s3:// URL. Reached through the ad-hoc source, which
+    /// is the shortest route to a chain with a device this test controls exactly - and it also
+    /// pins the case that matters most for the check's shape: a device recorded as a PATH which
+    /// happens to be an s3:// URL, which is how an instance's own history reports one.
+    /// </summary>
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> LoadedAsync()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(Server());
+
+        var sql = new FakeSqlServerService
+        {
+            FileHeaders =
+            {
+                [S3Device] =
+                [
+                    new BackupHistoryEntry
+                    {
+                        DatabaseName = "VendorDb",
+                        Type = BackupType.Full,
+                        StartedAt = T0,
+                        FinishedAt = T0.AddMinutes(1),
+                        CheckpointLsn = 100m,
+                        Position = 1,
+                        Files = [S3Device]
+                    }
+                ]
+            },
+            Header = new BackupFileInfo
+            {
+                DatabaseName = "VendorDb",
+                Type = BackupType.Full,
+                BackupTypeCode = 1,
+                SoftwareVersionMajor = 16
+            }
+        };
+
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), sql, new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(),
+            new FakeRestoreHistoryStore(), TestAuditStores.Temp())
+        {
+            Mode = AppMode.Pro
+        };
+        vm.RefreshContainers();
+
+        vm.SelectedMedium = BackupMedium.AdHocFile;
+        vm.SourceServer = vm.SourceServers[0];
+        vm.AdHocPathsText = S3Device;
+        await vm.Inventory.LoadAsync(vm.CurrentLocation!);
+        vm.Inventory.SelectedDatabaseName = "VendorDb";
+        vm.Timeline.SelectedPoint = vm.Timeline.Points.Last();
+
+        Assert.NotNull(vm.RestoreChain);
+        return (vm, sql);
+    }
+
+    [Fact]
+    public async Task Sql2019RefusesAnS3RestoreInTheAppToo()
+    {
+        var (vm, sql) = await LoadedAsync();
+        sql.ProductMajorVersion = 15;
+
+        var result = await vm.PreflightAsync(Server(), _ => { });
+
+        Assert.False(result.CanProceed);
+        Assert.Contains("S3-compatible storage", result.Refusal);
+        Assert.Contains("SQL Server 2022", result.Refusal);
+    }
+
+    [Fact]
+    public async Task ExpressRefusesAnS3RestoreEvenOn2022()
+    {
+        var (vm, sql) = await LoadedAsync();
+        sql.ProductMajorVersion = 16;
+        sql.EngineEdition = 4;
+
+        var result = await vm.PreflightAsync(Server(), _ => { });
+
+        Assert.False(result.CanProceed);
+        Assert.Contains("Express", result.Refusal);
+    }
+
+    [Fact]
+    public async Task A2022StandardInstanceProceeds()
+    {
+        var (vm, sql) = await LoadedAsync();
+        sql.ProductMajorVersion = 16;
+        sql.EngineEdition = 3;
+
+        var result = await vm.PreflightAsync(Server(), _ => { });
+
+        Assert.True(result.CanProceed);
+    }
+
+    /// <summary>
+    /// No verdict from silence, the same rule every other preflight here follows: an instance
+    /// that will not report its version is not evidence of an incapable one.
+    /// </summary>
+    [Fact]
+    public async Task AnInstanceThatWillNotSayIsNotRefused()
+    {
+        var (vm, sql) = await LoadedAsync();
+        sql.ProductMajorVersion = null;
+        sql.EngineEdition = null;
+
+        var result = await vm.PreflightAsync(Server(), _ => { });
+
+        Assert.True(result.CanProceed);
+    }
+
+    /// <summary>An Azure chain is not asked the question at all.</summary>
+    [Fact]
+    public void AnAzureChainDoesNotTriggerTheGate()
+    {
+        var chain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                SetId = "1",
+                Type = BackupType.Full,
+                Files =
+                [
+                    new BackupFileInfo
+                    {
+                        BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/a.bak"
+                    }
+                ]
+            }
+        };
+
+        Assert.False(S3CapabilityPreflight.UsesS3(chain));
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2552,6 +2552,18 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     internal async Task<CredentialPreflight> PreflightAsync(ServerConnection server, Action<string> appendLog)
     {
+        // Can this engine speak S3 at all (#51)? Asked first, and asked here rather than only in
+        // the CLI - which is where it shipped, leaving the app promising a check that only the
+        // other front end performed. A capability, so nothing overrides it: the connector is
+        // either in the engine or it is not.
+        if (S3CapabilityPreflight.UsesS3(RestoreChain))
+        {
+            appendLog("Checking the target can restore from S3-compatible storage...");
+            if (await S3CapabilityPreflight.RefusalAsync(_sqlService, server, RestoreChain)
+                is { } s3Refusal)
+                return CredentialPreflight.Stop(s3Refusal);
+        }
+
         // Both non-blob media end in FROM DISK on the target, so both need the same answer: can
         // the instance that will run the RESTORE actually read these files (#203).
         if (MediumIsSharedPath || MediumIsAdHocFile)


### PR DESCRIPTION
Closes #349. Found by a review pass over what shipped today.

The SQL 2022+/non-Express gate from #51 went into `NineLives.Cli/Preflights.cs` and nowhere else. `GetEngineEditionAsync` had exactly one caller in the solution, and it was the CLI - so the app performed no S3 capability check at all, while `README.md:140` promises one under **Safety nets**, the section whose claim is that these fire before `WITH REPLACE` drops anything.

## What changes

The check moves to `NineLives.Core/Services/S3CapabilityPreflight.cs` and both front ends call it. Two things improved in the move:

- **The whole chain, not just the full set.** Containers are per-source and a chain can span several, so a full on Azure carried forward by logs in a bucket is an ordinary shape - and still needs the connector.
- **`RestoreDevice`, not `BlobUrl`.** A set discovered by listing a bucket carries its `s3://` URL in `BlobUrl`; one read back from an instance's own history carries the same URL in `LocalPath`, which makes `IsOnDisk` true for something that was never on a disk. `RestoreDevice` resolves to whichever is populated, so the question is asked once instead of twice. This is what made the existing CLI gate tests fail against a naive port, which is worth knowing.

Still a hard refusal with no override: `--force` overrides a judgement made on evidence, and no amount of insistence puts a connector into SQL 2019.

## Verification

1,881 unit tests (5 new on the app's own path: 2019 refused, Express refused even on 2022, Standard proceeds, an instance that will not answer is not refused, an Azure chain is never asked). Release `-warnaserror` clean.