### PR TITLE
Two ways the app said yes when the answer was neither (#368, #369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A container that answers and holds nothing is no longer reported as a success** (#368).
+  "Connected! 0 files found (0 B)" was the commonest new-user failure there is - a base path
+  that does not match how the backups are actually laid out - presented in the voice of a
+  tick. The user goes on, and meets an inexplicably empty Browse Backups two screens later
+  with nothing to connect it to. It now reads as the finding it is, and says the three things
+  worth saying: the credential works, the container exists, and the backups may be under a
+  path this container's base path does not cover. The credential keeps its own sentence
+  deliberately, because it *is* proven and re-checking a working SAS token is its own wasted
+  afternoon.
+
+- **The keyboard cannot escape the first-run mode cards** (#369). Ctrl+0..9 are bound on the
+  window and stayed live behind them, so a keystroke landed on Blob Storage with the sidebar
+  collapsed to zero width, no mode chosen, no navigation and no way back to the cards - an app
+  that had to be restarted, and one that would not even record which screen it was on. The
+  comment beside the cards called them a gate there was no way past; there were ten. The
+  milder version of the same hole: in Basic mode, Ctrl+4 reached the Back Up screen the mode
+  exists to hide, and Ctrl+3 reached Browse Backups. Navigation now refuses while the cards
+  are up, and a screen the mode hides falls back to Home the way narrowing the mode already
+  does.
+
 - **A backup set with no files no longer generates a restore that ends the sequence** (#365).
   A set discovered with nothing recorded against it produced a RESTORE naming no device -
   which is not a syntax error but the valid recovery-only form. Run against a target sitting

--- a/src/NineLives.Tests/AppModeTests.cs
+++ b/src/NineLives.Tests/AppModeTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -235,7 +235,7 @@ public class AppModeTests
         var store = new FakeCredentialStore();
         store.Config.Mode = AppMode.Pro;
 
-        var main = new MainViewModel(store);
+        var main = Launched.App(store, AppMode.Pro);
         main.NavigateToCommand.Execute(MainViewModel.Nav.CopyDatabase);
         Assert.Same(main.CopyDatabase, main.CurrentView);
 
@@ -253,7 +253,7 @@ public class AppModeTests
         var store = new FakeCredentialStore();
         store.Config.Mode = AppMode.Pro;
 
-        var main = new MainViewModel(store);
+        var main = Launched.App(store, AppMode.Pro);
         main.NavigateToCommand.Execute(MainViewModel.Nav.History);
 
         main.Mode = AppMode.Standard;

--- a/src/NineLives.Tests/ExpectedResponsesTests.cs
+++ b/src/NineLives.Tests/ExpectedResponsesTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -67,7 +67,7 @@ public class ExpectedResponsesTests
     [Fact]
     public void ReloadReachesTheExposureDashboard()
     {
-        var main = new MainViewModel(new FakeCredentialStore());
+        var main = Launched.App(AppMode.Pro);
         main.NavigateToCommand.Execute(MainViewModel.Nav.Exposure);
 
         Assert.Equal(MainViewModel.Nav.Exposure, main.CurrentViewName);

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -768,3 +768,28 @@ internal static class RestoreSetup
         vm.Timeline.SelectedPoint ??= vm.Timeline.Points.LastOrDefault();
     }
 }
+
+/// <summary>
+/// A MainViewModel past the mode cards - where a test about screens wants to start (#369).
+///
+/// The cards are the landing screen on EVERY launch, not just the first, and navigation is now
+/// refused behind them: Ctrl+1..9 stay bound on the window, and a keystroke used to land on a
+/// screen with the sidebar collapsed to zero width, no mode chosen and no way back.
+///
+/// So a test that constructs a MainViewModel and navigates straight away is staging a state the
+/// app does not have. Choosing a mode is what a first-run user does, and it is the one route past
+/// the cards that works whether or not a mode was saved.
+/// </summary>
+public static class Launched
+{
+    public static MainViewModel App(AppMode mode = AppMode.Pro) =>
+        App(new FakeCredentialStore(), mode);
+
+    public static MainViewModel App(FakeCredentialStore store, AppMode mode = AppMode.Pro)
+    {
+        var main = new MainViewModel(store);
+        main.ModeSelection.ChooseCommand.Execute(
+            main.ModeSelection.Cards.Single(c => c.Mode == mode));
+        return main;
+    }
+}

--- a/src/NineLives.Tests/NavigationTests.cs
+++ b/src/NineLives.Tests/NavigationTests.cs
@@ -1,4 +1,5 @@
-using System.Windows.Controls.Primitives;
+﻿using System.Windows.Controls.Primitives;
+using Blackcat.NineLives.Models;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
 
@@ -17,7 +18,10 @@ public class NavigationTests(WpfFixture wpf)
     [Fact]
     public void EveryNameInTheListReachesItsOwnView()
     {
-        var vm = new MainViewModel(new FakeCredentialStore());
+        // Past the cards first (#369): navigation is refused behind them, so a MainViewModel
+        // straight from the constructor cannot navigate anywhere. Pro, because this walks every
+        // name and the narrower modes hide three of them.
+        var vm = Launched.App(AppMode.Pro);
         var reached = new List<object>();
 
         foreach (var name in MainViewModel.Nav.Views)
@@ -36,11 +40,16 @@ public class NavigationTests(WpfFixture wpf)
     [Fact]
     public void AnUnknownNameFallsBackRatherThanCrashing()
     {
-        var vm = new MainViewModel(new FakeCredentialStore());
+        var vm = Launched.App(AppMode.Pro);
+        vm.NavigateToCommand.Execute(MainViewModel.Nav.History);
 
         vm.NavigateToCommand.Execute("Not A View");
 
+        // Landed somewhere real rather than throwing - and specifically NOT left on the screen
+        // it was already on, which is what "NotNull" alone would have accepted once navigation
+        // learned to refuse things (#369).
         Assert.NotNull(vm.CurrentView);
+        Assert.NotSame(vm.History, vm.CurrentView);
     }
 
     /// <summary>

--- a/src/NineLives.Tests/ReachedButEmptyTests.cs
+++ b/src/NineLives.Tests/ReachedButEmptyTests.cs
@@ -1,0 +1,174 @@
+﻿using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Two ways the app said yes when the answer was neither (#368, #369).
+///
+/// A container that answers and holds nothing rendered "Connected! 0 files found (0 B)" - the
+/// commonest new-user failure there is, presented in the voice of a tick, and the user meets an
+/// inexplicably empty Browse Backups two screens later with nothing to connect it to. And
+/// Ctrl+1..9 stayed live behind the first-run mode cards, which the code called a gate there was
+/// no way past.
+/// </summary>
+public class ReachedButEmptyTests
+{
+    // ── a container that answers and holds nothing ──────────────────────────────
+
+    private static (BlobConfigViewModel vm, FakeBlobStorageService blob) Screen(
+        params BackupFileInfo[] files)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var blob = new FakeBlobStorageService { Files = files.ToList() };
+        var vm = new BlobConfigViewModel(store, blob);
+        vm.SelectedContainer = vm.Containers.First();
+        return (vm, blob);
+    }
+
+    private static BackupFileInfo File(string name) => new()
+    {
+        BlobName = name,
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/{name}",
+        Type = BackupType.Full,
+        SizeBytes = 1024
+    };
+
+    [Fact]
+    public async Task AContainerThatAnswersAndHoldsNothingIsNotReportedAsASuccess()
+    {
+        var (vm, _) = Screen();
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.True(vm.TestFoundNothing);
+        Assert.DoesNotContain("0 files found", vm.TestResult);
+
+        // The credential still gets its sentence - it IS proven, and sending somebody off to
+        // re-check a SAS token that works is its own wasted afternoon.
+        Assert.Contains("credential works", vm.TestResult);
+
+        // And the actual next move, which is the one thing the old message did not have.
+        Assert.Contains("base path", vm.TestResult);
+    }
+
+    [Fact]
+    public async Task AContainerWithBackupsInItStillReadsAsASuccess()
+    {
+        var (vm, _) = Screen(File("20260804_220000.bak"), File("20260804_230000.trn"));
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.False(vm.TestFoundNothing);
+        Assert.True(vm.TestSuccess);
+        Assert.Contains("Connected!", vm.TestResult);
+        Assert.Contains("2 files found", vm.TestResult);
+    }
+
+    /// <summary>
+    /// The warning state does not outlive the test that raised it. The refusals in this command
+    /// return before the result is written, so a stale flag would have painted the next test's
+    /// error message as a warning.
+    /// </summary>
+    [Fact]
+    public async Task AnEmptyResultDoesNotColourTheNextTest()
+    {
+        var (vm, blob) = Screen();
+
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+        Assert.True(vm.TestFoundNothing);
+
+        blob.Files = [File("20260804_220000.bak")];
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.False(vm.TestFoundNothing);
+    }
+
+    [Fact]
+    public async Task AFailedTestIsNotDressedAsAnEmptyOne()
+    {
+        var (vm, blob) = Screen();
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+        Assert.True(vm.TestFoundNothing);
+
+        blob.ListThrows = new InvalidOperationException("403 forbidden");
+        await vm.TestConnectionCommand.ExecuteAsync(null);
+
+        Assert.False(vm.TestFoundNothing);
+        Assert.False(vm.TestSuccess);
+    }
+
+    // ── the keyboard behind the first-run cards ─────────────────────────────────
+
+    /// <summary>
+    /// Ctrl+1 on the mode cards used to land on Blob Storage with the sidebar collapsed to zero
+    /// width, no mode chosen, no navigation and no way back - an app that had to be restarted.
+    /// </summary>
+    [Fact]
+    public void NavigationIsRefusedWhileTheModeCardsAreUp()
+    {
+        // A store with no mode chosen puts the cards up on construction - the first-run case.
+        var main = new MainViewModel(new FakeCredentialStore());
+
+        Assert.True(main.IsChoosingMode);
+        var before = main.CurrentView;
+
+        main.NavigateToCommand.Execute(MainViewModel.Nav.BlobStorage);
+
+        Assert.True(main.IsChoosingMode);
+        Assert.Same(before, main.CurrentView);
+        Assert.Equal(new System.Windows.GridLength(0), main.SidebarWidth);
+    }
+
+    /// <summary>Choosing a mode still navigates - the gate closes on the keyboard, not on itself.</summary>
+    [Fact]
+    public void ChoosingAModeStillLands()
+    {
+        var main = new MainViewModel(new FakeCredentialStore());
+        Assert.True(main.IsChoosingMode);
+
+        main.ModeSelection.ChooseCommand.Execute(
+            main.ModeSelection.Cards.Single(c => c.Mode == AppMode.Standard));
+
+        Assert.False(main.IsChoosingMode);
+        Assert.Equal(MainViewModel.Nav.Home, main.CurrentViewName);
+    }
+
+    /// <summary>
+    /// A mode that hides a screen hides it from the keyboard too. Basic mode's sidebar offers
+    /// neither Back Up nor Browse Backups, and Ctrl+4 and Ctrl+3 reached both.
+    /// </summary>
+    [Theory]
+    [InlineData(MainViewModel.Nav.Backup)]
+    [InlineData(MainViewModel.Nav.BrowseBackups)]
+    [InlineData(MainViewModel.Nav.CopyDatabase)]
+    public void AScreenTheModeHidesIsNotReachableByKeyboard(string hidden)
+    {
+        var main = Launched.App(AppMode.Basic);
+
+        Assert.False(main.IsViewAvailable(hidden));
+
+        main.NavigateToCommand.Execute(hidden);
+
+        Assert.Equal(MainViewModel.Nav.Home, main.CurrentViewName);
+    }
+
+    [Fact]
+    public void AScreenTheModeOffersIsStillReachable()
+    {
+        var main = Launched.App(AppMode.Basic);
+
+        main.NavigateToCommand.Execute(MainViewModel.Nav.Restore);
+
+        Assert.Equal(MainViewModel.Nav.Restore, main.CurrentViewName);
+    }
+}

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -192,6 +192,17 @@ public partial class BlobConfigViewModel : ViewModelBase
     [ObservableProperty]
     private bool _testSuccess;
 
+    /// <summary>
+    /// The connection worked and the container held nothing (#368).
+    ///
+    /// Separate from <see cref="TestSuccess"/> because it is neither outcome: the credential is
+    /// proven, so calling it a failure would send somebody to re-check a SAS token that is fine,
+    /// and the thing they were looking for is not there, so calling it a success is how they end
+    /// up at an empty Browse Backups two screens later with no idea why.
+    /// </summary>
+    [ObservableProperty]
+    private bool _testFoundNothing;
+
     [ObservableProperty]
     private string? _sasExpiryText;
 
@@ -926,6 +937,11 @@ public partial class BlobConfigViewModel : ViewModelBase
     [RelayCommand]
     private async Task TestConnectionAsync()
     {
+        // Cleared here rather than beside the result, because the refusals below return before
+        // ever reaching it - and a stale "found nothing" would paint the next test's error
+        // message in the wrong colour (#368).
+        TestFoundNothing = false;
+
         BlobContainerConfig? config;
         if (IsEditing)
         {
@@ -1011,7 +1027,24 @@ public partial class BlobConfigViewModel : ViewModelBase
             var summary = _blobService.GetContainerSummary(files);
             ContainerSummary = summary;
             TestSuccess = true;
-            TestResult = $"Connected! {summary.TotalFiles} files found ({summary.TotalSizeDisplay})";
+
+            // Reaching a container and finding nothing in it is not the same result as reaching
+            // one full of backups, and "Connected! 0 files found (0 B)" said it in the voice of a
+            // tick (#368). It is the commonest new-user failure there is - a base path that does
+            // not match how the backups are actually laid out - and the cost of dressing it as
+            // success is that the user goes on, and meets an inexplicably empty Browse Backups
+            // two screens later with nothing to connect it to.
+            //
+            // The credential still gets its own sentence, because it IS proven and that is what
+            // the button claims to test. What follows is the next move.
+            TestFoundNothing = summary.TotalFiles == 0;
+            TestResult = TestFoundNothing
+                ? "Connected, but no backups were found in this container. The credential works " +
+                  "and the container exists - so either it is empty, or the backups sit under a " +
+                  "path this container's base path does not cover. Check the base path above " +
+                  "against where the backup job actually writes."
+                : $"Connected! {summary.TotalFiles} " +
+                  $"{(summary.TotalFiles == 1 ? "file" : "files")} found ({summary.TotalSizeDisplay})";
         }
         catch (OperationCanceledException)
         {

--- a/src/NineLives/ViewModels/MainViewModel.cs
+++ b/src/NineLives/ViewModels/MainViewModel.cs
@@ -329,6 +329,10 @@ public partial class MainViewModel : ViewModelBase
             // choice about what the sidebar contains would be answering it twice - and there is no
             // way past it, because leaving would mean an app that has not been told how much of
             // itself to show.
+            //
+            // That last sentence was a claim about intent rather than about the code until #369:
+            // Ctrl+0..9 are bound on the window and stayed live behind the cards, so there were
+            // ten ways past. NavigateTo now refuses while IsChoosingMode.
             IsChoosingMode = true;
             CurrentView = ModeSelection;
         }
@@ -598,6 +602,19 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private void NavigateTo(string viewName)
     {
+        // The mode cards are a gate, not a screen (#369). Ctrl+0..9 are bound on the Window and
+        // stay live behind them, so a keystroke landed on Blob Storage with the sidebar collapsed
+        // to zero width, no mode chosen, no navigation and no way back to the cards - an app that
+        // had to be restarted, and one that would not even record which screen it was on. Both
+        // internal callers clear the flag before navigating, so this refuses only the keyboard.
+        if (IsChoosingMode) return;
+
+        // A mode that hides a screen hides it from the keyboard too (#369). Basic mode's sidebar
+        // offers neither Back Up nor Browse Backups, and Ctrl+4 and Ctrl+3 reached both. Home
+        // rather than nothing, the same fallback OnModeChanged uses, so the key still does
+        // something explicable.
+        if (!IsViewAvailable(viewName)) viewName = Nav.Home;
+
         CurrentViewName = viewName;
         CurrentView = viewName switch
         {

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -286,12 +286,26 @@
                                             Command="{Binding DeleteCommand}" />
                                 </StackPanel>
 
-                                <!-- Test Result -->
-                                <Border Background="{DynamicResource InputBackgroundBrush}"
-                                        CornerRadius="4"
+                                <!-- Test Result. Reached-but-empty is neither outcome (#368):
+                                     the credential is proven and the thing being looked for is
+                                     not there, so it is styled as the finding it is. -->
+                                <Border CornerRadius="4"
                                         Padding="12,8"
                                         Margin="0,16,0,0"
+                                        BorderThickness="1"
                                         Visibility="{Binding TestResult, Converter={StaticResource NullToVis}}">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+                                            <Setter Property="BorderBrush" Value="Transparent" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding TestFoundNothing}" Value="True">
+                                                    <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
+                                                    <Setter Property="BorderBrush" Value="{DynamicResource WarningPanelBorderBrush}" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
                                     <TextBlock Text="{Binding TestResult}"
                                                Style="{StaticResource BodyText}"
                                                TextWrapping="Wrap" />
@@ -828,12 +842,25 @@
                                            Visibility="{Binding HasUnsavedChanges, Converter={StaticResource BoolToVis}}" />
                             </StackPanel>
 
-                            <!-- Test Result in Edit Mode -->
-                            <Border Background="{DynamicResource InputBackgroundBrush}"
-                                    CornerRadius="4"
+                            <!-- Test Result in Edit Mode. Same warning state as above (#368) -
+                                 this is the form somebody is on while getting the path right. -->
+                            <Border CornerRadius="4"
                                     Padding="12,8"
                                     Margin="0,16,0,0"
+                                    BorderThickness="1"
                                     Visibility="{Binding TestResult, Converter={StaticResource NullToVis}}">
+                                <Border.Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="Background" Value="{DynamicResource InputBackgroundBrush}" />
+                                        <Setter Property="BorderBrush" Value="Transparent" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding TestFoundNothing}" Value="True">
+                                                <Setter Property="Background" Value="{DynamicResource WarningPanelBackgroundBrush}" />
+                                                <Setter Property="BorderBrush" Value="{DynamicResource WarningPanelBorderBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Border.Style>
                                 <TextBlock Text="{Binding TestResult}"
                                            Style="{StaticResource BodyText}"
                                            TextWrapping="Wrap" />


### PR DESCRIPTION
Closes #368, #369.

## A container that answers and holds nothing (#368)

`TestSuccess = true` and `"Connected! {n} files found"` rendered an empty container as **"Connected! 0 files found (0 B)"**.

That is the commonest new-user failure there is — a base path that does not match how the backups are actually laid out — presented in the voice of a tick. The README already concedes that path inference "is right most of the time and wrong in ways that stay invisible"; this is exactly where it becomes visible, except it was dressed as a success. The user proceeds, and finds an inexplicably empty Browse Backups two screens later with nothing to connect it to.

It now reads as the finding it is, in a warning panel rather than the neutral one, and says the three things worth saying: the credential works, the container exists, and the backups may sit under a path this container's base path does not cover.

The credential keeps its own sentence deliberately. It **is** proven, and sending somebody off to re-check a SAS token that works is its own wasted afternoon — which is why this is a third state (`TestFoundNothing`) rather than flipping `TestSuccess` to false. The flag is cleared at the top of the command, not beside the result, because the refusals in it return before ever reaching the result — otherwise a stale "found nothing" would paint the next test's *error* message as a warning. That one is pinned.

Rendered both states to check the panel actually appears rather than trusting the binding:

| | |
|---|---|
| **Empty** | amber panel, full explanation, and the 0/0/0 summary card underneath reinforcing it |
| **Found** | unchanged neutral panel, "Connected! 1 file found (4.0 KB)" |

(Also fixed "1 files found" while in that expression.)

## The keyboard escapes the first-run mode cards (#369)

`MainWindow.xaml` binds Ctrl+0..9 to `NavigateToCommand` on the Window, always live. `NavigateTo` set `CurrentView` unconditionally: it never checked `IsViewAvailable` and never consulted `IsChoosingMode`.

So Ctrl+1 on the first-run cards landed on Blob Storage with `SidebarWidth` at zero, no navigation, no way back to the cards, and no mode chosen. The app was unusable until restarted, and `SaveShutdownState` would not record the screen either. The comment beside the cards says of the first-run gate "there is no way past it" — there were ten. That comment now describes the code instead of the intent.

Milder version of the same hole: in Basic mode, Ctrl+4 reached the Back Up screen the mode exists to hide, and Ctrl+3 reached Browse Backups.

`NavigateTo` now returns early while `IsChoosingMode`, and routes through `IsViewAvailable`, falling back to `Nav.Home` the way `OnModeChanged` already does. Both internal callers clear the flag before navigating, so this closes the keyboard and nothing else — choosing a mode still lands on Home, and that is pinned.

## Four existing tests were staging a state the app does not have

They constructed a `MainViewModel` and navigated straight away — but the cards are the landing screen on **every** launch, not just the first, so that sequence never happens. They now go through the cards, via a shared `Launched.App(...)` helper that documents why.

One of them, `AnUnknownNameFallsBackRatherThanCrashing`, asserted only `Assert.NotNull(vm.CurrentView)` — which navigation refusing outright would have satisfied, leaving it passing for the wrong reason. It now navigates somewhere real first and pins that the fallback actually moves off it.

## Effect

`dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test NineLives.sln -c Release` → **1,960 passed, 0 failed** (up 10).
