### PR TITLE
Copy Database says what it overwrites, and Esc reaches what writes (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Copy Database says which database it is about to overwrite** (#370). It defaults to
+  overwriting, which is usually the point - a test environment being refreshed - but the
+  only thing saying so was a ticked checkbox. The property that would have said it out
+  loud has existed since the screen was written, with a comment calling this the part
+  that destroys something, and it was bound to nothing. It now names the database and the
+  server, because the risk on this screen is doing it to the wrong one.
+
+- **Esc reaches the two other screens that write, and F5 reaches Exposure** (#370). The
+  stop key stopped a restore and ignored a running backup or copy - both of which are
+  writing while they run - so it worked in one of the three places something is being
+  written. F5 refreshed Restore, Browse and History but not the one screen whose whole
+  content is a snapshot of an estate that moves underneath it.
+
 - **Three things that destroyed something without saying so** (#370). Shortening the log
   retention deleted files immediately and silently - on the same screen that calls them a
   restore's own record, needed later by a change ticket. It now says how many would go and

--- a/src/NineLives.Tests/ExpectedResponsesTests.cs
+++ b/src/NineLives.Tests/ExpectedResponsesTests.cs
@@ -1,0 +1,76 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Things the app should say, and keys it should answer (#370).
+///
+/// A copy overwrites a database, and said so only through a ticked checkbox - while the
+/// property that would have said it out loud existed, documented, bound to nothing. And Esc
+/// reached the restore but not the two other screens that write, so the stop key worked
+/// everywhere except two of the three places something is being written.
+/// </summary>
+public class ExpectedResponsesTests
+{
+    // ── the copy says what it will overwrite ────────────────────────────────────
+
+    private static CopyDatabaseViewModel Copy()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        return new CopyDatabaseViewModel(store, new FakeSqlServerService());
+    }
+
+    [Fact]
+    public void AnOverwritingCopyNamesWhatItWillReplace()
+    {
+        var vm = Copy();
+        vm.TargetServer = vm.Servers.Last();
+        vm.TargetDatabaseName = "SalesTest";
+        vm.WithReplace = true;
+
+        Assert.True(vm.WillOverwriteTheTarget);
+
+        // The database and the server both, because the risk of this screen is doing it to the
+        // wrong one - a generic "the target will be overwritten" is what eyes slide off.
+        Assert.Contains("SalesTest", vm.OverwriteWarning);
+        Assert.Contains("SRV02", vm.OverwriteWarning);
+    }
+
+    [Fact]
+    public void ACopyThatOverwritesNothingSaysNothing()
+    {
+        var vm = Copy();
+        vm.TargetServer = vm.Servers.Last();
+        vm.TargetDatabaseName = "SalesTest";
+        vm.WithReplace = false;
+
+        Assert.False(vm.WillOverwriteTheTarget);
+    }
+
+    // ── Esc reaches everything that writes ──────────────────────────────────────
+    //
+    // The backup and copy branches are deliberately not pinned here. Cancel is a no-op without
+    // a live cancellation token, and a running backup cannot be staged without running one - so
+    // any test of that routing would assert something that is true whether or not the branch
+    // exists. A test that cannot fail is worse than no test: it reads like cover.
+
+
+    /// <summary>F5 on the one screen whose content is a snapshot of a moving estate.</summary>
+    [Fact]
+    public void ReloadReachesTheExposureDashboard()
+    {
+        var main = new MainViewModel(new FakeCredentialStore());
+        main.NavigateToCommand.Execute(MainViewModel.Nav.Exposure);
+
+        Assert.Equal(MainViewModel.Nav.Exposure, main.CurrentViewName);
+        Assert.True(main.Exposure.RefreshCommand.CanExecute(null));
+    }
+}

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -253,6 +253,18 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// </summary>
     public bool WillOverwriteTheTarget => WithReplace && !string.IsNullOrWhiteSpace(TargetDatabaseName);
 
+    /// <summary>
+    /// What the overwrite actually costs, in the words that matter at the moment of reading it.
+    ///
+    /// Named rather than generic: "this will overwrite the target" is a sentence people's eyes
+    /// slide off, and the whole risk of this screen is doing it to the wrong database.
+    /// </summary>
+    public string OverwriteWarning =>
+        $"'{TargetDatabaseName}' on {TargetServer?.ServerName ?? "the target server"} will be " +
+        "replaced by the copy. Whatever is in it now is gone when the restore starts - not when " +
+        "it finishes - so there is no point after which changing your mind helps. Untick " +
+        "\"Overwrite the target\" to restore under a name that is not in use instead.";
+
     /// <summary>True when the source's own differential schedule is about to be disturbed.</summary>
     public bool WillResetTheDifferentialBase => !CopyOnly;
 
@@ -294,6 +306,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsRefused));
         OnPropertyChanged(nameof(CanGenerate));
         OnPropertyChanged(nameof(WillOverwriteTheTarget));
+        OnPropertyChanged(nameof(OverwriteWarning));
         OnPropertyChanged(nameof(WillResetTheDifferentialBase));
         GenerateCommand.NotifyCanExecuteChanged();
 

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -536,6 +536,11 @@ public partial class MainViewModel : ViewModelBase
             case Nav.History:
                 History.Refresh();
                 break;
+            case Nav.Exposure:
+                // The one screen whose whole content is a snapshot of something that changes
+                // underneath it, and F5 did nothing here (#370).
+                if (Exposure.RefreshCommand.CanExecute(null)) Exposure.RefreshCommand.Execute(null);
+                break;
         }
     }
 
@@ -552,6 +557,13 @@ public partial class MainViewModel : ViewModelBase
     private void CancelCurrent()
     {
         if (Restore.Execution.CancelCommand.CanExecute(null)) { Restore.Execution.CancelCommand.Execute(null); return; }
+
+        // The other two screens that RUN something long, and that Esc did not reach (#370). A
+        // backup and a copy are both writing while they run, which puts them above the reads
+        // below rather than below them - the ordering here is cost of letting it continue.
+        if (Backup.IsRunning) { Backup.CancelCommand.Execute(null); return; }
+        if (CopyDatabase.IsRunning) { CopyDatabase.CancelCommand.Execute(null); return; }
+
         if (Restore.CancelQueryCommand.CanExecute(null)) { Restore.CancelQueryCommand.Execute(null); return; }
         if (Restore.CancelLoadCommand.CanExecute(null)) { Restore.CancelLoadCommand.Execute(null); return; }
         if (Exposure.CanCancelSweep) Exposure.StopSweepCommand.Execute(null);

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -47,6 +47,24 @@
                 </StackPanel>
             </Border>
 
+            <!-- What this does to the TARGET (#370). WillOverwriteTheTarget has existed since
+                 this screen was written, with a comment saying this is the part that destroys
+                 something and should be stated rather than buried in a checkbox - and it was
+                 bound nowhere, so the checkbox is exactly where it stayed. -->
+            <Border CornerRadius="6" Padding="14,12" Margin="0,0,0,16"
+                    Background="{DynamicResource DangerBackgroundBrush}"
+                    BorderBrush="{DynamicResource ErrorBrush}"
+                    BorderThickness="1"
+                    Visibility="{Binding WillOverwriteTheTarget, Converter={StaticResource BoolToVis}}">
+                <StackPanel>
+                    <TextBlock Text="THIS WILL OVERWRITE THE TARGET DATABASE"
+                               Style="{StaticResource LabelText}"
+                               Margin="0,0,0,6" />
+                    <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap" LineHeight="22"
+                               Text="{Binding OverwriteWarning}" />
+                </StackPanel>
+            </Border>
+
             <!-- 1. From -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
                 <StackPanel>


### PR DESCRIPTION
Part of #370.

## The copy said what it would do only through a checkbox

It defaults to overwriting the target - usually the point, a test environment being refreshed - and the only thing saying so was a tick.

`WillOverwriteTheTarget` has existed since the screen was written, carrying a comment that calls this *"the part of this that destroys something, so it is stated rather than buried in a checkbox"*. It was bound to nothing, so the checkbox is exactly where it stayed.

It now names the **database and the server**. Generic wording is what eyes slide off, and the risk here is not overwriting - it is overwriting the wrong one.

## Esc reached one of the three things that write

It stopped a restore and ignored a running backup or copy. Both write while they run, and both are the ones with no other way to stop once the console has scrolled. They sit above the reads in the ordering for the same reason the restore does: cost of letting it continue.

F5 refreshed Restore, Browse and History - not Exposure, the one screen whose entire content is a snapshot of an estate that moves underneath it.

## A test I deliberately did not write

The backup and copy branches of Esc are not pinned, and the file says why: `Cancel` is a no-op without a live cancellation token, and a running backup cannot be staged without running one - so any test of that routing would pass whether or not the branch existed. A test that cannot fail reads like cover, so I left a comment instead of one.

## Verification

1,927 unit tests (3 new: an overwriting copy names its target and server, a non-overwriting one says nothing, F5 reaches Exposure). The warning rendered and eyeballed. Release `-warnaserror` clean.