### PR TITLE
A scripted restore creates the credential it authenticates with (#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A scripted restore creates the credential it authenticates with** (#353). RESTORE
+  FROM URL needs a credential on the TARGET instance for the container's URL, and the
+  generated script deliberately never carries one - the app writes it from its credential
+  panel, and nothing in the CLI did. So the provisioning template the README leads with,
+  add-server then add-container then `restore --execute` on a freshly built VM, died on
+  its last line with Msg 3201, after both provisioning verbs had validated green.
+  `rehearse` gets it too, and gets it before the file list rather than before the
+  restore: FILELISTONLY reads the backup itself, so a scheduled rehearsal without the
+  credential failed at the read and reported NOT PROVEN - blaming the backup for a host
+  that had never been told how to reach it. The README's own list of restore preflights
+  was missing the credential too, which is how the gap stayed invisible.
+
 - **The bucket's region reaches the statement, not just the listing** (#361). The region
   was stored, used when the app listed a container, and understood by both generators -
   but only the app's restore path ever put it on the options object. Every other path

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The full reference ships inside the exe: `9lives help` for the overview, `9lives
 9lives restore --container backups --database Sales --target target --at "%POINT_IN_TIME%" --execute
 ```
 
-Two verbs execute, and they are built out of refusals: `restore` and `rehearse` run nothing without `--execute`; overwriting an existing database is said with `--with-replace`, its own flag that `--force` cannot substitute for; and the same preflights the app fires - file readability, version direction (error 3169), the TDE certificate (error 33111) - refuse before anything is dropped, `--force` being the deliberate override for evidence only. Executed runs land in the app's History and notify the same webhooks, so `9lives rehearse --execute` on a schedule is nightly proof with receipts - no SQL Agent required.
+Two verbs execute, and they are built out of refusals: `restore` and `rehearse` run nothing without `--execute`; overwriting an existing database is said with `--with-replace`, its own flag that `--force` cannot substitute for; and the same preflights the app fires - the server-side credential the restore authenticates with, file readability, version direction (error 3169), the TDE certificate (error 33111) - refuse before anything is dropped, `--force` being the deliberate override for evidence only. Executed runs land in the app's History and notify the same webhooks, so `9lives rehearse --execute` on a schedule is nightly proof with receipts - no SQL Agent required.
 
 ## Features
 

--- a/src/NineLives.Cli/Preflights.cs
+++ b/src/NineLives.Cli/Preflights.cs
@@ -22,10 +22,18 @@ internal static class Preflights
     /// consent to overwrite, can the target read the files, does the version direction work,
     /// and is the TDE certificate where the restore will need it.
     /// </summary>
+    /// <param name="container">
+    /// The container the chain came from, when it came from one. Needed because the RESTORE
+    /// authenticates with a credential on the TARGET instance, which nothing else in a
+    /// scripted run would create (#353). Null for a --server source or a shared path.
+    /// </param>
+    /// <param name="appendLog">Where the credential step narrates what it did.</param>
     public static async Task<Result> RunAsync(
         CliServices services, ServerConnection target, BackupChain chain,
         string targetDatabase, bool withReplace, bool force,
-        IReadOnlyList<FileMoveOption>? fileMoves = null)
+        IReadOnlyList<FileMoveOption>? fileMoves = null,
+        BlobContainerConfig? container = null,
+        Action<string>? appendLog = null)
     {
         var refusals = new List<string>();
         var warnings = new List<string>();
@@ -34,6 +42,25 @@ internal static class Preflights
         {
             if (force) warnings.Add(message + " (--force: proceeding anyway)");
             else refusals.Add(message);
+        }
+
+        // 0a. The credential the RESTORE will authenticate with (#353).
+        //
+        // RESTORE FROM URL needs a credential on the TARGET instance for the container's URL,
+        // and the generated script deliberately never carries one. The app creates it from its
+        // credential panel; a scripted restore had nothing that did, so the advertised
+        // provision-then-restore template died on its last line with Msg 3201 - after the
+        // server and container had both validated green.
+        //
+        // Hard refusal rather than a Verdict: --force overrides a judgement made on evidence,
+        // and a missing credential is not a judgement. The restore cannot authenticate.
+        if (container != null)
+        {
+            var credential = await BlobCredentialPreflight.EnsureAsync(
+                services.Store, services.Sql, null, container, target,
+                appendLog ?? (_ => { }));
+
+            if (!credential.CanProceed) refusals.Add(credential.Refusal!);
         }
 
         // 1. WITH REPLACE is its own consent - never inherited, never forced (#63).

--- a/src/NineLives.Cli/Verbs/RehearseVerb.cs
+++ b/src/NineLives.Cli/Verbs/RehearseVerb.cs
@@ -126,6 +126,25 @@ internal static class RehearseVerb
         var sourceDatabase = args.Get("database")!;
         var scratch = RehearsalPlanner.ScratchName(sourceDatabase, DateTime.Now);
 
+        // The credential the rehearsal authenticates with, on the TARGET instance (#353).
+        //
+        // Ensured before the file list rather than before the restore: FILELISTONLY reads the
+        // backup itself, so without this a scheduled rehearsal against a container fails at
+        // the read and reports NOT PROVEN - which says the backup is bad when the truth is
+        // that this host was never told how to reach it.
+        if (sourceContainer != null)
+        {
+            var credential = await BlobCredentialPreflight.EnsureAsync(
+                services.Store, services.Sql, null, sourceContainer, target,
+                line => errors.WriteLine(line));
+
+            if (!credential.CanProceed)
+            {
+                errors.WriteLine($"REFUSED: {credential.Refusal}");
+                return ExitCodes.Failed;
+            }
+        }
+
         // Relocation is not optional here: the scratch copy must never collide with the real
         // database's files, so every file moves to the target's defaults under the scratch name.
         var devices = chain.FullSet.Files

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -231,7 +231,8 @@ internal static class RestoreVerb
         // that says "this WOULD be refused" is the pipeline's cheap rehearsal of its own DR step.
         // With relocation, the space check judges the volumes the files actually LAND on.
         var preflight = await Preflights.RunAsync(
-            services, target, chain, targetDatabase, withReplace, args.Has("force"), moves);
+            services, target, chain, targetDatabase, withReplace, args.Has("force"), moves,
+            sourceContainer, line => errors.WriteLine(line));
 
         errors.WriteLine($"Chain: {point.TypeDisplay} reaching " +
                          $"{(stopAt ?? point.Timestamp):yyyy-MM-dd HH:mm:ss}, restoring " +

--- a/src/NineLives.Tests/CliRestoreCredentialTests.cs
+++ b/src/NineLives.Tests/CliRestoreCredentialTests.cs
@@ -1,0 +1,139 @@
+using System.IO;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A scripted restore creates the credential it will authenticate with (#353).
+///
+/// RESTORE FROM URL needs a credential on the TARGET instance for the container's URL, and the
+/// generated script deliberately never carries one - the app writes it from its credential
+/// panel. Nothing in the CLI did, so the provisioning template the README leads with -
+/// add-server, add-container, restore --execute on a fresh VM - died on its last line with
+/// Msg 3201, after both provisioning verbs had validated green. `backup` had the step; the two
+/// verbs that restore did not.
+/// </summary>
+public class CliRestoreCredentialTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private const string ContainerUrl = "https://acct.blob.core.windows.net/backups";
+
+    private static (CliServices services, FakeSqlServerService sql, FakeCredentialStore store) Stage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        var container = new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = ContainerUrl,
+            PathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}"
+        };
+        store.Config.BlobContainers.Add(container);
+        store.SaveSasToken(container, "sv=2026-01-01&sig=secret");
+
+        var blobs = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = "FULL/SRV01/MyDb/MyDb_FULL_20260801_220000.bak",
+                    BlobUrl = $"{ContainerUrl}/FULL/SRV01/MyDb/MyDb_FULL_20260801_220000.bak",
+                    Type = BackupType.Full,
+                    ContainerId = "c1",
+                    InferredDatabaseName = "MyDb",
+                    InferredServerName = "SRV01",
+                    SizeBytes = 5_000_000,
+                    LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+                }
+            ]
+        };
+
+        var sql = new FakeSqlServerService();
+        var services = new CliServices(
+            store, sql, blobs, new FakeRestoreHistoryStore(), new FakeRunNotifier());
+
+        return (services, sql, store);
+    }
+
+    private static async Task<(int exit, string errors)> Run(
+        Func<CliArguments, CliServices, TextWriter, TextWriter, CancellationToken, Task<int>> verb,
+        VerbSpec spec, string[] args, CliServices services)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await verb(CliArguments.Parse(args, spec), services, output, errors, default);
+        return (exit, errors.ToString());
+    }
+
+    /// <summary>
+    /// The one this exists for. A generate-only restore is enough to prove it: the credential
+    /// belongs to the preflights, which run whether or not the restore executes.
+    /// </summary>
+    [Fact]
+    public async Task ARestoreFromAContainerCreatesTheCredentialOnTheTarget()
+    {
+        var (services, sql, _) = Stage();
+        sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.Missing, null);
+
+        await Run(RestoreVerb.RunAsync, RestoreVerb.Spec,
+            ["--container", "backups", "--database", "MyDb", "--target", "SRV02"], services);
+
+        Assert.Contains(ContainerUrl, sql.CredentialWrites);
+    }
+
+    [Fact]
+    public async Task ARehearsalFromAContainerCreatesItTooBeforeTheFileListIsRead()
+    {
+        var (services, sql, _) = Stage();
+        sql.Credential = new BlobCredentialStatus(BlobCredentialIdentity.Missing, null);
+
+        await Run(RehearseVerb.RunAsync, RehearseVerb.Spec,
+            ["--container", "backups", "--database", "MyDb", "--target", "SRV02"], services);
+
+        // Before, not after: FILELISTONLY reads the backup itself, so a rehearsal without the
+        // credential fails at the read and reports NOT PROVEN - which blames the backup for
+        // what is really an unconfigured host.
+        Assert.Contains(ContainerUrl, sql.CredentialWrites);
+    }
+
+    /// <summary>
+    /// A source that is an instance's own history has no container to take a credential from,
+    /// and must not be refused for it - those backups are read FROM DISK.
+    /// </summary>
+    [Fact]
+    public async Task AServerSourcedRestoreIsNotRefusedForHavingNoContainer()
+    {
+        var (services, sql, _) = Stage();
+        services.Store.LoadConfig().Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+
+        sql.BackupHistory =
+        [
+            new BackupHistoryEntry
+            {
+                DatabaseName = "MyDb",
+                Type = BackupType.Full,
+                StartedAt = T0,
+                FinishedAt = T0.AddMinutes(5),
+                CheckpointLsn = 100,
+                Position = 1,
+                Files = [@"X:\backups\full.bak"]
+            }
+        ];
+
+        var (_, errors) = await Run(RestoreVerb.RunAsync, RestoreVerb.Spec,
+            ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02"], services);
+
+        Assert.DoesNotContain("credential", errors, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(sql.CredentialWrites);
+    }
+}


### PR DESCRIPTION
Closes #353.

`RESTORE FROM URL` needs a credential on the **target** instance for the container's URL, and the generated script deliberately never carries one - the app writes it from its credential panel. Nothing in the CLI did.

So the provisioning template the README leads with - `add-server`, `add-container`, `restore --execute` on a freshly built VM - died on its last line with **Msg 3201**, after both provisioning verbs had reported success. `backup` had the step all along; the two verbs that restore were the two without it.

## What changes

- **`Preflights.RunAsync`** takes the container the chain came from and ensures the credential. Hard refusal rather than a `Verdict`: `--force` overrides a judgement made on evidence, and a missing credential is not a judgement - the restore cannot authenticate.
- **`rehearse`** gets it separately and *earlier* - before the file list, not before the restore. `FILELISTONLY` reads the backup itself, so a scheduled rehearsal against a container failed at that read and reported **NOT PROVEN**, which says the backup is bad when the truth is the rehearsal host was never told how to reach it. That is the worst answer a nightly proof loop can give.
- A `--server` source has no container and is not refused for it: those backups are read `FROM DISK` and need no credential.
- **README corrected** - its list of restore preflights named file readability, version direction and the TDE certificate, and not this one. The gap was in the prose as well as the code, which is part of why it went unnoticed.

## Still open

Full preflights for `rehearse` - space, version direction, TDE certificate - remain missing (#359). This PR only gives it the credential, because that is the one that made the verb fail at its own first read.

## Verification

1,893 unit tests (3 new: a container-sourced restore writes the credential on the target, a rehearsal does too, and a server-sourced restore is not refused for having no container). Release `-warnaserror` clean.