### PR TITLE
A blocked rehearsal says so, instead of blaming the backup (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A rehearsal blocked by its own host says so, instead of blaming the backup** (#359).
+  `rehearse` ran no preflights at all - no space check, no version direction, no TDE
+  certificate, no S3 capability - so a scratch volume too small, a certificate missing
+  from the rehearsal target, or an engine that cannot read the storage all died inside
+  the restore and came back as NOT PROVEN, exit 2, with the scratch copy retained as
+  evidence. That reads as "this backup is bad", when the backup was never in question
+  and the host was. It now runs the same preflights the restore verb does, and a refusal
+  is its own outcome and its own exit code - could not be proven, which is a different
+  answer from proven false, and a proof loop that conflates them is worse at 3am than one
+  that does not run.
+
 - **A failure in the early restore steps is actually shown** (#355). The screen's only
   error banner sat inside step 5, which is not on screen until step 4 has been confirmed -
   so everything that can go wrong before that had no banner at all. An expired container,

--- a/src/NineLives.Cli/Verbs/RehearseVerb.cs
+++ b/src/NineLives.Cli/Verbs/RehearseVerb.cs
@@ -64,7 +64,8 @@ internal static class RehearseVerb
         [
             "0   PROVEN - restored, CHECKDB clean, scratch dropped (or, without --execute, printed)",
             "2   NOT PROVEN - the failure is recorded, the scratch copy retained as evidence",
-            "3   the source or target could not be reached, or FILELISTONLY answered nothing",
+            "3   could not be PROVEN - the target could not be reached, FILELISTONLY answered " +
+            "nothing, or a preflight refused (a fact about this target, not about the backup)",
             "64  usage",
             "130 cancelled with Ctrl+C - recorded, told to the channel, scratch retained if begun"
         ],
@@ -160,6 +161,48 @@ internal static class RehearseVerb
 
         var (dataPath, logPath) = await services.Sql.GetDefaultPathsAsync(target);
         var moves = RehearsalPlanner.ScratchMoves(files, scratch, dataPath, logPath);
+
+        // The same preflights the restore verb runs (#359).
+        //
+        // Without them a rehearsal that failed because of the HOST - a scratch volume too
+        // small, a missing TDE certificate, a target older than the backup, an engine that
+        // cannot read S3 - died inside the restore and reported NOT PROVEN. That says the
+        // backup is bad. It is not; the host is misconfigured, and the two want opposite
+        // responses at three in the morning.
+        //
+        // So a refusal gets its own outcome and its own exit code: "could not be proven" is a
+        // different answer from "proven false", and a proof loop that conflates them is worse
+        // than one that does not run.
+        //
+        // No container passed - the credential was ensured above, before the file list that
+        // needed it, and asking twice would only repeat the line.
+        var preflight = await Preflights.RunAsync(
+            services, target, chain, scratch, withReplace: false, force: false, moves);
+
+        foreach (var warning in preflight.Warnings)
+            errors.WriteLine($"WARNING: {warning}");
+
+        if (preflight.Refusals.Count > 0)
+        {
+            foreach (var refusal in preflight.Refusals)
+                errors.WriteLine($"REFUSED: {refusal}");
+
+            errors.WriteLine("The rehearsal did not run, so this backup is neither proven nor " +
+                             "disproven - the refusals above are about this target, not the backup.");
+
+            if (args.Has("json"))
+                CliRunResult.Write(output, new
+                {
+                    Verb = "rehearse",
+                    Outcome = "Blocked",
+                    Server = target.ServerName,
+                    Database = sourceDatabase,
+                    Scratch = scratch,
+                    Refusals = preflight.Refusals
+                });
+
+            return ExitCodes.CouldNotAnswer;
+        }
 
         var restoreScript = new RestoreScriptGenerator().Generate(chain, new RestoreOptions
         {

--- a/src/NineLives.Tests/CliExecuteVerbTests.cs
+++ b/src/NineLives.Tests/CliExecuteVerbTests.cs
@@ -247,7 +247,8 @@ public class CliExecuteVerbTests
     private static string[] RehearseArgs(params string[] extra) =>
         [.. new[] { "--server", "SRV01", "--database", "MyDb", "--target", "SRV02" }, .. extra];
 
-    private static void GiveFileList(FakeSqlServerService sql) =>
+    private static void GiveFileList(FakeSqlServerService sql)
+    {
         sql.FileList =
         [
             new FileMoveOption
@@ -258,6 +259,13 @@ public class CliExecuteVerbTests
                 SizeBytes = 1024
             }
         ];
+
+        // The volume has to report its free space now that rehearse runs the space preflight
+        // (#359). An unreported volume is deliberately a refusal rather than a pass - not
+        // knowing is not the same as fitting - so a target that says nothing about C: is a
+        // target this rehearsal will not run on.
+        sql.VolumeFreeSpace = new Dictionary<string, long> { [@"D:\"] = 500L * 1024 * 1024 * 1024 };
+    }
 
     [Fact]
     public async Task ARehearsalProvesRestoresChecksAndDrops()
@@ -369,6 +377,7 @@ public class CliExecuteVerbTests
     {
         var (services, sql, _, _) = Stage(Full(100, T0));
         sql.FileList = [DataFile(@"D:\Data\MyDb.mdf", 1024)];
+        // The target reports C: and says nothing about the D: these files land on.
         sql.VolumeFreeSpace = new() { [@"C:\"] = 500L * 1024 * 1024 * 1024 };
 
         var (exit, _, errors) = await Run(

--- a/src/NineLives.Tests/CliJsonResultTests.cs
+++ b/src/NineLives.Tests/CliJsonResultTests.cs
@@ -128,6 +128,9 @@ public class CliJsonResultTests
     {
         var (services, sql, history) = Stage();
         sql.FileList = [ScratchableFile()];
+        // rehearse now runs the space preflight (#359), and an unreported volume is a
+        // refusal by design, so the target has to say what it has free.
+        sql.VolumeFreeSpace = new() { [@"D:\"] = 500L * 1024 * 1024 * 1024 };
 
         var (exit, output, _) = await Run(RehearseVerb.RunAsync, RehearseVerb.Spec,
             ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02",
@@ -146,6 +149,9 @@ public class CliJsonResultTests
     {
         var (services, sql, _) = Stage();
         sql.FileList = [ScratchableFile()];
+        // rehearse now runs the space preflight (#359), and an unreported volume is a
+        // refusal by design, so the target has to say what it has free.
+        sql.VolumeFreeSpace = new() { [@"D:\"] = 500L * 1024 * 1024 * 1024 };
         sql.FailOnExecuteNumber = 1;
 
         var (exit, output, _) = await Run(RehearseVerb.RunAsync, RehearseVerb.Spec,

--- a/src/NineLives.Tests/CliRestoreCredentialTests.cs
+++ b/src/NineLives.Tests/CliRestoreCredentialTests.cs
@@ -105,6 +105,50 @@ public class CliRestoreCredentialTests
         Assert.Contains(ContainerUrl, sql.CredentialWrites);
     }
 
+    // ── rehearse runs the same preflights (#359) ────────────────────────────────
+
+    /// <summary>
+    /// A rehearsal blocked by the HOST says so, rather than reporting the backup unproven.
+    ///
+    /// A missing TDE certificate on the rehearsal target used to surface as NOT PROVEN, exit
+    /// 2, with a retained scratch copy - which reads as "this backup is bad". It is not; this
+    /// target cannot restore it. At three in the morning those want opposite responses.
+    /// </summary>
+    [Fact]
+    public async Task ARehearsalRefusedByItsTargetIsBlockedNotDisproven()
+    {
+        var (services, sql, _) = Stage();
+
+        // The certificate the backup needs is not on the target.
+        sql.Header = new BackupFileInfo
+        {
+            DatabaseName = "MyDb",
+            Type = BackupType.Full,
+            BackupTypeCode = 1,
+            TdeThumbprint = [1, 2, 3, 4]
+        };
+        // CertificatesByThumbprint stays empty, so the target holds no such certificate.
+
+        // FILELISTONLY has to answer, or the rehearsal stops before the preflights - which is
+        // its own early return, not the refusal this test is about.
+        sql.FileList =
+        [
+            new FileMoveOption { LogicalName = "MyDb", PhysicalName = @"D:\data\MyDb.mdf", Type = "D" },
+            new FileMoveOption { LogicalName = "MyDb_log", PhysicalName = @"L:\logs\MyDb.ldf", Type = "L" }
+        ];
+
+        var (exit, errors) = await Run(RehearseVerb.RunAsync, RehearseVerb.Spec,
+            ["--container", "backups", "--database", "MyDb", "--target", "SRV02", "--execute"],
+            services);
+
+        Assert.Equal(ExitCodes.CouldNotAnswer, exit);
+        Assert.Contains("REFUSED", errors);
+        Assert.Contains("neither proven nor disproven", errors);
+
+        // And nothing ran: a blocked rehearsal is not a failed one.
+        Assert.Empty(sql.ExecutedScripts);
+    }
+
     /// <summary>
     /// A source that is an instance's own history has no container to take a credential from,
     /// and must not be refused for it - those backups are read FROM DISK.


### PR DESCRIPTION
Closes #359.

`rehearse` ran **no preflights at all** - no space check, no version direction, no TDE certificate, no S3 capability. So a scratch volume too small, a certificate missing from the rehearsal target, or an engine that cannot read the storage all died inside the restore and came back as **NOT PROVEN**, exit 2, with the scratch copy retained as evidence.

That answer says the backup is bad. The backup was never in question; the host was. At 3am those want opposite responses, and a proof loop that confuses them is worse than one that does not run.

## What changes

It runs the same preflights the restore verb does, and a refusal gets its own outcome and its own exit code:

- **3** - could not be PROVEN (a fact about this target)
- **2** - NOT PROVEN (a fact about the backup)

The message says out loud that the backup is neither proven nor disproven, and `--json` carries `Outcome: "Blocked"` with the refusals, so a pipeline can route a misconfigured host differently from a bad backup.

No container is passed to the preflights - the credential is already ensured earlier, before the file list that needs it, so asking again would only repeat the line.

## Test changes worth reviewing

Three existing rehearse tests had to stage free space, because they predate rehearse having a space check. They report the **target's default volume** rather than the source file's, which is the one the check judges - a rehearsal relocates every file to the target's default directories, and that is what stops the scratch copy writing where the real database lives.

The absent-volume test now reports a *different* volume than the files land on. That is what it was always demonstrating; it had been staging the very volume it meant to be missing, so it passed for the wrong reason.

## Verification

1,907 unit tests (1 new: a rehearsal refused by its target is Blocked with nothing executed, not disproven). Release `-warnaserror` clean.