### PR TITLE
Three places the app said nothing, or the wrong thing (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Three places the app said nothing, or the wrong thing** (#370). The Exposure
+  dashboard's "Open in Restore" button was live on unreachable rows and silently did
+  nothing when pressed - and those are the rows that sort to the top, because they are
+  the alarms; it is now replaced on those rows by the actual next step, which is fixing
+  the connection. The explanation for an empty script pane lived INSIDE that pane, and
+  the two states are mutually exclusive, so every reason it could give - the STANDBY undo
+  file, a log mark on a chain with no logs - was unreachable; it now sits above the pane
+  where it can be read. And a database with no restore points at all was reported as a
+  filter problem, advising somebody to widen filters that the timeline had just reset to
+  fully open - it now says what is actually wrong, which is that a restore has to start
+  from a full backup.
+
 - **The CLI's exit codes stopped contradicting themselves** (#370). Two ways they lied to
   a pipeline. Adding `--json` to `list` changed the VERDICT: the JSON branch returned 0
   on a source holding nothing, while the same command without it returned 2 and the spec

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -1521,6 +1521,67 @@ public class XamlLoadTests(WpfFixture wpf)
         });
     }
 
+    // ── the screen says the true thing (#370) ───────────────────────────────────
+
+    /// <summary>
+    /// The reason there is no script is SHOWN.
+    ///
+    /// It lived inside the pane that holds the script, and the two states are mutually
+    /// exclusive - a non-empty reason is exactly the case where HasScript is false and that
+    /// pane is collapsed. So every explanation it could give was unreachable, and the screen
+    /// showed an empty area and said nothing.
+    /// </summary>
+    [Fact]
+    public void WhyThereIsNoScriptIsActuallyRendered()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            // The reason only arises once generation is being attempted, which is inside the
+            // execute step - so that is the state it has to be legible in.
+            vm.Steps.Execute.IsVisible = true;
+            vm.Steps.Execute.IsExpanded = true;
+
+            typeof(RestoreViewModel).GetProperty(nameof(vm.ScriptBlockedReason))!
+                .SetValue(vm, "STANDBY needs an undo file path.");
+            typeof(RestoreViewModel).GetProperty(nameof(vm.HasScript))!.SetValue(vm, false);
+            Realise(view);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.Contains(shown, t => t.Contains("STANDBY needs an undo file path"));
+        });
+    }
+
+    /// <summary>
+    /// A database with no restore points at all is not a filter problem.
+    ///
+    /// Load resets every filter to open before reporting an empty set, so the "widen the
+    /// filters" text was shown against filters that were already fully open - at the moment
+    /// somebody needed to be told there is no full backup here.
+    /// </summary>
+    [Fact]
+    public void NoRestorePointsAtAllIsNotReportedAsAFilterProblem()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = NewRestoreViewModel();
+            var view = new RestoreView { DataContext = vm };
+            Realise(view);
+
+            // Nothing loaded: no points, and none visible.
+            Assert.False(vm.Timeline.HasPoints);
+            Assert.False(vm.Timeline.HasVisiblePoints);
+
+            var shown = FindAll<TextBlock>(view).Where(IsShown).Select(t => t.Text).ToList();
+
+            Assert.DoesNotContain(shown, t => t.Contains("Widen the range"));
+        });
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────────
 
     private RestoreViewModel NewRestoreViewModel(ICredentialStore? credentialStore = null)

--- a/src/NineLives/Views/ExposureView.xaml
+++ b/src/NineLives/Views/ExposureView.xaml
@@ -115,6 +115,11 @@
                                                Text="{Binding ProvenDisplay}"
                                                ToolTip="When a rehearsal (#238) last PROVED this database restores, and how long the restore plus CHECKDB took - the measured RTO. Arithmetic says what could restore; only a rehearsal says it does." />
 
+                                    <!-- Disabled on an unreachable row, and saying why (#370).
+                                         The handler already refused those with a bare return, so
+                                         the loudest rows on the screen - the ones that sort to the
+                                         top because they are alarms - carried a live button that
+                                         did nothing at all when pressed. -->
                                     <Button Content="Open in Restore"
                                             Command="{Binding DataContext.RestoreFromRowCommand,
                                                       RelativeSource={RelativeSource AncestorType=ItemsControl}}"
@@ -122,7 +127,13 @@
                                             Style="{StaticResource SecondaryButton}"
                                             Padding="10,4" Margin="0,6,0,0"
                                             HorizontalAlignment="Left"
+                                            Visibility="{Binding IsUnreachable, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
                                             ToolTip="Jumps to the Restore screen with this server's backup history loaded and this database selected - one click from seeing to acting. From there, Rehearse proves it." />
+
+                                    <TextBlock Style="{StaticResource SecondaryText}" FontSize="11"
+                                               Margin="0,6,0,0" TextWrapping="Wrap"
+                                               Visibility="{Binding IsUnreachable, Converter={StaticResource BoolToVis}}"
+                                               Text="Nothing can be restored from here until this server answers - fix the connection on the SQL Servers screen." />
                                 </StackPanel>
                             </Grid>
                         </Border>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -7,6 +7,7 @@
     <UserControl.Resources>
         <converters:BoolToVisibilityConverter x:Key="BoolToVis" />
         <converters:NullToVisibilityConverter x:Key="NullToVis" />
+        <converters:StringToVisibilityConverter x:Key="StringToVis" />
         <converters:EnumToBoolConverter x:Key="EnumToBool" />
         <converters:BackupTypeToColorConverter x:Key="TypeToColor" />
         <converters:TimelinePositionConverter x:Key="TimelinePos" />
@@ -737,12 +738,51 @@
                         </Grid>
                     </Border>
 
+                    <!-- Two different emptinesses, two different answers (#370).
+                         Both used to say "widen the filters" - including when there was nothing
+                         to filter, because Load resets every filter to open before it reports
+                         an empty set. That sent somebody to fiddle with checkboxes that were
+                         already fully open, at the moment they needed to be told there is no
+                         full backup here. HasPoints is what separates them. -->
                     <TextBlock Text="No restore point matches these filters. Widen the range or switch a type back on."
-                               Style="{StaticResource SecondaryText}"
                                Foreground="{DynamicResource WarningBrush}"
                                TextWrapping="Wrap"
-                               Margin="0,0,0,12"
-                               Visibility="{Binding Timeline.HasVisiblePoints, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+                               Margin="0,0,0,12">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding Timeline.HasPoints}" Value="True" />
+                                            <Condition Binding="{Binding Timeline.HasVisiblePoints}" Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <TextBlock Text="This database has no restore points. A restore must start from a full backup - check retention, or whether the full backups sit under a different path than the container's pattern expects."
+                               Foreground="{DynamicResource WarningBrush}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,12">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding Timeline.HasPoints}" Value="False" />
+                                            <Condition Binding="{Binding Inventory.SelectedDatabaseName, Converter={StaticResource StringToVis}}" Value="Visible" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
 
                     <!-- ========== VISUAL TIMELINE ========== -->
                     <Border Background="{DynamicResource InputBackgroundBrush}"
@@ -2093,6 +2133,22 @@
                         </TextBlock>
                     </Border>
 
+                    <!-- Why there is no script, OUTSIDE the pane that holds the script (#370).
+                         This lived inside it, and the two states are mutually exclusive: a
+                         non-empty reason is exactly the case where HasScript is false and the
+                         pane is collapsed. So every explanation it could give - the STANDBY
+                         undo file, a log mark on a chain with no logs - was unreachable, and
+                         the screen showed an empty area and said nothing. -->
+                    <Border Background="{DynamicResource WarningPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource WarningBrush}"
+                            BorderThickness="1"
+                            CornerRadius="4" Padding="12,10" Margin="0,0,0,12"
+                            Visibility="{Binding ScriptBlockedReason, Converter={StaticResource StringToVis}}">
+                        <TextBlock Text="{Binding ScriptBlockedReason}"
+                                   Style="{StaticResource BodyText}"
+                                   TextWrapping="Wrap" />
+                    </Border>
+
                     <!-- The generated script. Stays visible during and after execution: it used to
                          be hidden the moment Execute was pressed, so the script and the console
                          shared one slot and you could not see what was running while it ran. -->
@@ -2103,14 +2159,6 @@
                             <Grid Margin="12,8,12,4">
                                 <TextBlock Text="GENERATED SCRIPT" Style="{StaticResource LabelText}" />
 
-                        <!-- Why the pane is empty, where the eye already is - the script builds
-                             itself live, so there is no button to press and no dialog to read. -->
-                        <TextBlock Text="{Binding ScriptBlockedReason}"
-                                   Style="{StaticResource SecondaryText}"
-                                   TextWrapping="Wrap"
-                                   Margin="0,6,0,0">
-                            <TextBlock.Resources />
-                        </TextBlock>
                                 <TextBlock Text="updates as you change options"
                                            Style="{StaticResource SecondaryText}"
                                            FontSize="11"


### PR DESCRIPTION
Part of #370.

## Exposure's dead button

"Open in Restore" was live on unreachable rows and did nothing when pressed - the handler refused those with a bare `return`, no message. Those rows sort to the **top**, because they are the alarms, so the loudest thing on the dashboard carried a button that did nothing. Unreachable rows now show the actual next step instead: fix the connection on the SQL Servers screen.

## An explanation that could never render

`ScriptBlockedReason` lived **inside** the script pane, and the two states are mutually exclusive - a non-empty reason is exactly the case where `HasScript` is false and that pane collapses. So every reason it could give was unreachable. Somebody who set STANDBY without an undo file, or picked a log mark on a chain with no log backups, saw an empty area and no explanation - while the Execute button offered the wrong diagnosis ("pick a restore point and a target database name").

It now sits above the pane, where it renders precisely when there is no script to show.

## A filter problem that wasn't

A database with no restore points at all was reported as *"No restore point matches these filters. Widen the range or switch a type back on."* - but `Load` resets every filter to open before reporting an empty set, so that advice pointed at filters that were already fully open. It now says what is actually wrong: a restore has to start from a full backup, so check retention or the container's path pattern.

`HasPoints` is what separates the two emptinesses. It existed already and was bound nowhere.

## Verification

1,914 unit tests (2 new, both asserting against a **realised visual tree** - every one of these was invisible at the view-model level, which is how all three survived this long). Release `-warnaserror` clean.