### PR TITLE
A bucket path recorded in msdb restores from a URL (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A bucket path recorded in msdb restores from a URL, not from a disk** (#375). Whether
+  a device is a path or a URL was answered two different ways: the inspection statements
+  read the device string, and the restore generator read which FIELD of the file held it.
+  Those agree for anything discovered by listing a container, and disagree for a backup
+  written to a bucket and later read back from the instance's own history - that arrives
+  with its `s3://` URL in the local-path field, so the generated statement said
+  `DISK = N's3://...'`, which SQL Server cannot open, and the region was stripped off it
+  as well. There is now one rule, in one place, and it asks the device: a UNC prefix or a
+  drive letter is a path and everything else is a URL, so a provider whose scheme nobody
+  has thought of yet is still addressed correctly.
+
 - **A scripted restore creates the credential it authenticates with** (#353). RESTORE
   FROM URL needs a credential on the TARGET instance for the container's URL, and the
   generated script deliberately never carries one - the app writes it from its credential

--- a/src/NineLives.Core/Services/BackupDevice.cs
+++ b/src/NineLives.Core/Services/BackupDevice.cs
@@ -1,0 +1,36 @@
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Whether a backup device is a path or a URL, and the clause that names it (#375).
+///
+/// One rule, in one place, because there were two. The inspection statements answered it from
+/// the device STRING - a UNC prefix or a drive letter is a path, everything else is a URL - and
+/// the restore generator answered it from which FIELD of BackupFileInfo happened to hold the
+/// device. Those agree for everything discovered by listing a container, and disagree for a
+/// backup written to a bucket and later read back from the instance's own msdb: that arrives
+/// with its s3:// URL in LocalPath, so IsOnDisk is true for something that was never on a disk,
+/// and the generated statement said <c>DISK = N's3://...'</c>, which SQL Server cannot open.
+///
+/// The string is the honest thing to ask. A device is what the RESTORE will name, and where the
+/// app happened to learn it says nothing about what it is.
+/// </summary>
+public static class BackupDevice
+{
+    /// <summary>
+    /// True when this device is a filesystem path rather than a URL.
+    ///
+    /// A UNC prefix or a drive letter, and nothing else. Deliberately not a list of known URL
+    /// schemes: a new provider's scheme should be treated as a URL by default, which is what
+    /// happens when the question is "is it a path" rather than "is it one of the URLs I know".
+    /// </summary>
+    public static bool IsPath(string? device) =>
+        !string.IsNullOrWhiteSpace(device)
+        && (device.StartsWith(@"\\", StringComparison.Ordinal)
+            || (device.Length >= 2 && device[1] == ':'));
+
+    /// <summary>The device clause naming one backup device, escaped for a string literal.</summary>
+    public static string Clause(string device) =>
+        IsPath(device)
+            ? $"DISK = N'{TSql.EscapeLiteral(device)}'"
+            : $"URL = N'{TSql.EscapeLiteral(device)}'";
+}

--- a/src/NineLives.Core/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives.Core/Services/RestoreScriptGenerator.cs
@@ -12,9 +12,10 @@ public class RestoreScriptGenerator
         // Region is an S3 concept (#51): meaningful only when the chain's devices are s3://,
         // and a stale value from a previous source must not leak into another provider's
         // statements.
-        var s3 = chain.FullSet.Files.Any(f =>
-            !f.IsOnDisk && f.BlobUrl.StartsWith("s3://", StringComparison.OrdinalIgnoreCase));
-        if (!s3) options.S3Region = null;
+        // The whole chain, and read from the device the RESTORE will name (#375): a chain can
+        // span containers, and a set read from an instance's history keeps its URL in a
+        // different field than one discovered by listing.
+        if (!S3CapabilityPreflight.UsesS3(chain)) options.S3Region = null;
 
         var dbName = EscapeName(options.TargetDatabaseName);
         var hasDiffs = chain.DiffSets.Count > 0;
@@ -174,9 +175,12 @@ public class RestoreScriptGenerator
         {
             var file = set.Files[i];
 
-            var device = file.IsOnDisk
+            // Asked of the device string, not of which field held it (#375). A backup written
+            // to a bucket and read back from the instance's own msdb carries its s3:// URL in
+            // LocalPath, which made IsOnDisk true and emitted DISK = N's3://...'.
+            var device = BackupDevice.IsPath(file.RestoreDevice)
                 ? $"DISK = N'{TSql.EscapeLiteral(file.RestoreDevice)}'"
-                : $"URL = N'{TSql.EscapeLiteral(BlobUrlEncoder.Encode(file.BlobUrl))}'";
+                : $"URL = N'{TSql.EscapeLiteral(BlobUrlEncoder.Encode(file.RestoreDevice))}'";
 
             var prefix = i == 0 ? "    FROM" : "        ";
             var suffix = i < set.Files.Count - 1 ? "," : "";

--- a/src/NineLives.Core/Services/SqlServerService.cs
+++ b/src/NineLives.Core/Services/SqlServerService.cs
@@ -458,15 +458,7 @@ public class SqlServerService : ISqlServerService
     /// which quietly limited HEADERONLY, FILELISTONLY and VERIFYONLY to blob - the restore itself
     /// has been device-aware since #149, and the inspection statements should match it.
     /// </summary>
-    private static string DeviceClause(string device)
-    {
-        var isPath = device.StartsWith(@"\\", StringComparison.Ordinal)
-                     || (device.Length >= 2 && device[1] == ':');
-
-        return isPath
-            ? $"DISK = N'{TSql.EscapeLiteral(device)}'"
-            : $"URL = N'{TSql.EscapeLiteral(device)}'";
-    }
+    private static string DeviceClause(string device) => BackupDevice.Clause(device);
 
     public async Task<List<FileMoveOption>> RestoreFileListOnlyAsync(
         ServerConnection server, IReadOnlyList<string> blobUrls, CancellationToken ct = default)

--- a/src/NineLives.Tests/BackupDeviceTests.cs
+++ b/src/NineLives.Tests/BackupDeviceTests.cs
@@ -1,0 +1,96 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A device is what the RESTORE will name, and where the app learned it says nothing about
+/// what it is (#375).
+///
+/// The inspection statements asked the device STRING; the restore generator asked which FIELD
+/// of BackupFileInfo held it. Those agree for anything discovered by listing a container, and
+/// disagree for a backup written to a bucket and read back from the instance's own msdb - that
+/// arrives with its s3:// URL in LocalPath, so IsOnDisk is true for something that was never on
+/// a disk, and the statement said DISK = N's3://...', which SQL Server cannot open.
+/// </summary>
+public class BackupDeviceTests
+{
+    [Theory]
+    [InlineData(@"\\nas01\sql\MyDb.bak", true)]
+    [InlineData(@"D:\backups\MyDb.bak", true)]
+    [InlineData("https://acct.blob.core.windows.net/backups/MyDb.bak", false)]
+    [InlineData("s3://s3.eu-west-2.amazonaws.com/backups/MyDb.bak", false)]
+    [InlineData("", false)]
+    public void APathIsAPathAndEverythingElseIsAUrl(string device, bool isPath)
+    {
+        Assert.Equal(isPath, BackupDevice.IsPath(device));
+    }
+
+    /// <summary>
+    /// The case the bug was made of: an s3:// URL that arrived through msdb, so it sits in
+    /// LocalPath and IsOnDisk answers true.
+    /// </summary>
+    [Fact]
+    public void ABucketUrlRecordedAsAPathStillRestoresFromUrl()
+    {
+        var chain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                SetId = "20260801_220000",
+                Type = BackupType.Full,
+                Timestamp = new DateTime(2026, 8, 1, 22, 0, 0),
+                Files =
+                [
+                    new BackupFileInfo
+                    {
+                        // How an instance's own history reports it.
+                        LocalPath = "s3://s3.eu-west-2.amazonaws.com/backups/FULL/MyDb.bak",
+                        BlobName = "MyDb.bak",
+                        Type = BackupType.Full
+                    }
+                ]
+            }
+        };
+
+        var script = new RestoreScriptGenerator().Generate(
+            chain, new RestoreOptions { TargetDatabaseName = "MyDb", S3Region = "eu-west-2" });
+
+        Assert.Contains("URL = N's3://s3.eu-west-2.amazonaws.com/backups/FULL/MyDb.bak'", script);
+        Assert.DoesNotContain("DISK = N's3://", script);
+
+        // And it is recognised as S3, so the region survives rather than being stripped.
+        Assert.Contains("eu-west-2", script);
+    }
+
+    /// <summary>A genuine path is still FROM DISK, and carries no region.</summary>
+    [Fact]
+    public void ASharedPathIsStillRestoredFromDisk()
+    {
+        var chain = new BackupChain
+        {
+            FullSet = new BackupSet
+            {
+                SetId = "20260801_220000",
+                Type = BackupType.Full,
+                Timestamp = new DateTime(2026, 8, 1, 22, 0, 0),
+                Files =
+                [
+                    new BackupFileInfo
+                    {
+                        LocalPath = @"\\nas01\sql\MyDb.bak",
+                        BlobName = "MyDb.bak",
+                        Type = BackupType.Full
+                    }
+                ]
+            }
+        };
+
+        var script = new RestoreScriptGenerator().Generate(
+            chain, new RestoreOptions { TargetDatabaseName = "MyDb", S3Region = "eu-west-2" });
+
+        Assert.Contains(@"DISK = N'\\nas01\sql\MyDb.bak'", script);
+        Assert.DoesNotContain("eu-west-2", script);
+    }
+}


### PR DESCRIPTION
Closes #375.

Whether a device is a path or a URL was answered **two different ways**:

- the inspection statements (`HEADERONLY`, `FILELISTONLY`, `VERIFYONLY`) read the device **string** - a UNC prefix or a drive letter is a path, everything else is a URL
- the restore generator read which **field** of `BackupFileInfo` held it

Those agree for everything discovered by listing a container, and disagree for a backup written to a bucket and later read back from the instance's own msdb: that arrives with its `s3://` URL in `LocalPath`, so `IsOnDisk` is true for something that was never on a disk. The generated statement said `DISK = N's3://...'`, which SQL Server cannot open - and the same misreading stripped the region, because the S3 test was made of the same field.

## What changes

One rule, in one place (`BackupDevice`), asking the device. `SqlServerService.DeviceClause` delegates to it, so the two can no longer drift.

Phrased as *"is it a path"* rather than *"is it one of the URL schemes I know"*, deliberately: a provider whose scheme nobody has thought of yet is then addressed as a URL by default rather than as a filename.

The region test also now reads the whole chain through the same predicate the capability gate uses, which fixes a second case in passing - a chain whose full is on Azure and whose logs are in a bucket had its region decided by the full set alone.

## Worth noting

This is the third bug this week from asking one field a question whose answer lives in another - the capability gate (#349) and the striped-set sizes (#351) were the same shape. Both are now fixed by reading the thing itself rather than the field it arrived in.

## Verification

1,900 unit tests (7 new: the path/URL rule directly, a bucket URL recorded as a path still restores `FROM URL` and keeps its region, a genuine share still restores `FROM DISK` and gets no region). Release `-warnaserror` clean; the full suite passes with the shared rule now behind both call sites.