### PR TITLE
Three more from the review's catch-all (#370)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -83,6 +83,6 @@ body:
     attributes:
       label: Log
       description: >
-        **Open log folder** on the About screen. Secrets are already stripped, but names are not,
-        so have a read before pasting.
+        **Open log folder** on the Settings screen. Secrets are already stripped, but names are
+        not, so have a read before pasting.
       render: text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Save output on the execution console writes what its tooltip promises** (#370). It offered
+  "a header naming the server, the target database and the outcome" and wrote the raw console:
+  no header, and - the part that matters - no redaction. The method that built exactly that
+  header, and put it through the same redactor the operation log uses, existed and was called
+  from nowhere. A file people attach to change tickets was going out with SAS signatures still
+  in it.
+
+- **Every restore says whether the target has room** (#370). The free-space check had one
+  caller - the optional Get file names button - so whether a restore was checked at all
+  depended on whether somebody happened to press it, on a screen whose own comment calls
+  running out of disk "the worst outcome this screen can produce". It now reports on every run,
+  in the run's own log, including saying plainly when it could not check. Still a warning
+  rather than a refusal: it reads another instance's view of another machine's storage, and one
+  that under-reports must not be able to block a restore that would have worked.
+
+- **Three documents pointed at screens that do not exist** (#370). The bug report template said
+  the log folder button is on About; it is on Settings, so reports arrived without the single
+  most useful attachment. CONTRIBUTING and SECURITY cited `Services/` and `Models/` inside the
+  app project - the services are in `NineLives.Core` and that Models folder does not exist -
+  and both said "Help → About" in an app with no menu bar.
+
 - **The Backup and Copy consoles no longer vanish when the run ends** (#358). Both were bound to
   "a run is in progress", so the panel holding SQL Server's own account of what happened
   collapsed at the moment its contents started to matter. The error text left behind on the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,9 +84,9 @@ Every PR runs on `windows-latest`:
 
 ## Expectations for a change
 
-- New logic in `Services/` or `Models/` comes with tests. These are the parts that decide which
+- New logic in `src/NineLives.Core/Services/` or `src/NineLives.Core/Models/` comes with tests. These are the parts that decide which
   backups form a restore chain, so they carry the most risk.
-- **All generated T-SQL goes through `Services/TSql.cs`.** Identifiers use `QuoteName`, string
+- **All generated T-SQL goes through `src/NineLives.Core/Services/TSql.cs`.** Identifiers use `QuoteName`, string
   literals use `EscapeLiteral`. Do not hand-roll escaping.
 - If you change restore-chain logic, say in the PR what a DBA would see differently.
 - No credentials, SAS tokens, or real server/database names in code, comments, tests, or
@@ -94,7 +94,7 @@ Every PR runs on `windows-latest`:
 
 ## Reporting bugs
 
-Include the app version (Help → About), Windows and SQL Server versions, your backup layout
+Include the app version (the About screen, or the bottom right of the window), Windows and SQL Server versions, your backup layout
 (path pattern or Ola naming), and — where relevant — the generated script with identifying
 details replaced.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ replace databases. Security reports are taken seriously here.
   the fix stay in one place until there's something to release.
 - **jake@blackcat.wales** if you'd rather use email.
 
-Useful things to include: the version (Help → About), what an attacker would gain, and the smallest
+Useful things to include: the version (the About screen), what an attacker would gain, and the smallest
 set of steps that shows it. A proof of concept helps but is not required — a clear description of
 the flaw is enough.
 
@@ -73,7 +73,7 @@ unexpected, or turns untrusted data into executed T-SQL, is.
 - Any stored secret — a SAS token, an S3 secret key, a SQL password, a webhook URL — ending up
   anywhere other than Credential Manager: logs, the generated script, `config.json`, the exported
   config, the clipboard, an error message, a crash dump.
-- Anything that reaches T-SQL without going through `Services/TSql.cs`, or a way past its quoting.
+- Anything that reaches T-SQL without going through `src/NineLives.Core/Services/TSql.cs`, or a way past its quoting.
 - A restore being aimed at a server or database other than the one shown in the confirmation.
 - Credentials being sent over a connection that isn't validated the way the settings claim.
 

--- a/src/NineLives.Tests/SavedExecutionLogTests.cs
+++ b/src/NineLives.Tests/SavedExecutionLogTests.cs
@@ -1,0 +1,83 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// What Save output on the execution console actually writes (#370).
+///
+/// The button's tooltip promises "a header naming the server, the target database and the
+/// outcome". The method that builds exactly that - and runs it through <see cref="LogRedactor"/>,
+/// for the same reason the operation log is redacted: this file gets attached to tickets - existed,
+/// was documented, and was called from nowhere. What the button wrote was the raw console: no
+/// context, and no redaction.
+/// </summary>
+public class SavedExecutionLogTests
+{
+    private static RestoreViewModel Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        });
+
+        return new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(),
+            new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            new OperationLog(System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "ninelives-saved-log", Guid.NewGuid().ToString("n"))),
+            new FakeRestoreHistoryStore());
+    }
+
+    [Fact]
+    public void TheSaveButtonHasSomethingToWriteBesidesTheRawConsole()
+    {
+        var vm = Screen();
+
+        // The wiring itself is the fix: without it the command falls back to Console.Text.
+        Assert.NotNull(vm.Execution.BuildSavedDocument);
+    }
+
+    [Fact]
+    public void TheSavedDocumentCarriesTheContextTheConsoleDoesNot()
+    {
+        var vm = Screen();
+        vm.TargetDatabaseName = "Sales_Restored";
+        vm.Execution.Console.Append("RESTORE DATABASE ... 10 percent processed.");
+
+        var saved = vm.Execution.BuildSavedDocument!();
+
+        Assert.Contains("Nine Lives - restore execution log", saved);
+        Assert.Contains("Sales_Restored", saved);
+        Assert.Contains("Outcome:", saved);
+
+        // And the console is still in it - the header is added, not substituted.
+        Assert.Contains("10 percent processed", saved);
+    }
+
+    /// <summary>
+    /// The one that matters. A SAS signature reaching a file somebody attaches to a ticket is the
+    /// failure the redactor exists to prevent, and the save path was walking straight past it.
+    /// </summary>
+    [Fact]
+    public void TheSavedDocumentIsRedacted()
+    {
+        var vm = Screen();
+        vm.TargetDatabaseName = "Sales_Restored";
+        vm.Execution.Console.Append(
+            "RESTORE FROM URL = N'https://acct.blob.core.windows.net/b/x.bak?sv=2022-11-02&sig=SECRETSIGNATUREVALUE'");
+
+        var saved = vm.Execution.BuildSavedDocument!();
+
+        Assert.DoesNotContain("SECRETSIGNATUREVALUE", saved);
+        Assert.Contains("[redacted]", saved);
+
+        // Still readable as a diagnosis: the URL keeps its shape.
+        Assert.Contains("acct.blob.core.windows.net", saved);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.IO;
 using System.Windows;
 using Blackcat.NineLives.Models;
@@ -688,6 +688,17 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     [RelayCommand]
     private void CopyConsole() => TryCopyToClipboard(Console.Text, "Execution log copied to clipboard.");
 
+    /// <summary>
+    /// Builds the file Save output writes: the console, plus the context needed to read it a week
+    /// later, redacted (#370).
+    ///
+    /// Supplied by the restore screen, because every fact in that header - which server, which
+    /// target, which chain - lives up there and none of it is visible from a console. Null in a
+    /// context that has no such screen, in which case the raw console is still saved: a log with
+    /// no header beats a Save button that does nothing.
+    /// </summary>
+    internal Func<string>? BuildSavedDocument { get; set; }
+
     [RelayCommand]
     private void SaveConsole()
     {
@@ -704,7 +715,11 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
         try
         {
-            File.WriteAllText(dialog.FileName, Console.Text);
+            // Not Console.Text (#370). The tooltip on this button promises "a header naming the
+            // server, the target database and the outcome", and the method that builds exactly
+            // that - and runs it through LogRedactor, for the same reason the operation log is
+            // redacted: this file gets attached to tickets - existed and was called from nowhere.
+            File.WriteAllText(dialog.FileName, BuildSavedDocument?.Invoke() ?? Console.Text);
             SetStatus($"Execution log saved to {dialog.FileName}");
         }
         catch (Exception ex)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -874,6 +874,10 @@ public partial class RestoreViewModel : ViewModelBase
         // The run reports through the same status line as the rest of the screen, and its cancel
         // state feeds the one Stop button that covers every server call here.
         Execution.CancelStateChanged += RefreshCancelState;
+
+        // What Save output actually writes (#370). The console alone has none of the context and
+        // none of the redaction.
+        Execution.BuildSavedDocument = BuildSavedLog;
         Execution.PropertyChanged += (_, e) =>
         {
             switch (e.PropertyName)
@@ -2582,7 +2586,50 @@ public partial class RestoreViewModel : ViewModelBase
         var containers = await CheckOtherContainersHaveCredentialsAsync(server, appendLog);
         if (!containers.CanProceed) return containers;
 
+        await ReportSpaceAsync(appendLog);
+
         return await CheckVersionCompatibilityAsync(server, appendLog);
+    }
+
+    /// <summary>
+    /// Puts the free-space answer into the run's own record, every run (#370).
+    ///
+    /// The check itself has one caller - Get file names - so whether a restore was checked for
+    /// room depended on whether somebody had pressed an optional button, on a screen whose own
+    /// comment calls running out of disk "the worst outcome this screen can produce". Its inputs
+    /// are the file sizes RESTORE FILELISTONLY returns, so it genuinely cannot run without that
+    /// read; what it can do is stop being silent about which of the two happened.
+    ///
+    /// A warning, not a refusal, deliberately. This reads someone else's DMV about someone else's
+    /// storage, and an instance that under-reports free space must not be able to block a restore
+    /// that would have worked - the same reasoning that already makes a failure to answer silent
+    /// rather than scary. What changes is that the answer, or its absence, is now on the record
+    /// beside everything else the run did.
+    /// </summary>
+    private async Task ReportSpaceAsync(Action<string> appendLog)
+    {
+        try
+        {
+            if (FetchedFileMoves.Count == 0)
+            {
+                appendLog(
+                    "Free space on the target was not checked - press Get file names before a " +
+                    "restore to have it read the file sizes and compare them with the target's " +
+                    "volumes.");
+                return;
+            }
+
+            await CheckSpaceAsync(CancellationToken.None);
+
+            appendLog(HasSpaceWarning
+                ? $"WARNING: {SpaceWarning}"
+                : "Checked free space on the target: the restored files fit.");
+        }
+        catch (Exception ex)
+        {
+            // Never the reason a restore does not start.
+            _log.Info($"[space] could not check before execute: {ex.Message}");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Three verified items from [#370](https://github.com/jakemorgangit/NineLives/issues/370), the review pass's catch-all.

## Save output wrote the raw console — including secrets

`ExecutionWindow.xaml` promises the saved file carries "a header naming the server, the target database and the outcome". `SaveConsole` wrote `Console.Text`.

Meanwhile `RestoreViewModel.BuildSavedLog()` builds exactly that header **and** runs the result through `LogRedactor` — with a comment saying why: *this file gets attached to tickets*. It had no callers at all.

So the button produced a file with no context and no redaction. A SAS signature that appeared in the console went out in the saved log. The execution console now takes the document builder from the screen that owns the context, falling back to the raw console where there is no such screen — a log without a header beats a Save button that does nothing.

Pinned, including the redaction: a signature in the console must not survive into the saved document, while the URL keeps enough shape to still be diagnosable.

## Free space was only checked if you pressed an optional button

`CheckSpaceAsync` had one caller, inside `FetchLogicalNamesAsync` — the Get file names button. Whether a restore was checked for room depended on whether somebody happened to press it, on a screen whose own comment calls running out of disk *"the worst outcome this screen can produce"*. Copy Database runs the equivalent check automatically.

The check's inputs are the file sizes `RESTORE FILELISTONLY` returns, so it genuinely cannot run without that read. What it can stop doing is being silent about which of the two happened. The preflight that runs before every execute now reports the answer into the run's own log, or states plainly that room was not checked and how to have it checked.

**Deliberately still a warning, not a refusal.** It reads one instance's view of another machine's storage, and an instance that under-reports free space must not be able to block a restore that would have worked — the same reasoning that already makes a failure to answer silent rather than alarming. Turning it into a refusal is a product decision, not a bug fix.

## Three documents pointed at screens that do not exist

- The **bug report template** says the log folder button is on About. It is on Settings — so reports arrive without the single most useful attachment.
- `CONTRIBUTING.md` cites `Services/` and `Models/` in the app project. The services are in `src/NineLives.Core/Services/`, and `src/NineLives/Models` does not exist.
- `CONTRIBUTING.md` and `SECURITY.md` both said "Help → About" in an app with no menu bar.

## Effect

`dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test NineLives.sln -c Release` → **1,969 passed, 0 failed** (up 3).
