### PR TITLE
Screens that say nothing: confirmations, and a fresh install (#404, #406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A fresh install says what is missing and where to fix it** (#406). Rendering every screen
+  with no containers and no servers found three that did not. Browse Backups said "Select a
+  container and click Load Backups to browse" when there were no containers to select - an
+  instruction nobody could follow, on the screen that is the natural thing to press when you want
+  to look before committing to anything. Back Up showed two empty dropdowns and no words at all;
+  Copy Database showed three, and since a copy needs two servers, somebody with one configured
+  hit the same wall. The Restore and Exposure screens already named the missing thing, named the
+  screen that fills it and said what would then happen; the other three now do too.
+
 - **Five screens now say what they just did** (#404). Four of them - Settings, SQL Servers,
   Blob Storage and Exposure - carried an error banner and bound nothing to their status line, so
   failures showed and every confirmation, instruction and consequence did not. A config import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Five screens now say what they just did** (#404). Four of them - Settings, SQL Servers,
+  Blob Storage and Exposure - carried an error banner and bound nothing to their status line, so
+  failures showed and every confirmation, instruction and consequence did not. A config import
+  reported what it had added and updated to nobody, and the sentence telling you where to go and
+  look went with it. An export's "the file holds no secrets" - the one thing worth knowing before
+  emailing it to a colleague - was never shown. "Enter the new SAS token below" never appeared
+  beside the box it was about. Pressing Stop on an exposure sweep looked like it had done
+  nothing. And on History, the one screen with no banner by design, an error was drawn in exactly
+  the same grey as a success, so a refusal to destroy a restore's evidence read like "Script
+  copied to clipboard".
+
 - **Execute is no longer live while a restore is running** (#401). The button took its enabled
   state from the same property that supplies the "why you cannot press this" sentence - and that
   sentence is deliberately empty during a run, because mid-restore the control anybody wants is

--- a/src/NineLives.Tests/EveryScreenSaysWhatItDidTests.cs
+++ b/src/NineLives.Tests/EveryScreenSaysWhatItDidTests.cs
@@ -1,0 +1,149 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A screen that reports a failure also reports a success (#404).
+///
+/// The mirror image of #356. Four screens carried an ErrorBanner and bound no StatusMessage, so
+/// their failures showed and every confirmation, instruction and consequence did not: a config
+/// import told nobody what it had changed, "Enter the new SAS token below" never appeared beside
+/// the box it was about, and pressing Stop on an exposure sweep looked like it had done nothing.
+///
+/// And History, the one view with no banner - deliberately, because SetError writes the status
+/// line too so an error there is not silent - drew that error in the same grey as everything
+/// else. A refusal to destroy a restore's evidence looked exactly like "Script copied to
+/// clipboard".
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class EveryScreenSaysWhatItDidTests(WpfFixture wpf)
+{
+    private static (FrameworkElement View, ViewModelBase Vm) Screen(string name)
+    {
+        var store = new FakeCredentialStore();
+
+        return name switch
+        {
+            "Settings" => Pair(new SettingsView(), new SettingsViewModel(store, TestLogs.Temp())),
+            "Servers" => Pair(new ServerManagerView(), new ServerManagerViewModel(store, new FakeSqlServerService())),
+            "Blob" => Pair(new BlobConfigView(), new BlobConfigViewModel(store, new FakeBlobStorageService())),
+            "Exposure" => Pair(new ExposureView(), new ExposureViewModel(store, new FakeSqlServerService(), new FakeRestoreHistoryStore())),
+            "History" => Pair(new HistoryView(), new HistoryViewModel(new FakeRestoreHistoryStore())),
+            _ => throw new ArgumentOutOfRangeException(nameof(name))
+        };
+
+        static (FrameworkElement, ViewModelBase) Pair(FrameworkElement v, ViewModelBase vm)
+        {
+            v.DataContext = vm;
+            return (v, vm);
+        }
+    }
+
+    [Theory]
+    [InlineData("Settings")]
+    [InlineData("Servers")]
+    [InlineData("Blob")]
+    [InlineData("Exposure")]
+    [InlineData("History")]
+    public void AStatusMessageReachesTheScreen(string name)
+    {
+        wpf.Invoke(() =>
+        {
+            var (view, vm) = Screen(name);
+            const string said = "Nine Lives status probe sentence.";
+
+            Layout(view);
+            Assert.DoesNotContain(said, Shown(view));
+
+            vm.SetStatusForTests(said);
+            Layout(view);
+
+            Assert.Contains(said, Shown(view));
+        });
+    }
+
+    /// <summary>
+    /// SetError writes the status line as well as the banner, because not every screen surfaces
+    /// both. On the four that surface both, the same sentence must not appear twice - once in red
+    /// and once in grey reads as two separate things having gone wrong.
+    /// </summary>
+    [Theory]
+    [InlineData("Settings")]
+    [InlineData("Servers")]
+    [InlineData("Blob")]
+    [InlineData("Exposure")]
+    public void AnErrorIsNotAlsoPrintedOnTheStatusLine(string name)
+    {
+        wpf.Invoke(() =>
+        {
+            var (view, vm) = Screen(name);
+            const string wrong = "Nine Lives error probe sentence.";
+
+            vm.SetErrorForTests(wrong);
+            Layout(view);
+
+            var appearances = Shown(view).Count(t => t == wrong);
+
+            Assert.True(appearances == 1,
+                $"{name} shows the same error {appearances} times.");
+        });
+    }
+
+    /// <summary>
+    /// History is the exception and stays visible - it has no banner, so collapsing its status
+    /// line on error is exactly the silence the arrangement exists to prevent. It carries the
+    /// error appearance instead.
+    /// </summary>
+    [Fact]
+    public void HistoryShowsItsErrorAndMarksItAsOne()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new HistoryViewModel(new FakeRestoreHistoryStore { CouldNotRead = true });
+            var view = new HistoryView { DataContext = vm };
+
+            vm.Refresh();
+            Layout(view);
+
+            var line = FindAll<TextBlock>(view)
+                .FirstOrDefault(t => t.Visibility == Visibility.Visible
+                                     && t.Text.Contains("could not be read"));
+
+            Assert.True(line != null, "History does not show its own refusal.");
+
+            var error = (SolidColorBrush)Application.Current!.Resources["ErrorBrush"];
+            Assert.Equal(error.Color, ((SolidColorBrush)line!.Foreground).Color);
+        });
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<string> Shown(DependencyObject view) =>
+        FindAll<TextBlock>(view)
+            .Where(t => t.Visibility == Visibility.Visible)
+            .Select(t => t.Text)
+            .ToList();
+
+    private static void Layout(FrameworkElement element)
+    {
+        element.Measure(new Size(1280, 900));
+        element.Arrange(new Rect(0, 0, 1280, 900));
+        element.UpdateLayout();
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        int count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var node = VisualTreeHelper.GetChild(root, i);
+            if (node is T match) yield return match;
+            foreach (var descendant in FindAll<T>(node)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives.Tests/NothingToPickFromTests.cs
+++ b/src/NineLives.Tests/NothingToPickFromTests.cs
@@ -1,0 +1,186 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A fresh install says what is missing and where to fix it (#406).
+///
+/// Rendering every screen with no containers and no servers showed three that did not. Browse
+/// Backups said "Select a container and click Load Backups to browse" when there were no
+/// containers to select - an instruction nobody could follow, on the screen that is the natural
+/// thing to press when you want to LOOK before committing. Back Up showed two empty dropdowns and
+/// no words; Copy Database showed three, and a copy needs two servers, so somebody with one hits
+/// the same wall.
+///
+/// Restore and Exposure already had the sentence. These tests hold all five to it.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class NothingToPickFromTests(WpfFixture wpf)
+{
+    private static FakeCredentialStore Furnished()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+        return store;
+    }
+
+    // ── Back Up ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BackUpNamesBothMissingThings()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BackupViewModel(new FakeCredentialStore(), new FakeSqlServerService());
+            var view = new BackupView { DataContext = vm };
+            Layout(view);
+
+            Assert.True(vm.HasNoServers);
+            Assert.True(vm.HasNoContainers);
+
+            var shown = string.Join(" | ", Shown(view));
+            Assert.Contains("SQL Servers screen", shown);
+            Assert.Contains("Blob Storage screen", shown);
+        });
+    }
+
+    [Fact]
+    public void BackUpSaysNothingOnceThereIsSomethingToPick()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BackupViewModel(Furnished(), new FakeSqlServerService());
+            var view = new BackupView { DataContext = vm };
+            Layout(view);
+
+            Assert.False(vm.HasNoServers);
+            Assert.False(vm.HasNoContainers);
+
+            var shown = string.Join(" | ", Shown(view));
+            Assert.DoesNotContain("No saved servers yet", shown);
+            Assert.DoesNotContain("No storage configured yet", shown);
+        });
+    }
+
+    // ── Copy Database ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CopySaysACopyNeedsTwoServers()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new CopyDatabaseViewModel(new FakeCredentialStore(), new FakeSqlServerService());
+            var view = new CopyDatabaseView { DataContext = vm };
+            Layout(view);
+
+            var shown = string.Join(" | ", Shown(view));
+            Assert.Contains("a copy needs two", shown);
+            Assert.Contains("Blob Storage screen", shown);
+        });
+    }
+
+    // ── Browse Backups ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The one that was actively wrong rather than merely absent: an instruction to select
+    /// something that does not exist.
+    /// </summary>
+    [Fact]
+    public void BrowseDoesNotAskForAContainerWhenThereAreNone()
+    {
+        var vm = new BlobBrowserViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new FakeCredentialStore());
+
+        Assert.True(vm.MediumIsBlob);
+        Assert.DoesNotContain("Select a container", vm.BrowseHint);
+        Assert.Contains("Blob Storage screen", vm.BrowseHint);
+    }
+
+    [Fact]
+    public void BrowseAsksForAContainerOnceThereIsOne()
+    {
+        var vm = new BlobBrowserViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), Furnished());
+        vm.RefreshContainers();
+
+        Assert.Contains("Select a container", vm.BrowseHint);
+    }
+
+    [Fact]
+    public void BrowseSwitchesTheSentenceWithTheMedium()
+    {
+        var vm = new BlobBrowserViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new FakeCredentialStore())
+        {
+            SelectedMedium = BackupMedium.SharedPath
+        };
+
+        Assert.Contains("SQL Servers screen", vm.BrowseHint);
+        Assert.DoesNotContain("Blob Storage", vm.BrowseHint);
+    }
+
+    // ── and the two that already had it ─────────────────────────────────────────
+
+    [Fact]
+    public void RestoreStillSaysItAboutServers()
+    {
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), new FakeCredentialStore(),
+            TestLogs.Temp(), new FakeRestoreHistoryStore());
+
+        Assert.True(vm.HasNoTargetServers);
+    }
+
+    [Fact]
+    public async Task ExposureStillSaysItAboutServers()
+    {
+        var vm = new ExposureViewModel(
+            new FakeCredentialStore(), new FakeSqlServerService(), new FakeRestoreHistoryStore());
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Contains("No servers configured", vm.Summary);
+        Assert.Contains("SQL Servers screen", vm.Summary);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<string> Shown(DependencyObject view) =>
+        FindAll<TextBlock>(view)
+            .Where(t => t.Visibility == Visibility.Visible)
+            .Select(t => t.Text)
+            .ToList();
+
+    private static void Layout(FrameworkElement element)
+    {
+        element.Measure(new Size(1280, 1400));
+        element.Arrange(new Rect(0, 0, 1280, 1400));
+        element.UpdateLayout();
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        int count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var node = VisualTreeHelper.GetChild(root, i);
+            if (node is T match) yield return match;
+            foreach (var descendant in FindAll<T>(node)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -243,6 +243,52 @@
         <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
     </Style>
 
+    <!--
+        The screen's own status line: what it just did, or is doing (#404).
+
+        Four screens had an ErrorBanner and nothing bound to StatusMessage, so their failures
+        showed and every confirmation, instruction and consequence did not - a config import
+        reported what it had changed to nobody, and "Enter the new SAS token below" never appeared
+        beside the box it was talking about.
+
+        Collapses while there is an error. SetError deliberately writes the status line as well as
+        the banner, because not every screen surfaces both, so on a screen that surfaces both the
+        same sentence would appear twice - once in red and once in grey, which reads as two
+        separate things having gone wrong.
+    -->
+    <Style x:Key="StatusLine" TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+        <Setter Property="TextWrapping" Value="Wrap" />
+        <Setter Property="Margin" Value="0,8,0,0" />
+        <Setter Property="Visibility" Value="Visible" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding StatusMessage}" Value="">
+                <Setter Property="Visibility" Value="Collapsed" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding HasError}" Value="True">
+                <Setter Property="Visibility" Value="Collapsed" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <!--
+        The same line for the one screen that has no banner (#404).
+
+        History renders only a status line, by design - SetError writes it too, precisely so an
+        error there is not silent. But it was drawn in the same grey as everything else, so
+        "This history could not be read, so there is no telling what clearing it would destroy"
+        looked exactly like "Script copied to clipboard". This one stays visible during an error
+        and turns red for it.
+    -->
+    <Style x:Key="StatusLineNoBanner" TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+        <Setter Property="TextWrapping" Value="Wrap" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding HasError}" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="LabelText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="12" />

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -240,6 +240,24 @@ public partial class BackupViewModel : ViewModelBase
 
     [ObservableProperty]
     private ObservableCollection<BlobContainerConfig> _containers = [];
+    /// <summary>
+    /// Nothing to pick from, and where to go and fix that (#406).
+    ///
+    /// A fresh install put empty "Select..." dropdowns on this screen with no words at all, while
+    /// the Restore and Exposure screens both already named the missing thing, named the screen
+    /// that fills it, and said what would then happen. The app knows exactly what is absent; it
+    /// simply was not saying.
+    /// </summary>
+    public bool HasNoServers => Servers.Count == 0;
+
+    public bool HasNoContainers => Containers.Count == 0;
+
+    partial void OnServersChanged(ObservableCollection<ServerConnection> value) =>
+        OnPropertyChanged(nameof(HasNoServers));
+
+    partial void OnContainersChanged(ObservableCollection<BlobContainerConfig> value) =>
+        OnPropertyChanged(nameof(HasNoContainers));
+
 
     [ObservableProperty]
     private BlobContainerConfig? _container;

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -42,6 +42,30 @@ public partial class BlobBrowserViewModel : ViewModelBase
 
     [ObservableProperty]
     private ObservableCollection<BlobContainerConfig> _containers = [];
+    /// <summary>
+    /// Nothing to pick from, and where to go and fix that (#406).
+    ///
+    /// A fresh install put empty "Select..." dropdowns on this screen with no words at all, while
+    /// the Restore and Exposure screens both already named the missing thing, named the screen
+    /// that fills it, and said what would then happen. The app knows exactly what is absent; it
+    /// simply was not saying.
+    /// </summary>
+    public bool HasNoServers => Servers.Count == 0;
+
+    public bool HasNoContainers => Containers.Count == 0;
+
+    partial void OnServersChanged(ObservableCollection<ServerConnection> value)
+    {
+        OnPropertyChanged(nameof(HasNoServers));
+        OnPropertyChanged(nameof(BrowseHint));
+    }
+
+    partial void OnContainersChanged(ObservableCollection<BlobContainerConfig> value)
+    {
+        OnPropertyChanged(nameof(HasNoContainers));
+        OnPropertyChanged(nameof(BrowseHint));
+    }
+
 
     [ObservableProperty]
     private BlobContainerConfig? _selectedContainer;
@@ -112,10 +136,32 @@ public partial class BlobBrowserViewModel : ViewModelBase
     public bool MediumIsBlob => SelectedMedium == BackupMedium.AzureBlob;
     public bool MediumIsSharedPath => SelectedMedium == BackupMedium.SharedPath;
 
+    /// <summary>
+    /// The one line under the empty-state folder: what to do next, or why there is nothing to do
+    /// yet (#406).
+    ///
+    /// Four cases collapsed into one string rather than four TextBlocks and a MultiDataTrigger.
+    /// The bug it fixes is the fourth: on a fresh install this said "Select a container and click
+    /// Load Backups to browse" when there were no containers to select - an instruction nobody
+    /// could follow, on a screen that is one click from the sidebar and the natural thing to press
+    /// when you want to LOOK before committing to anything.
+    /// </summary>
+    public string BrowseHint =>
+        MediumIsBlob
+            ? HasNoContainers
+                ? "No storage configured yet. Add a container or bucket on the Blob Storage " +
+                  "screen, and what is in it can be browsed here."
+                : "Select a container and click Load Backups to browse."
+            : HasNoServers
+                ? "No saved servers yet. Add one on the SQL Servers screen, and what it has " +
+                  "recorded backing up can be read here."
+                : "Select a server and click Load Backups to read what it has backed up.";
+
     partial void OnSelectedMediumChanged(BackupMedium value)
     {
         OnPropertyChanged(nameof(MediumIsBlob));
         OnPropertyChanged(nameof(MediumIsSharedPath));
+        OnPropertyChanged(nameof(BrowseHint));
 
         // What is on screen came from the other source and no longer belongs to what is selected
         // above it. Leaving it there would put a container's files under a server's name.

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -74,6 +74,24 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
     [ObservableProperty]
     private ObservableCollection<BlobContainerConfig> _containers = [];
+    /// <summary>
+    /// Nothing to pick from, and where to go and fix that (#406).
+    ///
+    /// A fresh install put empty "Select..." dropdowns on this screen with no words at all, while
+    /// the Restore and Exposure screens both already named the missing thing, named the screen
+    /// that fills it, and said what would then happen. The app knows exactly what is absent; it
+    /// simply was not saying.
+    /// </summary>
+    public bool HasNoServers => Servers.Count == 0;
+
+    public bool HasNoContainers => Containers.Count == 0;
+
+    partial void OnServersChanged(ObservableCollection<ServerConnection> value) =>
+        OnPropertyChanged(nameof(HasNoServers));
+
+    partial void OnContainersChanged(ObservableCollection<BlobContainerConfig> value) =>
+        OnPropertyChanged(nameof(HasNoContainers));
+
 
     [ObservableProperty]
     private BlobContainerConfig? _container;

--- a/src/NineLives/ViewModels/ViewModelBase.cs
+++ b/src/NineLives/ViewModels/ViewModelBase.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
@@ -46,6 +46,12 @@ public abstract partial class ViewModelBase : ObservableObject
     /// it.
     /// </summary>
     protected void SetStatus(string message) => StatusMessage = message;
+
+    /// <summary>Stage a status message without the operation that produces one.</summary>
+    internal void SetStatusForTests(string message) => SetStatus(message);
+
+    /// <summary>Stage an error without the failure that produces one.</summary>
+    internal void SetErrorForTests(string message) => SetError(message);
 
     /// <summary>
     /// Sticky: survives until another error supersedes it, the user dismisses it, or the next

--- a/src/NineLives/Views/BackupView.xaml
+++ b/src/NineLives/Views/BackupView.xaml
@@ -61,6 +61,11 @@
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
+                            <!-- Names the missing thing and the screen that fills it (#406). Restore and
+                                 Exposure already said this; the dropdowns here just sat empty. -->
+                            <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                       Text="No saved servers yet. Add one on the SQL Servers screen and it will appear here."
+                                       Visibility="{Binding HasNoServers, Converter={StaticResource BoolToVis}}" />
                         </StackPanel>
 
                         <Button Grid.Column="1"
@@ -153,6 +158,9 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
+                        <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                   Text="No storage configured yet. Add a container or bucket on the Blob Storage screen and it will appear here."
+                                   Visibility="{Binding HasNoContainers, Converter={StaticResource BoolToVis}}" />
                     </StackPanel>
 
                     <StackPanel Margin="0,12,0,0"

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -275,17 +275,16 @@
                                Style="{StaticResource BodyText}"
                                HorizontalAlignment="Center" />
                     <!-- Names the thing actually being asked for. Telling somebody who has chosen a
-                         server to select a container is an instruction they cannot follow (#197). -->
-                    <TextBlock Text="Select a container and click Load Backups to browse."
+                         server to select a container is an instruction they cannot follow (#197) -
+                         and so is telling somebody with no containers at all to select one (#406).
+                         All four cases live in BrowseHint, as one sentence. -->
+                    <TextBlock Text="{Binding BrowseHint}"
                                Style="{StaticResource SecondaryText}"
                                HorizontalAlignment="Center"
-                               Margin="0,4,0,0"
-                               Visibility="{Binding MediumIsBlob, Converter={StaticResource BoolToVis}}" />
-                    <TextBlock Text="Select a server and click Load Backups to read what it has backed up."
-                               Style="{StaticResource SecondaryText}"
-                               HorizontalAlignment="Center"
-                               Margin="0,4,0,0"
-                               Visibility="{Binding MediumIsSharedPath, Converter={StaticResource BoolToVis}}" />
+                               TextWrapping="Wrap"
+                               MaxWidth="440"
+                               TextAlignment="Center"
+                               Margin="0,4,0,0" />
                 </StackPanel>
 
                 <!-- DataGrid -->

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -29,6 +29,9 @@
             <TextBlock Text="Configure the containers holding your backups - Azure Blob Storage, or any S3-compatible bucket."
                        Style="{StaticResource SecondaryText}"
                        Margin="0,4,0,0" />
+            <!-- What this screen just did. Its confirmations, instructions and
+                 consequences used to reach nothing at all (#404). -->
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" />
         </StackPanel>
 
         <Grid Grid.Row="1">

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -90,6 +90,12 @@
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
+                            <!-- Names the missing thing and the screen that fills it (#406). A copy needs
+                                 two servers and somewhere to put the backup, and a fresh install offered
+                                 three empty dropdowns with no words at all. -->
+                            <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                       Text="No saved servers yet. Add one on the SQL Servers screen and it will appear here - a copy needs two."
+                                       Visibility="{Binding HasNoServers, Converter={StaticResource BoolToVis}}" />
                         </StackPanel>
 
                         <Button Grid.Column="1"
@@ -143,6 +149,9 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
+                        <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                   Text="No storage configured yet. Add a container or bucket on the Blob Storage screen and it will appear here."
+                                   Visibility="{Binding HasNoContainers, Converter={StaticResource BoolToVis}}" />
                     </StackPanel>
 
                     <StackPanel Margin="0,12,0,0"
@@ -195,6 +204,9 @@
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
+                            <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                       Text="No saved servers yet. Add one on the SQL Servers screen and it will appear here - a copy needs two."
+                                       Visibility="{Binding HasNoServers, Converter={StaticResource BoolToVis}}" />
                         </StackPanel>
 
                         <StackPanel Grid.Column="2">

--- a/src/NineLives/Views/ExposureView.xaml
+++ b/src/NineLives/Views/ExposureView.xaml
@@ -40,6 +40,10 @@
 
             <ContentControl Style="{StaticResource ErrorBanner}" Margin="0,0,0,12" />
 
+            <!-- "Cancelling..." and "Sweep cancelled." used to reach nothing, so pressing
+                 Stop on a long sweep looked like it had done nothing (#404). -->
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" />
+
             <ItemsControl ItemsSource="{Binding Rows}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>

--- a/src/NineLives/Views/HistoryView.xaml
+++ b/src/NineLives/Views/HistoryView.xaml
@@ -181,10 +181,13 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
+            <!-- This is the only view with no ErrorBanner, by design: SetError writes the
+                 status line too, precisely so an error here is not silent. But it was drawn in
+                 the same grey as everything else, so a refusal to destroy a restore's evidence
+                 looked exactly like "Script copied to clipboard" (#404). -->
             <TextBlock Grid.Column="0"
                        Text="{Binding StatusMessage}"
-                       Style="{StaticResource SecondaryText}"
-                       TextWrapping="Wrap"
+                       Style="{StaticResource StatusLineNoBanner}"
                        VerticalAlignment="Center" />
 
             <Button Grid.Column="1" Content="Keep it"

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -23,6 +23,9 @@
             <TextBlock Text="Manage SQL Server connections for executing restore scripts and reading backup metadata."
                        Style="{StaticResource SecondaryText}"
                        Margin="0,4,0,0" />
+            <!-- What this screen just did. Its confirmations, instructions and
+                 consequences used to reach nothing at all (#404). -->
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" />
         </StackPanel>
 
         <Grid Grid.Row="1">

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -13,6 +13,10 @@
 
             <ContentControl Style="{StaticResource ErrorBanner}" />
 
+            <!-- Where an import says what it changed, and an export says where it went and
+                 that it holds no secrets. Both reported to nobody until #404. -->
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" />
+
             <!-- Appearance -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
                 <StackPanel>


### PR DESCRIPTION
Closes #404 and #406. Both found by rendering screens and looking at them rather than by reading code.

## Part one: a screen that reports a failure also reports a success (#404)

The mirror image of #356. Four screens carried an `ErrorBanner` and bound nothing to `StatusMessage`, so their failures showed and **every confirmation, instruction and consequence reached nothing at all** — 12 `SetStatus` calls across Settings, SQL Servers, Blob Storage and Exposure.

**Config import** is the sharpest. It is a bulk operation over the server and container lists, and `summary.Describe()` is its entire account of what it did, followed by a sentence saying where to go and look. You pick a file and the screen does **nothing visible whatsoever** — no way to tell whether it worked, whether it was the right file, or what changed, and nothing to stop you doing it again.

**Export** loses *"the file holds no secrets — credentials are re-entered on the importing machine"*: exactly what somebody needs before emailing it to a colleague, and the only place the app says it. **SQL Servers** loses a consequence message about a stored credential being invalidated. **Blob Storage** loses *"Enter the new SAS token below to replace the existing one"* — an instruction, so without it the form appears with no explanation of what it wants. **Exposure** loses "Cancelling...", so Stop on a long sweep looks inert.

And on **History** — the one view with no banner, deliberately, because `SetError` writes the status line too — that error was drawn in the same grey as everything else. "This history could not be read, so there is no telling what clearing it would destroy" looked exactly like "Script copied to clipboard".

Two shared styles rather than five copies. `StatusLine` collapses while there is an error, since `SetError` writes both surfaces and the same sentence twice reads as two problems — the wrinkle #392 hit on Browse Backups. `StatusLineNoBanner` is History's: stays visible, turns red.

## Part two: a fresh install says what is missing (#406)

Rendered every screen with no containers and no servers. Three had nothing to say.

**Browse Backups** was actively wrong rather than merely absent: *"Select a container and click Load Backups to browse"* when there were no containers to select. The comment above that line already said, of an earlier fix, that telling somebody to select a container they cannot select is an instruction they cannot follow — the same sentence, one case further out.

**Back Up** showed two empty dropdowns and no words. **Copy Database** showed three, and a copy needs *two* servers, so somebody with one configured meets the same wall.

**Restore** and **Exposure** already had it — name the missing thing, name the screen that fills it, say what will then happen. The other three now do, in the same words. Browse's four cases (two media × with/without anything to pick) collapse into one `BrowseHint` string rather than four TextBlocks and a MultiDataTrigger, matching how the app already handles this kind of either-or.

## Effect

`-c Release -warnaserror` clean, **2,046 passed** (up 18). Rendered before and after in each case.
