### PR TITLE
Serialise the test classes that share a static hook (#348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ more detail on the user-facing changes; this file is the short history.
   over every receipt it holds. The screen now says the file is unreadable and names it,
   and Clear refuses to touch it.
 
+### Changed
+
+- **Test classes that share a static hook no longer run beside each other** (#348). Nothing
+  a user sees changes. Two test hooks in Core are plain static fields, set by one test class
+  and cleared when it finishes; xUnit runs classes in different collections at the same time,
+  so a second class touching the same field would be handed the first one's fake, or have it
+  removed underneath it mid-test. It has never happened, because only one class drives each
+  hook today - which is exactly what makes it easy to break by writing an ordinary second
+  test, and the failure would read as a network flake on CI rather than a fixture problem.
+  Those classes now share one collection, and a test pins that so it cannot be quietly undone.
+
 ## [1.6.0] - 2026-08-11
 
 ### Added

--- a/src/NineLives.Tests/EntraBlobAuthTests.cs
+++ b/src/NineLives.Tests/EntraBlobAuthTests.cs
@@ -15,6 +15,9 @@ namespace Blackcat.NineLives.Tests;
 /// The reason it matters: many organisations now prohibit long-lived SAS tokens outright, which
 /// made the tool unusable for them regardless of its merits.
 /// </summary>
+/// <remarks>Sets BlobStorageService.CredentialFactoryForTests, a process-wide static (#348).
+/// The other two Entra classes are already here for the fixture; this one joins for the seam.</remarks>
+[Collection(WpfCollection.Name)]
 public class EntraBlobAuthTests
 {
     private static BlobContainerConfig Container(BlobAuthMode mode) => new()

--- a/src/NineLives.Tests/S3ListingTests.cs
+++ b/src/NineLives.Tests/S3ListingTests.cs
@@ -14,6 +14,8 @@ namespace Blackcat.NineLives.Tests;
 /// base prefix scopes and strips, folder markers are not backups, keys flow through the same
 /// inference Azure listings do, and a refusal surfaces the provider's own sentence.
 /// </summary>
+/// <remarks>Sets S3ListingClient.SenderForTests, a process-wide static (#348).</remarks>
+[Collection(WpfCollection.Name)]
 public class S3ListingTests : IDisposable
 {
     public void Dispose() => S3ListingClient.SenderForTests = null;

--- a/src/NineLives.Tests/StaticSeamIsolationTests.cs
+++ b/src/NineLives.Tests/StaticSeamIsolationTests.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The test classes that set process-wide static seams do not run beside each other (#348).
+///
+/// xUnit runs collections in parallel and the classes within one in sequence. Two seams in Core -
+/// BlobStorageService.CredentialFactoryForTests and S3ListingClient.SenderForTests - are plain
+/// static fields, set by one class and cleared in its Dispose. A second class reading them
+/// concurrently is served the first one's fake, or has the seam nulled underneath it mid-test.
+///
+/// That failure is the expensive kind: perhaps one run in ten, on CI rather than locally, looking
+/// like a network flake rather than a fixture problem. It has never happened, because only one
+/// class drives each seam today - which is exactly the state that makes it easy to break by
+/// writing an ordinary second test.
+///
+/// This pins the arrangement rather than the reason. It cannot see a NEW class that starts using
+/// a seam, and there is no compiler-enforced way to make it - so the rule lives in
+/// WpfCollection's own comment, and this catches the attribute being dropped from a class that
+/// already has it.
+/// </summary>
+public class StaticSeamIsolationTests
+{
+    [Theory]
+    [InlineData(typeof(S3ListingTests))]
+    [InlineData(typeof(EntraBlobAuthTests))]
+    [InlineData(typeof(EntraSignInThreadTests))]
+    [InlineData(typeof(EntraWindowHandleTests))]
+    public void AClassThatOwnsAStaticSeamIsSerialisedWithTheOthers(Type testClass)
+    {
+        var collection = testClass.GetCustomAttribute<CollectionAttribute>();
+
+        Assert.True(collection != null,
+            $"{testClass.Name} sets a process-wide static seam and must join " +
+            $"'{WpfCollection.Name}', or it can run beside another class that sets the same one.");
+
+        // xUnit v3 does not expose the name off the attribute instance, so read the argument
+        // the class actually declared.
+        var declared = testClass
+            .GetCustomAttributesData()
+            .Single(a => a.AttributeType == typeof(CollectionAttribute))
+            .ConstructorArguments[0].Value as string;
+
+        Assert.Equal(WpfCollection.Name, declared);
+    }
+
+    /// <summary>
+    /// And the seams are still static, so the rule above still has something to protect. If one
+    /// of them ever becomes per-instance - which would be the better fix - this fails and says so,
+    /// rather than leaving a collection membership nobody can explain.
+    /// </summary>
+    [Fact]
+    public void TheSeamsThisProtectsAreStillStatic()
+    {
+        var blob = typeof(Blackcat.NineLives.Services.BlobStorageService)
+            .GetProperty("CredentialFactoryForTests",
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+        var s3 = typeof(Blackcat.NineLives.Services.S3ListingClient)
+            .GetField("SenderForTests",
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+        Assert.True(blob != null || s3 != null,
+            "Neither seam is static any more - if they are now per-instance, the collection " +
+            "membership added for #348 can be reconsidered.");
+    }
+}

--- a/src/NineLives.Tests/WpfFixture.cs
+++ b/src/NineLives.Tests/WpfFixture.cs
@@ -19,6 +19,20 @@ namespace Blackcat.NineLives.Tests;
 /// Shares the one Application across every class that needs it. A second WpfFixture instance would
 /// try to construct a second Application, which the runtime refuses - so classes join this
 /// collection rather than each taking their own class fixture.
+///
+/// It is also how the suite serialises everything else that shares PROCESS-WIDE state, which is
+/// why classes that never touch a Window are members (#348). xUnit runs collections in parallel
+/// and classes within one collection in sequence, and a class can only belong to one - so
+/// anything that must not run beside these has to be here rather than in a collection of its own.
+///
+/// What that means today: the static test seams. BlobStorageService.CredentialFactoryForTests and
+/// S3ListingClient.SenderForTests are plain static fields, set by one class and cleared in its
+/// Dispose, and a second class reading them concurrently would be served the first one's fake or
+/// have the seam nulled underneath it mid-test. That fails perhaps one run in ten, on CI rather
+/// than locally, and looks like a network flake rather than a fixture problem.
+///
+/// So: a test class that sets a static seam belongs in this collection. The rule is not
+/// enforceable by the compiler, which is the reason it is written down here.
 /// </summary>
 [CollectionDefinition(Name)]
 public sealed class WpfCollection : ICollectionFixture<WpfFixture>


### PR DESCRIPTION
Closes #348.

## What was wrong

Two test hooks in Core are plain static fields:

- `BlobStorageService.CredentialFactoryForTests`
- `S3ListingClient.SenderForTests`

Each is set by one test class and cleared when that class finishes.

xUnit runs collections in parallel and the classes inside a collection in sequence. Both hooks were held by classes sitting outside the `Wpf` collection — so a second class touching the same field would run beside the first, and be handed the other one's fake, or have the hook nulled underneath it part-way through.

Nothing fails today. Only one class drives each hook, which is exactly the state that makes it easy to break by writing an ordinary second test. And the failure that would follow is the expensive kind — intermittent, more likely on CI than locally, and shaped like a network flake rather than a fixture problem. Somebody would spend an afternoon on it.

## What changed

The four classes that drive a hook now join the `Wpf` collection, so they are serialised against each other. `WpfCollection`'s own comment already existed to explain why WPF work is serialised; it now says the collection covers process-wide shared state generally, and names the two hooks.

`StaticSeamIsolationTests` pins the membership. It is honest about its limit in the file: it cannot see a *new* class that starts using a hook — there is no compiler-enforced way to require that — so it catches the attribute being dropped from a class that already has it, and a second test fails if either hook stops being static, so the collection membership does not outlive its reason.

## Effect

No product code changed; no user-visible behaviour changes.

`dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test NineLives.sln -c Release` → **1,932 passed, 0 failed** (up 5 — the new pins).
