### PR TITLE
A disabled list should stop being clickable, not stop being readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to Nine Lives are recorded here.
 
@@ -11,6 +11,22 @@ more detail on the user-facing changes; this file is the short history.
 ## [Unreleased]
 
 ### Fixed
+
+- **The saved-containers list no longer turns white while the Add Container form is open.**
+  It is disabled mid-edit deliberately - the form writes to whichever container is selected, so
+  clicking another one while editing used to save this container's details over that one - but
+  nobody had looked at what "disabled" makes a ListBox look like. WPF's default template swaps
+  its background to a system colour the moment that happens, and a template trigger beats the
+  background set on the control, so the panel went white in every theme while the rows kept
+  drawing their names in white. Reported from the high-contrast theme, where it is unmissable.
+  It now dims instead of recolouring, and a test pins that disabling it must never change its
+  colour.
+
+- **The About screen links to the documentation, the issue tracker and the releases** (#370).
+  The only hyperlink anywhere in the app was blackcat.wales, so a user stuck on a screen had no
+  route to any of it from inside the tool. Its description also called this a restore-only,
+  cloud-only utility - in an app with a Back Up screen, a Copy Database screen and a shared-path
+  medium.
 
 - **Save output on the execution console writes what its tooltip promises** (#370). It offered
   "a header naming the server, the target database and the outcome" and wrote the raw console:

--- a/src/NineLives.Tests/DisabledListStaysLegibleTests.cs
+++ b/src/NineLives.Tests/DisabledListStaysLegibleTests.cs
@@ -1,0 +1,139 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The saved-containers list stays legible while the Add Container form is open.
+///
+/// It is disabled mid-edit, deliberately (#354) - the form writes to whichever container is
+/// selected, so clicking another one while editing used to save this container's details over
+/// that one. What nobody looked at afterwards was what "disabled" makes a ListBox LOOK like.
+///
+/// WPF's default ListBox template swaps its border background to SystemColors.ControlBrushKey the
+/// moment IsEnabled goes false, and a template trigger beats a Background set on the control - so
+/// the explicit Background="Transparent" lost. The panel turned WHITE in every theme, and the rows
+/// draw their names in PrimaryTextBrush, which is white in the dark and high-contrast themes.
+/// White on white. Reported from the high-contrast theme, where it is unmissable, but it was
+/// wrong everywhere.
+///
+/// Being unavailable for a moment is not a reason to stop being readable, so the rule pinned here
+/// is the general one: disabling this list must not RECOLOUR it. Dimming it is fine and is how
+/// the state is now carried.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class DisabledListStaysLegibleTests(WpfFixture wpf)
+{
+    [Fact]
+    public void DisablingTheContainerListDoesNotRecolourIt()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = Screen();
+            var view = new BlobConfigView { DataContext = vm };
+            Layout(view);
+
+            var list = ContainerList(view, vm);
+            Assert.True(list.IsEnabled, "the list should start selectable");
+
+            var enabled = BackgroundOfChrome(list);
+
+            // Opening Add Container is what disables it.
+            vm.AddNewCommand.Execute(null);
+            Layout(view);
+
+            Assert.False(list.IsEnabled, "opening the form should stop the list being selectable");
+
+            var disabled = BackgroundOfChrome(list);
+
+            Assert.Equal(Describe(enabled), Describe(disabled));
+        });
+    }
+
+    /// <summary>
+    /// And specifically not the system colour, which is the exact brush the default template
+    /// reaches for and the one that is white under a dark theme.
+    /// </summary>
+    [Fact]
+    public void TheDisabledListIsNotPaintedInASystemColour()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = Screen();
+            var view = new BlobConfigView { DataContext = vm };
+            vm.AddNewCommand.Execute(null);
+            Layout(view);
+
+            var list = ContainerList(view, vm);
+            Assert.False(list.IsEnabled);
+
+            var chrome = BackgroundOfChrome(list);
+
+            Assert.NotEqual(Describe(SystemColors.ControlBrush), Describe(chrome));
+            Assert.NotEqual(Describe(SystemColors.WindowBrush), Describe(chrome));
+        });
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static BlobConfigViewModel Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "prod-backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/prod-backups"
+        });
+
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+        vm.SelectedContainer = vm.Containers.FirstOrDefault();
+        return vm;
+    }
+
+    /// <summary>
+    /// The saved-containers list specifically. Matched on what it is bound to rather than by
+    /// type - this screen has other ListBoxes in it, inside the combo boxes' own templates.
+    /// </summary>
+    private static ListBox ContainerList(DependencyObject view, BlobConfigViewModel vm) =>
+        FindAll<ListBox>(view).Single(l => ReferenceEquals(l.ItemsSource, vm.Containers));
+
+    /// <summary>The Border the list's own template paints - the one that used to go white.</summary>
+    private static Brush? BackgroundOfChrome(ListBox list) =>
+        FindAll<Border>(list).FirstOrDefault()?.Background;
+
+    /// <summary>
+    /// Brushes are compared by their painted result rather than by reference: a DynamicResource
+    /// resolves to a different instance each time the theme is applied, so Assert.Same would fail
+    /// on two brushes that are the same colour.
+    /// </summary>
+    private static string Describe(Brush? brush) => brush switch
+    {
+        null => "(null)",
+        SolidColorBrush solid => solid.Color.ToString(),
+        _ => brush.GetType().Name
+    };
+
+    private static void Layout(FrameworkElement element)
+    {
+        element.Measure(new Size(1280, 900));
+        element.Arrange(new Rect(0, 0, 1280, 900));
+        element.UpdateLayout();
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        int count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var node = VisualTreeHelper.GetChild(root, i);
+            if (node is T match) yield return match;
+            foreach (var descendant in FindAll<T>(node)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -291,12 +291,51 @@
         </Setter>
     </Style>
 
+    <!--
+        A list that keeps the app's own colours when it is disabled.
+
+        WPF's default ListBox template swaps its border background to SystemColors.ControlBrushKey
+        the moment IsEnabled goes false, and a template trigger beats the Background set on the
+        control - so an explicit Background="Transparent" loses. The saved-containers list is
+        disabled while the Add Container form is open (#354), and the result was a WHITE panel in
+        every theme, with the unselected rows greyed to SystemColors.GrayText on top of it: in
+        high contrast that is grey on white, which is unreadable, and in dark it is a slab of
+        white in the middle of a dark window.
+
+        Being unavailable for a moment is not a reason to stop being legible. This template has no
+        system-colour swap at all; the disabled state is carried by opacity, which dims the list
+        without recolouring anything.
+    -->
     <Style x:Key="CardListBox" TargetType="ListBox">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
         <Setter Property="ItemContainerStyle" Value="{StaticResource CardListBoxItem}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListBox">
+                    <Border x:Name="bd"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="4"
+                            SnapsToDevicePixels="True">
+                        <ScrollViewer Focusable="False"
+                                      Padding="{TemplateBinding Padding}"
+                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </ScrollViewer>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="bd" Property="Opacity" Value="0.55" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <!-- Card Style -->

--- a/src/NineLives/ViewModels/AboutViewModel.cs
+++ b/src/NineLives/ViewModels/AboutViewModel.cs
@@ -39,6 +39,26 @@ public partial class AboutViewModel : ViewModelBase
     public string Author => "Jake Morgan";
     public string Company => "Blackcat Data Solutions Ltd";
     public string Website => "https://blackcat.wales";
-    public string Description => "Every database deserves nine lives. A production-ready utility for restoring SQL Server databases from Azure Blob Storage or S3-compatible object storage backups, with full support for point-in-time recovery using Full, Differential, and Transaction Log backup chains.";
+
+    /// <summary>
+    /// Where somebody stuck on a screen goes next (#370).
+    ///
+    /// The app had exactly one hyperlink in it - blackcat.wales - so the documentation, the
+    /// issue tracker and the release notes were reachable only by already knowing where they
+    /// are. A tool that generates T-SQL you are meant to read before running has a lot to
+    /// explain, and all of it lived somewhere the app never mentioned.
+    /// </summary>
+    public string RepositoryUrl => "https://github.com/jakemorgangit/NineLives";
+    public string DocumentationUrl => "https://github.com/jakemorgangit/NineLives#readme";
+    public string IssuesUrl => "https://github.com/jakemorgangit/NineLives/issues";
+    public string ReleasesUrl => "https://github.com/jakemorgangit/NineLives/releases";
+
+    /// <summary>
+    /// Both directions and every medium (#370). This described a restore-only, cloud-only tool
+    /// in an app that has had a Back Up screen, a Copy Database screen and a shared-path medium
+    /// for several releases - the one paragraph a stranger reads to find out what this is, and it
+    /// was describing half of it.
+    /// </summary>
+    public string Description => "Every database deserves nine lives. Nine Lives finds the SQL Server backups in your storage - an Azure Blob container, an S3-compatible bucket, a path the server can see, or an instance's own backup history - works out the restore chains, and turns any moment you pick into a script you can read. It takes backups too, copies a database from one instance to another, rehearses a restore to prove it works, and receipts everything it runs.";
 
 }

--- a/src/NineLives/Views/AboutView.xaml
+++ b/src/NineLives/Views/AboutView.xaml
@@ -54,6 +54,46 @@
                     </Hyperlink>
                 </TextBlock>
 
+                <!-- The way out of the app to everything that explains it (#370). Until this,
+                     the only hyperlink anywhere in Nine Lives was blackcat.wales, so somebody
+                     stuck on a screen had no route to the documentation from inside the tool. -->
+                <Border Height="1" Background="{DynamicResource CardBorderBrush}" Margin="0,0,0,20" />
+
+                <TextBlock Text="PROJECT" Style="{StaticResource LabelText}" HorizontalAlignment="Center" />
+                <TextBlock HorizontalAlignment="Center" TextAlignment="Center" TextWrapping="Wrap"
+                           Margin="0,4,0,20" Style="{StaticResource BodyText}">
+                    <Hyperlink NavigateUri="{Binding DocumentationUrl}"
+                               RequestNavigate="Hyperlink_RequestNavigate"
+                               Foreground="{DynamicResource AccentBrush}"
+                               TextDecorations="None"
+                               ToolTip="What every screen does, the path patterns, the CLI, and the permissions each provider needs.">
+                        <Run Text="Documentation" />
+                    </Hyperlink>
+                    <Run Text="   ·   " Foreground="{DynamicResource SecondaryTextBrush}" />
+                    <Hyperlink NavigateUri="{Binding IssuesUrl}"
+                               RequestNavigate="Hyperlink_RequestNavigate"
+                               Foreground="{DynamicResource AccentBrush}"
+                               TextDecorations="None"
+                               ToolTip="Report a bug or ask for something. The bug template says which log to attach and where to find it.">
+                        <Run Text="Report an issue" />
+                    </Hyperlink>
+                    <Run Text="   ·   " Foreground="{DynamicResource SecondaryTextBrush}" />
+                    <Hyperlink NavigateUri="{Binding ReleasesUrl}"
+                               RequestNavigate="Hyperlink_RequestNavigate"
+                               Foreground="{DynamicResource AccentBrush}"
+                               TextDecorations="None"
+                               ToolTip="What changed in each version, and the downloads.">
+                        <Run Text="Releases" />
+                    </Hyperlink>
+                    <LineBreak />
+                    <Hyperlink NavigateUri="{Binding RepositoryUrl}"
+                               RequestNavigate="Hyperlink_RequestNavigate"
+                               Foreground="{DynamicResource SecondaryTextBrush}"
+                               TextDecorations="None">
+                        <Run Text="{Binding RepositoryUrl, Mode=OneWay}" FontSize="11" />
+                    </Hyperlink>
+                </TextBlock>
+
                 <ContentControl Style="{StaticResource ErrorBanner}" />
 
                 <TextBlock HorizontalAlignment="Center"

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -59,7 +59,13 @@
                          is SELECTED when Save runs, so clicking another one while editing saved
                          this container's name, URL, credential and tags over that one - silently,
                          with the original left untouched and two containers left sharing a name. -->
+                    <!-- CardListBox for its TEMPLATE, not its look: the default one turns its
+                         background white the moment IsEnabled goes false, and the rows here draw
+                         their text in PrimaryTextBrush - white on white in the dark and
+                         high-contrast themes. The item template and container style below are
+                         local and still win. -->
                     <ListBox ItemsSource="{Binding Containers}"
+                             Style="{StaticResource CardListBox}"
                              IsEnabled="{Binding IsEditing, Converter={StaticResource InverseBool}}"
                              SelectedItem="{Binding SelectedContainer}"
                              Background="Transparent"


### PR DESCRIPTION
Reported live: the saved-containers list renders as a white panel with unreadable rows.

## What was wrong

The list is disabled while the Add Container form is open, deliberately ([#354](https://github.com/jakemorgangit/NineLives/issues/354)) — the form writes to whichever container is *selected*, so clicking another one mid-edit used to save this container's details over that one. What nobody looked at afterwards was what "disabled" makes a `ListBox` **look** like.

WPF's default `ListBox` template swaps its border background to `SystemColors.ControlBrushKey` the moment `IsEnabled` goes false, and a template trigger beats a `Background` set on the control — so the explicit `Background="Transparent"` lost. The panel turned white, while the rows carried on drawing their names in `PrimaryTextBrush`, which is white in the dark and high-contrast themes.

It was reported from the high-contrast theme, where a white slab in a black window is unmissable. Rendering both themes side by side showed **the dark theme had exactly the same white panel** — it just looked less alarming because the selected row paints its own background and stayed readable.

(The yellow buttons in the report are not a bug: `AccentColor` is `#FFFF00` in `Palette.HighContrast.xaml`, working as designed.)

## The fix

`CardListBox` now carries a template with no system-colour swap at all, and the disabled state is carried by opacity — being unavailable for a moment is not a reason to stop being legible. The container list takes that style **for its template only**; its own item template and container style are local values and still win.

Pinned by the general rule rather than the symptom: **disabling this list must not recolour it**, plus a specific check that it is not painted in a system colour. Both tests were confirmed to fail against the previous markup before being kept.

## Also on this branch: the About screen links out (#370)

The only hyperlink anywhere in Nine Lives was blackcat.wales, so somebody stuck on a screen had no route to the documentation, the issue tracker or the release notes from inside the tool — and this is a tool that generates T-SQL you are meant to read before running it, so it has a lot to explain.

Its description also called this a restore-only, cloud-only utility, in an app that has had a Back Up screen, a Copy Database screen and a shared-path medium for several releases. That is the one paragraph a stranger reads to find out what this is, and it was describing half of it.

## Effect

`-c Release -warnaserror` clean, **1,971 passed** (up 2).

