### PR TITLE
Three ways half a backup passed for a whole one (#363, #364, #365)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,39 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A backup set with no files no longer generates a restore that ends the sequence** (#365).
+  A set discovered with nothing recorded against it produced a RESTORE naming no device -
+  which is not a syntax error but the valid recovery-only form. Run against a target sitting
+  in RESTORING, a log-shipping secondary or a paused restore, it would have brought the
+  database online wherever it had got to and ended the restore sequence for good: no further
+  log applicable, the whole chain to start again. The validator now reports it as an error,
+  the restore screen explains it where the script would be, and the generator refuses rather
+  than emitting it.
+
+- **A striped set missing its first file is caught** (#363). The stripe check returned early
+  on a single-file set, so a set holding only `..._2.bak` - stripe 1 purged by retention or
+  never uploaded - passed clean, while the *same* set as stripes 2 and 3 was correctly
+  flagged. It was blind precisely at its worst case. The question is now asked of the stripe
+  numbers rather than the file count: a lone `_2` says stripe 1 is missing on its own. A set
+  mixing an unnumbered file with a numbered one is caught too, and named.
+
+- **One striped set written to two folders is no longer offered as two restore points**
+  (#363). Multi-directory striping - how a large backup gets spread over two volumes - groups
+  by parent folder, so it arrived as two sets at the same instant, each holding half a media
+  set and each looking complete. A chain that should have offered four restore points offered
+  seven, every one of them restoring from half a set. The halves are now recognised by their
+  stripe numbers: no overlap and together running 1..N means one media set and nothing else.
+  Two genuinely complete backups that share a second each contain a stripe 1, so they are left
+  alone as the warning they are.
+
+- **KEEP_REPLICATION and the broker options only on the statement that recovers** (#364). They
+  were emitted on every statement in the chain while the recovery clause was chosen
+  separately, and SQL Server refuses the combination outright - Msg 3031, "Option 'norecovery'
+  conflicts with option(s) 'keep_replication'". The first statement failed, which made the
+  option unusable for any chain longer than one statement: every log-shipping and replication
+  scenario it exists for. A chain deliberately left in NORECOVERY or STANDBY now carries them
+  nowhere, since it never brings a database online for them to describe.
+
 - **Copy Database says which database it is about to overwrite** (#370). It defaults to
   overwriting, which is usually the point - a test environment being refreshed - but the
   only thing saying so was a ticked checkbox. The property that would have said it out

--- a/src/NineLives.Core/Services/BackupChainValidator.cs
+++ b/src/NineLives.Core/Services/BackupChainValidator.cs
@@ -77,10 +77,12 @@ public class BackupChainValidator
 
         foreach (var set in chain.AllSets)
         {
+            CheckSetHasFiles(set, issues);
             CheckStripes(set, issues);
             CheckEmptyFiles(set, issues);
         }
 
+        CheckSplitStripeSets(chain.AllSets, issues);
         CheckLogCadence(chain, issues);
         CheckLogCoverageStart(chain, issues);
         CheckOrdering(chain, issues);
@@ -97,6 +99,12 @@ public class BackupChainValidator
     {
         var issues = new List<ChainIssue>();
         if (sets.Count == 0) return issues;
+
+        // Asked of the whole inventory as well as of a chain (#363). A full split across two
+        // folders puts only one of its halves in any chain the builder assembles, so the chain
+        // never sees the pair - but the browse list does, and this is where the extra restore
+        // points come from.
+        CheckSplitStripeSets(sets, issues);
 
         var fulls = sets.Where(s => s.Type == BackupType.Full && !s.IsCopyOnly)
             .OrderBy(s => s.Timestamp).ToList();
@@ -210,36 +218,150 @@ public class BackupChainValidator
     }
 
     /// <summary>
-    /// A striped set is only restorable with EVERY stripe present - SQL Server rejects a partial
-    /// set. Stripe numbers should run 1..N with no holes.
+    /// A backup set with no files at all (#365).
     ///
-    /// Note this cannot detect a uniformly truncated set (stripes 1 and 2 of an original 4), since
-    /// nothing in the filename records how many there were. It catches holes, which is the common
-    /// shape of a failed or partial upload.
+    /// Checked before anything else about the set, because every other check reads
+    /// <see cref="BackupSet.Files"/> and finds nothing to complain about - which is how this
+    /// reached the generator, where a set with no devices produces the recovery-only form of
+    /// RESTORE and ends the restore sequence.
+    /// </summary>
+    private static void CheckSetHasFiles(BackupSet set, List<ChainIssue> issues)
+    {
+        if (set.FileCount > 0) return;
+
+        issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+            $"{set.TypeDisplay} backup at {set.Timestamp:yyyy-MM-dd HH:mm} has no files",
+            "The set was discovered but nothing is recorded against it to restore from. A " +
+            "statement generated for it would name no device at all, which SQL Server reads as " +
+            "a recovery-only restore - it would bring the database online where it stands and " +
+            "end the restore sequence. Re-scan the container, or pick a different restore point."));
+    }
+
+    /// <summary>
+    /// A striped set is only restorable with EVERY stripe present - SQL Server rejects a partial
+    /// set with Msg 3132.
+    ///
+    /// The question is asked of the stripe NUMBERS, not of the file count (#363). Both previous
+    /// guards bailed exactly where the damage was worst: a set holding only <c>..._2.bak</c> -
+    /// stripe 1 purged, or never uploaded - has one file, and one file looked like an ordinary
+    /// unstriped backup. The same set as stripes 2 and 3 was correctly flagged, so the check was
+    /// blind precisely at its worst case. A lone <c>_2</c> means stripe 1 is missing, and that is
+    /// visible from the number alone.
+    ///
+    /// This still cannot detect a uniformly truncated set (stripes 1 and 2 of an original 4).
+    /// Nothing in the filename records how many there were, so a set that ends early looks exactly
+    /// like a smaller set. It catches holes, which is the common shape of a partial upload.
     /// </summary>
     private static void CheckStripes(BackupSet set, List<ChainIssue> issues)
     {
-        if (set.FileCount <= 1) return;
-
         var stripes = set.Files
             .Select(f => BackupSet.ParseFileName(f.FileName).stripe)
             .Where(n => n > 0)
+            .Distinct()
             .OrderBy(n => n)
             .ToList();
 
-        // Not a numbered stripe set - nothing to verify.
-        if (stripes.Count != set.FileCount) return;
+        // No file claims a stripe number - an ordinary unstriped backup, nothing to verify.
+        if (stripes.Count == 0) return;
 
-        var missing = Enumerable.Range(1, stripes[^1])
-            .Where(n => !stripes.Contains(n))
+        var highest = stripes[^1];
+        var missing = Enumerable.Range(1, highest).Where(n => !stripes.Contains(n)).ToList();
+        if (missing.Count == 0) return;
+
+        // Files carrying no number cannot be the missing stripes - the writer numbers all of a
+        // media set or none of it - but they are worth naming, because a set mixing the two is
+        // usually two different backups grouped together and the reader needs to see that.
+        var unnumbered = set.Files
+            .Where(f => BackupSet.ParseFileName(f.FileName).stripe == 0)
+            .Select(f => f.FileName)
             .ToList();
 
-        if (missing.Count > 0)
-            issues.Add(new ChainIssue(ChainIssueSeverity.Error,
-                $"{set.TypeDisplay} backup at {set.Timestamp:yyyy-MM-dd HH:mm} is missing stripe(s) " +
-                string.Join(", ", missing),
-                $"The set has {set.FileCount} file(s) numbered up to {stripes[^1]}. A striped backup cannot be " +
-                "restored unless every file is present, so this restore will fail."));
+        var detail =
+            $"The set holds {set.FileCount} file(s) and the highest stripe number present is " +
+            $"{highest}, so at least {missing.Count} file(s) of the media set are absent. A striped " +
+            "backup cannot be restored unless every stripe is present - this restore will fail " +
+            "with Msg 3132.";
+
+        if (unnumbered.Count > 0)
+            detail += $" {unnumbered.Count} file(s) in the set carry no stripe number at all " +
+                      $"({string.Join(", ", unnumbered)}), which usually means two different " +
+                      "backups have been grouped together.";
+
+        issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+            $"{set.TypeDisplay} backup at {set.Timestamp:yyyy-MM-dd HH:mm} is missing stripe(s) " +
+            string.Join(", ", missing),
+            detail));
+    }
+
+    /// <summary>
+    /// One striped set written across two locations, discovered as two sets (#363).
+    ///
+    /// Sets are grouped by their parent folder, so multi-directory striping - Ola's
+    /// <c>@Directory = 'X,Y'</c>, which is how people spread a large backup over two volumes -
+    /// arrives as two sets carrying the same database, server, type and timestamp, each holding
+    /// half a media set. Neither half is restorable, and the timeline offers both, so a chain
+    /// that should have had four restore points had seven, every one of them broken.
+    ///
+    /// The stripe numbers are what make this provable rather than suspected. If the halves'
+    /// numbers do not overlap and together run 1..N with no holes, they are one media set and
+    /// nothing else: two independent backups of the same database would each be complete, and so
+    /// would both contain a stripe 1. Overlapping numbers are left alone for that reason - they
+    /// are two backup jobs that happened to start in the same second, and each still restores.
+    /// </summary>
+    private static void CheckSplitStripeSets(IEnumerable<BackupSet> sets, List<ChainIssue> issues)
+    {
+        var groups = sets
+            .GroupBy(s => (
+                s.Type,
+                Database: s.DatabaseName?.ToLowerInvariant() ?? string.Empty,
+                Server: s.ServerDisplay?.ToLowerInvariant() ?? string.Empty,
+                s.Timestamp))
+            .Where(g => g.Count() > 1);
+
+        foreach (var group in groups)
+        {
+            var members = group.ToList();
+            var numbers = members
+                .SelectMany(s => s.Files.Select(f => BackupSet.ParseFileName(f.FileName).stripe))
+                .Where(n => n > 0)
+                .ToList();
+
+            var distinct = numbers.Distinct().OrderBy(n => n).ToList();
+            var isOneMediaSet =
+                numbers.Count > 0
+                && numbers.Count == distinct.Count               // no half holds the same stripe twice
+                && distinct[^1] == numbers.Count                 // and together they run 1..N
+                && members.All(s => s.Files.Count > 0);
+
+            var first = members[0];
+            var where = string.Join(", ", members
+                .Select(s => s.Files.Count > 0 ? FolderOf(s.Files[0].BlobName) : "(empty)")
+                .Distinct());
+
+            if (isOneMediaSet)
+                issues.Add(new ChainIssue(ChainIssueSeverity.Error,
+                    $"{first.TypeDisplay} backup at {first.Timestamp:yyyy-MM-dd HH:mm} is one " +
+                    $"striped set split across {members.Count} locations",
+                    $"Stripes 1-{distinct[^1]} of a single media set are spread over: {where}. " +
+                    "Each location holds only part of the set, so both appear on the timeline and " +
+                    "neither can be restored - SQL Server needs every stripe named in one " +
+                    "statement. Point the container at the parent path that holds all of them, or " +
+                    "restore by hand naming every file."));
+            else
+                issues.Add(new ChainIssue(ChainIssueSeverity.Warning,
+                    $"{members.Count} {first.TypeDisplay.ToLowerInvariant()} backups share the " +
+                    $"same timestamp ({first.Timestamp:yyyy-MM-dd HH:mm})",
+                    $"Same database, same server, same second, in: {where}. Each is offered as its " +
+                    "own restore point, so the timeline shows more points than there were backups. " +
+                    "Usually two jobs writing the same backup to two places; check they are not " +
+                    "halves of one striped set before restoring either."));
+        }
+    }
+
+    private static string FolderOf(string blobName)
+    {
+        var cut = blobName.LastIndexOf('/');
+        return cut <= 0 ? "(root)" : blobName[..cut];
     }
 
     private static void CheckEmptyFiles(BackupSet set, List<ChainIssue> issues)

--- a/src/NineLives.Core/Services/RestoreScriptGenerator.cs
+++ b/src/NineLives.Core/Services/RestoreScriptGenerator.cs
@@ -7,6 +7,13 @@ public class RestoreScriptGenerator
 {
     public string Generate(BackupChain chain, RestoreOptions options)
     {
+        // Nothing is written before this (#365). A set with no files produced a statement with
+        // no FROM, which is not a syntax error - it is the valid recovery-only form, and against
+        // a target sitting in RESTORING it recovers the database wherever it had reached and
+        // ends the restore sequence for good.
+        if (DescribeSetWithNoFiles(chain) is string empty)
+            throw new InvalidOperationException(empty);
+
         var sb = new StringBuilder();
 
         // Region is an S3 concept (#51): meaningful only when the chain's devices are s3://,
@@ -48,6 +55,33 @@ public class RestoreScriptGenerator
         AppendFooter(sb);
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// The one shape of chain this generator refuses outright (#365): a member with no files at
+    /// all. Returns the reason, or null when every set has something to restore from.
+    ///
+    /// Public because refusing at generation time is the last line, not the first. The restore
+    /// screen asks the same question before it generates, so the user reads a sentence rather
+    /// than catching an exception - but the CLI verbs and the copy screen build chains too, and
+    /// this is the statement that must never be emitted by any of them.
+    ///
+    /// A recovery-only RESTORE is a legitimate thing to write by hand; what makes this dangerous
+    /// is arriving at one by accident, in the middle of a chain, while a database sits in
+    /// RESTORING waiting for the rest of it.
+    /// </summary>
+    public static string? DescribeSetWithNoFiles(BackupChain? chain)
+    {
+        var empty = chain?.AllSets.FirstOrDefault(s => s.Files.Count == 0);
+        if (empty == null) return null;
+
+        return $"The {empty.TypeDisplay.ToLowerInvariant()} backup at " +
+               $"{empty.Timestamp:yyyy-MM-dd HH:mm} has no files recorded against it, so there is " +
+               "nothing to restore from. A statement generated for it would name no device, which " +
+               "SQL Server reads as a recovery-only restore: it would bring the database online " +
+               "at whatever point it had reached and end the restore sequence, and the rest of " +
+               "the chain could not then be applied. Re-scan the container, or pick a different " +
+               "restore point.";
     }
 
     private static void AppendHeader(StringBuilder sb, RestoreOptions options, BackupChain chain)
@@ -106,7 +140,7 @@ public class RestoreScriptGenerator
         AppendFileMoves(sb, options);
 
         sb.AppendLine($"         {recoveryClause},");
-        AppendCommonOptions(sb, options);
+        AppendCommonOptions(sb, options, Recovers(options, moreToFollow));
         sb.AppendLine("GO");
         sb.AppendLine();
     }
@@ -121,7 +155,7 @@ public class RestoreScriptGenerator
         sb.AppendLine($"RESTORE DATABASE {dbName}");
         AppendFromUrls(sb, diffSet, options);
         sb.AppendLine($"         {recoveryClause},");
-        AppendCommonOptions(sb, options);
+        AppendCommonOptions(sb, options, Recovers(options, moreToFollow));
         sb.AppendLine("GO");
         sb.AppendLine();
     }
@@ -154,7 +188,7 @@ public class RestoreScriptGenerator
             sb.AppendLine($"         STOPAT = '{options.StopAt.Value:yyyy-MM-ddTHH:mm:ss}',");
 
         sb.AppendLine($"         {recoveryClause},");
-        AppendCommonOptions(sb, options);
+        AppendCommonOptions(sb, options, Recovers(options, moreToFollow: !isLast));
         sb.AppendLine("GO");
         sb.AppendLine();
     }
@@ -213,14 +247,29 @@ public class RestoreScriptGenerator
         }
     }
 
-    private static void AppendCommonOptions(StringBuilder sb, RestoreOptions options)
+    /// <summary>
+    /// The options every statement in the chain carries.
+    ///
+    /// <paramref name="recovers"/> separates the three that belong to the statement that brings
+    /// the database online from the ones that apply to each RESTORE individually (#364).
+    /// KEEP_REPLICATION is refused outright alongside NORECOVERY - Msg 3031, "Option 'norecovery'
+    /// conflicts with option(s) 'keep_replication'" - so emitting it on every statement made the
+    /// option unusable for any chain longer than one statement, which is every log-shipping and
+    /// replication scenario it exists for. The broker options describe what a database should do
+    /// once it is up, and a database mid-chain is not up.
+    /// </summary>
+    private static void AppendCommonOptions(StringBuilder sb, RestoreOptions options, bool recovers)
     {
-        if (options.KeepReplication)
-            sb.AppendLine("         KEEP_REPLICATION,");
-        if (options.EnableBroker)
-            sb.AppendLine("         ENABLE_BROKER,");
-        if (options.NewBroker)
-            sb.AppendLine("         NEW_BROKER,");
+        if (recovers)
+        {
+            if (options.KeepReplication)
+                sb.AppendLine("         KEEP_REPLICATION,");
+            if (options.EnableBroker)
+                sb.AppendLine("         ENABLE_BROKER,");
+            if (options.NewBroker)
+                sb.AppendLine("         NEW_BROKER,");
+        }
+
         if (options.WithChecksum)
             sb.AppendLine("         CHECKSUM,");
         if (options.ContinueAfterError)
@@ -249,6 +298,17 @@ public class RestoreScriptGenerator
         sb.AppendLine("-- Restore script complete.");
         sb.AppendLine("-- ============================================================");
     }
+
+    /// <summary>
+    /// Whether THIS statement is the one that brings the database online.
+    ///
+    /// Not the same question as "is it the last statement": a chain deliberately left in
+    /// NORECOVERY or STANDBY - a log-shipping secondary, a restore somebody means to add more
+    /// logs to - ends without ever recovering, and the options that describe a running database
+    /// belong on none of its statements.
+    /// </summary>
+    private static bool Recovers(RestoreOptions options, bool moreToFollow)
+        => !moreToFollow && options.RecoveryMode == RecoveryMode.Recovery;
 
     private static string GetRecoveryClause(RestoreOptions options)
     {

--- a/src/NineLives.Tests/PartialMediaSetTests.cs
+++ b/src/NineLives.Tests/PartialMediaSetTests.cs
@@ -1,0 +1,246 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Half a backup, reported as a whole one (#363, #365).
+///
+/// Both checks bailed exactly where the damage was worst. The stripe check returned early on a
+/// single-file set, so a set holding only <c>..._2.bak</c> - stripe 1 purged or never uploaded -
+/// passed clean, while the SAME set as stripes 2 and 3 was correctly flagged. And a set with no
+/// files at all passed every check there was, then generated a RESTORE naming no device, which is
+/// the valid recovery-only form: against a target sitting in RESTORING it ends the restore
+/// sequence permanently.
+/// </summary>
+public class PartialMediaSetTests
+{
+    private readonly BackupChainValidator _validator = new();
+    private readonly RestoreScriptGenerator _generator = new();
+
+    private static readonly DateTime T0 = new(2026, 8, 4, 22, 0, 0);
+
+    /// <summary>A set whose files are named exactly as given, under an optional folder.</summary>
+    private static BackupSet Set(
+        BackupType type, DateTime timestamp, string[] fileNames,
+        string folder = "backups", string database = "Sales", string server = "SRV01") => new()
+        {
+            SetId = timestamp.ToString("yyyyMMdd_HHmmss"),
+            Type = type,
+            Timestamp = timestamp,
+            DatabaseName = database,
+            ServerName = server,
+            Files = fileNames.Select(n => new BackupFileInfo
+            {
+                BlobName = folder.Length == 0 ? n : $"{folder}/{n}",
+                BlobUrl = $"https://acct.blob.core.windows.net/c/{folder}/{n}",
+                Type = type,
+                SizeBytes = 1024
+            }).ToList()
+        };
+
+    private static BackupChain Chain(BackupSet full, BackupSet[]? logs = null) => new()
+    {
+        FullSet = full,
+        LogSets = logs?.ToList() ?? []
+    };
+
+    private static ChainIssue? ErrorAbout(IEnumerable<ChainIssue> issues, string fragment) =>
+        issues.FirstOrDefault(i => i.IsError && (i.Title.Contains(fragment) || i.Detail.Contains(fragment)));
+
+    // ── a lone stripe is a missing stripe ───────────────────────────────────────
+
+    /// <summary>
+    /// The case the old guard was blind to: one file, numbered 2. There is no stripe 1, and the
+    /// number says so on its own - no file count needed.
+    /// </summary>
+    [Fact]
+    public void ASetHoldingOnlyStripeTwoIsMissingStripeOne()
+    {
+        var issues = _validator.Validate(
+            Chain(Set(BackupType.Full, T0, ["20260804_220000_2.bak"])));
+
+        var issue = ErrorAbout(issues, "missing stripe");
+        Assert.NotNull(issue);
+        Assert.Contains("1", issue!.Title);
+        Assert.Contains("3132", issue.Detail);
+    }
+
+    /// <summary>The same set as stripes 2 and 3 was always caught; it still is.</summary>
+    [Fact]
+    public void ASetHoldingStripesTwoAndThreeIsStillCaught()
+    {
+        var issues = _validator.Validate(Chain(
+            Set(BackupType.Full, T0, ["20260804_220000_2.bak", "20260804_220000_3.bak"])));
+
+        Assert.NotNull(ErrorAbout(issues, "missing stripe"));
+    }
+
+    /// <summary>
+    /// An unnumbered file beside a numbered one. The old check bailed because the counts
+    /// disagreed - which is the signal, not a reason to stop looking.
+    /// </summary>
+    [Fact]
+    public void ASetMixingAnUnnumberedFileWithStripeThreeIsRefusedAndNamesIt()
+    {
+        var issues = _validator.Validate(Chain(
+            Set(BackupType.Full, T0, ["20260804_220000.bak", "20260804_220000_3.bak"])));
+
+        var issue = ErrorAbout(issues, "missing stripe");
+        Assert.NotNull(issue);
+        Assert.Contains("20260804_220000.bak", issue!.Detail);
+        Assert.Contains("no stripe number", issue.Detail);
+    }
+
+    // ── and the shapes that must stay quiet ─────────────────────────────────────
+
+    /// <summary>An ordinary unstriped backup. No number, nothing to conclude.</summary>
+    [Fact]
+    public void AnOrdinaryUnstripedBackupRaisesNothing()
+    {
+        var issues = _validator.Validate(Chain(Set(BackupType.Full, T0, ["20260804_220000.bak"])));
+        Assert.Null(ErrorAbout(issues, "missing stripe"));
+    }
+
+    /// <summary>
+    /// A single file numbered 1. Some writers number even a one-file set, and 1..1 has no hole -
+    /// the check must not read the number itself as evidence of a sibling.
+    /// </summary>
+    [Fact]
+    public void ASingleFileNumberedOneRaisesNothing()
+    {
+        var issues = _validator.Validate(Chain(Set(BackupType.Full, T0, ["20260804_220000_1.bak"])));
+        Assert.Null(ErrorAbout(issues, "missing stripe"));
+    }
+
+    [Fact]
+    public void ACompleteStripedSetRaisesNothing()
+    {
+        var issues = _validator.Validate(Chain(Set(BackupType.Full, T0,
+            ["20260804_220000_1.bak", "20260804_220000_2.bak", "20260804_220000_3.bak"])));
+
+        Assert.Null(ErrorAbout(issues, "missing stripe"));
+    }
+
+    // ── one media set, two folders ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Multi-directory striping, which is how a large backup gets spread over two volumes. Sets
+    /// group by parent folder, so this arrives as two sets at the same instant, each holding half
+    /// a media set and each looking complete on its own.
+    /// </summary>
+    [Fact]
+    public void StripesSplitAcrossTwoFoldersAreOneSetAndRefused()
+    {
+        var issues = _validator.ValidateInventory(
+        [
+            Set(BackupType.Full, T0, ["20260804_220000_1.bak"], folder: "vol-a"),
+            Set(BackupType.Full, T0, ["20260804_220000_2.bak"], folder: "vol-b")
+        ]);
+
+        var issue = ErrorAbout(issues, "split across");
+        Assert.NotNull(issue);
+        Assert.Contains("vol-a", issue!.Detail);
+        Assert.Contains("vol-b", issue.Detail);
+    }
+
+    /// <summary>
+    /// Two complete backups that happen to share a second are NOT one split set - each contains a
+    /// stripe 1, so neither is half of anything, and each restores. Overlapping numbers are what
+    /// tells the two cases apart, and calling this an Error would disable a restore that works.
+    /// </summary>
+    [Fact]
+    public void TwoCompleteBackupsSharingATimestampAreAWarningNotAnError()
+    {
+        var issues = _validator.ValidateInventory(
+        [
+            Set(BackupType.Full, T0, ["20260804_220000_1.bak"], folder: "vol-a"),
+            Set(BackupType.Full, T0, ["20260804_220000_1.bak"], folder: "vol-b")
+        ]);
+
+        Assert.Null(ErrorAbout(issues, "split across"));
+
+        var warning = issues.FirstOrDefault(i => !i.IsError && i.Title.Contains("same timestamp"));
+        Assert.NotNull(warning);
+        Assert.Contains("halves of one striped set", warning!.Detail);
+    }
+
+    /// <summary>Different databases at the same instant are just two backup jobs.</summary>
+    [Fact]
+    public void TwoDatabasesBackedUpInTheSameSecondRaiseNothing()
+    {
+        var issues = _validator.ValidateInventory(
+        [
+            Set(BackupType.Full, T0, ["20260804_220000_1.bak"], folder: "a", database: "Sales"),
+            Set(BackupType.Full, T0, ["20260804_220000_2.bak"], folder: "b", database: "Payroll")
+        ]);
+
+        Assert.Null(ErrorAbout(issues, "split across"));
+        Assert.DoesNotContain(issues, i => i.Title.Contains("same timestamp"));
+    }
+
+    // ── a set with no files at all ──────────────────────────────────────────────
+
+    [Fact]
+    public void ASetWithNoFilesIsAnError()
+    {
+        var empty = Set(BackupType.Full, T0, []);
+        var issue = ErrorAbout(_validator.Validate(Chain(empty)), "has no files");
+
+        Assert.NotNull(issue);
+        Assert.Contains("recovery-only", issue!.Detail);
+    }
+
+    /// <summary>
+    /// The one that matters. A statement with no FROM is not a syntax error - it is the valid
+    /// recovery-only form, so nothing would have failed at run time. It would have recovered a
+    /// database mid-chain and ended the restore sequence for good.
+    /// </summary>
+    [Fact]
+    public void GeneratingFromASetWithNoFilesIsRefusedRatherThanEmitted()
+    {
+        var chain = Chain(Set(BackupType.Full, T0, []));
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _generator.Generate(chain, new RestoreOptions
+            {
+                TargetDatabaseName = "Sales",
+                RecoveryMode = RecoveryMode.Recovery
+            }));
+
+        Assert.Contains("no files", ex.Message);
+        Assert.Contains("recovery-only", ex.Message);
+    }
+
+    /// <summary>An empty set anywhere in the chain, not only the full.</summary>
+    [Fact]
+    public void AnEmptyLogSetIsCaughtToo()
+    {
+        var chain = Chain(
+            Set(BackupType.Full, T0, ["20260804_220000.bak"]),
+            [Set(BackupType.TransactionLog, T0.AddHours(1), [])]);
+
+        Assert.NotNull(RestoreScriptGenerator.DescribeSetWithNoFiles(chain));
+        Assert.NotNull(ErrorAbout(_validator.Validate(chain), "has no files"));
+    }
+
+    [Fact]
+    public void AChainWhoseSetsAllHaveFilesIsNotRefused()
+    {
+        var chain = Chain(
+            Set(BackupType.Full, T0, ["20260804_220000.bak"]),
+            [Set(BackupType.TransactionLog, T0.AddHours(1), ["20260804_230000.trn"])]);
+
+        Assert.Null(RestoreScriptGenerator.DescribeSetWithNoFiles(chain));
+
+        var script = _generator.Generate(chain, new RestoreOptions
+        {
+            TargetDatabaseName = "Sales",
+            RecoveryMode = RecoveryMode.Recovery
+        });
+
+        Assert.Contains("RESTORE DATABASE", script);
+        Assert.Contains("RESTORE LOG", script);
+    }
+}

--- a/src/NineLives.Tests/RecoveryOnlyOptionsTests.cs
+++ b/src/NineLives.Tests/RecoveryOnlyOptionsTests.cs
@@ -1,0 +1,162 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The three options that belong only on the statement that brings the database online (#364).
+///
+/// KEEP_REPLICATION, ENABLE_BROKER and NEW_BROKER were emitted on every statement of the chain,
+/// while the recovery clause was chosen independently. SQL Server refuses the combination -
+/// Msg 3031, "Option 'norecovery' conflicts with option(s) 'keep_replication'" - so the first
+/// statement failed and the option was unusable for any chain longer than one statement. Which is
+/// every log-shipping and replication scenario it exists for.
+///
+/// The pin that existed used a full-only chain, which ends in RECOVERY, so the case that was
+/// broken had never been covered.
+/// </summary>
+public class RecoveryOnlyOptionsTests
+{
+    private readonly RestoreScriptGenerator _generator = new();
+
+    private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);
+
+    private static BackupSet Set(BackupType type, DateTime timestamp) => new()
+    {
+        SetId = timestamp.ToString("yyyyMMdd_HHmmss"),
+        Type = type,
+        Timestamp = timestamp,
+        Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = $"{timestamp:yyyyMMdd_HHmmss}.bak",
+                BlobUrl = $"https://acct.blob.core.windows.net/backups/{timestamp:yyyyMMdd_HHmmss}.bak",
+                Type = type
+            }
+        ]
+    };
+
+    /// <summary>Full + diff + two logs: four statements, three of them NORECOVERY.</summary>
+    private static BackupChain FourStatementChain() => new()
+    {
+        FullSet = Set(BackupType.Full, T0),
+        DiffSets = [Set(BackupType.Differential, T0.AddHours(4))],
+        LogSets = [Set(BackupType.TransactionLog, T0.AddHours(5)), Set(BackupType.TransactionLog, T0.AddHours(6))]
+    };
+
+    private static RestoreOptions Options(Action<RestoreOptions>? mutate = null)
+    {
+        var o = new RestoreOptions
+        {
+            TargetDatabaseName = "TestDb",
+            DisconnectSessions = false,
+            RecoveryMode = RecoveryMode.Recovery,
+            KeepReplication = true,
+            EnableBroker = true,
+            NewBroker = true
+        };
+        mutate?.Invoke(o);
+        return o;
+    }
+
+    /// <summary>Every RESTORE ... GO block in the script, in order.</summary>
+    private static List<string> Statements(string script) => script
+        .Replace("\r\n", "\n")
+        .Split("GO\n")
+        .Where(s => s.Contains("RESTORE DATABASE") || s.Contains("RESTORE LOG"))
+        .ToList();
+
+    [Fact]
+    public void OnlyTheRecoveringStatementCarriesThem()
+    {
+        var statements = Statements(_generator.Generate(FourStatementChain(), Options()));
+
+        Assert.Equal(4, statements.Count);
+
+        foreach (var norecovery in statements.Take(3))
+        {
+            Assert.Contains("NORECOVERY", norecovery);
+            Assert.DoesNotContain("KEEP_REPLICATION", norecovery);
+            Assert.DoesNotContain("ENABLE_BROKER", norecovery);
+            Assert.DoesNotContain("NEW_BROKER", norecovery);
+        }
+
+        var last = statements[^1];
+        Assert.DoesNotContain("NORECOVERY", last);
+        Assert.Contains("KEEP_REPLICATION,", last);
+        Assert.Contains("ENABLE_BROKER,", last);
+        Assert.Contains("NEW_BROKER,", last);
+    }
+
+    /// <summary>
+    /// A chain deliberately left open carries them nowhere. This is the distinction the fix turns
+    /// on: not "the last statement" but "the statement that recovers" - a log-shipping secondary
+    /// ends in NORECOVERY and never has a running database for these options to describe.
+    /// </summary>
+    [Fact]
+    public void AChainLeftInNoRecoveryCarriesThemNowhere()
+    {
+        var script = _generator.Generate(
+            FourStatementChain(), Options(o => o.RecoveryMode = RecoveryMode.NoRecovery));
+
+        Assert.DoesNotContain("KEEP_REPLICATION", script);
+        Assert.DoesNotContain("ENABLE_BROKER", script);
+        Assert.DoesNotContain("NEW_BROKER", script);
+    }
+
+    /// <summary>Same for STANDBY - readable, but still mid-sequence.</summary>
+    [Fact]
+    public void AChainEndingInStandbyCarriesThemNowhere()
+    {
+        var script = _generator.Generate(FourStatementChain(), Options(o =>
+        {
+            o.RecoveryMode = RecoveryMode.Standby;
+            o.StandbyFilePath = @"D:\undo\standby.bak";
+        }));
+
+        Assert.Contains("STANDBY", script);
+        Assert.DoesNotContain("KEEP_REPLICATION", script);
+        Assert.DoesNotContain("ENABLE_BROKER", script);
+    }
+
+    /// <summary>
+    /// The single-statement case still works, which is what the old pin covered and what kept
+    /// this looking correct.
+    /// </summary>
+    [Fact]
+    public void ASingleStatementChainStillCarriesThem()
+    {
+        var script = _generator.Generate(
+            new BackupChain { FullSet = Set(BackupType.Full, T0) }, Options());
+
+        Assert.Contains("RECOVERY,", script);
+        Assert.Contains("KEEP_REPLICATION,", script);
+        Assert.Contains("ENABLE_BROKER,", script);
+    }
+
+    /// <summary>
+    /// The options that DO belong on every statement stayed there. CHECKSUM and
+    /// CONTINUE_AFTER_ERROR describe how each backup is read, not what the database does
+    /// afterwards, so the split must not have swept them along.
+    /// </summary>
+    [Fact]
+    public void ThePerStatementOptionsAreStillOnEveryStatement()
+    {
+        var statements = Statements(_generator.Generate(FourStatementChain(), Options(o =>
+        {
+            o.WithChecksum = true;
+            o.ContinueAfterError = true;
+            o.StatsPercent = 5;
+        })));
+
+        Assert.Equal(4, statements.Count);
+        Assert.All(statements, s =>
+        {
+            Assert.Contains("CHECKSUM,", s);
+            Assert.Contains("CONTINUE_AFTER_ERROR,", s);
+            Assert.Contains("STATS = 5;", s);
+        });
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1903,7 +1903,9 @@ public partial class RestoreViewModel : ViewModelBase
             : !Options.HasStandbyFileIfNeeded
                 ? "STANDBY needs an undo file path - without one the script would end in " +
                   "STANDBY = '', which fails after the database has already been overwritten."
-            : null;
+            // The generator refuses this one outright rather than emitting it (#365); asked here
+            // so the screen explains it instead of surfacing an exception.
+            : RestoreScriptGenerator.DescribeSetWithNoFiles(chain);
 
         ScriptBlockedReason = blocked ?? string.Empty;
 


### PR DESCRIPTION
Closes #363, #364, #365.

Three findings that share a shape: a check that bails exactly where the damage is worst, or a question asked of the wrong statement.

## A backup set with no files generated a restore that ends the sequence (#365)

A set discovered with nothing recorded against it passed every check — they all read `Files` and found nothing to complain about — and then generated:

```sql
RESTORE DATABASE [Sales]
    WITH
         RECOVERY,
         STATS = 10;
```

That is not a syntax error. It is the valid recovery-only form, so nothing fails at run time. Against a target sitting in RESTORING — a log-shipping secondary, a paused restore — it brings the database online wherever it had reached and **ends the restore sequence permanently**: no further log can be applied, and the whole chain has to start again.

The validator now reports it as an error, the restore screen explains it where the script would be, and `Generate` throws rather than emitting it. Refusing at generation time is the last line, not the first — the CLI verbs and the copy screen build chains too, and this is the statement that must never come out of any of them.

## A striped set missing its first file (#363)

`CheckStripes` returned early on `set.FileCount <= 1`. So a set holding only `..._2.bak` — stripe 1 purged by retention, or never uploaded — passed clean, while the **same set** as stripes 2 and 3 was correctly flagged. The check was blind precisely at its worst case, and the generated restore fails at run time with Msg 3132.

The question belongs to the stripe numbers, not the file count: a lone `_2` says stripe 1 is missing on its own. The second bail (`stripes.Count != set.FileCount`) skipped a set mixing an unnumbered file with a numbered one — that mixture is the signal, not a reason to stop looking — so it now reports the holes and names the unnumbered files.

Still cannot detect a uniformly truncated set (stripes 1 and 2 of an original 4); nothing in the filename records how many there were. That limit is written down where the check is.

## One striped set in two folders, offered as two restore points (#363)

Multi-directory striping — Ola's `@Directory = 'X,Y'`, which is how a large backup gets spread over two volumes — groups by parent folder, so it arrives as two sets carrying the same database, server, type and timestamp, each holding half a media set and each looking complete. A chain that should have offered four restore points offered seven, every one restoring from half a set, with both validators returning zero issues.

The stripe numbers make it provable rather than suspected: if the halves' numbers do not overlap and together run 1..N, they are one media set and nothing else — two independent backups would each be complete, so both would contain a stripe 1. Overlapping numbers are therefore left as a warning: those are two jobs that started in the same second, and each still restores. Calling that an error would disable a restore that works.

Checked over the whole inventory as well as over a chain, because a split *full* puts only one half in any chain the builder assembles — the browse list is where the extra points come from.

## KEEP_REPLICATION and the broker options on NORECOVERY statements (#364)

`AppendCommonOptions` was called unconditionally while the recovery clause was chosen independently, so all four statements of a Full + Diff + 2 Log chain carried `NORECOVERY, KEEP_REPLICATION, ENABLE_BROKER`. SQL Server refuses that outright — Msg 3031, "Option 'norecovery' conflicts with option(s) 'keep_replication'" — so the first statement failed and the option was unusable for any chain longer than one statement. Which is every log-shipping and replication scenario it exists for.

They now go only on the statement that recovers. That is deliberately **not** "the last statement": a chain left in NORECOVERY or STANDBY never brings a database online for these options to describe, and carries them nowhere. `CHECKSUM`, `CONTINUE_AFTER_ERROR` and `RESTORE_OPTIONS` describe how each backup is read rather than what the database does afterwards, so they stay on every statement — pinned, so the split cannot sweep them along later.

The existing pin used a full-only chain, which ends in RECOVERY, so the broken case had never been covered.

## Effect

`dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test NineLives.sln -c Release` → **1,950 passed, 0 failed** (up 23).

The new tests include the false-positive guards each check needs: an unstriped backup, a single file numbered `_1`, a complete striped set, two databases backed up in the same second, and a chain whose sets all have files.
