### PR TITLE
The CLI's exit codes stopped contradicting themselves (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,19 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The CLI's exit codes stopped contradicting themselves** (#370). Two ways they lied to
+  a pipeline. Adding `--json` to `list` changed the VERDICT: the JSON branch returned 0
+  on a source holding nothing, while the same command without it returned 2 and the spec
+  documented 2 - so putting `--json` on a monitoring check turned a container that had
+  silently stopped receiving backups into a pass, and the pipeline piped an empty array
+  into jq and did nothing. An output format must never change the answer.
+
+  And a finding wore a usage error's clothes: "this source has no backups for a database
+  called Sales" came back as 64, indistinguishable from a malformed command line, so a
+  pipeline branching on the documented contract logged and aborted rather than paging -
+  when that is precisely the alarm `validate` is watched for. The loader now says which
+  kind of failure it had, and a genuinely malformed invocation still exits 64.
+
 - **A rehearsal blocked by its own host says so, instead of blaming the backup** (#359).
   `rehearse` ran no preflights at all - no space check, no version direction, no TDE
   certificate, no S3 capability - so a scratch volume too small, a certificate missing

--- a/src/NineLives.Cli/InventoryLoader.cs
+++ b/src/NineLives.Cli/InventoryLoader.cs
@@ -21,7 +21,14 @@ internal static class InventoryLoader
     /// something the sets do not carry: the bucket's region (#361). Null for a --server source,
     /// which has no container - the backups were found through an instance's own history.
     /// </summary>
-    public static async Task<(List<BackupSet>? sets, BlobContainerConfig? container, string? error)> LoadAsync(
+    /// <param name="exitCode">
+    /// What the caller should exit with when this fails (#370). Not every failure here is a
+    /// usage error: "give exactly one source" and "no container by that name" are things the
+    /// INVOCATION got wrong, but "this source holds no backups for that database" is a finding
+    /// about the estate - the alarm `validate` exists to raise. Returning 64 for it told a
+    /// pipeline its own command line was malformed, so it logged and moved on instead of paging.
+    /// </param>
+    public static async Task<(List<BackupSet>? sets, BlobContainerConfig? container, string? error, int exitCode)> LoadAsync(
         CliArguments args, CliServices services)
     {
         BlobContainerConfig? source = null;
@@ -30,14 +37,15 @@ internal static class InventoryLoader
         var serverName = args.Get("server");
 
         if ((containerName == null) == (serverName == null))
-            return (null, null, "Give exactly one source: --container NAME or --server NAME.");
+            return (null, null, "Give exactly one source: --container NAME or --server NAME.",
+                    ExitCodes.Usage);
 
         List<BackupSet> sets;
 
         if (containerName != null)
         {
             var (container, error) = services.FindContainer(containerName);
-            if (container == null) return (null, null, error);
+            if (container == null) return (null, null, error, ExitCodes.Usage);
             source = container;
 
             var files = await services.Blobs.ListBackupFilesAsync(container);
@@ -46,7 +54,7 @@ internal static class InventoryLoader
         else
         {
             var (server, error) = services.FindServer(serverName!);
-            if (server == null) return (null, null, error);
+            if (server == null) return (null, null, error, ExitCodes.Usage);
 
             var history = await services.Sql.ReadBackupHistoryAsync(server, args.Get("database"));
             sets = BackupHistoryInventory.ToSets(history);
@@ -61,10 +69,12 @@ internal static class InventoryLoader
                 .ToList();
 
             if (sets.Count == 0)
-                return (null, null, $"The source has no backups for a database called '{database}'. " +
-                              "Run the list verb to see what it does hold.");
+                return (null, null,
+                    $"The source has no backups for a database called '{database}'. " +
+                    "Run the list verb to see what it does hold.",
+                    ExitCodes.Failed);
         }
 
-        return (sets, source, null);
+        return (sets, source, null, ExitCodes.Ok);
     }
 }

--- a/src/NineLives.Cli/Verbs/ListVerb.cs
+++ b/src/NineLives.Cli/Verbs/ListVerb.cs
@@ -57,11 +57,14 @@ internal static class ListVerb
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)
     {
-        var (sets, _, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, _, error, loadExit) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);
-            return ExitCodes.Usage;
+            // The loader says which kind of failure this was (#370): a malformed
+            // invocation exits 64, a source that holds nothing for this database
+            // exits 2 - the finding, not a usage error.
+            return loadExit;
         }
 
         var byDatabase = sets
@@ -78,17 +81,21 @@ internal static class ListVerb
             })
             .ToList();
 
+        // An empty source is the same finding whichever way it is printed (#370). The JSON
+        // branch returned Ok unconditionally, so adding --json to a check flipped its verdict:
+        // a container that had silently stopped receiving backups reported success, and the
+        // pipeline piped [] into jq and did nothing. An output format must never change the
+        // answer - the spec has documented 2 for this case all along.
+        if (byDatabase.Count == 0)
+            errors.WriteLine("The source holds no recognisable backups.");
+
         if (args.Has("json"))
         {
             output.WriteLine(JsonSerializer.Serialize(byDatabase, JsonOut.Options));
-            return ExitCodes.Ok;
+            return byDatabase.Count == 0 ? ExitCodes.Failed : ExitCodes.Ok;
         }
 
-        if (byDatabase.Count == 0)
-        {
-            errors.WriteLine("The source holds no recognisable backups.");
-            return ExitCodes.Failed;
-        }
+        if (byDatabase.Count == 0) return ExitCodes.Failed;
 
         TableWriter.Write(output,
             ["DATABASE", "FULL", "DIFF", "LOG", "LATEST BACKUP"],

--- a/src/NineLives.Cli/Verbs/PointsVerb.cs
+++ b/src/NineLives.Cli/Verbs/PointsVerb.cs
@@ -42,7 +42,8 @@ internal static class PointsVerb
         ExitCodes:
         [
             "0   points listed",
-            "2   nothing in the source forms a valid chain for this database",
+            "2   nothing in the source forms a valid chain for this database, including the " +
+            "case where it holds no backups for it at all",
             "3   the source could not be read at all",
             "64  usage"
         ],
@@ -63,11 +64,14 @@ internal static class PointsVerb
             return ExitCodes.Usage;
         }
 
-        var (sets, _, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, _, error, loadExit) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);
-            return ExitCodes.Usage;
+            // The loader says which kind of failure this was (#370): a malformed
+            // invocation exits 64, a source that holds nothing for this database
+            // exits 2 - the finding, not a usage error.
+            return loadExit;
         }
 
         var points = new BackupChainBuilder().ComputeRestorePoints(sets);

--- a/src/NineLives.Cli/Verbs/RehearseVerb.cs
+++ b/src/NineLives.Cli/Verbs/RehearseVerb.cs
@@ -107,11 +107,14 @@ internal static class RehearseVerb
             return ExitCodes.Usage;
         }
 
-        var (sets, sourceContainer, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, sourceContainer, error, loadExit) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);
-            return ExitCodes.Usage;
+            // The loader says which kind of failure this was (#370): a malformed
+            // invocation exits 64, a source that holds nothing for this database
+            // exits 2 - the finding, not a usage error.
+            return loadExit;
         }
 
         var builder = new BackupChainBuilder();

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -153,11 +153,14 @@ internal static class RestoreVerb
             return ExitCodes.Usage;
         }
 
-        var (sets, sourceContainer, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, sourceContainer, error, loadExit) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);
-            return ExitCodes.Usage;
+            // The loader says which kind of failure this was (#370): a malformed
+            // invocation exits 64, a source that holds nothing for this database
+            // exits 2 - the finding, not a usage error.
+            return loadExit;
         }
 
         var builder = new BackupChainBuilder();

--- a/src/NineLives.Cli/Verbs/ScriptVerb.cs
+++ b/src/NineLives.Cli/Verbs/ScriptVerb.cs
@@ -57,7 +57,8 @@ internal static class ScriptVerb
         ExitCodes:
         [
             "0   script emitted",
-            "2   no chain covers the moment asked for",
+            "2   no chain covers the moment asked for, or the source holds no backups for " +
+            "this database",
             "3   the source could not be read at all",
             "64  usage"
         ],
@@ -108,11 +109,14 @@ internal static class ScriptVerb
             }
         }
 
-        var (sets, sourceContainer, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, sourceContainer, error, loadExit) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);
-            return ExitCodes.Usage;
+            // The loader says which kind of failure this was (#370): a malformed
+            // invocation exits 64, a source that holds nothing for this database
+            // exits 2 - the finding, not a usage error.
+            return loadExit;
         }
 
         var points = new BackupChainBuilder().ComputeRestorePoints(sets);

--- a/src/NineLives.Cli/Verbs/ValidateVerb.cs
+++ b/src/NineLives.Cli/Verbs/ValidateVerb.cs
@@ -48,7 +48,8 @@ internal static class ValidateVerb
         ExitCodes:
         [
             "0   every chain intact",
-            "2   something is broken - the stderr lines say what and why",
+            "2   something is broken - the stderr lines say what and why - or the source " +
+            "holds no backups at all for this database, which is the same alarm",
             "3   the source could not be read at all",
             "64  usage"
         ],
@@ -63,11 +64,14 @@ internal static class ValidateVerb
     public static async Task<int> RunAsync(
         CliArguments args, CliServices services, TextWriter output, TextWriter errors)
     {
-        var (sets, _, error) = await InventoryLoader.LoadAsync(args, services);
+        var (sets, _, error, loadExit) = await InventoryLoader.LoadAsync(args, services);
         if (sets == null)
         {
             errors.WriteLine(error);
-            return ExitCodes.Usage;
+            // The loader says which kind of failure this was (#370): a malformed
+            // invocation exits 64, a source that holds nothing for this database
+            // exits 2 - the finding, not a usage error.
+            return loadExit;
         }
 
         var builder = new BackupChainBuilder();

--- a/src/NineLives.Tests/CliExitCodeTests.cs
+++ b/src/NineLives.Tests/CliExitCodeTests.cs
@@ -1,0 +1,138 @@
+using System.IO;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The exit code is the contract a pipeline branches on (#370).
+///
+/// Two ways it lied. An output format changed the verdict: `list --json` returned 0 on a source
+/// holding nothing, while the same command without --json returned 2 and the spec documented 2 -
+/// so adding --json to a monitoring check turned a silent backup failure into a pass, and the
+/// pipeline piped an empty array into jq and did nothing.
+///
+/// And a finding wore a usage error's clothes: "this source has no backups for a database called
+/// Sales" came back as 64, indistinguishable from a malformed command line. A pipeline reading
+/// the documented contract treats 64 as "I invoked it wrongly" - log and abort, never page -
+/// when the correct reading is the alarm the verb exists to raise.
+/// </summary>
+public class CliExitCodeTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static CliServices Stage(params BackupHistoryEntry[] history)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+
+        var sql = new FakeSqlServerService { BackupHistory = history.ToList() };
+        return new CliServices(
+            store, sql, new FakeBlobStorageService(),
+            new FakeRestoreHistoryStore(), new FakeRunNotifier());
+    }
+
+    private static BackupHistoryEntry Full(string database) => new()
+    {
+        DatabaseName = database,
+        Type = BackupType.Full,
+        StartedAt = T0,
+        FinishedAt = T0.AddMinutes(5),
+        CheckpointLsn = 100,
+        Position = 1,
+        Files = [@"X:\backups\full.bak"]
+    };
+
+    private static async Task<(int exit, string output)> RunList(
+        CliServices services, params string[] args)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await ListVerb.RunAsync(
+            CliArguments.Parse(args, ListVerb.Spec), services, output, errors);
+        return (exit, output.ToString());
+    }
+
+    // ── an output format does not change the answer ─────────────────────────────
+
+    [Fact]
+    public async Task AnEmptySourceFailsWhicheverWayItIsPrinted()
+    {
+        var (human, _) = await RunList(Stage(), "--server", "SRV01");
+        var (json, jsonOut) = await RunList(Stage(), "--server", "SRV01", "--json");
+
+        Assert.Equal(ExitCodes.Failed, human);
+        Assert.Equal(ExitCodes.Failed, json);
+
+        // And it still emits parseable JSON - the caller asked for JSON, so it gets JSON.
+        Assert.Equal("[]", jsonOut.Trim());
+    }
+
+    [Fact]
+    public async Task ASourceWithBackupsSucceedsWhicheverWayItIsPrinted()
+    {
+        var (human, _) = await RunList(Stage(Full("Sales")), "--server", "SRV01");
+        var (json, _) = await RunList(Stage(Full("Sales")), "--server", "SRV01", "--json");
+
+        Assert.Equal(ExitCodes.Ok, human);
+        Assert.Equal(ExitCodes.Ok, json);
+    }
+
+    // ── a finding is not a usage error ──────────────────────────────────────────
+
+    /// <summary>
+    /// The alarm case: the source is fine and the database is not in it. That is exactly what
+    /// validate is watched for, and it used to exit 64.
+    /// </summary>
+    [Fact]
+    public async Task ADatabaseWithNoBackupsIsAFindingNotAUsageError()
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+
+        var exit = await ValidateVerb.RunAsync(
+            CliArguments.Parse(
+                ["--server", "SRV01", "--database", "Sales"], ValidateVerb.Spec),
+            Stage(Full("Payroll")), output, errors);
+
+        Assert.Equal(ExitCodes.Failed, exit);
+        Assert.NotEqual(ExitCodes.Usage, exit);
+        Assert.Contains("no backups for a database called 'Sales'", errors.ToString());
+    }
+
+    /// <summary>
+    /// And a genuinely malformed invocation still exits 64, or the distinction is worthless.
+    /// </summary>
+    [Fact]
+    public async Task AMalformedInvocationIsStillAUsageError()
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+
+        // Neither source given.
+        var exit = await ValidateVerb.RunAsync(
+            CliArguments.Parse(["--database", "Sales"], ValidateVerb.Spec),
+            Stage(Full("Sales")), output, errors);
+
+        Assert.Equal(ExitCodes.Usage, exit);
+        Assert.Contains("exactly one source", errors.ToString());
+    }
+
+    [Fact]
+    public async Task AnUnknownContainerNameIsStillAUsageError()
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+
+        var exit = await ValidateVerb.RunAsync(
+            CliArguments.Parse(
+                ["--container", "no-such-container", "--database", "Sales"], ValidateVerb.Spec),
+            Stage(Full("Sales")), output, errors);
+
+        Assert.Equal(ExitCodes.Usage, exit);
+    }
+}


### PR DESCRIPTION
Part of #370. Two ways the exit codes lied to a pipeline.

## An output format changed the verdict

`list --json` returned **0** on a source holding nothing, while the same command without `--json` returned **2** - and the spec documented 2 all along.

So adding `--json` to a monitoring check (which the README recommends for exactly that step) turned a container that had silently stopped receiving backups into a pass, and the pipeline piped `[]` into jq and did nothing.

The empty case now fails either way, and still emits parseable JSON - the caller asked for JSON and gets JSON.

## A finding wore a usage error's clothes

*"This source has no backups for a database called Sales"* came back as **64** - the same code as "give exactly one source" and "no container by that name" - because `InventoryLoader` returned one undifferentiated error string and all six callers mapped it to `Usage`.

A pipeline reading the documented contract treats 64 as *"my invocation is wrong"*: log and abort, never page. The correct reading is the alarm `validate` is watched for.

The loader now returns the exit code alongside the error, so the distinction is made where the knowledge is rather than guessed at six call sites. A malformed invocation still exits 64 - which is what makes the distinction worth anything.

## Verification

1,912 unit tests (5 new: an empty source fails whichever way it is printed, a populated one succeeds either way, a database with no backups is a finding not a usage error, and both a missing source and an unknown container name are still usage errors). Release `-warnaserror` clean.