### PR TITLE
A restore receipt can no longer destroy the receipt beside it (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A restore receipt can no longer destroy the receipt beside it** (#371). When two
+  writers went for the history file at once - a scheduled `9lives rehearse` while the app
+  is open, which is what #298 added the cross-process lock for - a writer that could not
+  take the lock within its retry budget went ahead and wrote anyway. That is a
+  read-modify-write with no exclusion: it does not risk the entry being written, it
+  silently drops whatever the other writer added in between. CI caught it losing four
+  receipts out of fifty on a loaded runner. A writer that cannot take the lock now writes
+  nothing, and the backoff starts short and jitters so it very rarely comes to that.
+
 - **A bucket has an endpoint, not a storage account** (#345). The container details pane
   read the first label of the host name into a row labelled STORAGE ACCOUNT - correct for
   Azure, and "s3" for every AWS bucket. Both the label and the value now follow the

--- a/src/NineLives.Core/Services/RestoreHistoryStore.cs
+++ b/src/NineLives.Core/Services/RestoreHistoryStore.cs
@@ -48,17 +48,41 @@ public sealed class RestoreHistoryStore : IRestoreHistoryStore
     /// existed, the exact thing the exposure dashboard's Proven column reads.
     ///
     /// A sidecar .lock file held with FileShare.None; DeleteOnClose so a crash cannot
-    /// orphan it. Writers queue in a short retry loop. After the timeout the write proceeds
-    /// WITHOUT the lock: the overlap window is milliseconds, and losing this entry for
-    /// certain is worse than the small chance of the race the lock exists to close.
+    /// orphan it. Writers queue with an exponential backoff, and a writer that never gets the
+    /// lock does not write.
+    ///
+    /// That last rule reverses the original one, which let the write proceed WITHOUT the lock
+    /// on the reasoning that losing this entry for certain was worse than a small chance of
+    /// the race. The premise was wrong in both halves, and CI proved it: this test lost FOUR
+    /// of fifty entries on a loaded runner. An unlocked read-modify-write does not risk losing
+    /// THIS entry - it silently drops whatever the other writer put in between the read and
+    /// the write, so the trade was one certain loss against several possible ones, and the
+    /// entries at risk are the receipts proving a restore happened.
+    ///
+    /// The backoff below is the other half of the fix, and the reason the timeout is now
+    /// rarely reached: it starts at 2ms rather than 50 (the first attempt after a release
+    /// should be quick - the old fixed sleep made every writer wait out most of a slot it
+    /// could have had immediately), and it jitters, because writers that collide once will
+    /// collide forever if they all back off by exactly the same amount.
     /// </summary>
+    private const int LockTimeoutMs = 10_000;
+
+    /// <summary>
+    /// Per instance rather than a static seam, so a test that shortens it cannot affect another
+    /// test running beside it.
+    /// </summary>
+    private readonly int _lockTimeoutMs;
+
     private FileStream? AcquireCrossProcessLock()
     {
         var directory = Path.GetDirectoryName(_path)!;
         Directory.CreateDirectory(directory);
         var lockPath = _path + ".lock";
 
-        for (var attempt = 0; attempt < 40; attempt++)
+        var deadline = Environment.TickCount64 + _lockTimeoutMs;
+        var wait = 2;
+
+        while (true)
         {
             try
             {
@@ -66,17 +90,14 @@ public sealed class RestoreHistoryStore : IRestoreHistoryStore
                     lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None,
                     bufferSize: 1, FileOptions.DeleteOnClose);
             }
-            catch (IOException)
-            {
-                Thread.Sleep(50);
-            }
-            catch (UnauthorizedAccessException)
-            {
-                Thread.Sleep(50);
-            }
-        }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
 
-        return null;
+            if (Environment.TickCount64 >= deadline) return null;
+
+            Thread.Sleep(wait + Random.Shared.Next(wait));
+            wait = Math.Min(wait * 2, 50);
+        }
     }
 
     public RestoreHistoryStore() : this(Path.Combine(
@@ -84,9 +105,15 @@ public sealed class RestoreHistoryStore : IRestoreHistoryStore
         "NineLives"))
     { }
 
-    /// <summary>Lets the tests write somewhere disposable instead of the real profile.</summary>
-    internal RestoreHistoryStore(string directory)
-        => _path = Path.Combine(directory, "restore-history.json");
+    /// <summary>
+    /// Lets the tests write somewhere disposable instead of the real profile, and shorten the
+    /// lock wait so the refusal path can be exercised without a ten-second test.
+    /// </summary>
+    internal RestoreHistoryStore(string directory, int lockTimeoutMs = LockTimeoutMs)
+    {
+        _path = Path.Combine(directory, "restore-history.json");
+        _lockTimeoutMs = lockTimeoutMs;
+    }
 
     public string FilePath => _path;
 
@@ -105,6 +132,12 @@ public sealed class RestoreHistoryStore : IRestoreHistoryStore
             lock (_gate)
             {
                 using var crossProcess = AcquireCrossProcessLock();
+
+                // A lock that could not be taken is not a lock. Writing anyway makes this a
+                // read-modify-write with no exclusion, which drops whatever the other writer
+                // added in between - so the entries lost are somebody else's, not this one's.
+                // `using` a null is a silent no-op, which is exactly how this went unnoticed.
+                if (crossProcess == null) return;
 
                 var existing = ReadUnlocked();
 
@@ -140,6 +173,12 @@ public sealed class RestoreHistoryStore : IRestoreHistoryStore
             lock (_gate)
             {
                 using var crossProcess = AcquireCrossProcessLock();
+
+                // Same rule as Append. Clearing without the lock would take the other writer's
+                // in-flight entry with it, and a Clear that did not happen is visible - the
+                // list is still there - where a silently destroyed receipt is not.
+                if (crossProcess == null) return;
+
                 WriteUnlocked([]);
             }
         }

--- a/src/NineLives.Tests/RestoreHistoryTests.cs
+++ b/src/NineLives.Tests/RestoreHistoryTests.cs
@@ -261,6 +261,33 @@ public class RestoreHistoryTests : IDisposable
         }
     }
 
+    /// <summary>
+    /// A writer that never gets the lock writes NOTHING.
+    ///
+    /// It used to write anyway, deliberately - the reasoning being that losing this one entry
+    /// for certain was worse than a small chance of the race. Both halves were wrong. An
+    /// unlocked read-modify-write does not risk THIS entry; it drops whatever the holder wrote
+    /// between the read and the write, so the trade was one certain loss against several
+    /// possible ones. And the chance was not small: CI lost four of fifty on a loaded runner.
+    /// </summary>
+    [Fact]
+    public void AWriterThatCannotTakeTheLockDestroysNothing()
+    {
+        Store().Append(Entry("First"));
+
+        var lockPath = Path.Combine(_dir, "restore-history.json.lock");
+        using var holder = new FileStream(
+            lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+
+        // A writer whose patience runs out while the lock is still held.
+        new RestoreHistoryStore(_dir, lockTimeoutMs: 150).Append(Entry("Second"));
+
+        // It did not land - and, the point, it took nothing with it.
+        var all = Store().Load();
+        Assert.Single(all);
+        Assert.Equal("First", all[0].TargetDatabase);
+    }
+
     /// <summary>A writer waits for the holder instead of clobbering - and then lands.</summary>
     [Fact]
     public async Task AWriterQueuesBehindTheLockHolderAndStillLands()


### PR DESCRIPTION
Closes #371. Found because CI failed on an unrelated PR (#350) with the one test that exists to pin this: `TwoWritersOnOnePathLoseNothing` expected 50 entries and found **46**.

## The bug

`AcquireCrossProcessLock` returns null when it cannot take the sidecar lock in time, and `Append` carried on regardless - `using` a null is a silent no-op, so the read-modify-write ran with no exclusion. That is the race #298 added the lock to close.

It was deliberate, and the comment argued for it: *"losing this entry for certain is worse than the small chance of the race"*. Both halves are wrong:

- **It is not this entry at risk.** An unlocked read-modify-write drops whatever the *other* writer committed between this one's read and its write. The trade was one certain loss against several possible ones - and the losses belong to somebody else.
- **The chance is not small.** Four in fifty is not a window of milliseconds.

The entries at risk are the receipts proving a restore or rehearsal happened, which is what the Exposure dashboard's Proven column reads.

## The fix

- A writer that cannot take the lock **writes nothing**, in `Clear` as well as `Append`. A Clear that did not happen is visible - the list is still there - where a silently destroyed receipt is not.
- The backoff was a flat 50ms with no jitter and a 2s budget: every writer waited out most of a slot it could have had immediately, and writers that collided once collided forever in lockstep. It now starts at 2ms, doubles to a 50ms ceiling, jitters, and gives up after 10s.
- The timeout seam for the new test is an **instance field** on the internal constructor rather than a static, so a test that shortens it cannot reach a test running beside it (see #348).

## Verification

1,877 unit tests (1 new: a writer that cannot take the lock destroys nothing). History tests run five times consecutively with no flake. Release `-warnaserror` clean.

Once this lands, #350 needs a re-run - its CI failure was this, not its own change.