### PR TITLE
Prepare v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-11
+
 ### Added
 
 - **A front door** (#343). Choosing a mode now lands on Home: what Nine Lives is in a
@@ -121,7 +123,6 @@ more detail on the user-facing changes; this file is the short history.
   belongs to the rehearsal alone; a failed run still retains its scratch copy as evidence until
   the next run has been seen (#259)
 
-### Added
 
 - **The CLI: 9lives.exe** (#63). The restore engine from a terminal - the same chain
   calculation, striped-set grouping and script generation the app runs, against the same
@@ -177,6 +178,20 @@ more detail on the user-facing changes; this file is the short history.
   two servers both backing up a database called Sales are the everyday DR pair, and a mixed
   list meant guessing whose history the timeline would show. One instance answers its own
   filter automatically; the database choice itself always stays with the user
+
+### Changed
+
+- **The screens stopped assuming Azure** (#51). "Azure Blob Storage" as a backup
+  source, destination or browse medium now reads "Cloud storage" - a saved container,
+  whichever provider answers it - across Restore, Back Up, Copy Database and Browse
+  Backups, with labels, empty-states and the delete-container dialog following. The
+  genuinely Azure-specific texts (Entra guidance, SAS specifics) still say Azure,
+  because there they mean it.
+
+- The engine - every service and model - now lives in NineLives.Core, a library with no UI
+  framework behind it. Nothing a user can see is different; this is the load-bearing wall for
+  the command-line front end (#63), where the same chain calculation, the same preflights and
+  the same script generation must run without a window ever existing
 
 ### Fixed
 
@@ -336,21 +351,6 @@ more detail on the user-facing changes; this file is the short history.
   because the fix is always in one of its parts. Easy to reach with a long endpoint, a base
   path and the default four-segment pattern; striping makes every stripe carry it.
 
-### Changed
-
-- **The screens stopped assuming Azure** (#51). "Azure Blob Storage" as a backup
-  source, destination or browse medium now reads "Cloud storage" - a saved container,
-  whichever provider answers it - across Restore, Back Up, Copy Database and Browse
-  Backups, with labels, empty-states and the delete-container dialog following. The
-  genuinely Azure-specific texts (Entra guidance, SAS specifics) still say Azure,
-  because there they mean it.
-
-- The engine - every service and model - now lives in NineLives.Core, a library with no UI
-  framework behind it. Nothing a user can see is different; this is the load-bearing wall for
-  the command-line front end (#63), where the same chain calculation, the same preflights and
-  the same script generation must run without a window ever existing
-
-### Fixed
 
 - **Two processes cannot lose each other's receipts** (#298). The restore history's
   read-modify-write was serialised in-process only - and the CLI made it two processes: a

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>


### PR DESCRIPTION
Part of #366 - the preparation, not the publish.

Fifty-odd commits have landed since v1.5.0, including two things that are not increments: **a second front end and a second storage provider**. The README documents both in the present tense, and neither exists in anything anybody can download - `git ls-tree v1.5.0 src/` has no `NineLives.Cli` and no `NineLives.Core`. Somebody reading about `9lives.exe`, downloading the release and finding no such file concludes the download is broken, which is the correct conclusion from what they can see.

## What this changes

- **CHANGELOG reorganised.** The Unreleased section could not be turned into release notes as it stood: two `### Added` blocks, two `### Fixed` blocks, and a `### Changed` between them - not the shape the file's own header promises. Now one section per type in Keep a Changelog order, moved under `## [1.6.0] - 2026-08-11`. Entry text is untouched and all **67** entries are accounted for before and after (asserted while rewriting, not eyeballed).
- **Version bumped to 1.6.0** in all three projects - which is also what `check-version-bump.yml` requires before dev can reach main.

1.6.0 rather than 1.5.1 because a new front end and a new storage provider are not a patch.

## What this does not change

Screenshots are still from v1.0.0 and show a five-item sidebar against today's ten. Worth reshooting - not worth holding a release that fixes a chain builder pairing two servers' backups together.

## Verification

1,919 unit tests, Release `-warnaserror` clean, and both published exes stamp `1.6.0+e4d4f81`.

## After this merges

The release itself is an outward-facing publish, so I have left it: it needs a `dev` -> `main` PR and then a tagged release, which is what triggers `release.yml` to build and attach both exes for both architectures with checksums and provenance.