### PR TITLE
A screen that is running something stops offering to run it again (#401, #402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Fixed
+
+- **Execute is no longer live while a restore is running** (#401). The button took its enabled
+  state from the same property that supplies the "why you cannot press this" sentence - and that
+  sentence is deliberately empty during a run, because mid-restore the control anybody wants is
+  Stop. Empty read as "not blocked", so the button stayed pressable, and two presses armed it and
+  called the run again: the first thing that does is begin a new cancellation, which abandons the
+  restore in flight and starts the chain over, leaving the target mid-restore in RESTORING. The
+  Backup and Copy Database screens both had this right already; this was the one where WITH
+  REPLACE has already dropped the target. The run itself now refuses to re-enter as well, since
+  the rehearsal path reaches it too.
+
+- **Verify Last Backup says it is running, and cannot be started twice** (#402). RESTORE
+  VERIFYONLY reads the whole backup - minutes on a real database - and the button looked exactly
+  as it had before, so the natural response was to press it again, which cancelled the verify and
+  started it over. The flag that would have said so existed and was bound to nothing.
+
 ## [1.6.1] - 2026-08-11
 
 ### Added

--- a/src/NineLives.Tests/ExecuteDuringARunTests.cs
+++ b/src/NineLives.Tests/ExecuteDuringARunTests.cs
@@ -1,0 +1,188 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A screen that is running something does not offer to run it again (#401, #402).
+///
+/// Backup and Copy Database both had this right - `HasScript &amp;&amp; !IsRunning` - and Restore,
+/// the screen where WITH REPLACE has already dropped the target, did not. Its Execute button took
+/// its enablement from `ExecuteBlockedReason`, which is deliberately EMPTY during a run because
+/// there is nothing to nag about mid-restore. Empty read as "not blocked", so the button stayed
+/// live.
+///
+/// Two presses then armed it and called `RunAsync` again, whose first act is a cancellation
+/// `Begin()` - abandoning the restore in flight, leaving its target mid-chain in RESTORING, and
+/// starting the whole thing over.
+///
+/// The same shape on the backup screen's Verify: RESTORE VERIFYONLY reads the entire backup, the
+/// button looked unchanged throughout, and a second press cancelled and restarted it.
+/// </summary>
+public class ExecuteDuringARunTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    // ── the restore screen ──────────────────────────────────────────────────────
+
+    private static async Task<RestoreViewModel> LoadedRestore()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = "FULL/SRV01/Sales/20260801_220000.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/SRV01/Sales/20260801_220000.bak",
+                    Type = BackupType.Full,
+                    InferredServerName = "SRV01",
+                    InferredDatabaseName = "Sales",
+                    SizeBytes = 1000,
+                    LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+                }
+            ]
+        };
+
+        var vm = new RestoreViewModel(
+            blob, new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store,
+            new OperationLog(System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "ninelives-exec", Guid.NewGuid().ToString("n"))),
+            new FakeRestoreHistoryStore());
+
+        vm.SelectedContainer = store.Config.BlobContainers[0];
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
+        vm.TargetDatabaseName = "Sales_Restored";
+        return vm;
+    }
+
+    [Fact]
+    public async Task ExecuteIsNotPressableWhileARestoreRuns()
+    {
+        var vm = await LoadedRestore();
+
+        vm.Execution.SetExecutingForTests(true);
+
+        Assert.True(vm.IsExecuting);
+        Assert.False(vm.CanPressExecute);
+    }
+
+    /// <summary>
+    /// The reason line stays empty on purpose - mid-restore the wanted control is Stop, not an
+    /// explanation - so this pins that the two questions are answered separately rather than one
+    /// being derived from the other.
+    /// </summary>
+    [Fact]
+    public async Task TheBlockedReasonStaysQuietDuringTheRun()
+    {
+        var vm = await LoadedRestore();
+
+        vm.Execution.SetExecutingForTests(true);
+
+        Assert.Equal(string.Empty, vm.ExecuteBlockedReason);
+        Assert.False(vm.CanPressExecute);
+    }
+
+    /// <summary>And the button comes back when the run ends.</summary>
+    [Fact]
+    public async Task ExecuteIsPressableAgainOnceTheRunEnds()
+    {
+        var vm = await LoadedRestore();
+        vm.IsConnectedToServer = true;
+
+        vm.Execution.SetExecutingForTests(true);
+        Assert.False(vm.CanPressExecute);
+
+        vm.Execution.SetExecutingForTests(false);
+        Assert.True(vm.CanPressExecute);
+    }
+
+    /// <summary>
+    /// The last line of defence. RunAsync is reachable from the rehearsal path too, and its first
+    /// act is a cancellation Begin() - so re-entering it does not waste a call, it abandons a
+    /// restore that is running.
+    /// </summary>
+    [Fact]
+    public async Task RunAsyncRefusesToStartASecondRun()
+    {
+        var vm = await LoadedRestore();
+        vm.Execution.SetExecutingForTests(true);
+
+        await vm.Execution.RunAsync(
+            new RestoreRun(
+                new ServerConnection { Name = "SRV01", ServerName = "SRV01" },
+                "RESTORE DATABASE [x] FROM DISK = N'y' WITH RECOVERY;",
+                "Sales_Restored", "Sales", "backups", "1 Full", null, "options"),
+            _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.True(vm.Execution.HasError);
+        Assert.Contains("already running", vm.Execution.ErrorMessage);
+    }
+
+    // ── the backup screen's verify ──────────────────────────────────────────────
+
+    [Fact]
+    public void VerifyIsNotPressableWhileVerifying()
+    {
+        var vm = new BackupViewModel(new FakeCredentialStore(), new FakeSqlServerService())
+        {
+            CanVerifyLastBackup = true
+        };
+
+        Assert.True(vm.CanVerify);
+        Assert.True(vm.VerifyLastBackupCommand.CanExecute(null));
+
+        vm.IsVerifying = true;
+
+        Assert.False(vm.CanVerify);
+        Assert.False(vm.VerifyLastBackupCommand.CanExecute(null));
+    }
+
+    /// <summary>Nothing written means nothing to verify, running or not.</summary>
+    [Fact]
+    public void VerifyIsNotOfferedBeforeAnythingHasBeenWritten()
+    {
+        var vm = new BackupViewModel(new FakeCredentialStore(), new FakeSqlServerService());
+
+        Assert.False(vm.CanVerify);
+        Assert.False(vm.VerifyLastBackupCommand.CanExecute(null));
+    }
+
+    // ── and the two screens that already had it right ───────────────────────────
+
+    [Fact]
+    public void TheBackupRunIsStillGatedOnNotAlreadyRunning()
+    {
+        var vm = new BackupViewModel(new FakeCredentialStore(), new FakeSqlServerService())
+        {
+            IsRunning = true
+        };
+
+        Assert.False(vm.CanExecute);
+    }
+
+    [Fact]
+    public void TheCopyRunIsStillGatedOnNotAlreadyRunning()
+    {
+        var vm = new CopyDatabaseViewModel(new FakeCredentialStore(), new FakeSqlServerService())
+        {
+            IsRunning = true
+        };
+
+        Assert.False(vm.CanRun);
+    }
+}

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -770,7 +770,31 @@ public partial class BackupViewModel : ViewModelBase
     /// WITH CHECKSUM follows the backup's own setting - verifying checksums that were never
     /// written fails the verify for a backup that is fine.
     /// </summary>
-    [RelayCommand]
+    /// <summary>
+    /// Pressable only when there is something to verify and nothing being verified (#402).
+    ///
+    /// The second half is what was missing. RESTORE VERIFYONLY reads the whole backup - minutes,
+    /// on a real database - and the button looked exactly as it had before, so the natural
+    /// response was to press it again. That call begins a new cancellation, which cancels the
+    /// verify in flight: every minute of reading thrown away, and a console reading "Verify
+    /// cancelled." immediately followed by "Verifying...", which looks like the app changed its
+    /// mind rather than like a button that should have been disabled.
+    /// </summary>
+    public bool CanVerify => CanVerifyLastBackup && !IsVerifying;
+
+    partial void OnIsVerifyingChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanVerify));
+        VerifyLastBackupCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnCanVerifyLastBackupChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanVerify));
+        VerifyLastBackupCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanVerify))]
     private async Task VerifyLastBackupAsync()
     {
         if (Server == null || _lastWrittenDevices.Count == 0) return;

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -180,8 +180,24 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     /// The server-side credential check (#115 seam 5). A refusal has written nothing, so the run is
     /// abandoned without a history entry - it was never attempted.
     /// </param>
+    /// <summary>
+    /// Stage a run in progress without one, for the screens that have to behave differently
+    /// while a restore is running (#401). A real run needs a server.
+    /// </summary>
+    internal void SetExecutingForTests(bool value) => IsExecuting = value;
+
     public async Task RunAsync(RestoreRun run, Func<Action<string>, Task<CredentialPreflight>> preflight)
     {
+        // The last line of defence (#401). The screen's button is gated, but this is also reached
+        // from the rehearsal path, and the cost of re-entering is not a wasted call: the first
+        // thing below is a cancellation Begin(), which would abandon the restore already running
+        // and leave its target mid-chain in RESTORING.
+        if (IsExecuting)
+        {
+            SetError("A restore is already running. Stop it first, or wait for it to finish.");
+            return;
+        }
+
         // What the notifications call the run. A rehearsal's TARGET is the scratch copy, which
         // is an implementation detail - the thing being PROVEN is the source database, and that
         // is the name a Teams channel can recognise.

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -324,9 +324,6 @@ public partial class RestoreViewModel : ViewModelBase
     private string _moveLogFilePath = string.Empty;
 
     [ObservableProperty]
-    private bool _isFetchingPaths;
-
-    [ObservableProperty]
     private bool _pathsFromServer;
 
     [ObservableProperty]
@@ -1277,7 +1274,6 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        IsFetchingPaths = true;
         PathSourceText = $"Querying {ConnectedServer.ServerName} for default paths...";
         try
         {
@@ -1304,10 +1300,6 @@ public partial class RestoreViewModel : ViewModelBase
             MoveLogFilePath = Path.Combine(fallbackDir, $"{dbName}_log.ldf");
             PathsFromServer = false;
             PathSourceText = $"Could not fetch paths: {ex.Message}. Using generic placeholders.";
-        }
-        finally
-        {
-            IsFetchingPaths = false;
         }
     }
 
@@ -1721,8 +1713,21 @@ public partial class RestoreViewModel : ViewModelBase
 
     public bool IsExecuteBlocked => ExecuteBlockedReason.Length > 0;
 
-    /// <summary>The button's own IsEnabled, so the reason and the enabled state cannot disagree.</summary>
-    public bool CanPressExecute => !IsExecuteBlocked;
+    /// <summary>
+    /// The button's own IsEnabled.
+    ///
+    /// NOT simply the inverse of the blocked reason (#401). That reason is deliberately empty
+    /// while a restore runs - there is nothing to nag about mid-run, the Stop button is what is
+    /// wanted then - and reading the enablement off it therefore left Execute LIVE during a
+    /// restore. Two presses armed it and called RunAsync again, whose cancellation source cancels
+    /// the run in flight: a production restore abandoned mid-chain, leaving the target in
+    /// RESTORING, and started over from the top.
+    ///
+    /// So the two questions are asked separately. Backup and Copy Database both had this right
+    /// already - CanExecute => HasScript &amp;&amp; !IsRunning - and this is the screen where
+    /// getting it wrong costs the most, because WITH REPLACE has already dropped the target.
+    /// </summary>
+    public bool CanPressExecute => !IsExecuteBlocked && !IsExecuting;
 
     private void RefreshExecuteBlockedReason()
     {

--- a/src/NineLives/Views/BackupView.xaml
+++ b/src/NineLives/Views/BackupView.xaml
@@ -286,6 +286,15 @@
                                 Visibility="{Binding CanVerifyLastBackup, Converter={StaticResource BoolToVis}}"
                                 Padding="16,8" Margin="0,0,8,8"
                                 ToolTip="RESTORE VERIFYONLY over the files the last run wrote. A backup nobody has verified is a hope, not a backup." />
+
+                        <!-- Says it is happening (#402). Reading a whole backup takes minutes, and
+                             the button used to look identical throughout - so it got pressed
+                             again, which cancelled the verify and started it over. -->
+                        <TextBlock Text="Verifying the backup..."
+                                   Style="{StaticResource SecondaryText}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,8,8"
+                                   Visibility="{Binding IsVerifying, Converter={StaticResource BoolToVis}}" />
                     </WrapPanel>
 
                     <!-- Where the files will land, readable before anything is written. -->


### PR DESCRIPTION
Closes #401, #402. Both found in a review pass; the first was confirmed with a test before being fixed.

## Execute was live during a restore

`RestoreViewModel` derived the button's enablement from the sentence shown next to it:

```csharp
public string ExecuteBlockedReason
{
    get
    {
        if (IsExecuting) return string.Empty;   // nothing to nag about mid-run
        ...
    }
}
public bool IsExecuteBlocked => ExecuteBlockedReason.Length > 0;
public bool CanPressExecute => !IsExecuteBlocked;
```

The early return is right for the *message* — mid-restore the control anybody wants is Stop, not an explanation. It is wrong for the *enablement*, and one property was serving both. Empty reason → not blocked → **button live**.

The comment above `CanPressExecute` reads "so the reason and the enabled state cannot disagree". They agreed. They were both wrong.

**What two presses did.** `RestoreExecutionViewModel.RunAsync` had no re-entrancy guard, and its first act is `_executeCancellation.Begin()` — `Cancel(); Dispose(); new CancellationTokenSource();`. So: first press armed (the run had disarmed), second press called `RunAsync`, which **cancelled the restore in flight and started the chain from the top**. A restore abandoned mid-chain leaves its target in RESTORING — the screen has a recovery-actions panel for precisely that state.

**The other two screens had it right.** `BackupViewModel.CanExecute => HasScript && !IsRunning`, `CopyDatabaseViewModel.CanRun => HasScripts && !IsRunning && !IsRefused` (re-checked on entry). The same question, answered correctly where it costs less and missed on the screen where `WITH REPLACE` has already dropped the target.

Fixed by asking the two questions separately, and by making `RunAsync` refuse to re-enter regardless of caller — the rehearsal path reaches it too.

## Verify had the same shape

`IsVerifying` was set true and false and **read by nothing**. `RESTORE VERIFYONLY` reads the whole backup, the button looked unchanged throughout, and a second press cancelled the verify and restarted it — throwing away the reading already done and printing "Verify cancelled." immediately followed by "Verifying...", which looks like the app changing its mind rather than a button that should have been disabled.

It now gates the command and shows a line beside the button, copying `IsVerifyingChain` on the restore screen, which was already bound and does exactly this.

`RestoreViewModel.IsFetchingPaths` was dead the same way — harmless, since `PathSourceText` already narrates that fetch, so it is removed rather than bound.

## Effect

`-c Release -warnaserror` clean, **2,028 passed** (up 8). The new tests also pin that Backup and Copy keep their existing guards, so this cannot regress in the other direction.
