### PR TITLE
Two engine defects the review found (#351, #352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,22 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A striped backup read from an instance's own history is no longer called corrupt**
+  (#351). msdb records a backup's size once for the whole set rather than per stripe, so
+  every stripe after the first was left at zero - and zero already meant something here,
+  an interrupted or failed upload, which the validator raises as an Error that disables
+  the restore. So every striped backup discovered through the shared-path route was
+  declared damaged and refused, at DR time, on exactly the large databases that get
+  striped in the first place. A file whose size nobody could state now says so, which is
+  a different thing from being empty - and a genuinely zero-byte stripe in a container,
+  where every size IS known, is still caught.
+
+- **A backup set id cannot break out of the comment naming it** (#352). The header was
+  escaped in #294 and the three per-statement comments were not, so a set id carrying a
+  line break - and for a set read from msdb the id is built from the database name, which
+  is sysname and permits one - ended its comment and left the rest standing as a live
+  statement, in a script the app executes and `9lives script --out` hands to a pipeline.
+
 - **A restore receipt can no longer destroy the receipt beside it** (#371). When two
   writers went for the history file at once - a scheduled `9lives rehearse` while the app
   is open, which is what #298 added the cross-process lock for - a writer that could not

--- a/src/NineLives.Core/Models/BackupFileInfo.cs
+++ b/src/NineLives.Core/Models/BackupFileInfo.cs
@@ -186,6 +186,22 @@ public class BackupFileInfo
 
     public BackupType Type { get; set; } = BackupType.Unknown;
     public long SizeBytes { get; set; }
+
+    /// <summary>
+    /// True when nobody could say how big THIS file is, as opposed to it being empty (#351).
+    ///
+    /// msdb records a backup's size once for the whole set rather than per stripe, so every
+    /// stripe after the first has no size of its own to report. Zero was standing in for that,
+    /// and zero already means something here - an interrupted or failed upload, which the
+    /// validator raises as an Error that disables the restore. So every striped backup read
+    /// back from an instance's own history was declared damaged, at the moment somebody was
+    /// trying to restore it.
+    ///
+    /// A blob listing knows every file's real size and never sets this, which is what keeps a
+    /// genuinely zero-byte stripe in a container detectable.
+    /// </summary>
+    public bool SizeIsUnknown { get; set; }
+
     public DateTimeOffset LastModified { get; set; }
 
     public string? InferredServerName { get; set; }

--- a/src/NineLives.Core/Services/BackupChainValidator.cs
+++ b/src/NineLives.Core/Services/BackupChainValidator.cs
@@ -244,7 +244,11 @@ public class BackupChainValidator
 
     private static void CheckEmptyFiles(BackupSet set, List<ChainIssue> issues)
     {
-        var empty = set.Files.Where(f => f.SizeBytes == 0).ToList();
+        // Only files whose size is actually known (#351). A stripe read back from msdb has no
+        // size of its own - the set carries one total - and reading that absence as zero made
+        // every striped backup from an instance's own history look like a run of failed
+        // uploads, raising an Error that disables the restore on a chain that is perfectly fine.
+        var empty = set.Files.Where(f => !f.SizeIsUnknown && f.SizeBytes == 0).ToList();
         if (empty.Count == 0) return;
 
         issues.Add(new ChainIssue(ChainIssueSeverity.Error,

--- a/src/NineLives.Core/Services/BackupHistoryInventory.cs
+++ b/src/NineLives.Core/Services/BackupHistoryInventory.cs
@@ -108,7 +108,13 @@ public static class BackupHistoryInventory
 
             // Size is per SET in msdb, not per stripe, so it is recorded once rather than repeated
             // on every file - a striped backup would otherwise report several times its real size.
-            SizeBytes = index == 0 ? entry.BackupSizeBytes ?? 0 : 0
+            //
+            // Every other file's size is UNKNOWN, and says so (#351). It used to be left at zero,
+            // which the validator reads as a failed upload - so a striped backup discovered
+            // through an instance's own history was reported as containing empty files and
+            // refused, when nothing was wrong with it at all.
+            SizeBytes = index == 0 ? entry.BackupSizeBytes ?? 0 : 0,
+            SizeIsUnknown = index > 0 || entry.BackupSizeBytes == null
         };
     }
 }

--- a/src/NineLives.Core/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives.Core/Services/RestoreScriptGenerator.cs
@@ -95,7 +95,7 @@ public class RestoreScriptGenerator
         var dbName = EscapeName(options.TargetDatabaseName);
         var recoveryClause = moreToFollow ? "NORECOVERY" : GetRecoveryClause(options);
 
-        sb.AppendLine($"-- Restore FULL backup ({fullSet.FileCount} file(s)): {fullSet.SetId}");
+        sb.AppendLine($"-- Restore FULL backup ({fullSet.FileCount} file(s)): {TSql.CommentText(fullSet.SetId)}");
         sb.AppendLine($"RESTORE DATABASE {dbName}");
         AppendFromUrls(sb, fullSet, options);
 
@@ -116,7 +116,7 @@ public class RestoreScriptGenerator
         var dbName = EscapeName(options.TargetDatabaseName);
         var recoveryClause = moreToFollow ? "NORECOVERY" : GetRecoveryClause(options);
 
-        sb.AppendLine($"-- Restore DIFFERENTIAL backup ({diffSet.FileCount} file(s)): {diffSet.SetId}");
+        sb.AppendLine($"-- Restore DIFFERENTIAL backup ({diffSet.FileCount} file(s)): {TSql.CommentText(diffSet.SetId)}");
         sb.AppendLine($"RESTORE DATABASE {dbName}");
         AppendFromUrls(sb, diffSet, options);
         sb.AppendLine($"         {recoveryClause},");
@@ -131,7 +131,7 @@ public class RestoreScriptGenerator
         var dbName = EscapeName(options.TargetDatabaseName);
         var recoveryClause = isLast ? GetRecoveryClause(options) : "NORECOVERY";
 
-        sb.AppendLine($"-- Restore LOG backup ({logSet.FileCount} file(s)): {logSet.SetId}");
+        sb.AppendLine($"-- Restore LOG backup ({logSet.FileCount} file(s)): {TSql.CommentText(logSet.SetId)}");
         sb.AppendLine($"RESTORE LOG {dbName}");
         AppendFromUrls(sb, logSet, options);
 

--- a/src/NineLives.Tests/ScriptHygieneTests.cs
+++ b/src/NineLives.Tests/ScriptHygieneTests.cs
@@ -57,6 +57,41 @@ public class ScriptHygieneTests
         Assert.Contains("SET SINGLE_USER", script);
     }
 
+    /// <summary>
+    /// The set id travels into three per-statement comments, and #294 escaped the header but
+    /// not those (#352). A set id is not a safe string: for an msdb-sourced set it is built
+    /// from the database name, which is sysname and permits a line break.
+    /// </summary>
+    [Fact]
+    public void ANewlineInASetIdCannotEscapeItsStatementComment()
+    {
+        var chain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                SetId = "Sales_20260110\nDROP DATABASE [Payroll]; --",
+                DatabaseName = "Sales",
+                Type = BackupType.Full,
+                Timestamp = new DateTime(2026, 8, 1, 22, 0, 0),
+                Files = [new BackupFileInfo
+                {
+                    BlobName = "FULL/Sales/20260801_220000.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/Sales/20260801_220000.bak",
+                    Type = BackupType.Full
+                }]
+            }
+        };
+
+        var script = new RestoreScriptGenerator().Generate(
+            chain, new RestoreOptions { TargetDatabaseName = "Sales" });
+
+        // One commented line - the newline became a space, so the DROP never stands alone.
+        Assert.Contains(
+            "-- Restore FULL backup (1 file(s)): Sales_20260110 DROP DATABASE [Payroll]; --",
+            script);
+        Assert.DoesNotContain("\nDROP DATABASE [Payroll]", script);
+    }
+
     [Fact]
     public void ANewlineInTheBackupDatabaseNameCannotEscapeTheHeaderComment()
     {

--- a/src/NineLives.Tests/StripedSetValidationTests.cs
+++ b/src/NineLives.Tests/StripedSetValidationTests.cs
@@ -1,0 +1,106 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A striped backup read back from an instance's own msdb is not damaged (#351).
+///
+/// msdb reports a backup's size once for the whole set rather than per stripe, so
+/// BackupHistoryInventory records it against the first file. Every other stripe was then left
+/// at zero, and the validator reads zero as "an interrupted or failed upload" - an Error, which
+/// the restore screen turns into "This chain cannot restore."
+///
+/// So every striped backup discovered through the shared-path route was declared damaged and
+/// refused, at DR time, on exactly the large databases that get striped in the first place.
+/// The distinction that fixes it is that unknown is not zero.
+/// </summary>
+public class StripedSetValidationTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupHistoryEntry Striped(int stripes) => new()
+    {
+        DatabaseName = "Sales",
+        Type = BackupType.Full,
+        StartedAt = T0,
+        FinishedAt = T0.AddMinutes(30),
+        ServerName = "SRV01",
+        Position = 1,
+        BackupSizeBytes = 900_000_000_000,
+        Files = [.. Enumerable.Range(1, stripes).Select(i => $@"\\nas01\sql\Sales_FULL_{i}.bak")]
+    };
+
+    [Fact]
+    public void AStripedBackupFromMsdbIsNotReportedAsEmpty()
+    {
+        var set = BackupHistoryInventory.ToSet(Striped(3));
+
+        var issues = new BackupChainValidator().Validate(
+            new BackupChain { FullSet = set });
+
+        Assert.DoesNotContain(issues, i => i.Title.Contains("empty file"));
+        Assert.DoesNotContain(issues, i => i.Severity == ChainIssueSeverity.Error);
+    }
+
+    /// <summary>
+    /// The set still reports its real size once, not once per stripe - the reason the zeroes
+    /// were there in the first place.
+    /// </summary>
+    [Fact]
+    public void TheSetStillReportsItsRealSizeOnce()
+    {
+        Assert.Equal(900_000_000_000, BackupHistoryInventory.ToSet(Striped(3)).TotalSizeBytes);
+    }
+
+    /// <summary>
+    /// A size msdb did not give at all is unknown too, rather than an empty first file.
+    /// </summary>
+    [Fact]
+    public void ASetWithNoRecordedSizeIsNotReportedAsEmpty()
+    {
+        var entry = new BackupHistoryEntry
+        {
+            DatabaseName = "Sales",
+            Type = BackupType.Full,
+            StartedAt = T0,
+            FinishedAt = T0.AddMinutes(30),
+            ServerName = "SRV01",
+            Position = 1,
+            BackupSizeBytes = null,
+            Files = [@"\nas01\sql\Sales_FULL.bak"]
+        };
+
+        var issues = new BackupChainValidator().Validate(
+            new BackupChain { FullSet = BackupHistoryInventory.ToSet(entry) });
+
+        Assert.DoesNotContain(issues, i => i.Title.Contains("empty file"));
+    }
+
+    /// <summary>
+    /// The other half: a container listing knows every file's size, so a genuinely zero-byte
+    /// stripe among good ones is still caught. This is the failed-upload case the check exists
+    /// for, and the fix must not cost it.
+    /// </summary>
+    [Fact]
+    public void AGenuinelyEmptyStripeInAContainerIsStillCaught()
+    {
+        var set = new BackupSet
+        {
+            SetId = "20260801_220000",
+            Type = BackupType.Full,
+            Timestamp = T0,
+            Files =
+            [
+                new BackupFileInfo { BlobName = "Sales_FULL_1.bak", BlobUrl = "https://a/1.bak", SizeBytes = 500 },
+                new BackupFileInfo { BlobName = "Sales_FULL_2.bak", BlobUrl = "https://a/2.bak", SizeBytes = 0 }
+            ]
+        };
+
+        var issues = new BackupChainValidator().Validate(new BackupChain { FullSet = set });
+
+        Assert.Contains(issues, i =>
+            i.Severity == ChainIssueSeverity.Error && i.Title.Contains("empty file"));
+    }
+}


### PR DESCRIPTION
Closes #351. Closes #352. Both found by the review pass, both confirmed by executing them rather than reading them.

**Stacks on #372** - that PR is the parent, so this diff shows its commit too until it merges. Merge in number order.

## A striped backup from msdb is no longer called corrupt (#351)

msdb reports a backup's size once for the whole set rather than per stripe, so `BackupHistoryInventory` recorded it against the first file and left the rest at zero. Zero already meant something to the validator - an interrupted or failed upload, raised as an **Error**, which `RestoreViewModel` turns into "This chain cannot restore."

So every striped backup discovered through the shared-path route was declared damaged and Execute was disabled. At DR time, on precisely the large databases that get striped, about backups with nothing wrong with them.

The fix is that **unknown is not zero**. A file whose size nobody could state now says so (`SizeIsUnknown`), and the empty-file check reads only sizes that are actually known. A container listing knows every file's real size and never sets the flag - so a genuinely zero-byte stripe among good ones, which is the failed upload the check exists for, is still caught. A set-level total would have been simpler and would have cost exactly that.

## A set id cannot break out of the comment naming it (#352)

The header was escaped in #294; the three per-statement comments were missed. A set id is not a safe string - for an msdb-sourced set it is built from the database name, which is `sysname` and permits a line break - so it could end its comment and leave the remainder standing as a live statement, in a script the app executes and that `9lives script --out` writes to a file for a pipeline to run.

Three `TSql.CommentText(...)` calls, plus a pin alongside the existing header one.

## Verification

1,882 unit tests (5 new: a striped msdb set is clean, the set still reports its real size once, a set with no recorded size is not flagged, a genuinely empty container stripe still is, and a newline in a set id cannot escape its comment). Release `-warnaserror` clean.