### PR TITLE
The bucket's region reaches the statement (#361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The bucket's region reaches the statement, not just the listing** (#361). The region
+  was stored, used when the app listed a container, and understood by both generators -
+  but only the app's restore path ever put it on the options object. Every other path
+  left it null, so the statement went to SQL Server signed for the provider's default
+  region. The failure shape was the nasty one: the container tests perfectly and `list`
+  works, because listing is signed by this app, and then the backup or restore fails,
+  because the statement is signed by the engine. It bit exactly the providers the feature
+  exists for - AWS-style hosts carry their region in the name, and Wasabi, Backblaze B2,
+  R2 and storage appliances generally do not. Now threaded through the Back Up screen,
+  Copy Database, and the CLI's backup, restore, rehearse and script verbs.
+
 - **A striped backup read from an instance's own history is no longer called corrupt**
   (#351). msdb records a backup's size once for the whole set rather than per stripe, so
   every stripe after the first was left at zero - and zero already meant something here,

--- a/src/NineLives.Cli/InventoryLoader.cs
+++ b/src/NineLives.Cli/InventoryLoader.cs
@@ -16,21 +16,29 @@ internal static class InventoryLoader
     /// --container or --server must be given: with neither there is nothing to read, and with
     /// both it is ambiguous which catalogue is meant to answer.
     /// </summary>
-    public static async Task<(List<BackupSet>? sets, string? error)> LoadAsync(
+    /// <summary>
+    /// The container is returned alongside the sets because the generated statement needs
+    /// something the sets do not carry: the bucket's region (#361). Null for a --server source,
+    /// which has no container - the backups were found through an instance's own history.
+    /// </summary>
+    public static async Task<(List<BackupSet>? sets, BlobContainerConfig? container, string? error)> LoadAsync(
         CliArguments args, CliServices services)
     {
+        BlobContainerConfig? source = null;
+
         var containerName = args.Get("container");
         var serverName = args.Get("server");
 
         if ((containerName == null) == (serverName == null))
-            return (null, "Give exactly one source: --container NAME or --server NAME.");
+            return (null, null, "Give exactly one source: --container NAME or --server NAME.");
 
         List<BackupSet> sets;
 
         if (containerName != null)
         {
             var (container, error) = services.FindContainer(containerName);
-            if (container == null) return (null, error);
+            if (container == null) return (null, null, error);
+            source = container;
 
             var files = await services.Blobs.ListBackupFilesAsync(container);
             sets = services.Blobs.GroupIntoBackupSets(files, container.BackupServerTimeZoneId);
@@ -38,7 +46,7 @@ internal static class InventoryLoader
         else
         {
             var (server, error) = services.FindServer(serverName!);
-            if (server == null) return (null, error);
+            if (server == null) return (null, null, error);
 
             var history = await services.Sql.ReadBackupHistoryAsync(server, args.Get("database"));
             sets = BackupHistoryInventory.ToSets(history);
@@ -53,10 +61,10 @@ internal static class InventoryLoader
                 .ToList();
 
             if (sets.Count == 0)
-                return (null, $"The source has no backups for a database called '{database}'. " +
+                return (null, null, $"The source has no backups for a database called '{database}'. " +
                               "Run the list verb to see what it does hold.");
         }
 
-        return (sets, null);
+        return (sets, source, null);
     }
 }

--- a/src/NineLives.Cli/Verbs/BackupVerb.cs
+++ b/src/NineLives.Cli/Verbs/BackupVerb.cs
@@ -177,7 +177,12 @@ internal static class BackupVerb
             Medium = container != null ? BackupMedium.AzureBlob : BackupMedium.SharedPath,
             Destinations = destinations,
             Type = type.Value,
-            CopyOnly = copyOnly
+            CopyOnly = copyOnly,
+
+            // Without this the statement is signed for the provider's default region (#361),
+            // so every bucket that does not carry its region in the host name fails here
+            // having listed perfectly a moment earlier.
+            S3Region = container?.S3Region
         });
 
         // BACKUP TO URL needs the credential on the SOURCE instance (#284's preflight, the

--- a/src/NineLives.Cli/Verbs/ListVerb.cs
+++ b/src/NineLives.Cli/Verbs/ListVerb.cs
@@ -57,7 +57,7 @@ internal static class ListVerb
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)
     {
-        var (sets, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, _, error) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);

--- a/src/NineLives.Cli/Verbs/PointsVerb.cs
+++ b/src/NineLives.Cli/Verbs/PointsVerb.cs
@@ -63,7 +63,7 @@ internal static class PointsVerb
             return ExitCodes.Usage;
         }
 
-        var (sets, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, _, error) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);

--- a/src/NineLives.Cli/Verbs/RehearseVerb.cs
+++ b/src/NineLives.Cli/Verbs/RehearseVerb.cs
@@ -106,7 +106,7 @@ internal static class RehearseVerb
             return ExitCodes.Usage;
         }
 
-        var (sets, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, sourceContainer, error) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);
@@ -148,7 +148,11 @@ internal static class RehearseVerb
             WithReplace = false,
             RecoveryMode = RecoveryMode.Recovery,
             StopAt = stopAt,
-            FileMoves = moves
+            FileMoves = moves,
+            // The bucket's region has to reach the statement, not just the listing (#361).
+            // Null for a --server source, which found its backups through an instance's own
+            // history and has no container to ask.
+            S3Region = sourceContainer?.S3Region
         });
 
         var script = RehearsalPlanner.BuildScript(restoreScript, scratch);

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -153,7 +153,7 @@ internal static class RestoreVerb
             return ExitCodes.Usage;
         }
 
-        var (sets, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, sourceContainer, error) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);
@@ -220,7 +220,11 @@ internal static class RestoreVerb
             StopAt = stopAt,
             StopAtMark = mark,
             StopBeforeMark = markAt == null,
-            FileMoves = moves ?? []
+            FileMoves = moves ?? [],
+            // The bucket's region has to reach the statement, not just the listing (#361).
+            // Null for a --server source, which found its backups through an instance's own
+            // history and has no container to ask.
+            S3Region = sourceContainer?.S3Region
         });
 
         // The preflights run whether or not this is an --execute: a generate-only invocation

--- a/src/NineLives.Cli/Verbs/ScriptVerb.cs
+++ b/src/NineLives.Cli/Verbs/ScriptVerb.cs
@@ -108,7 +108,7 @@ internal static class ScriptVerb
             }
         }
 
-        var (sets, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, sourceContainer, error) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);
@@ -131,7 +131,11 @@ internal static class ScriptVerb
             RecoveryMode = args.Has("norecovery") ? RecoveryMode.NoRecovery : RecoveryMode.Recovery,
             StopAt = stopAt,
             StopAtMark = mark,
-            StopBeforeMark = markAt == null
+            StopBeforeMark = markAt == null,
+            // The bucket's region has to reach the statement, not just the listing (#361).
+            // Null for a --server source, which found its backups through an instance's own
+            // history and has no container to ask.
+            S3Region = sourceContainer?.S3Region
         });
 
         if (args.Get("out") is { } path)

--- a/src/NineLives.Cli/Verbs/ValidateVerb.cs
+++ b/src/NineLives.Cli/Verbs/ValidateVerb.cs
@@ -63,7 +63,7 @@ internal static class ValidateVerb
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)
     {
-        var (sets, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, _, error) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);

--- a/src/NineLives.Tests/S3RegionReachesTheStatementTests.cs
+++ b/src/NineLives.Tests/S3RegionReachesTheStatementTests.cs
@@ -1,0 +1,115 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The bucket's region has to reach the generated statement, not just the listing (#361).
+///
+/// It was stored, and it was used when the app listed a container, and the generators knew how
+/// to emit it - but only the app's RESTORE path ever put it on the options object. Every other
+/// path left it null, so the statement went out signed for the provider's default region.
+///
+/// The shape of that failure is the nasty one: the container tests perfectly, `list` works,
+/// everything says healthy - and then the backup or restore fails, because listing is signed by
+/// this app and the statement is signed by SQL Server. It bites exactly the providers the
+/// feature exists for, since AWS-style hosts carry the region in the name and Wasabi, Backblaze
+/// B2, R2 and appliances generally do not.
+/// </summary>
+public class S3RegionReachesTheStatementTests
+{
+    private const string Bucket = "s3://storage.example.com/backups";
+    private const string Region = "eu-central-2";
+
+    private static FakeCredentialStore StoreWithBucket()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "bucket",
+            ContainerUrl = Bucket,
+            S3Region = Region
+        });
+        return store;
+    }
+
+    [Fact]
+    public void TheBackupScreenPutsTheRegionInTheStatement()
+    {
+        var store = StoreWithBucket();
+        var vm = new BackupViewModel(
+            store, new FakeSqlServerService { DatabaseList = ["MyDb"] }, TestLogs.Temp())
+        {
+            Medium = BackupMedium.AzureBlob
+        };
+
+        vm.Server = vm.Servers.Single();
+        vm.Container = vm.Containers.Single();
+        vm.SelectedDatabase = "MyDb";
+
+        vm.GenerateCommand.Execute(null);
+
+        Assert.Contains(Region, vm.GeneratedScript);
+    }
+
+    /// <summary>
+    /// And an Azure container does not acquire one, which is the guard the generators already
+    /// have - a stale region must not leak into a statement that has no bucket in it.
+    /// </summary>
+    [Fact]
+    public void AnAzureContainerGetsNoRegion()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "azure",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups",
+            S3Region = Region
+        });
+
+        var vm = new BackupViewModel(
+            store, new FakeSqlServerService { DatabaseList = ["MyDb"] }, TestLogs.Temp())
+        {
+            Medium = BackupMedium.AzureBlob
+        };
+
+        vm.Server = vm.Servers.Single();
+        vm.Container = vm.Containers.Single();
+        vm.SelectedDatabase = "MyDb";
+
+        vm.GenerateCommand.Execute(null);
+
+        Assert.DoesNotContain(Region, vm.GeneratedScript);
+    }
+
+    /// <summary>
+    /// A backup to a path the server can write to has no region either, whatever the selected
+    /// container happens to say.
+    /// </summary>
+    [Fact]
+    public void ASharedPathBackupGetsNoRegion()
+    {
+        var store = StoreWithBucket();
+        var vm = new BackupViewModel(
+            store, new FakeSqlServerService { DatabaseList = ["MyDb"] }, TestLogs.Temp())
+        {
+            Medium = BackupMedium.SharedPath,
+            SharedPathRoot = @"\\nas01\sql"
+        };
+
+        vm.Server = vm.Servers.Single();
+        vm.SelectedDatabase = "MyDb";
+
+        vm.GenerateCommand.Execute(null);
+
+        Assert.DoesNotContain(Region, vm.GeneratedScript);
+    }
+}

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -421,7 +421,12 @@ public partial class BackupViewModel : ViewModelBase
             Compression = Compression,
             Checksum = Checksum,
             EncryptionCertificate = Encrypt ? SelectedEncryptionCertificate : null,
-            Description = string.IsNullOrWhiteSpace(Description) ? null : Description
+            Description = string.IsNullOrWhiteSpace(Description) ? null : Description,
+
+            // The bucket's region, or the statement is signed for the wrong one (#361). Only
+            // the restore path was setting this, so a backup TO a bucket whose region is not
+            // in its host name failed after the container had tested perfectly.
+            S3Region = MediumIsBlob ? Container?.S3Region : null
         });
 
         return (script, destinations);

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -357,7 +357,10 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             CopyOnly = CopyOnly,
             Compression = Compression,
             Description = $"Copy of {SourceDatabase} from {SourceServer!.ServerName} " +
-                          $"to {TargetServer!.ServerName} as {TargetDatabaseName}"
+                          $"to {TargetServer!.ServerName} as {TargetDatabaseName}",
+
+            // Same as the backup screen (#361): the region has to reach the statement.
+            S3Region = MediumIsBlob ? Container?.S3Region : null
         });
 
         RestoreScript = _restoreGenerator.Generate(ChainForWhatWasWritten(destinations, takenAt),


### PR DESCRIPTION
Closes #361.

The region was stored, used when the app listed a container, and understood by both generators - and only the app's **restore** path ever put it on the options object. Every other path left it null, so the statement went to SQL Server signed for the provider's default region.

The failure shape is the nasty one: listing is signed by this app, so the container tests perfectly and `9lives list` works; the statement is signed by the engine, so the backup or restore is what fails. Everything reads healthy right up to the moment it matters - and it bites precisely the providers the feature exists for, since AWS-style hosts carry the region in the name and Wasabi, Backblaze B2, R2 and appliances generally do not.

## What changes

Threaded through the Back Up screen, Copy Database, and the CLI's `backup`, `restore`, `rehearse` and `script` verbs. `InventoryLoader` now returns the container alongside the sets to make that possible - the three read-only verbs discard it, the three that generate a statement keep it.

The guard the generators already had still holds: an Azure container or a shared-path backup gets no region, whatever the selected container says.

## Known gap, deliberately not fixed here

The container is null for a `--server` source, which found its backups through an instance's own msdb and has no container to ask - so an `s3://` path recorded in history still generates without a region. That is not just a threading problem: `RestoreScriptGenerator` detects S3 with `!f.IsOnDisk && f.BlobUrl.StartsWith("s3://")`, and an msdb-sourced set carries its URL in `LocalPath`, so those sets are not seen as S3 at all. Same `BlobUrl`-vs-`RestoreDevice` confusion I fixed in the capability preflight in #350. It deserves its own issue rather than a half-fix here.

## Verification

1,890 unit tests (3 new: the backup screen puts the region in the statement for a bucket, an Azure container does not acquire one, a shared-path backup does not either). Release `-warnaserror` clean.