### PR TITLE
script can relocate, and the exit codes are checked against the code (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+### Added
+
+- **`script` can relocate** (#370). `restore` took `--relocate`, `--data-path` and `--log-path`;
+  `script` took none of them, so the workflow the two exist to serve together - generate the
+  script here, hand it to a DBA, run it in the change window on a freshly provisioned machine -
+  silently dropped the WITH MOVE clauses, and the restore failed at run time with a
+  directory-not-found after WITH REPLACE had already dropped the target. Relocation cannot be
+  worked out offline: the logical file names come from RESTORE FILELISTONLY and the default
+  directories come from the instance. So `script` now takes a `--target` used only to ask those
+  two questions, and refuses the relocation flags without one rather than emitting a script that
+  quietly has no MOVE in it.
+
 ### Fixed
 
 - **The saved-containers list no longer turns white while the Add Container form is open.**

--- a/src/NineLives.Cli/Relocation.cs
+++ b/src/NineLives.Cli/Relocation.cs
@@ -1,0 +1,98 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+
+namespace Blackcat.NineLives.Cli;
+
+/// <summary>
+/// WITH MOVE, for the verbs that generate a restore (#299, #370).
+///
+/// Extracted from <c>restore</c> so <c>script</c> can relocate too. The workflow that needed it
+/// is the one where the two are used together: generate the script here, hand it to a DBA for the
+/// change window, and have them run it on a freshly provisioned machine that does not have the
+/// source server's drive layout. Without MOVE clauses that restore fails at run time with a
+/// directory-not-found - after WITH REPLACE has already dropped the target - and <c>script</c>
+/// silently dropped them while <c>restore</c>, doing the same job a different way, did not.
+///
+/// Relocation cannot be done offline. The logical file NAMES come from RESTORE FILELISTONLY, and
+/// the default directories come from the instance itself, so both need a server to ask. That is
+/// why <c>script</c> - which otherwise touches nothing - takes a <c>--target</c> purely to answer
+/// these two questions, and refuses the relocation flags without one rather than emitting a
+/// script that quietly has no MOVE in it.
+/// </summary>
+internal static class Relocation
+{
+    /// <summary>The flags that mean "relocate", on any verb that offers them.</summary>
+    internal static readonly string[] ValuedOptions = ["data-path", "log-path"];
+
+    internal static bool WasAskedFor(CliArguments args) =>
+        args.Has("relocate") || args.Get("data-path") != null || args.Get("log-path") != null;
+
+    /// <summary>
+    /// Resolves the MOVE clauses, or explains why it could not.
+    ///
+    /// Returns (null, null) when relocation was not asked for at all - the caller carries on with
+    /// no MOVE, which is the correct restore for a target whose layout matches the source.
+    /// </summary>
+    internal static async Task<(List<FileMoveOption>? Moves, string? Error)> ResolveAsync(
+        CliArguments args,
+        CliServices services,
+        ServerConnection target,
+        BackupChain chain,
+        Action<string> report,
+        CancellationToken ct)
+    {
+        if (!WasAskedFor(args)) return (null, null);
+
+        var devices = chain.FullSet.Files
+            .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
+            .ToList();
+
+        List<FileMoveOption> logicalFiles;
+        try
+        {
+            logicalFiles = await services.Sql.RestoreFileListOnlyAsync(target, devices, ct);
+        }
+        catch (Exception ex)
+        {
+            return (null, $"Could not read the backup's file list from {target.ServerName}, " +
+                          $"which relocation needs: {ex.Message}");
+        }
+
+        var dataDir = args.Get("data-path");
+        var logDir = args.Get("log-path");
+
+        // Explicit directories win; either side not given falls back to the target's own
+        // defaults, so --data-path alone is a complete instruction rather than half of one.
+        if (dataDir == null || logDir == null)
+        {
+            try
+            {
+                var (defaultData, defaultLog) = await services.Sql.GetDefaultPathsAsync(target, ct);
+                dataDir ??= defaultData;
+                logDir ??= defaultLog;
+            }
+            catch (Exception ex)
+            {
+                return (null, $"Could not read the default data and log directories from " +
+                              $"{target.ServerName}, which relocation needs when a directory is " +
+                              $"not given: {ex.Message}");
+            }
+        }
+
+        var moves = RestoreRelocation.ToDirectories(logicalFiles, dataDir, logDir);
+        report($"Relocating {moves.Count} file(s): data to {dataDir}, log to {logDir}.");
+        return (moves, null);
+    }
+
+    /// <summary>
+    /// The refusal for a verb that was given relocation flags and no instance to ask.
+    ///
+    /// Named rather than silent: emitting a script with no MOVE in it, when MOVE is exactly what
+    /// was asked for, produces a file that looks right and fails in the change window.
+    /// </summary>
+    internal static string NeedsATarget =>
+        "Relocation needs an instance to ask. The logical file names come from RESTORE " +
+        "FILELISTONLY and the default directories come from the instance itself, so neither can " +
+        "be worked out offline. Add --target NAME (the instance the script will eventually run " +
+        "on), or drop --relocate, --data-path and --log-path.";
+}

--- a/src/NineLives.Cli/Verbs/RestoreVerb.cs
+++ b/src/NineLives.Cli/Verbs/RestoreVerb.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.Cli.Verbs;
@@ -186,40 +186,15 @@ internal static class RestoreVerb
 
         // Relocation (#299): the Terraform case. A freshly provisioned VM rarely has the
         // source server's drive layout, and the recorded paths fail mid-run with
-        // directory-not-found - after WITH REPLACE has already dropped the target. The
-        // rehearse verb has always relocated; the restore verb, the one the template
-        // actually ends with, now can. Explicit directories win; either side not given
-        // falls back to the target's own defaults.
-        List<FileMoveOption>? moves = null;
-        if (args.Has("relocate") || args.Get("data-path") != null || args.Get("log-path") != null)
+        // directory-not-found - after WITH REPLACE has already dropped the target. Shared with
+        // the script verb since #370, which needed the same clauses for the same reason.
+        var (moves, relocationError) = await Relocation.ResolveAsync(
+            args, services, target, chain, errors.WriteLine, ct);
+
+        if (relocationError != null)
         {
-            var moveDevices = chain.FullSet.Files
-                .Select(f => f.IsOnDisk ? f.RestoreDevice : BlobUrlEncoder.Encode(f.BlobUrl))
-                .ToList();
-
-            List<FileMoveOption> logicalFiles;
-            try
-            {
-                logicalFiles = await services.Sql.RestoreFileListOnlyAsync(target, moveDevices, ct);
-            }
-            catch (Exception ex)
-            {
-                errors.WriteLine($"Could not read the backup's file list from " +
-                                 $"{target.ServerName}, which relocation needs: {ex.Message}");
-                return ExitCodes.CouldNotAnswer;
-            }
-
-            var dataDir = args.Get("data-path");
-            var logDir = args.Get("log-path");
-            if (dataDir == null || logDir == null)
-            {
-                var (defaultData, defaultLog) = await services.Sql.GetDefaultPathsAsync(target, ct);
-                dataDir ??= defaultData;
-                logDir ??= defaultLog;
-            }
-
-            moves = RestoreRelocation.ToDirectories(logicalFiles, dataDir, logDir);
-            errors.WriteLine($"Relocating {moves.Count} file(s): data to {dataDir}, log to {logDir}.");
+            errors.WriteLine(relocationError);
+            return ExitCodes.CouldNotAnswer;
         }
 
         var script = new RestoreScriptGenerator().Generate(chain, new RestoreOptions

--- a/src/NineLives.Cli/Verbs/ScriptVerb.cs
+++ b/src/NineLives.Cli/Verbs/ScriptVerb.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 
 namespace Blackcat.NineLives.Cli.Verbs;
@@ -18,10 +18,11 @@ internal static class ScriptVerb
         "script",
         "Emit the validated restore T-SQL for a moment",
         "9lives script (--container NAME | --server NAME) --database DB [--at \"yyyy-MM-dd HH:mm:ss\"] " +
-        "[--target-database NAME] [--with-replace] [--norecovery] [--stop-before-mark NAME | --stop-at-mark NAME] [--out FILE]",
-        Valued: ["container", "server", "database", "at", "target-database",
-                 "stop-before-mark", "stop-at-mark", "out"],
-        Switches: ["with-replace", "norecovery"],
+        "[--target-database NAME] [--with-replace] [--norecovery] [--stop-before-mark NAME | --stop-at-mark NAME] " +
+        "[--target NAME [--relocate | --data-path DIR [--log-path DIR]]] [--out FILE]",
+        Valued: ["container", "server", "database", "at", "target-database", "target",
+                 "stop-before-mark", "stop-at-mark", "data-path", "log-path", "out"],
+        Switches: ["with-replace", "norecovery", "relocate"],
         Options:
         [
             ("--container NAME", "A blob container configured in the app."),
@@ -38,6 +39,15 @@ internal static class ScriptVerb
                 "deployment never happened. Marks are planted with BEGIN TRANSACTION ... " +
                 "WITH MARK; the app's restore screen finds them in msdb."),
             ("--stop-at-mark NAME", "Stop AT the mark, including the marked transaction."),
+            ("--target NAME", "The instance the script will eventually run ON. Only needed for " +
+                "relocation, and used only to ask it two questions - nothing is executed."),
+            ("--relocate", "MOVE every file to the target's default data and log directories, " +
+                "keeping its original name. Needs --target."),
+            ("--data-path DIR", "MOVE data files into this directory (log files follow " +
+                "--log-path, or the target's default log directory). Implies relocation, " +
+                "needs --target."),
+            ("--log-path DIR", "MOVE log files into this directory. Implies relocation; data " +
+                "files follow --data-path, or the target's default data directory."),
             ("--out FILE", "Write the script to a file instead of stdout.")
         ],
         Notes:
@@ -52,14 +62,21 @@ internal static class ScriptVerb
             "is a hole no chain reaches: the verb refuses and names the nearest reachable " +
             "points either side, because quietly restoring to somewhere nearby is worse.",
             "A mark and a time are the same mechanism aimed differently, so giving both is " +
-            "refused rather than ranked."
+            "refused rather than ranked.",
+            "Relocation is the one thing here that cannot be done offline (#370). The logical " +
+            "file names come from RESTORE FILELISTONLY and the default directories come from " +
+            "the instance, so --relocate, --data-path and --log-path need a --target to ask. " +
+            "That target is read, never written to. Without one they are refused rather than " +
+            "ignored: a script that silently has no MOVE in it is a script that fails in the " +
+            "change window it was generated for."
         ],
         ExitCodes:
         [
             "0   script emitted",
             "2   no chain covers the moment asked for, or the source holds no backups for " +
             "this database",
-            "3   the source could not be read at all",
+            "3   the source could not be read at all, or the target could not answer the two " +
+            "questions relocation needs",
             "64  usage"
         ],
         Examples:
@@ -67,7 +84,10 @@ internal static class ScriptVerb
             ("9lives script --container backups --database Sales --at \"2026-08-02 19:00\" --out restore.sql",
                 "the validated script for that moment, into a file"),
             ("9lives script --server SRV01 --database Sales --stop-before-mark deploy_v2",
-                "undo a marked deployment - the sharpest point-in-time tool SQL Server has")
+                "undo a marked deployment - the sharpest point-in-time tool SQL Server has"),
+            ("9lives script --container backups --database Sales --target SRV02 --relocate --out restore.sql",
+                "generate here, run in the change window - with MOVE clauses for a machine that " +
+                "does not share the source's drive layout")
         ]);
 
     public static async Task<int> RunAsync(
@@ -128,6 +148,39 @@ internal static class ScriptVerb
         }
 
         var chain = new BackupChainBuilder().BuildChainFromRestorePoint(point);
+
+        // Relocation, the one thing this verb cannot answer on its own (#370). Refused without a
+        // target rather than dropped, because the workflow this exists for - generate here, hand
+        // it over, run it in the change window on a machine with a different drive layout - is
+        // exactly the one where a missing MOVE is not discovered until it is expensive.
+        List<FileMoveOption>? moves = null;
+        if (Relocation.WasAskedFor(args))
+        {
+            if (args.Get("target") == null)
+            {
+                errors.WriteLine(Relocation.NeedsATarget);
+                return ExitCodes.Usage;
+            }
+
+            var (relocateTo, targetError) = services.FindServer(args.Get("target")!);
+            if (relocateTo == null)
+            {
+                errors.WriteLine(targetError);
+                return ExitCodes.Usage;
+            }
+
+            var (resolved, relocationError) = await Relocation.ResolveAsync(
+                args, services, relocateTo, chain, errors.WriteLine, CancellationToken.None);
+
+            if (relocationError != null)
+            {
+                errors.WriteLine(relocationError);
+                return ExitCodes.CouldNotAnswer;
+            }
+
+            moves = resolved;
+        }
+
         var script = new RestoreScriptGenerator().Generate(chain, new RestoreOptions
         {
             TargetDatabaseName = args.Get("target-database") ?? args.Get("database")!,
@@ -136,6 +189,7 @@ internal static class ScriptVerb
             StopAt = stopAt,
             StopAtMark = mark,
             StopBeforeMark = markAt == null,
+            FileMoves = moves ?? [],
             // The bucket's region has to reach the statement, not just the listing (#361).
             // Null for a --server source, which found its backups through an instance's own
             // history and has no container to ask.

--- a/src/NineLives.Tests/CliScriptRelocationTests.cs
+++ b/src/NineLives.Tests/CliScriptRelocationTests.cs
@@ -1,0 +1,153 @@
+using System.IO;
+using Blackcat.NineLives.Cli;
+using Blackcat.NineLives.Cli.Verbs;
+using Blackcat.NineLives.Models;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// <c>script</c> can relocate (#370).
+///
+/// <c>restore</c> took --relocate, --data-path and --log-path; <c>script</c> took none of them.
+/// So the workflow the two exist to serve together - generate the script here, hand it to a DBA,
+/// run it in the change window on a freshly provisioned machine - silently dropped the WITH MOVE
+/// clauses, and the restore failed at run time with a directory-not-found, after WITH REPLACE had
+/// already dropped the target.
+///
+/// The interesting part is that relocation cannot be done offline, and <c>script</c> is otherwise
+/// a verb that touches nothing. The logical file names come from RESTORE FILELISTONLY and the
+/// default directories come from the instance, so both need a server. Hence --target, used only
+/// to ask those two questions, and a refusal rather than a silent omission when it is absent.
+/// </summary>
+public class CliScriptRelocationTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    private static CliServices Stage()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "Sales",
+                    Type = BackupType.Full,
+                    StartedAt = T0,
+                    FinishedAt = T0.AddMinutes(5),
+                    CheckpointLsn = 100,
+                    Position = 1,
+                    Files = [@"X:\backups\Sales_full.bak"]
+                }
+            ],
+            FileList =
+            [
+                new FileMoveOption { LogicalName = "Sales", Type = "D", PhysicalName = @"X:\data\Sales.mdf" },
+                new FileMoveOption { LogicalName = "Sales_log", Type = "L", PhysicalName = @"X:\log\Sales.ldf" }
+            ]
+        };
+
+        return new CliServices(
+            store, sql, new FakeBlobStorageService(),
+            new FakeRestoreHistoryStore(), new FakeRunNotifier());
+    }
+
+    private static async Task<(int exit, string script, string said)> RunScript(params string[] argv)
+    {
+        var services = Stage();
+        var output = new StringWriter();
+        var errors = new StringWriter();
+
+        var args = CliArguments.Parse(argv, ScriptVerb.Spec);
+        var exit = await ScriptVerb.RunAsync(args, services, output, errors);
+        return (exit, output.ToString(), errors.ToString());
+    }
+
+    [Fact]
+    public async Task RelocateMovesEveryFileToTheTargetsDefaults()
+    {
+        var (exit, script, said) = await RunScript(
+            "--server", "SRV01", "--database", "Sales", "--target", "SRV02", "--relocate");
+
+        Assert.Equal(ExitCodes.Ok, exit);
+        Assert.Contains(@"MOVE N'Sales' TO N'D:\Data\Sales.mdf'", script);
+        Assert.Contains(@"MOVE N'Sales_log' TO N'D:\Logs\Sales.ldf'", script);
+        Assert.Contains("Relocating 2 file(s)", said);
+    }
+
+    [Fact]
+    public async Task ExplicitDirectoriesWin()
+    {
+        var (exit, script, _) = await RunScript(
+            "--server", "SRV01", "--database", "Sales", "--target", "SRV02",
+            "--data-path", @"E:\SQLData", "--log-path", @"F:\SQLLogs");
+
+        Assert.Equal(ExitCodes.Ok, exit);
+        Assert.Contains(@"E:\SQLData\Sales.mdf", script);
+        Assert.Contains(@"F:\SQLLogs\Sales.ldf", script);
+    }
+
+    /// <summary>
+    /// Half an instruction is still a complete one: the side not given falls back to the target's
+    /// own default rather than leaving those files where the backup recorded them.
+    /// </summary>
+    [Fact]
+    public async Task OneDirectoryGivenLeavesTheOtherOnTheTargetsDefault()
+    {
+        var (exit, script, _) = await RunScript(
+            "--server", "SRV01", "--database", "Sales", "--target", "SRV02",
+            "--data-path", @"E:\SQLData");
+
+        Assert.Equal(ExitCodes.Ok, exit);
+        Assert.Contains(@"E:\SQLData\Sales.mdf", script);
+        Assert.Contains(@"D:\Logs\Sales.ldf", script);
+    }
+
+    /// <summary>
+    /// The refusal that matters. Emitting a script with no MOVE in it, when MOVE is exactly what
+    /// was asked for, produces a file that looks right and fails in the change window it was
+    /// generated for.
+    /// </summary>
+    [Theory]
+    [InlineData("--relocate")]
+    [InlineData("--data-path", @"D:\Data")]
+    [InlineData("--log-path", @"L:\Logs")]
+    public async Task RelocationWithoutATargetIsRefusedRatherThanDropped(params string[] flags)
+    {
+        var argv = new[] { "--server", "SRV01", "--database", "Sales" }.Concat(flags).ToArray();
+        var (exit, script, said) = await RunScript(argv);
+
+        Assert.Equal(ExitCodes.Usage, exit);
+        Assert.Empty(script);
+        Assert.Contains("--target", said);
+        Assert.Contains("FILELISTONLY", said);
+    }
+
+    /// <summary>Without any relocation flag, nothing is moved - and no server is asked.</summary>
+    [Fact]
+    public async Task NoRelocationFlagsMeansNoMoveAndNoTargetNeeded()
+    {
+        var (exit, script, _) = await RunScript("--server", "SRV01", "--database", "Sales");
+
+        Assert.Equal(ExitCodes.Ok, exit);
+        Assert.Contains("RESTORE DATABASE", script);
+        Assert.DoesNotContain("MOVE", script);
+    }
+
+    [Fact]
+    public async Task AnUnknownTargetIsAUsageError()
+    {
+        var (exit, _, said) = await RunScript(
+            "--server", "SRV01", "--database", "Sales", "--target", "SRV99", "--relocate");
+
+        Assert.Equal(ExitCodes.Usage, exit);
+        Assert.Contains("SRV99", said);
+    }
+}

--- a/src/NineLives.Tests/ExitCodeContractTests.cs
+++ b/src/NineLives.Tests/ExitCodeContractTests.cs
@@ -1,0 +1,185 @@
+using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Blackcat.NineLives.Cli;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The exit codes a verb documents are the ones it can actually return (#370).
+///
+/// The exit code IS the contract - a script cannot read prose, so the WHY of a failure has to be
+/// in the number. Two bugs got through precisely because nothing checked that contract against
+/// the code: "this source has no backups for database X" exited 64, which a pipeline reads as
+/// "my invocation is wrong" rather than as the alarm the verb exists to raise; and `list --json`
+/// returned 0 on an empty source while the human branch returned 2, so adding --json to a check
+/// flipped its verdict.
+///
+/// Both were single-line fixes. What let them survive was that the help page and the code were
+/// two independent descriptions of the same thing, and only one of them ran.
+///
+/// This checks the direction that matters: every code a verb can return must be documented.
+/// The reverse is deliberately allowed - a verb returns its loader's and preflight's codes too,
+/// and those are not visible in its own source - so a documented-but-not-locally-returned code is
+/// not an error.
+/// </summary>
+public class ExitCodeContractTests
+{
+    /// <summary>The name each constant is written under, and the number it stands for.</summary>
+    private static readonly Dictionary<string, int> Defined =
+        typeof(ExitCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(int))
+            .ToDictionary(f => f.Name, f => (int)f.GetRawConstantValue()!);
+
+    public static TheoryData<string> VerbNames()
+    {
+        var data = new TheoryData<string>();
+        foreach (var verb in VerbCatalogue.All) data.Add(verb.Name);
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(VerbNames))]
+    public void EveryDocumentedCodeIsOneTheCliDefines(string verbName)
+    {
+        var verb = VerbCatalogue.All.Single(v => v.Name == verbName);
+        var documented = Documented(verb).ToList();
+
+        Assert.NotEmpty(documented);
+
+        foreach (var code in documented)
+            Assert.True(Defined.ContainsValue(code),
+                $"{verbName} documents exit code {code}, which is not one of " +
+                $"[{string.Join(", ", Defined.Values.Order())}].");
+    }
+
+    /// <summary>Success is always a possible outcome, and always worth stating.</summary>
+    [Theory]
+    [MemberData(nameof(VerbNames))]
+    public void EveryVerbDocumentsSuccess(string verbName)
+    {
+        var verb = VerbCatalogue.All.Single(v => v.Name == verbName);
+        Assert.Contains(ExitCodes.Ok, Documented(verb));
+    }
+
+    [Theory]
+    [MemberData(nameof(VerbNames))]
+    public void NoCodeIsDocumentedTwice(string verbName)
+    {
+        var verb = VerbCatalogue.All.Single(v => v.Name == verbName);
+        var documented = Documented(verb).ToList();
+
+        Assert.Equal(documented.Count, documented.Distinct().Count());
+    }
+
+    /// <summary>
+    /// The one that would have caught both bugs: read the verb's own source and check every
+    /// <c>ExitCodes.X</c> it returns is on its help page.
+    ///
+    /// Source-reading rather than reflection because a constant is inlined by the compiler -
+    /// there is nothing left in the IL to ask. Skipped rather than failed when the source is not
+    /// beside the test run, so this cannot break a packaging arrangement it has no opinion about.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(VerbNames))]
+    public void EveryCodeAVerbReturnsIsDocumented(string verbName)
+    {
+        var source = SourceFor(verbName);
+        if (source == null) return;
+
+        var documented = Documented(VerbCatalogue.All.Single(v => v.Name == verbName)).ToHashSet();
+
+        var returned = Regex.Matches(source, @"ExitCodes\.(\w+)")
+            .Select(m => m.Groups[1].Value)
+            .Where(Defined.ContainsKey)
+            .Select(name => Defined[name])
+            .Distinct()
+            .ToList();
+
+        Assert.NotEmpty(returned);
+
+        foreach (var code in returned)
+            Assert.True(documented.Contains(code),
+                $"{verbName} can return {code} but does not say so on its help page. " +
+                $"A pipeline branching on the documented contract would read it as something " +
+                $"else - which is exactly how #370's two exit-code bugs survived.");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    /// <summary>The leading number on each ExitCodes line, e.g. "2   no chain covers ...".</summary>
+    private static IEnumerable<int> Documented(VerbSpec verb) =>
+        verb.ExitCodes
+            .Select(line => Regex.Match(line, @"^\s*(\d+)"))
+            .Where(m => m.Success)
+            .Select(m => int.Parse(m.Groups[1].Value));
+
+    private static string? SourceFor(string verbName)
+    {
+        // "add-container" -> "AddContainerVerb.cs"
+        var file = string.Concat(verbName.Split('-')
+            .Select(part => char.ToUpperInvariant(part[0]) + part[1..])) + "Verb.cs";
+
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "NineLives.Cli", "Verbs", file);
+            if (File.Exists(candidate)) return File.ReadAllText(candidate);
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// The environment variables the CLI reads are the ones its help page names (#370).
+///
+/// The same shape as the exit-code contract above: the code and the help are two independent
+/// descriptions of one thing, and only one of them runs. NINELIVES_S3_REGION was read by
+/// EnvironmentCredentials and appeared in no help text at all, so the only way to discover it was
+/// to read the source - which is not a discovery route a CI agent's author has.
+/// </summary>
+public class EnvironmentVariableHelpTests
+{
+    [Fact]
+    public void EveryEnvironmentVariableTheCliReadsIsNamedInTheHelp()
+    {
+        var source = SourceOfEnvironmentCredentials();
+        if (source == null) return;
+
+        var read = Regex.Matches(source, @"""(NINELIVES_[A-Z0-9_]+)""")
+            .Select(m => m.Groups[1].Value)
+            .Distinct()
+            .Order()
+            .ToList();
+
+        Assert.NotEmpty(read);
+
+        var help = new StringWriter();
+        HelpWriter.WriteOverview(VerbCatalogue.All, help);
+        var text = help.ToString();
+
+        var missing = read.Where(name => !text.Contains(name, StringComparison.Ordinal)).ToList();
+
+        Assert.True(missing.Count == 0,
+            $"Read by the CLI but named in no help text: {string.Join(", ", missing)}. " +
+            "The only way to discover these would be to read the source.");
+    }
+
+    private static string? SourceOfEnvironmentCredentials()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName, "src", "NineLives.Cli", "EnvironmentCredentials.cs");
+            if (File.Exists(candidate)) return File.ReadAllText(candidate);
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Closes the CLI half of [#370](https://github.com/jakemorgangit/NineLives/issues/370).

## `script` can relocate

`restore` took `--relocate`, `--data-path` and `--log-path`. `script` took none of them — so the workflow the two exist to serve *together* (generate the script here, hand it to a DBA, run it in the change window on a freshly provisioned machine) silently dropped the WITH MOVE clauses. That restore fails at run time with a directory-not-found, **after** WITH REPLACE has already dropped the target, in the window it was scheduled for.

The awkward part is that relocation cannot be worked out offline, and `script` is otherwise a verb that touches nothing:

- the logical file **names** come from `RESTORE FILELISTONLY`
- the default **directories** come from the instance

So `script` now takes a `--target` used *only* to ask those two questions — read, never written to — and **refuses** `--relocate`/`--data-path`/`--log-path` without one rather than emitting a script that quietly has no MOVE in it. A file that looks right and fails later is worse than a refusal, and that refusal is pinned for all three flags.

```bash
9lives script --container backups --database Sales --target SRV02 --relocate --out restore.sql
```

The resolution logic is now shared with `restore` rather than copied, so the two cannot drift apart again.

## The exit-code contract is checked against the code

Two bugs got through because nothing checked the documented contract against the implementation — "no backups for database X" exited 64 (a pipeline reads that as *"I invoked it wrongly"*, not as the alarm the verb exists to raise), and `list --json` returned 0 where the human branch returned 2, so adding `--json` to a check flipped its verdict.

Both were one-line fixes. What let them survive is that the help page and the code were two independent descriptions of one thing, and only one of them ran.

Now every verb's documented codes are checked against the `ExitCodes.X` its own source can return. Source-read rather than reflected, because a `const` is inlined and there is nothing left in the IL to ask; skipped rather than failed when the source is not beside the test run, so it cannot break a packaging arrangement it has no opinion about.

Checked in the direction that matters — **a code a verb can return must be documented**. The reverse is deliberately allowed, since a verb also returns its loader's and preflight's codes and those are not visible in its own source. Verified by removing a documented code from a verb spec: the test fails.

Plus the same shape of drift for environment variables. `NINELIVES_S3_REGION` was read by the CLI and named in no help text at all, so the only way to discover it was to read the source — not a discovery route a CI agent's author has. Every `NINELIVES_*` the CLI reads must now appear in the overview help.

## Effect

`-c Release -warnaserror` clean, **2,018 passed** (up 47).
