### PR TITLE
Three things that destroyed something without saying so (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Three things that destroyed something without saying so** (#370). Shortening the log
+  retention deleted files immediately and silently - on the same screen that calls them a
+  restore's own record, needed later by a change ticket. It now says how many would go and
+  asks, and only when something actually would. Removing a webhook took the URL with it on
+  one click; the URL is a secret the app never displays back, and most carry their own
+  token, so that was the only copy - it now asks, like the container and server lists do.
+  And a history file that exists but cannot be read was reported as "No restores recorded
+  yet", which is the opposite fact: Clear sat one press away from writing an empty file
+  over every receipt it holds. The screen now says the file is unreadable and names it,
+  and Clear refuses to touch it.
+
 ## [1.6.0] - 2026-08-11
 
 ### Added

--- a/src/NineLives.Core/Services/OperationLog.cs
+++ b/src/NineLives.Core/Services/OperationLog.cs
@@ -129,6 +129,32 @@ public sealed class OperationLog
     /// Drops files past the retention window. Called once at startup rather than on every write -
     /// enumerating a directory to append one line would be silly.
     /// </summary>
+    /// <summary>
+    /// How many log files a given retention would delete, without deleting any of them (#370).
+    ///
+    /// Shortening the retention destroys evidence: the screen that offers the setting says in
+    /// its own words that a restore's record lives in these files and a change ticket may need
+    /// it later. Asking first is only reasonable if the question can say what is at stake, and
+    /// asking at all is only reasonable when something actually goes.
+    /// </summary>
+    public int CountPrunable(int retentionDays)
+    {
+        try
+        {
+            if (!System.IO.Directory.Exists(_directory)) return 0;
+
+            var cutoff = DateTime.Now.AddDays(-Math.Max(1, retentionDays));
+            return System.IO.Directory
+                .EnumerateFiles(_directory, "ninelives-*.log")
+                .Count(f => File.GetLastWriteTime(f) < cutoff);
+        }
+        catch
+        {
+            // Counting must not be able to fail the thing that asked.
+            return 0;
+        }
+    }
+
     public void Prune()
     {
         try

--- a/src/NineLives.Core/Services/RestoreHistoryStore.cs
+++ b/src/NineLives.Core/Services/RestoreHistoryStore.cs
@@ -9,6 +9,16 @@ public interface IRestoreHistoryStore
     /// <summary>Most recent first. Never throws - an unreadable history is not worth an error dialog.</summary>
     List<RestoreHistoryEntry> Load();
 
+    /// <summary>
+    /// True when the file is there and could not be read (#370).
+    ///
+    /// Load answers an empty list either way, and the two mean opposite things: one is a fresh
+    /// install, the other is a history that exists and is unreadable. Reporting the second as
+    /// "no restores recorded yet" hides it - and then Clear, offered right next to that
+    /// sentence, would overwrite a file that may still hold every receipt.
+    /// </summary>
+    bool CouldNotRead { get; }
+
     /// <summary>Adds one execution. Never throws: recording history must not be able to fail a restore.</summary>
     void Append(RestoreHistoryEntry entry);
 
@@ -117,11 +127,16 @@ public sealed class RestoreHistoryStore : IRestoreHistoryStore
 
     public string FilePath => _path;
 
+    /// <inheritdoc />
+    public bool CouldNotRead { get; private set; }
+
     public List<RestoreHistoryEntry> Load()
     {
         lock (_gate)
         {
-            return ReadUnlocked() ?? [];
+            var entries = ReadUnlocked();
+            CouldNotRead = entries == null;
+            return entries ?? [];
         }
     }
 

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -199,6 +199,9 @@ public sealed class FakeRestoreHistoryStore : IRestoreHistoryStore
 
     public string FilePath => "(in memory)";
 
+    /// <summary>Set to play a history file that exists and cannot be read (#370).</summary>
+    public bool CouldNotRead { get; set; }
+
     public List<RestoreHistoryEntry> Load() => Entries.ToList();
 
     public void Append(RestoreHistoryEntry entry) => Entries.Insert(0, entry);

--- a/src/NineLives.Tests/QuietDestructionTests.cs
+++ b/src/NineLives.Tests/QuietDestructionTests.cs
@@ -1,0 +1,115 @@
+using System.IO;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Things that destroyed something without saying so (#370).
+///
+/// The pattern in each: an action whose cost is invisible at the moment it is taken. Shortening
+/// log retention deletes files the same screen calls evidence for a change ticket. An unreadable
+/// history renders as an empty one, and Clear sits beside it. Neither asked, and neither could
+/// be undone.
+/// </summary>
+public class QuietDestructionTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(
+        Path.GetTempPath(), "ninelives-quiet-" + Guid.NewGuid().ToString("n"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    // ── the count that makes the question worth asking ──────────────────────────
+
+    /// <summary>
+    /// Counting is not deleting. The confirmation needs a number before it can be honest about
+    /// what is at stake, and asking that question must not itself destroy anything.
+    /// </summary>
+    [Fact]
+    public void CountingWhatARetentionWouldDeleteDeletesNothing()
+    {
+        Directory.CreateDirectory(_dir);
+
+        var old = Path.Combine(_dir, "ninelives-20260101.log");
+        var fresh = Path.Combine(_dir, "ninelives-20260810.log");
+        File.WriteAllText(old, "old");
+        File.WriteAllText(fresh, "fresh");
+        File.SetLastWriteTime(old, DateTime.Now.AddDays(-40));
+        File.SetLastWriteTime(fresh, DateTime.Now.AddDays(-1));
+
+        var log = new OperationLog(_dir);
+
+        Assert.Equal(1, log.CountPrunable(30));
+        Assert.Equal(0, log.CountPrunable(90));
+
+        // Both files still there - the question was asked, not acted on.
+        Assert.True(File.Exists(old));
+        Assert.True(File.Exists(fresh));
+    }
+
+    /// <summary>A retention that loses nothing should not interrupt anybody.</summary>
+    [Fact]
+    public void ARetentionThatDestroysNothingCountsZero()
+    {
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path.Combine(_dir, "ninelives-20260810.log"), "fresh");
+
+        Assert.Equal(0, new OperationLog(_dir).CountPrunable(30));
+    }
+
+    // ── an unreadable history is not an empty one ───────────────────────────────
+
+    [Fact]
+    public void AnUnreadableHistorySaysSoRatherThanReportingNothingRecorded()
+    {
+        var store = new FakeRestoreHistoryStore { CouldNotRead = true };
+        var vm = new HistoryViewModel(store);
+
+        vm.Refresh();
+
+        Assert.True(vm.HasError);
+        Assert.Contains("could not be read", vm.ErrorMessage);
+        Assert.DoesNotContain("No restores recorded yet", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// The one that matters: Clear would write an empty file over one that may still hold every
+    /// receipt, and the screen was telling the user there was nothing in it.
+    /// </summary>
+    [Fact]
+    public void ClearRefusesOverAHistoryItCouldNotRead()
+    {
+        var store = new FakeRestoreHistoryStore { CouldNotRead = true };
+        store.Entries.Add(new Models.RestoreHistoryEntry { TargetDatabase = "Sales" });
+
+        var vm = new HistoryViewModel(store);
+
+        vm.ClearHistoryCommand.Execute(null);
+        vm.ClearHistoryCommand.Execute(null);
+
+        Assert.False(vm.IsClearArmed);
+        Assert.NotEmpty(store.Entries);
+        Assert.Contains("could not be read", vm.ErrorMessage);
+    }
+
+    /// <summary>A readable history still clears, on the second press, exactly as before.</summary>
+    [Fact]
+    public void AReadableHistoryStillClearsOnTheSecondPress()
+    {
+        var store = new FakeRestoreHistoryStore();
+        store.Entries.Add(new Models.RestoreHistoryEntry { TargetDatabase = "Sales" });
+
+        var vm = new HistoryViewModel(store);
+
+        vm.ClearHistoryCommand.Execute(null);
+        Assert.True(vm.IsClearArmed);
+        Assert.NotEmpty(store.Entries);
+
+        vm.ClearHistoryCommand.Execute(null);
+        Assert.Empty(store.Entries);
+    }
+}

--- a/src/NineLives/ViewModels/HistoryViewModel.cs
+++ b/src/NineLives/ViewModels/HistoryViewModel.cs
@@ -53,9 +53,17 @@ public partial class HistoryViewModel : ViewModelBase
         // Selecting the newest is what someone opening this view is nearly always after: the
         // restore they just ran.
         SelectedEntry = Entries.FirstOrDefault();
-        SetStatus(HasEntries
-            ? $"{_all.Count} restore(s) recorded."
-            : "No restores recorded yet.");
+        // "Nothing here" and "cannot read what is here" are opposite facts, and both used to
+        // arrive as an empty list (#370). Reporting the second as the first hides a damaged
+        // file - and Clear sits on this screen, one click from overwriting it.
+        if (_history.CouldNotRead)
+            SetError(
+                "The history file exists but could not be read, so this list is not what it " +
+                "holds. Do not clear it - copy it somewhere safe first: " + _history.FilePath);
+        else
+            SetStatus(HasEntries
+                ? $"{_all.Count} restore(s) recorded."
+                : "No restores recorded yet.");
     }
 
     partial void OnFilterTextChanged(string value) => ApplyFilter();
@@ -151,6 +159,18 @@ public partial class HistoryViewModel : ViewModelBase
     [RelayCommand]
     private void ClearHistory()
     {
+        // Never over a file that could not be read (#370). The list is empty because the read
+        // failed, not because there is nothing there - clearing would write an empty file over
+        // what may still hold every receipt, and a receipt is the proof a restore happened.
+        if (_history.CouldNotRead)
+        {
+            IsClearArmed = false;
+            SetError(
+                "This history could not be read, so there is no telling what clearing it would " +
+                "destroy. Move or repair the file first: " + _history.FilePath);
+            return;
+        }
+
         if (!IsClearArmed)
         {
             IsClearArmed = true;

--- a/src/NineLives/ViewModels/SettingsViewModel.cs
+++ b/src/NineLives/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using Blackcat.NineLives.Models;
 using System.IO;
+using System.Windows;
 using Blackcat.NineLives.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -108,6 +109,19 @@ public partial class SettingsViewModel : ViewModelBase
     private void RemoveWebhook(WebhookEndpointViewModel? row)
     {
         if (row == null) return;
+
+        // A webhook URL is a secret this app never displays back - most carry their own token
+        // in the path - so removing one destroys the only copy it holds, on a single click, with
+        // nothing to undo with (#370). The same question the container and server lists ask.
+        var confirm = MessageBox.Show(
+            $"Remove the webhook \"{row.Name}\"?\n\n" +
+            "Its URL is stored in Windows Credential Manager and never displayed, so if this is " +
+            "the only copy you will need the original to add it back.\n\n" +
+            "Runs will stop being announced to it. Nothing else changes.",
+            "Nine Lives", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
+
+        if (confirm != MessageBoxResult.Yes) return;
+
         Webhooks.Remove(row);
         SaveWebhooks();
     }
@@ -255,6 +269,10 @@ public partial class SettingsViewModel : ViewModelBase
     /// <summary>True while the constructor is filling the properties from config.</summary>
     private readonly bool _loading;
 
+    /// <summary>Set while putting the retention box back, so the revert does not
+    /// re-enter its own handler and ask again (#370).</summary>
+    private bool _revertingRetention;
+
     public SettingsViewModel(ICredentialStore credentialStore, OperationLog? log = null)
     {
         _credentialStore = credentialStore;
@@ -366,7 +384,34 @@ public partial class SettingsViewModel : ViewModelBase
     /// </summary>
     partial void OnLogRetentionDaysChanged(int value)
     {
-        if (_loading) return;
+        if (_loading || _revertingRetention) return;
+
+        // Asked before anything is deleted, and only when something would be (#370).
+        //
+        // This screen's own words are that a restore's record lives in these files and a change
+        // ticket may need the evidence later - and then it deleted them on the way past, with
+        // no question and nothing to undo with. The count is what makes the question worth
+        // asking: shortening retention on a machine that has nothing old enough to lose is not
+        // a decision, and should not be interrupted like one.
+        var doomed = _log.CountPrunable(value);
+        if (doomed > 0)
+        {
+            var confirm = MessageBox.Show(
+                $"Keeping logs for {value} day(s) deletes {doomed} log file(s) now.\n\n" +
+                "A restore's own record lives in these files. If a change ticket or an incident " +
+                "review might need the evidence, copy them out first - Open log folder is on " +
+                "this screen.\n\nDelete them?",
+                "Nine Lives", MessageBoxButton.YesNo, MessageBoxImage.Warning, MessageBoxResult.No);
+
+            if (confirm != MessageBoxResult.Yes)
+            {
+                // Put the box back to what is actually in force, without re-entering this.
+                _revertingRetention = true;
+                LogRetentionDays = _log.RetentionDays;
+                _revertingRetention = false;
+                return;
+            }
+        }
 
         _log.RetentionDays = value;
         _log.Prune();


### PR DESCRIPTION
Part of #370. Each is an action whose cost was invisible at the moment it was taken.

## Log retention deleted evidence, silently

Shortening it pruned immediately - on the same screen that says *"A restore's own record lives here, so a change ticket that needs the evidence later needs this set high enough to keep it."*

It now counts what would go, says the number, and asks. **Only when something actually would**: interrupting somebody whose machine has nothing old enough to lose would just teach them to click through the question that matters.

`CountPrunable` is deliberately separate from `Prune` - asking a question must not be able to answer it.

## Removing a webhook took its URL with it

One click, no question. The URL is a secret the app never displays back and most carry their own token in the path, so that was the only copy the machine held. It now asks the way the container and server lists do, and says what is lost rather than just "are you sure".

## An unreadable history looked like an empty one

`Load` answered an empty list whether the file was absent or unreadable, so a damaged history rendered as *"No restores recorded yet"* - the opposite fact - with **Clear one press away from writing an empty file over every receipt it may still hold**.

The store now reports `CouldNotRead`; the screen says so and names the file; and Clear refuses outright rather than arming.

## Verification

1,924 unit tests (5 new: counting deletes nothing and is zero when nothing is at stake, an unreadable history says so, Clear refuses over one, and a readable history still clears on the second press). Release `-warnaserror` clean.