### PR TITLE
SECURITY.md describes the app that exists (#367)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 # Security policy
 
-Nine Lives holds Azure SAS tokens and SQL Server passwords, and it generates and runs T-SQL against
-instances you point it at — usually with rights to drop and replace databases. Security reports are
-taken seriously here.
+Nine Lives holds Azure SAS tokens, S3 access key pairs, SQL Server passwords and webhook URLs, and
+it generates and runs T-SQL against instances you point it at — usually with rights to drop and
+replace databases. Security reports are taken seriously here.
 
 ## Reporting a vulnerability
 
@@ -40,9 +40,23 @@ Worth stating plainly, because it determines whether a given finding is a bug or
 
 - **It runs locally as you.** It has whatever access your Windows account has, and no privilege
   boundary of its own.
-- **Secrets live in Windows Credential Manager**, per-user, under `NineLives:Blob:*` and
-  `NineLives:SQL:*`. They are never written to `config.json`, never included in generated scripts,
-  and never sent anywhere except the SQL Server you connect to.
+- **Secrets live in Windows Credential Manager**, per-user, under four prefixes:
+  `NineLives:Blob:*` (SAS tokens, and S3 access key pairs as `AccessKeyId:SecretKey`),
+  `NineLives:SQL:*` (SQL Server passwords), `NineLives:Webhook:*` (one per configured endpoint)
+  and `NineLives:WebhookProxy` (proxy credentials). A webhook URL counts as a secret here: the app
+  never displays one back, and most carry their own token in the path. None are written to
+  `config.json` and none appear in an exported config. Each goes to exactly one place and nowhere
+  else: a SQL password to the instance it belongs to, a SAS token or S3 key pair to the storage
+  endpoint it authenticates against, a webhook URL to the endpoint it addresses.
+- **A generated script never contains a credential.** The server-side `CREDENTIAL` a restore from
+  a URL needs is created on the instance separately, so the script you read before running it is
+  safe to paste into a change ticket.
+- **An Azure container can be reached without a stored secret at all.** Entra ID is supported —
+  interactive sign-in, or `DefaultAzureCredential` for a managed identity or a service principal
+  from the environment — and neither writes anything to Credential Manager. Worth saying here
+  because the usual reason to read this file is to find out whether long-lived SAS tokens are
+  compulsory. They are not. S3-compatible buckets authenticate with an access key pair, which is
+  stored.
 - **`config.json` is trusted input.** It sits in `%LOCALAPPDATA%\NineLives`, is plain text, and has
   no integrity checking. Anything able to write it is already running as you. That said, values
   read from it still get escaped properly before reaching T-SQL — someone who can write that file
@@ -56,8 +70,9 @@ unexpected, or turns untrusted data into executed T-SQL, is.
 
 ### Particularly interested in
 
-- SAS tokens or SQL passwords ending up anywhere other than Credential Manager — logs, the
-  generated script, `config.json`, the clipboard, an error message, a crash dump.
+- Any stored secret — a SAS token, an S3 secret key, a SQL password, a webhook URL — ending up
+  anywhere other than Credential Manager: logs, the generated script, `config.json`, the exported
+  config, the clipboard, an error message, a crash dump.
 - Anything that reaches T-SQL without going through `Services/TSql.cs`, or a way past its quoting.
 - A restore being aimed at a server or database other than the one shown in the confirmation.
 - Credentials being sent over a connection that isn't validated the way the settings claim.
@@ -72,8 +87,6 @@ Not vulnerabilities to report — they're on the list:
   you can verify in the meantime.
 - `TrustServerCertificate` defaults to true
   ([#17](https://github.com/jakemorgangit/NineLives/issues/17)).
-- Entra ID / Managed Identity is not supported yet; SAS tokens only
-  ([#29](https://github.com/jakemorgangit/NineLives/issues/29)).
 
 ## Thank you
 


### PR DESCRIPTION
Closes #367.

Three staleness points, each misleading exactly the reader this file is written for.

## Entra ID was documented as unsupported

`SECURITY.md` said, under "Known and already tracked":

> Entra ID / Managed Identity is not supported yet; SAS tokens only (#29).

[#29](https://github.com/jakemorgangit/NineLives/issues/29) is closed and the feature shipped — `EntraAuthentication.cs`, `EntraIdentity.cs`, `ManagedIdentitySupport.cs`, and three places in the README.

This is wrong in the worst possible place. An organisation that has banned long-lived SAS tokens reads SECURITY.md *precisely* to check this, and was told the thing they need does not exist.

The bullet is gone, and the assumptions section now says positively what a container can be reached with — including that Entra writes nothing to Credential Manager at all — because finding that out is the usual reason to open this file.

## It listed half the secrets the app holds

The opening line said "Azure SAS tokens and SQL Server passwords". It also holds **S3 access key pairs** and **webhook URLs**. A webhook URL is a secret: the app never displays one back, and most carry their own token in the path — and nobody reading this document was told the app stores one.

## It listed two of the four vault prefixes

`NineLives:Blob:*` and `NineLives:SQL:*` were named. There are also `NineLives:Webhook:*` (one per configured endpoint) and `NineLives:WebhookProxy`. All four verified against the source before writing them down.

## One correction that was imprecise rather than stale

The file said secrets are "never sent anywhere except the SQL Server you connect to". That was never true of a SAS token — it goes to the storage endpoint, by design, and an S3 key pair signs requests to the bucket. Each secret now has its one destination named instead.

And the generated script carrying no credential is now stated outright, because it is *why* a script is safe to paste into a change ticket. Verified rather than assumed: `BlobCredentialStatement.Build` has exactly one caller, which assigns it to a `SqlCommand.CommandText` and executes it — it is never rendered to a screen, written to the operation log, or included in a generated script.

Docs only; no code changed.
