### PR TITLE
Two UX defects the review found (#354, #355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,21 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A failure in the early restore steps is actually shown** (#355). The screen's only
+  error banner sat inside step 5, which is not on screen until step 4 has been confirmed -
+  so everything that can go wrong before that had no banner at all. An expired container,
+  a chain that will not build, a header that will not read: each reached only the status
+  line, in grey, at the foot of a two-thousand-line page, indistinguishable from "Script
+  copied to clipboard", and with no way to dismiss it. The banner is now docked above the
+  scroll beside the summary of what the restore will do.
+
+- **Editing a container can no longer save over a different one** (#354). The list stayed
+  clickable while the edit form was open, and Save writes to whichever container is
+  SELECTED - so starting an edit, clicking another container to check something, then
+  saving wrote the first one's name, URL, credential and tags over the second. Silently,
+  leaving the original untouched and two containers sharing a name. The list is now
+  disabled while an edit is open.
+
 - **A chain can no longer take one server's full and another's logs** (#362). Restore
   points were computed by partitioning the sets on backup TYPE alone. Set grouping goes to
   real trouble to keep two servers' same-named databases apart - a container holding Sales

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -1444,6 +1444,83 @@ public class XamlLoadTests(WpfFixture wpf)
         });
     }
 
+    // ── errors are visible where they happen (#354, #355) ───────────────────────
+
+    /// <summary>
+    /// A failure in the early steps is SEEN.
+    ///
+    /// The screen's only error banner used to live inside step 5, which is not visible until
+    /// step 4 has been confirmed - so loading an expired container, a chain that would not
+    /// build or a header that would not read produced no banner at all. The message reached
+    /// only the status line: grey, at the foot of a two-thousand-line page, indistinguishable
+    /// from "Script copied to clipboard".
+    /// </summary>
+    [Fact]
+    public void AnErrorBeforeStepFiveIsStillShown()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            // Nothing confirmed, so step 5 is not on screen - the state every early failure
+            // happens in.
+            Assert.False(vm.Steps.Execute.IsVisible);
+
+            typeof(ViewModelBase).GetProperty("ErrorMessage")!
+                .SetValue(vm, "No valid restore points found. Ensure there is at least one full backup.");
+            typeof(ViewModelBase).GetProperty("HasError")!.SetValue(vm, true);
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.Contains(shown, t => t.Contains("No valid restore points found"));
+        });
+    }
+
+    /// <summary>
+    /// The container list cannot be changed while the edit form is open.
+    ///
+    /// Save writes to whichever container is SELECTED, so clicking another one mid-edit wrote
+    /// this container's name, URL, credential and tags over that one - silently, leaving the
+    /// original untouched and two containers sharing a name.
+    /// </summary>
+    [Fact]
+    public void TheContainerListIsNotSelectableWhileEditing()
+    {
+        wpf.Invoke(() =>
+        {
+            var store = new FakeCredentialStore();
+            store.Config.BlobContainers.Add(new BlobContainerConfig
+            {
+                Id = "c1",
+                Name = "prod",
+                ContainerUrl = "https://acct.blob.core.windows.net/prod"
+            });
+            store.Config.BlobContainers.Add(new BlobContainerConfig
+            {
+                Id = "c2",
+                Name = "dr",
+                ContainerUrl = "https://acct.blob.core.windows.net/dr"
+            });
+
+            var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+            var view = new BlobConfigView { DataContext = vm };
+            Realise(view);
+
+            var list = FindAll<System.Windows.Controls.ListBox>(view).First();
+            Assert.True(list.IsEnabled);
+
+            vm.SelectedContainer = vm.Containers.First();
+            vm.EditCommand.Execute(null);
+            Realise(view);
+
+            Assert.True(vm.IsEditing);
+            Assert.False(list.IsEnabled);
+        });
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────────
 
     private RestoreViewModel NewRestoreViewModel(ICredentialStore? credentialStore = null)

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -13,6 +13,7 @@
         <converters:BlobAuthModeToDisplayConverter x:Key="BlobAuthModeDisplay" />
         <converters:BlobAuthModeIsSasConverter x:Key="BlobAuthModeIsSas" />
         <converters:StringToVisibilityConverter x:Key="StringToVis" />
+        <converters:InverseBoolConverter x:Key="InverseBool" />
     </UserControl.Resources>
 
     <Grid>
@@ -54,7 +55,12 @@
                                 HorizontalAlignment="Stretch" />
                     </StackPanel>
 
+                    <!-- Not selectable mid-edit (#354). The form writes to whichever container
+                         is SELECTED when Save runs, so clicking another one while editing saved
+                         this container's name, URL, credential and tags over that one - silently,
+                         with the original left untouched and two containers left sharing a name. -->
                     <ListBox ItemsSource="{Binding Containers}"
+                             IsEnabled="{Binding IsEditing, Converter={StaticResource InverseBool}}"
                              SelectedItem="{Binding SelectedContainer}"
                              Background="Transparent"
                              BorderThickness="0"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -42,6 +42,15 @@
             </StackPanel>
         </Border>
 
+        <!-- Docked, not buried (#355).
+             This lived inside step 5, which only becomes visible once step 4 is confirmed - so
+             every failure before that point had no banner at all. Loading an expired container,
+             a chain that will not build, a header that will not read: each set an error that
+             appeared only as grey status text at the foot of a two-thousand-line page,
+             indistinguishable from "Script copied to clipboard". Up here it is above the scroll,
+             beside the summary of what the restore will do, and it can actually be dismissed. -->
+        <ContentControl DockPanel.Dock="Top" Style="{StaticResource ErrorBanner}" />
+
         <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
             <!-- Header -->
@@ -2083,8 +2092,6 @@
                             <Run Text=" Connect to a SQL Server instance (SQL Servers tab) to enable script execution." />
                         </TextBlock>
                     </Border>
-
-                    <ContentControl Style="{StaticResource ErrorBanner}" />
 
                     <!-- The generated script. Stays visible during and after execution: it used to
                          be hidden the moment Execute was pressed, so the script and the console


### PR DESCRIPTION
Closes #354. Closes #355.

## A failure in the early restore steps is actually shown (#355)

The screen's only error banner sat inside step 5, which is not on screen until step 4 has been confirmed. So everything that can go wrong before that point had **no banner at all**: an expired container, a chain that will not build, a header that will not read, a listing that returns nothing.

Each reached only the status line - grey, at the foot of a two-thousand-line page, visually identical to "Script copied to clipboard" - and could not be dismissed, because the dismiss button was inside the same hidden panel.

This is the failure I was shown a screenshot of: *"No valid restore points found"* rendered as grey body text under the source panel. The banner is now docked above the scroll, beside the summary of what the restore will do.

## Editing a container can no longer save over a different one (#354)

The list stayed clickable while the edit form was open, and `Save` writes to whichever container is **selected** - so starting an edit, clicking another container to check something, then saving wrote the first one's name, URL, credential and tags over the second. Silently, with the original left untouched, two containers left sharing a name, and the typed secret stored under the wrong key.

The list is now disabled while an edit is open. That is the smallest change that removes the whole class rather than one path through it - a prompt would still leave the selection able to move underneath a half-finished form.

## Verification

1,906 unit tests (2 new, both asserting against a **realised visual tree** rather than the view model, since both defects were invisible at the view-model level: an error raised with step 5 hidden is on screen, and the container list is disabled once editing starts). Rendered and eyeballed in the early-failure state. Release `-warnaserror` clean.