### PR TITLE
The CLI says what it does (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The CLI says what it does** (#370). A scripted restore always issued
+  `ALTER DATABASE ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE` and never mentioned it -
+  a capability the app presents as a tick box was invisible and unrefusable from a
+  script, and since MULTI_USER is only restored after the whole chain succeeds, a chain
+  that failed part way left the database single-user. There is now `--keep-sessions`,
+  and the default behaviour is documented on the verb's own page. A refusal under
+  `--json` now answers in JSON rather than putting a page of T-SQL on stdout, or nothing
+  at all - which was the one path a wrapper most needs to read. And `--ephemeral` is
+  matched without regard to case like every other option, with `NINELIVES_S3_REGION`
+  named in the help that had always omitted it.
+
 - **Three places the app said nothing, or the wrong thing** (#370). The Exposure
   dashboard's "Open in Restore" button was live on unreachable rows and silently did
   nothing when pressed - and those are the rows that sort to the top, because they are

--- a/src/NineLives.Cli/HelpWriter.cs
+++ b/src/NineLives.Cli/HelpWriter.cs
@@ -38,8 +38,10 @@ internal static class HelpWriter
             "agents where nothing may outlive the job. NINELIVES_SERVER (address, resolvable " +
             "as the name NINELIVES_SERVER_NAME or 'env'), NINELIVES_SQL_USER and " +
             "NINELIVES_SQL_PASSWORD (SQL auth; omit both for Windows auth), " +
-            "NINELIVES_CONTAINER_URL (resolvable as NINELIVES_CONTAINER_NAME or 'env') and " +
-            "NINELIVES_SAS. Secrets stay in process memory; history receipts still write and " +
+            "NINELIVES_CONTAINER_URL (resolvable as NINELIVES_CONTAINER_NAME or 'env'), " +
+            "NINELIVES_SAS - the SAS token, or for an s3:// URL the pair AccessKeyId:SecretKey - " +
+            "and NINELIVES_S3_REGION, for a bucket whose region its host name does not carry. " +
+            "Secrets stay in process memory; history receipts still write and " +
             "webhooks still fire - they are the point.");
         output.WriteLine();
         Wrapped(output,

--- a/src/NineLives.Cli/Program.cs
+++ b/src/NineLives.Cli/Program.cs
@@ -12,6 +12,10 @@ namespace Blackcat.NineLives.Cli;
 /// </summary>
 internal static class Program
 {
+    /// <summary>The one switch that belongs to the invocation rather than to a verb.</summary>
+    private static bool IsEphemeral(string arg) =>
+        string.Equals(arg, "--ephemeral", StringComparison.OrdinalIgnoreCase);
+
     private static async Task<int> Main(string[] rawArgs)
     {
         Console.OutputEncoding = Encoding.UTF8;
@@ -82,12 +86,14 @@ internal static class Program
         // to the invocation, not to any one verb - and it is an explicit switch so the
         // command line SAYS it, rather than depending on invisible environment state.
         var verbArgs = rawArgs.Skip(1).ToArray();
-        var ephemeral = verbArgs.Any(a => a is "--ephemeral");
+        // Case-insensitive, like every other option the parser handles (#370). This was
+        // the one flag where --EPHEMERAL came back as an unknown argument.
+        var ephemeral = verbArgs.Any(IsEphemeral);
         ServerConnection? envServer = null;
         BlobContainerConfig? envContainer = null;
         if (ephemeral)
         {
-            verbArgs = verbArgs.Where(a => a is not "--ephemeral").ToArray();
+            verbArgs = verbArgs.Where(a => !IsEphemeral(a)).ToArray();
             envServer = EnvironmentCredentials.Server(Environment.GetEnvironmentVariable);
             envContainer = EnvironmentCredentials.Container(Environment.GetEnvironmentVariable);
             if (envServer == null && envContainer == null)

--- a/src/NineLives.Cli/Verbs/BackupVerb.cs
+++ b/src/NineLives.Cli/Verbs/BackupVerb.cs
@@ -168,6 +168,20 @@ internal static class BackupVerb
         if (BackupDestinationBuilder.DescribeTooLong(destinations) is { } tooLong)
         {
             errors.WriteLine($"REFUSED: {tooLong}");
+
+            // A refusal is an ending like any other, so --json gets an object here too (#370).
+            // It used to put nothing on stdout at all, which is the one path a wrapper most
+            // needs to read: why did this not run?
+            if (args.Has("json"))
+                CliRunResult.Write(output, new
+                {
+                    Verb = "backup",
+                    Outcome = "Refused",
+                    Server = server.ServerName,
+                    Database = database,
+                    Refusals = new[] { tooLong }
+                });
+
             return ExitCodes.Usage;
         }
 
@@ -195,7 +209,22 @@ internal static class BackupVerb
             if (!preflight.CanProceed)
             {
                 errors.WriteLine($"REFUSED: {preflight.Refusal}");
-                if (!args.Has("execute")) output.WriteLine(script);
+
+                // Under --json the ending is an object, not a T-SQL script (#370). Printing the
+                // script onto stdout here handed a jq pipeline a page of SQL where it expected
+                // the reason.
+                if (args.Has("json"))
+                    CliRunResult.Write(output, new
+                    {
+                        Verb = "backup",
+                        Outcome = "Refused",
+                        Server = server.ServerName,
+                        Database = database,
+                        Refusals = new[] { preflight.Refusal }
+                    });
+                else if (!args.Has("execute"))
+                    output.WriteLine(script);
+
                 return ExitCodes.Failed;
             }
         }

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -26,7 +26,8 @@ internal static class RestoreVerb
         "[--stop-before-mark NAME | --stop-at-mark NAME] [--execute] [--force] [--json]",
         Valued: ["container", "server", "database", "at", "target", "target-database",
                  "stop-before-mark", "stop-at-mark", "data-path", "log-path"],
-        Switches: ["execute", "with-replace", "norecovery", "force", "relocate", "json"],
+        Switches: ["execute", "with-replace", "norecovery", "force", "relocate", "json",
+                   "keep-sessions"],
         Options:
         [
             ("--container NAME", "A blob container configured in the app, as the source."),
@@ -52,6 +53,12 @@ internal static class RestoreVerb
             ("--stop-at-mark NAME", "Stop at the mark, inclusive."),
             ("--execute", "Actually run it. Without this, the script and every preflight " +
                 "verdict print and nothing is touched."),
+            ("--keep-sessions", "Leave other connections alone. The default disconnects them - " +
+                "ALTER DATABASE ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE, rolling back " +
+                "whatever they were doing - because a restore cannot begin while anybody is " +
+                "connected. The database is put back to MULTI_USER after the whole chain " +
+                "succeeds, so a chain that fails part way leaves it single-user until somebody " +
+                "says otherwise; pass this to keep that decision your own."),
             ("--force", "Override what the EVIDENCE says - version direction, missing TDE " +
                 "certificate, unreadable files - loudly, as warnings. It cannot stand in " +
                 "for --with-replace: evidence is overridable, consent is not."),
@@ -220,6 +227,11 @@ internal static class RestoreVerb
             TargetDatabaseName = targetDatabase,
             WithReplace = withReplace,
             RecoveryMode = args.Has("norecovery") ? RecoveryMode.NoRecovery : RecoveryMode.Recovery,
+
+            // Kicking the other sessions out is the default here as it is in the app, because a
+            // restore cannot begin while anybody is connected - but the app makes it a visible
+            // tick box and the CLI made it silent and unrefusable (#370).
+            DisconnectSessions = !args.Has("keep-sessions"),
             StopAt = stopAt,
             StopAtMark = mark,
             StopBeforeMark = markAt == null,

--- a/src/NineLives.Tests/CliSaysWhatItDoesTests.cs
+++ b/src/NineLives.Tests/CliSaysWhatItDoesTests.cs
@@ -1,0 +1,154 @@
+using System.IO;
+using System.Text.Json;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// What the CLI does, and what it says it does (#370).
+///
+/// Three ways those had come apart: a restore always kicked every other session out of the
+/// database and never mentioned it, a refusal under --json put something other than JSON on
+/// stdout, and the ephemeral switch was documented as working on any verb while being matched
+/// more strictly than every other option.
+/// </summary>
+public class CliSaysWhatItDoesTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private const string ContainerUrl = "https://acct.blob.core.windows.net/backups";
+
+    private static (CliServices services, FakeSqlServerService sql) Stage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        var container = new BlobContainerConfig
+        { Id = "c1", Name = "backups", ContainerUrl = ContainerUrl };
+        store.Config.BlobContainers.Add(container);
+        store.SaveSasToken(container, "sv=2026&sig=secret");
+
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "MyDb",
+                    Type = BackupType.Full,
+                    StartedAt = T0,
+                    FinishedAt = T0.AddMinutes(5),
+                    CheckpointLsn = 100,
+                    Position = 1,
+                    Files = [@"X:\backups\full.bak"]
+                }
+            ]
+        };
+
+        return (new CliServices(
+            store, sql, new FakeBlobStorageService(),
+            new FakeRestoreHistoryStore(), new FakeRunNotifier()), sql);
+    }
+
+    private static async Task<(int exit, string output, string errors)> Run(
+        Func<CliArguments, CliServices, TextWriter, TextWriter, CancellationToken, Task<int>> verb,
+        VerbSpec spec, string[] args, CliServices services)
+    {
+        var output = new StringWriter();
+        var errors = new StringWriter();
+        var exit = await verb(CliArguments.Parse(args, spec), services, output, errors, default);
+        return (exit, output.ToString(), errors.ToString());
+    }
+
+    // ── the sessions it disconnects ─────────────────────────────────────────────
+
+    /// <summary>
+    /// The default still disconnects - a restore cannot begin while anybody is connected - but
+    /// it is now sayable, which is what the app's tick box has always been.
+    /// </summary>
+    [Fact]
+    public async Task ARestoreDisconnectsSessionsUnlessToldOtherwise()
+    {
+        var (services, _) = Stage();
+
+        var (_, withDefault, _) = await Run(RestoreVerb.RunAsync, RestoreVerb.Spec,
+            ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02"], services);
+
+        Assert.Contains("SET SINGLE_USER", withDefault);
+
+        var (services2, _) = Stage();
+        var (_, kept, _) = await Run(RestoreVerb.RunAsync, RestoreVerb.Spec,
+            ["--server", "SRV01", "--database", "MyDb", "--target", "SRV02", "--keep-sessions"],
+            services2);
+
+        Assert.DoesNotContain("SET SINGLE_USER", kept);
+    }
+
+    // ── a refusal under --json is still JSON ────────────────────────────────────
+
+    /// <summary>
+    /// The path a wrapper most needs to read is why something did NOT run. It used to put a
+    /// page of T-SQL on stdout instead, or nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task ABackupRefusedForItsUrlLengthStillAnswersInJson()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+
+        // A container deep enough to push the destination past the engine's 259-character cap.
+        var container = new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "s3://s3.eu-west-2.amazonaws.com/" + new string('b', 60) + "/" + new string('p', 60),
+            PathPattern = "{BackupType}/{ServerName}/{DatabaseName}/{FileName}"
+        };
+        store.Config.BlobContainers.Add(container);
+        store.SaveSasToken(container, "AKID:secret");
+
+        var services = new CliServices(
+            store, new FakeSqlServerService(), new FakeBlobStorageService(),
+            new FakeRestoreHistoryStore(), new FakeRunNotifier());
+
+        var (exit, output, _) = await Run(BackupVerb.RunAsync, BackupVerb.Spec,
+            ["--server", "SRV01", "--container", "backups",
+             "--database", new string('d', 60), "--type", "full", "--json"],
+            services);
+
+        Assert.Equal(ExitCodes.Usage, exit);
+
+        // Parseable, and it says why - not a T-SQL script, not an empty stream.
+        var parsed = JsonDocument.Parse(output).RootElement;
+        Assert.Equal("Refused", parsed.GetProperty("outcome").GetString());
+        Assert.True(parsed.GetProperty("refusals").GetArrayLength() > 0);
+    }
+
+    // ── the switch that spans every verb ────────────────────────────────────────
+
+    /// <summary>
+    /// Every other option is matched without regard to case; this one was not, so --EPHEMERAL
+    /// came back as an unknown argument on a switch the overview says works anywhere.
+    /// </summary>
+    [Theory]
+    [InlineData("--ephemeral")]
+    [InlineData("--EPHEMERAL")]
+    [InlineData("--Ephemeral")]
+    public void TheEphemeralSwitchIsRecognisedWhateverItsCase(string spelling)
+    {
+        var recognised = typeof(Program)
+            .GetMethod("IsEphemeral", System.Reflection.BindingFlags.NonPublic
+                                      | System.Reflection.BindingFlags.Static)!
+            .Invoke(null, [spelling]);
+
+        Assert.True((bool)recognised!);
+    }
+}


### PR DESCRIPTION
Part of #370. Three places where what the CLI did and what it said had come apart.

## It disconnected every session, silently

A scripted restore always issued `ALTER DATABASE ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE`, documented nowhere. The app makes that a visible tick box; the CLI made it invisible and unrefusable.

It matters more than a missing option: `MULTI_USER` is only restored after the **whole chain** succeeds, so a chain that fails part way leaves the database single-user - a locked production database as the residue of a run that refused itself.

`--keep-sessions` now exists, and the default is written on the verb's own page.

## A refusal under `--json` was not JSON

The length refusal put **nothing** on stdout; the credential refusal printed the raw **T-SQL script** there - handing a jq pipeline a page of SQL where it expected the reason. That is the one path a wrapper most needs to read. Both now emit the same `Outcome: "Refused"` shape `restore` already used.

## `--ephemeral` was matched more strictly than everything else

Ordinal and case-sensitive, while every other option is matched case-insensitively - so `--EPHEMERAL` came back as an unknown argument, on a switch the overview says works on any verb. And `NINELIVES_S3_REGION`, read by the code since the S3 work landed, was named in no help text despite every other variable being listed.

## Verification

1,919 unit tests (5 new: the default still disconnects and `--keep-sessions` does not, a length-refused backup answers in parseable JSON with its reason, and the ephemeral switch is recognised in three casings). Release `-warnaserror` clean; the help-drift tests still hold every documented option to the parser.