### PR TITLE
A chain can no longer take one server's full and another's logs (#362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A chain can no longer take one server's full and another's logs** (#362). Restore
+  points were computed by partitioning the sets on backup TYPE alone. Set grouping goes to
+  real trouble to keep two servers' same-named databases apart - a container holding Sales
+  from SRV01 and SRV02 is the everyday DR pair - and the pairing then discarded the
+  distinction. The app never showed it, because its inventory screen filters to one
+  instance first; the CLI has no such filter and a container source cannot narrow to a
+  server at all, so `9lives script --container backups --database Sales` produced exactly
+  that mixture, and nothing downstream caught it because the identity check compares
+  database names and both are Sales. Chains are now built per database-and-instance and
+  the results concatenated: nothing is dropped and nothing is refused, each server's
+  points are offered and each is internally consistent.
+
 - **A bucket path recorded in msdb restores from a URL, not from a disk** (#375). Whether
   a device is a path or a URL was answered two different ways: the inspection statements
   read the device string, and the restore generator read which FIELD of the file held it.

--- a/src/NineLives.Core/Services/BackupChainBuilder.cs
+++ b/src/NineLives.Core/Services/BackupChainBuilder.cs
@@ -10,6 +10,35 @@ public class BackupChainBuilder
     /// </summary>
     public List<RestorePoint> ComputeRestorePoints(List<BackupSet> allSets)
     {
+        // A chain belongs to ONE database on ONE instance, and this used to partition the sets
+        // by Type alone (#362).
+        //
+        // Grouping goes to real trouble to keep two servers' same-named databases apart - a
+        // container holding Sales from SRV01 and SRV02 is the everyday DR pair - and then the
+        // pairing below discarded the distinction and matched a full from one with the logs of
+        // the other. The app never saw it because the inventory screen filters to one instance
+        // before it gets here; the CLI has no such filter, and a container source cannot even
+        // narrow to a server, so `9lives script --container backups --database Sales` produced
+        // exactly that mixture. Nothing downstream catches it either: the identity check
+        // compares database NAMES, and both are Sales.
+        //
+        // Chains are therefore built per identity and the results concatenated. Nothing is
+        // dropped and nothing is refused: each server's points are offered, each internally
+        // consistent. The single-identity case - which is every path through the app - takes
+        // exactly the route it always did.
+        var identities = allSets
+            .GroupBy(s => (Database: s.DatabaseName ?? string.Empty,
+                           Server: s.ServerDisplay ?? string.Empty))
+            .ToList();
+
+        if (identities.Count > 1)
+            return [.. identities.SelectMany(g => ComputeRestorePointsForOneIdentity([.. g]))];
+
+        return ComputeRestorePointsForOneIdentity(allSets);
+    }
+
+    private List<RestorePoint> ComputeRestorePointsForOneIdentity(List<BackupSet> allSets)
+    {
         var fulls = allSets.Where(s => s.Type == BackupType.Full).OrderBy(s => s.Timestamp).ToList();
         var diffs = allSets.Where(s => s.Type == BackupType.Differential).OrderBy(s => s.Timestamp).ToList();
         var logs = allSets.Where(s => s.Type == BackupType.TransactionLog).OrderBy(s => s.Timestamp).ToList();

--- a/src/NineLives.Tests/ChainIdentityTests.cs
+++ b/src/NineLives.Tests/ChainIdentityTests.cs
@@ -1,0 +1,133 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A chain belongs to one database on one instance (#362).
+///
+/// The builder partitioned by Type alone, so a container holding the same database from two
+/// servers - the everyday DR pair - produced chains that took a full from one and the logs of
+/// the other. The app never saw it because its inventory screen filters to one instance first;
+/// the CLI has no such filter, and a container source cannot narrow to a server at all, so
+/// `9lives script --container backups --database Sales` produced exactly that mixture. Nothing
+/// downstream catches it: the identity check compares database NAMES, and both are Sales.
+/// </summary>
+public class ChainIdentityTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static BackupSet Set(BackupType type, string server, DateTime at, decimal? lsn = null) => new()
+    {
+        SetId = $"{server}_{at:yyyyMMdd_HHmmss}",
+        Type = type,
+        Timestamp = at,
+        DatabaseName = "Sales",
+        ServerName = server,
+        CheckpointLsn = lsn,
+        Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = $"{server}_{at:yyyyMMddHHmmss}.bak",
+                BlobUrl = $"https://acct.blob.core.windows.net/backups/{server}_{at:yyyyMMddHHmmss}.bak",
+                Type = type,
+                SizeBytes = 1000
+            }
+        ]
+    };
+
+    /// <summary>Every set a restore point would actually restore from.</summary>
+    private static IEnumerable<BackupSet> SetsOf(RestorePoint p) =>
+        new[] { p.RequiredFullSet }.Concat(p.RequiredDiffSets).Concat(p.RequiredLogSets);
+
+    /// <summary>
+    /// The one this exists for: no restore point may mix two servers' backups.
+    /// </summary>
+    [Fact]
+    public void NoChainPairsOneServersFullWithAnothersLog()
+    {
+        var sets = new List<BackupSet>
+        {
+            Set(BackupType.Full, "SRV01", T0),
+            Set(BackupType.Full, "SRV02", T0.AddMinutes(30)),
+            Set(BackupType.TransactionLog, "SRV01", T0.AddHours(1)),
+            Set(BackupType.TransactionLog, "SRV02", T0.AddHours(2))
+        };
+
+        var points = new BackupChainBuilder().ComputeRestorePoints(sets);
+
+        Assert.NotEmpty(points);
+        foreach (var point in points)
+        {
+            var servers = SetsOf(point)
+                .Select(s => s.ServerName)
+                .Distinct()
+                .ToList();
+
+            Assert.Single(servers);
+        }
+    }
+
+    /// <summary>
+    /// Both servers are still offered - the fix separates the chains, it does not throw half
+    /// the container away.
+    /// </summary>
+    [Fact]
+    public void BothServersStillGetTheirOwnRestorePoints()
+    {
+        var sets = new List<BackupSet>
+        {
+            Set(BackupType.Full, "SRV01", T0),
+            Set(BackupType.Full, "SRV02", T0.AddMinutes(30)),
+            Set(BackupType.TransactionLog, "SRV01", T0.AddHours(1)),
+            Set(BackupType.TransactionLog, "SRV02", T0.AddHours(2))
+        };
+
+        var points = new BackupChainBuilder().ComputeRestorePoints(sets);
+
+        Assert.Contains(points, p => SetsOf(p).All(s => s.ServerName == "SRV01"));
+        Assert.Contains(points, p => SetsOf(p).All(s => s.ServerName == "SRV02"));
+    }
+
+    /// <summary>
+    /// Two databases on one server are separated by the same rule - the identity is the pair,
+    /// not just the server.
+    /// </summary>
+    [Fact]
+    public void TwoDatabasesOnOneServerDoNotShareAChain()
+    {
+        var sales = Set(BackupType.Full, "SRV01", T0);
+        var payroll = Set(BackupType.Full, "SRV01", T0.AddMinutes(5));
+        payroll.DatabaseName = "Payroll";
+        var payrollLog = Set(BackupType.TransactionLog, "SRV01", T0.AddHours(1));
+        payrollLog.DatabaseName = "Payroll";
+
+        var points = new BackupChainBuilder().ComputeRestorePoints([sales, payroll, payrollLog]);
+
+        foreach (var point in points)
+            Assert.Single(SetsOf(point).Select(s => s.DatabaseName).Distinct());
+    }
+
+    /// <summary>
+    /// The ordinary case - one database, one server - goes down exactly the path it always did.
+    /// This is every route through the app, so it is the one that must not move.
+    /// </summary>
+    [Fact]
+    public void OneIdentityBehavesExactlyAsBefore()
+    {
+        var sets = new List<BackupSet>
+        {
+            Set(BackupType.Full, "SRV01", T0),
+            Set(BackupType.TransactionLog, "SRV01", T0.AddHours(1)),
+            Set(BackupType.TransactionLog, "SRV01", T0.AddHours(2))
+        };
+
+        var points = new BackupChainBuilder().ComputeRestorePoints(sets);
+
+        // One full point plus one per log that carries the chain forward.
+        Assert.Equal(3, points.Count);
+        Assert.Equal(BackupType.Full, points[0].Type);
+    }
+}


### PR DESCRIPTION
Closes #362.

`ComputeRestorePoints` partitioned the incoming sets on backup **type** alone. Set grouping goes to real trouble to keep two servers' same-named databases apart - the key carries server, instance and directory precisely so a container holding `Sales` from SRV01 and SRV02 does not collapse into one timeline - and then the pairing discarded that and matched a full from one server with the logs of the other.

The app never showed it, because its inventory screen filters to one instance before the builder sees anything. The CLI has no such filter, and a container source cannot narrow to a server at all, so this against the everyday DR pair:

```
9lives script --container backups --database Sales
```

produced a chain reading SRV02's full and SRV01's log. Nothing downstream catches it either - the identity check compares database *names*, and both are `Sales`.

## What changes

Chains are built per database-and-instance and the results concatenated. Nothing is dropped and nothing is refused: each server's points are offered, each internally consistent. The single-identity case - every route through the app - takes exactly the path it always did, which is what keeps this low risk.

## Not in scope

Narrowing a container source to one server from the CLI is still worth having, and is a separate change.

## Verification

1,904 unit tests (4 new: no point mixes two servers, both servers still get their own points, two databases on one server do not share a chain, and the one-identity case is unchanged). Full suite green with the partition in place - the existing chain-building tests all run through the single-identity path unchanged. Release `-warnaserror` clean.