### PR TITLE
Three screens that failed without saying so (#356, #357, #358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The Backup and Copy consoles no longer vanish when the run ends** (#358). Both were bound to
+  "a run is in progress", so the panel holding SQL Server's own account of what happened
+  collapsed at the moment its contents started to matter. The error text left behind on the
+  backup screen reads "see the console for each failure" - and the console it names was gone.
+  On the copy screen it was worse: that console is where the target's recovery explanation and
+  the literal `RESTORE ... WITH RECOVERY` statements are printed when the restore half fails, so
+  the app hid the exact statements needed to get the target out of RESTORING, and the only way
+  back to them was to re-run a production operation. They are now bound to having output.
+
+- **Browse Backups says what went wrong** (#356). It had no error banner and no status line, so
+  every failure on it was silent: an expired SAS, a 403, a DNS failure, a genuinely empty
+  container and never having pressed the button all left the identical empty state, and pressing
+  Load Backups with nothing selected was a button that visibly did nothing at all. The view model
+  had been writing those messages the whole time - into a screen with nothing bound to them.
+
+- **A failed Connect on the SQL Servers screen explains itself** (#357). The message went to the
+  error banner, which lives inside the edit form; the Connect button lives in the panel shown
+  when that form is closed. So on the last step of first run, a typo'd instance name or a wrong
+  password flashed "Connecting..." and returned to a screen with nothing on it - while Test, one
+  button away against the same server, explained itself properly. Connect now writes the same
+  surface Test does, in the same words, since they fail the same way for the same reasons.
+
 - **A container that answers and holds nothing is no longer reported as a success** (#368).
   "Connected! 0 files found (0 B)" was the commonest new-user failure there is - a base path
   that does not match how the backups are actually laid out - presented in the voice of a

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -253,8 +253,13 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Set to make the restore fail the way a real one does.</summary>
     public Exception? ExecuteThrows { get; set; }
 
+    /// <summary>Refuse the connection, for the screens that have to explain one (#357).</summary>
+    public Exception? TestConnectionThrows { get; set; }
+
     public Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default)
-        => Task.FromResult(true);
+        => TestConnectionThrows != null
+            ? Task.FromException<bool>(TestConnectionThrows)
+            : Task.FromResult(true);
 
     public Task<bool?> WouldConnectWithCertificateValidationAsync(ServerConnection server, CancellationToken ct = default)
         => Task.FromResult<bool?>(true);

--- a/src/NineLives.Tests/SilentFailureTests.cs
+++ b/src/NineLives.Tests/SilentFailureTests.cs
@@ -1,0 +1,213 @@
+using System.Windows;
+using System.Windows.Controls;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Three screens that failed without saying so (#356, #357, #358).
+///
+/// The shape is the same each time: the view model wrote a message and the view rendered no
+/// surface for it, or rendered one and then collapsed it. Browse Backups had neither an error
+/// banner nor a status line, so every SetError in it was a dead call - an expired SAS, a 403, a
+/// DNS failure and never having pressed the button all left the identical screen. Connect on the
+/// SQL Servers screen wrote a banner that lives inside the edit form, while the button itself
+/// lives in the panel shown when the form is closed. And the Backup and Copy consoles were bound
+/// to IsRunning, so they vanished at exactly the moment their contents mattered.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class SilentFailureTests(WpfFixture wpf)
+{
+    // ── Browse Backups has somewhere to put a failure (#356) ────────────────────
+
+    /// <summary>
+    /// Pinned in the view rather than the view model, because the view model was never the
+    /// problem: it had been writing SetError all along, into a screen with nothing bound to it.
+    /// </summary>
+    [Fact]
+    public void BrowseBackupsRendersAnErrorBanner()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BlobBrowserViewModel(
+                new FakeBlobStorageService(), new FakeSqlServerService(), new FakeCredentialStore());
+
+            var view = new BlobBrowserView { DataContext = vm };
+            Layout(view);
+
+            // Nothing to show yet, so nothing is showing.
+            Assert.Empty(VisibleBanners(view));
+
+            vm.LoadBackupsCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+            Layout(view);
+
+            // The refusal reached a surface: pressing Load Backups with nothing selected used to
+            // be a button that visibly did nothing at all.
+            Assert.True(vm.HasError);
+            Assert.Contains("select a container", vm.ErrorMessage);
+
+            Assert.Single(VisibleBanners(view));
+        });
+    }
+
+    /// <summary>
+    /// SetError writes the status line as well as the banner, because not every screen surfaces
+    /// both. This one does, and the same sentence in red above itself in grey reads as two
+    /// separate things having gone wrong.
+    /// </summary>
+    [Fact]
+    public void AnErrorIsNotPrintedTwiceOnTheSameScreen()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BlobBrowserViewModel(
+                new FakeBlobStorageService(), new FakeSqlServerService(), new FakeCredentialStore());
+
+            var view = new BlobBrowserView { DataContext = vm };
+            vm.LoadBackupsCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+            Layout(view);
+
+            // The view model writes both, deliberately - so the check is that the view shows one.
+            Assert.Equal(vm.ErrorMessage, vm.StatusMessage);
+
+            var showingIt = FindAll<TextBlock>(view)
+                .Count(t => t.Visibility == Visibility.Visible && t.Text == vm.ErrorMessage);
+
+            Assert.Equal(0, showingIt);
+        });
+    }
+
+    // ── Connect explains itself, like Test does (#357) ──────────────────────────
+
+    /// <summary>
+    /// Two buttons on the same screen against the same server, with opposite behaviour: Test
+    /// wrote TestResult, which view mode renders, and Connect wrote a banner that view mode does
+    /// not. On the last step of first run, a typo'd instance or a wrong password flashed
+    /// "Connecting..." and returned to a screen with nothing on it.
+    /// </summary>
+    [Fact]
+    public async Task AFailedConnectSaysWhyOnTheSurfaceViewModeRenders()
+    {
+        var vm = Servers(new FakeSqlServerService
+        {
+            TestConnectionThrows = new InvalidOperationException(
+                "A network-related or instance-specific error occurred.")
+        });
+
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        Assert.False(vm.IsConnected);
+        Assert.False(vm.TestSuccess);
+        Assert.Contains("Connection failed", vm.TestResult);
+        Assert.Contains("network-related", vm.TestResult);
+    }
+
+    [Fact]
+    public async Task ASuccessfulConnectClearsAPreviousFailure()
+    {
+        var sql = new FakeSqlServerService
+        {
+            TestConnectionThrows = new InvalidOperationException("Login failed for user 'sa'.")
+        };
+        var vm = Servers(sql);
+
+        await vm.ConnectCommand.ExecuteAsync(null);
+        Assert.Contains("Login failed", vm.TestResult);
+
+        sql.TestConnectionThrows = null;
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        Assert.True(vm.IsConnected);
+        Assert.True(vm.TestSuccess);
+        Assert.DoesNotContain("Login failed", vm.TestResult);
+        Assert.Contains("Connected to", vm.TestResult);
+    }
+
+    private static ServerManagerViewModel Servers(FakeSqlServerService sql)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        });
+
+        var vm = new ServerManagerViewModel(store, sql);
+        vm.SelectedServer = vm.Servers.First();
+        return vm;
+    }
+
+    // ── the console outlives the run that wrote it (#358) ───────────────────────
+
+    /// <summary>
+    /// The error text left on screen when a striped backup partly fails says "see the console for
+    /// each failure". Bound to IsRunning, the console it names was gone by the time anyone read
+    /// that sentence.
+    /// </summary>
+    [Fact]
+    public void TheBackupConsoleStaysUpAfterTheRunEnds()
+    {
+        var vm = new BackupViewModel(new FakeCredentialStore(), new FakeSqlServerService());
+
+        Assert.False(vm.HasConsoleOutput);
+
+        vm.AppendConsoleForTests("Msg 3201, Level 16, State 1");
+
+        Assert.True(vm.HasConsoleOutput);
+        Assert.False(vm.IsRunning);
+        Assert.NotEmpty(vm.Console);
+    }
+
+    /// <summary>
+    /// The copy screen is the worse of the two: this console is where the target's recovery
+    /// explanation and the literal RESTORE ... WITH RECOVERY statements are printed when the
+    /// restore half fails, so collapsing it hid the exact statements needed to get the target out
+    /// of RESTORING - and the only way back to them was to re-run a production operation.
+    /// </summary>
+    [Fact]
+    public void TheCopyConsoleStaysUpAfterTheRunEnds()
+    {
+        var vm = new CopyDatabaseViewModel(new FakeCredentialStore(), new FakeSqlServerService());
+
+        Assert.False(vm.HasConsoleOutput);
+
+        vm.AppendConsoleForTests("RESTORE DATABASE [Sales] WITH RECOVERY;");
+
+        Assert.True(vm.HasConsoleOutput);
+        Assert.False(vm.IsRunning);
+        Assert.Contains(vm.Console, l => l.Contains("WITH RECOVERY"));
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The error banners on screen. Matched on the exact type rather than with an "is" test,
+    /// because Button, RadioButton and CheckBox all derive from ContentControl - the banner is
+    /// the only bare one in these views.
+    /// </summary>
+    private static List<ContentControl> VisibleBanners(DependencyObject view) =>
+        FindAll<ContentControl>(view)
+            .Where(c => c.GetType() == typeof(ContentControl) && c.Visibility == Visibility.Visible)
+            .ToList();
+
+    private static void Layout(FrameworkElement element)
+    {
+        element.Measure(new Size(1600, 1200));
+        element.Arrange(new Rect(0, 0, 1600, 1200));
+        element.UpdateLayout();
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        foreach (var child in LogicalTreeHelper.GetChildren(root))
+        {
+            if (child is not DependencyObject node) continue;
+            if (node is T match) yield return match;
+            foreach (var descendant in FindAll<T>(node)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -506,6 +506,20 @@ public partial class BackupViewModel : ViewModelBase
     /// <summary>SQL Server's own words as it goes, in the order it said them.</summary>
     public ObservableCollection<string> Console { get; } = [];
 
+    /// <summary>
+    /// Whether the console has anything in it - which is not the same as a run being in progress
+    /// (#358).
+    ///
+    /// The console used to be bound to IsRunning, so it collapsed the instant the run ended and
+    /// took SQL Server's own account of the failure with it. The error text left on screen says
+    /// "see the console for each failure", and the console was gone.
+    ///
+    /// Set as lines arrive rather than computed from Console.Count, so it survives the collection
+    /// being repopulated and can be pinned by a test that never touches a view.
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasConsoleOutput;
+
     public bool CanExecute => HasScript && !IsRunning;
 
     [RelayCommand(CanExecute = nameof(CanExecute))]
@@ -523,6 +537,7 @@ public partial class BackupViewModel : ViewModelBase
         IsRunning = true;
         ClearStatus();
         Console.Clear();
+        HasConsoleOutput = false;
 
         var ct = _runCancellation.Begin();
         var started = DateTime.Now;
@@ -812,9 +827,21 @@ public partial class BackupViewModel : ViewModelBase
     /// since its console was built; this screen now carries it too. InvokeAsync, not Invoke - a
     /// blocked connection thread is how "live" output arrives in bursts.
     /// </summary>
+
+    /// <summary>
+    /// Write one console line, as the run itself does (#358).
+    ///
+    /// The console outliving its run is a property of the screen, not of a SQL connection, and
+    /// staging a real run to prove it would need a server. This writes the same line by the same
+    /// route the run uses.
+    /// </summary>
+    internal void AppendConsoleForTests(string line) => Append(line);
+
     private void Append(string line)
     {
         if (_consoleDispatcher == null || _consoleDispatcher.CheckAccess()) Console.Add(line);
         else _consoleDispatcher.InvokeAsync(() => Console.Add(line));
+
+        HasConsoleOutput = true;
     }
 }

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -671,6 +671,20 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     public ObservableCollection<string> Console { get; } = [];
 
     /// <summary>
+    /// Whether the console has anything in it - which is not the same as a run being in progress
+    /// (#358).
+    ///
+    /// The console used to be bound to IsRunning, so it collapsed the instant the run ended and
+    /// took SQL Server's own account of the failure with it. The error text left on screen says
+    /// "see the console for each failure", and the console was gone.
+    ///
+    /// Set as lines arrive rather than computed from Console.Count, so it survives the collection
+    /// being repopulated and can be pinned by a test that never touches a view.
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasConsoleOutput;
+
+    /// <summary>
     /// The confirmation, naming BOTH servers.
     ///
     /// The whole point of this screen is that two are involved, so a prompt that names one of them
@@ -716,6 +730,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         IsRunning = true;
         ClearStatus();
         Console.Clear();
+        HasConsoleOutput = false;
         Outcome = CopyOutcome.NotStarted;
         OutcomeText = string.Empty;
 
@@ -1014,9 +1029,21 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// since its console was built; this screen now carries it too. InvokeAsync, not Invoke - a
     /// blocked connection thread is how "live" output arrives in bursts.
     /// </summary>
+
+    /// <summary>
+    /// Write one console line, as the run itself does (#358).
+    ///
+    /// The console outliving its run is a property of the screen, not of a SQL connection, and
+    /// staging a real copy to prove it would need two servers. This writes the same line by the
+    /// same route the run uses.
+    /// </summary>
+    internal void AppendConsoleForTests(string line) => Append(line);
+
     private void Append(string line)
     {
         if (_consoleDispatcher == null || _consoleDispatcher.CheckAccess()) Console.Add(line);
         else _consoleDispatcher.InvokeAsync(() => Console.Add(line));
+
+        HasConsoleOutput = true;
     }
 }

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -542,11 +542,23 @@ public partial class ServerManagerViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Connect, and say so either way (#357).
+    ///
+    /// SetError and SetStatus both write surfaces this screen does not render in view mode - the
+    /// error banner sits inside the edit form, gated on IsEditing, and the Connect button sits in
+    /// the panel gated on the inverse of it, so a message written here reached a collapsed
+    /// control. TestResult is the one surface view mode DOES render, which is why Test explains
+    /// itself and Connect, on the same screen against the same server, did not: a typo'd instance
+    /// or a wrong password on the last step of first run flashed "Connecting..." and returned to
+    /// a screen with nothing on it, a button indistinguishable from a broken one.
+    /// </summary>
     [RelayCommand]
     private async Task ConnectAsync()
     {
         if (SelectedServer == null) return;
 
+        TestResult = string.Empty;
         IsBusy = true;
         try
         {
@@ -573,10 +585,19 @@ public partial class ServerManagerViewModel : ViewModelBase
                 ConnectedServer = SelectedServer
             });
             SetStatus($"Connected to {SelectedServer.ServerName}");
+
+            TestSuccess = true;
+            TestResult = $"Connected to {SelectedServer.DisplayText}.";
         }
         catch (Exception ex)
         {
             SetError($"Connection failed: {ex.Message}");
+
+            // Same wording as Test's own failure, because they fail the same way for the same
+            // reasons - and reading differently would suggest the two buttons had found
+            // different things.
+            TestSuccess = false;
+            TestResult = $"Connection failed: {ex.Message}";
         }
         finally
         {

--- a/src/NineLives/Views/BackupView.xaml
+++ b/src/NineLives/Views/BackupView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.BackupView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.BackupView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
@@ -322,12 +322,15 @@
                         </ScrollViewer>
                     </Border>
 
-                    <!-- What the server said, as it said it. -->
+                    <!-- What the server said, as it said it - and it STAYS said (#358).
+                         Bound to IsRunning, this collapsed the moment the run ended, taking SQL
+                         Server's own account of the failure with it. The error text left behind
+                         reads "see the console for each failure", and the console was gone. -->
                     <Border Background="{DynamicResource ConsoleBackgroundBrush}"
                             BorderBrush="{DynamicResource ConsoleBorderBrush}"
                             BorderThickness="1" CornerRadius="4"
                             Margin="0,12,0,0"
-                            Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}">
+                            Visibility="{Binding HasConsoleOutput, Converter={StaticResource BoolToVis}}">
                         <ScrollViewer MaxHeight="220"
                                       VerticalScrollBarVisibility="Auto"
                                       Padding="12,10,12,10">

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -17,6 +17,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -146,7 +147,40 @@
         </Border>
 
         <!-- Summary + Filters -->
-        <Border Grid.Row="2" Style="{StaticResource CardBorder}" Margin="0,0,0,12"
+        <!-- What happened, on the screen it happened on (#356).
+             This view had neither, so every failure was silent: an expired SAS, a 403, a DNS
+             failure, a genuinely empty container and never having pressed the button all left
+             the identical empty state. The view models were writing SetError and SetStatus the
+             whole time - the shell's status bar only ever renders MainViewModel's own, so those
+             were dead calls into nothing. Pressing Load Backups with nothing selected was a
+             button that visibly did nothing at all. -->
+        <StackPanel Grid.Row="2">
+            <ContentControl Style="{StaticResource ErrorBanner}" />
+
+            <TextBlock Text="{Binding StatusMessage}"
+                       TextWrapping="Wrap"
+                       Margin="0,0,0,12">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                        <Setter Property="Visibility" Value="Visible" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding StatusMessage}" Value="">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <!-- SetError writes the status line as well as the banner, because
+                                 not every screen surfaces both. This one does, so without this
+                                 the same sentence appears twice - once in red and once in grey,
+                                 which reads as two separate things having gone wrong. -->
+                            <DataTrigger Binding="{Binding HasError}" Value="True">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+        </StackPanel>
+
+        <Border Grid.Row="3" Style="{StaticResource CardBorder}" Margin="0,0,0,12"
                 Visibility="{Binding HasFiles, Converter={StaticResource BoolToVis}}">
             <StackPanel>
                 <!-- Summary Stats (set-based, filtered) -->
@@ -230,7 +264,7 @@
         </Border>
 
         <!-- Backup Files Grid -->
-        <Border Grid.Row="3" Style="{StaticResource CardBorder}">
+        <Border Grid.Row="4" Style="{StaticResource CardBorder}">
             <Grid>
                 <!-- Empty State -->
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center"

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="Blackcat.NineLives.Views.CopyDatabaseView"
+﻿<UserControl x:Class="Blackcat.NineLives.Views.CopyDatabaseView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:converters="clr-namespace:Blackcat.NineLives.Converters"
@@ -360,11 +360,17 @@
                         <TextBlock Text="{Binding OutcomeText}" TextWrapping="Wrap" Style="{StaticResource BodyText}" />
                     </Border>
 
+                    <!-- Bound to the output, not to the run (#358). This console is where the
+                         target's recovery explanation and the literal RESTORE ... WITH RECOVERY
+                         statements are printed when the restore half fails - so binding it to
+                         IsRunning collapsed the panel that had just printed the exact statements
+                         needed to get the target out of RESTORING, and the only way back to them
+                         was to re-run a production operation. -->
                     <Border Background="{DynamicResource ConsoleBackgroundBrush}"
                             BorderBrush="{DynamicResource ConsoleBorderBrush}"
                             BorderThickness="1" CornerRadius="4"
                             Margin="0,12,0,0"
-                            Visibility="{Binding IsRunning, Converter={StaticResource BoolToVis}}">
+                            Visibility="{Binding HasConsoleOutput, Converter={StaticResource BoolToVis}}">
                         <ScrollViewer MaxHeight="220"
                                       VerticalScrollBarVisibility="Auto"
                                       Padding="12,10,12,10">


### PR DESCRIPTION
Closes #356, #357, #358.

The same shape each time: a view model writing a message into a screen that renders no surface for it, or renders one and then collapses it.

## Browse Backups had nowhere to put a failure (#356)

`BlobBrowserView.xaml` contained no `ErrorBanner` and bound no `StatusMessage`. The shell's status bar binds `GlobalStatus`, which only `MainViewModel` ever writes — child view models are never forwarded to it. So every one of these was a dead call: "Failed to load backups: …", "Please select a container first", the results line, "Loading cancelled", "path copied".

An expired SAS, a 403, a DNS failure, a genuinely empty container and never having pressed the button all left the identical empty state. Pressing Load Backups with nothing selected was a button that visibly did nothing at all.

It now has both surfaces. One wrinkle worth knowing: `SetError` writes the status line **as well as** the banner, deliberately, because not every screen surfaces both — the History screen binds only the status line. This screen binds both, so without care the same sentence appears in red above itself in grey, which reads as two separate things having gone wrong. The status line collapses while there is an error, and that is pinned.

Rendered to check, rather than trusting the binding: a 403 shows the banner with the provider's own sentence and no duplicate; nothing-selected shows "Please select a container first."

## Connect said nothing; Test, one button away, explained itself (#357)

`ConnectAsync`'s catch called `SetError`. That banner lives inside the edit-form `Border`, gated on `IsEditing` — and the Connect button lives in the view-mode panel, gated on the inverse. The message went to a control that is collapsed whenever the button that produces it is on screen.

So on the last step of first run, a typo'd instance name or a wrong password flashed "Connecting..." and returned to a screen with no message of any kind. Meanwhile **Test**, on the same screen against the same server, writes `TestResult` — which view mode does render. Two buttons, same screen, opposite behaviour.

`ConnectAsync` now writes `TestResult` too, in the same words as Test's own failure, because they fail the same way for the same reasons and reading differently would suggest they had found different things. A successful connect replaces a previous failure's message rather than leaving it sitting underneath.

## The consoles vanished, taking the recovery SQL with them (#358)

`BackupView.xaml` and `CopyDatabaseView.xaml` both bound the console `Border` to `IsRunning`, which the `finally` sets false. Nothing re-showed it, and `Console.Clear()` wiped it on the next run.

The backup screen's own error text says **"The others finished and are real backups - see the console for each failure."** The console it names was no longer on screen.

The copy screen is worse. That console is where `CopyDatabaseViewModel` appends the target's recovery explanation, **the literal `RESTORE ... WITH RECOVERY` statements**, and the orphaned-user fix SQL. So the moment the restore half failed, the app collapsed the panel that had just printed the exact statements needed to get the target out of RESTORING — and the only way to see them again was to re-run a production operation.

Both now bind to `HasConsoleOutput`, which is a different question from "a run is in progress". It is set as lines arrive rather than computed from the collection, so it survives the collection being repopulated and can be pinned without a server.

## Effect

`dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test NineLives.sln -c Release` → **1,966 passed, 0 failed** (up 6).
