### PR TITLE
A status light that never checked anything (#407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The dot beside a container says something** (#407). It was drawn in the success colour
+  unconditionally - a green light beside every container whether or not it had a credential,
+  whether or not it had ever been tested, with no tooltip and no legend, so the only reading
+  available was "fine". The case that makes it matter is one the app creates itself: a config
+  export carries no secrets by design, so the first thing somebody saw after importing on a new
+  machine was a list of green dots on containers that could not reach anything. It now reports
+  what the vault actually holds - present, expired or missing - in words as well as in colour,
+  since this app's own styles already note that meaning must not ride on colour alone. Entra
+  containers are not reported as missing anything, having no stored secret to miss.
+
 - **A fresh install says what is missing and where to fix it** (#406). Rendering every screen
   with no containers and no servers found three that did not. Browse Backups said "Select a
   container and click Load Backups to browse" when there were no containers to select - an

--- a/src/NineLives.Core/Models/BlobContainerConfig.cs
+++ b/src/NineLives.Core/Models/BlobContainerConfig.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Globalization;
@@ -242,6 +242,63 @@ public class BlobContainerConfig : INotifyPropertyChanged
     /// </summary>
     public bool IsExpired => AuthMode.NeedsSasToken() && ReadSasExpiry().IsExpired;
 
+    /// <summary>
+    /// Whether this container has the secret it needs, as far as can be known without asking the
+    /// network (#407).
+    ///
+    /// The list used to draw a green dot beside every container unconditionally - a status light
+    /// that never checked anything, in an app whose whole premise is that a backup is not fine
+    /// until something has proved it. The case that makes it matter is one the app creates
+    /// itself: a config export carries no secrets by design, so the first thing somebody sees
+    /// after importing on a new machine is a list of green dots on containers that cannot reach
+    /// anything.
+    ///
+    /// Set by whoever loaded the container from the vault; Unknown until then, so nothing claims
+    /// an answer it has not looked up.
+    /// </summary>
+    public ContainerCredentialState CredentialState
+    {
+        get => _credentialState;
+        set
+        {
+            if (_credentialState == value) return;
+            _credentialState = value;
+
+            // Notifying, so fixing a credential repaints the dot rather than leaving it red until
+            // the screen is rebuilt - the list is bound live and Save does not reload it.
+            OnPropertyChanged(nameof(CredentialState));
+            OnPropertyChanged(nameof(CredentialStateNote));
+            OnPropertyChanged(nameof(CredentialIsMissing));
+            OnPropertyChanged(nameof(CredentialIsExpired));
+        }
+    }
+
+    private ContainerCredentialState _credentialState = ContainerCredentialState.Unknown;
+
+    /// <summary>What the dot means, in words, for its tooltip.</summary>
+    public string CredentialStateNote => CredentialState switch
+    {
+        ContainerCredentialState.Present => AuthMode.IsEntra()
+            ? $"Signs in with {AuthMode.Describe()} - no stored secret to go stale."
+            : IsS3
+                ? "An access key pair is stored for this bucket."
+                : "A SAS token is stored for this container.",
+        ContainerCredentialState.Expired =>
+            "The stored SAS token has passed its expiry. Refresh it before restoring - the " +
+            "listing and the restore will both be refused.",
+        ContainerCredentialState.Missing => IsS3
+            ? "No access key pair is stored for this bucket. Nothing here can be listed or " +
+              "restored until one is added - a config imported from another machine arrives " +
+              "this way, by design."
+            : "No SAS token is stored for this container. Nothing here can be listed or " +
+              "restored until one is added - a config imported from another machine arrives " +
+              "this way, by design.",
+        _ => "Not checked yet."
+    };
+
+    public bool CredentialIsMissing => CredentialState == ContainerCredentialState.Missing;
+    public bool CredentialIsExpired => CredentialState == ContainerCredentialState.Expired;
+
     public DateTime? SasExpiry => GetSasExpiry();
 
     public string? StorageAccountName
@@ -427,4 +484,22 @@ public class PathElement
 
     public static string BuildPattern(IEnumerable<PathElement> elements)
         => string.Join("/", elements.Select(e => $"{{{e.Token}}}"));
+}
+
+/// <summary>
+/// What is known about a container's stored secret, without touching the network (#407).
+/// </summary>
+public enum ContainerCredentialState
+{
+    /// <summary>Nobody has asked the vault yet. Claims nothing.</summary>
+    Unknown,
+
+    /// <summary>The secret is there - or none is needed, under Entra.</summary>
+    Present,
+
+    /// <summary>Stored, and past its expiry. Reads and restores will both be refused.</summary>
+    Expired,
+
+    /// <summary>Not in the vault. The state a config import leaves behind, by design.</summary>
+    Missing
 }

--- a/src/NineLives.Tests/ContainerCredentialStateTests.cs
+++ b/src/NineLives.Tests/ContainerCredentialStateTests.cs
@@ -1,0 +1,186 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The dot beside a container says something (#407).
+///
+/// It was `Fill="{DynamicResource SuccessBrush}"` unconditionally: a green light beside every
+/// container whether or not it had a credential, whether or not it had ever been tested. No
+/// tooltip, no legend, so the only reading available was "fine".
+///
+/// The case that makes it matter is one the app creates itself. A config export carries no
+/// secrets - its own message says credentials are re-entered on the importing machine - so the
+/// first thing somebody sees after importing on a new machine was a list of green dots on
+/// containers that could not reach anything.
+///
+/// The SQL Servers screen had this right all along: its green dot sits behind IsConnected.
+/// </summary>
+public class ContainerCredentialStateTests
+{
+    private static (BlobConfigViewModel Vm, FakeCredentialStore Store) Screen(
+        params (string Name, string Url)[] containers)
+    {
+        var store = new FakeCredentialStore();
+        foreach (var (name, url) in containers)
+        {
+            store.Config.BlobContainers.Add(new BlobContainerConfig
+            {
+                Id = BlobContainerConfig.NewId(),
+                Name = name,
+                ContainerUrl = url
+            });
+        }
+
+        return (new BlobConfigViewModel(store, new FakeBlobStorageService()), store);
+    }
+
+    [Fact]
+    public void AContainerWithNoStoredSecretSaysSo()
+    {
+        var (vm, _) = Screen(("prod", "https://acct.blob.core.windows.net/prod"));
+
+        var container = vm.Containers.Single();
+
+        Assert.Equal(ContainerCredentialState.Missing, container.CredentialState);
+        Assert.True(container.CredentialIsMissing);
+        Assert.Contains("No SAS token is stored", container.CredentialStateNote);
+    }
+
+    [Fact]
+    public void AContainerWithAStoredSecretIsPresent()
+    {
+        var store = new FakeCredentialStore();
+        var config = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "prod",
+            ContainerUrl = "https://acct.blob.core.windows.net/prod"
+        };
+        store.Config.BlobContainers.Add(config);
+        store.SaveSasToken(config, "sv=2022-11-02&sig=abc");
+
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+
+        var container = vm.Containers.Single();
+        Assert.Equal(ContainerCredentialState.Present, container.CredentialState);
+        Assert.False(container.CredentialIsMissing);
+    }
+
+    /// <summary>
+    /// The case that would have gone stale. The list is bound live and Save deliberately does not
+    /// reload it, so without recomputing on save the dot stayed red on a container whose
+    /// credential had just been fixed - which would have been a worse bug than the one being
+    /// fixed, since it would teach people to ignore the marker.
+    /// </summary>
+    [Fact]
+    public void FixingTheCredentialTurnsTheMarkerOff()
+    {
+        var (vm, _) = Screen(("prod", "https://acct.blob.core.windows.net/prod"));
+
+        var container = vm.Containers.Single();
+        Assert.True(container.CredentialIsMissing);
+
+        var raised = new List<string>();
+        container.PropertyChanged += (_, e) => raised.Add(e.PropertyName ?? "");
+
+        vm.SelectedContainer = container;
+        vm.EditCommand.Execute(null);
+        vm.EditSasToken = "sv=2022-11-02&sig=abc";
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.Containers.Single().CredentialIsMissing);
+
+        // And the list is told, or the dot would not repaint until the screen was rebuilt.
+        Assert.Contains(nameof(BlobContainerConfig.CredentialIsMissing), raised);
+    }
+
+    /// <summary>
+    /// Entra has no stored secret to be missing - which is the entire reason an organisation
+    /// switches to it - so it must not be reported as a gap.
+    /// </summary>
+    [Fact]
+    public void AnEntraContainerIsNotReportedAsMissingACredential()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "prod",
+            ContainerUrl = "https://acct.blob.core.windows.net/prod",
+            AuthMode = BlobAuthMode.EntraInteractive
+        });
+
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+        var container = vm.Containers.Single();
+
+        Assert.Equal(ContainerCredentialState.Present, container.CredentialState);
+        Assert.Contains("no stored secret", container.CredentialStateNote);
+    }
+
+    /// <summary>An S3 bucket's missing secret is named for what it is.</summary>
+    [Fact]
+    public void AnS3BucketNamesTheKeyPair()
+    {
+        var (vm, _) = Screen(("dr", "s3://s3.eu-west-2.amazonaws.com/dr"));
+
+        var container = vm.Containers.Single();
+        Assert.True(container.CredentialIsMissing);
+        Assert.Contains("access key pair", container.CredentialStateNote);
+    }
+
+    /// <summary>
+    /// In words, not only in colour. The selected-row style in this app already carries a note
+    /// that high contrast makes a tinted fill nearly invisible, so meaning must not ride on
+    /// colour alone - and an 8px dot is the worst case of that.
+    /// </summary>
+    [Collection(WpfCollection.Name)]
+    public class Rendered(WpfFixture wpf)
+    {
+        [Fact]
+        public void TheListSaysItInWordsAsWellAsInColour()
+        {
+            wpf.Invoke(() =>
+            {
+                var store = new FakeCredentialStore();
+                store.Config.BlobContainers.Add(new BlobContainerConfig
+                {
+                    Id = BlobContainerConfig.NewId(),
+                    Name = "imported",
+                    ContainerUrl = "https://acct.blob.core.windows.net/imported"
+                });
+
+                var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+                var view = new BlobConfigView { DataContext = vm };
+
+                view.Measure(new Size(1280, 900));
+                view.Arrange(new Rect(0, 0, 1280, 900));
+                view.UpdateLayout();
+
+                var shown = FindAll<TextBlock>(view)
+                    .Where(t => t.Visibility == Visibility.Visible)
+                    .Select(t => t.Text)
+                    .ToList();
+
+                Assert.Contains("no credential stored", shown);
+            });
+        }
+
+        private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+        {
+            int count = VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < count; i++)
+            {
+                var node = VisualTreeHelper.GetChild(root, i);
+                if (node is T match) yield return match;
+                foreach (var descendant in FindAll<T>(node)) yield return descendant;
+            }
+        }
+    }
+}

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -247,7 +247,27 @@ public partial class BlobConfigViewModel : ViewModelBase
         {
             var sas = _credentialStore.GetSasToken(container);
             if (sas != null) container.CacheSasToken(sas);
+
+            RecordCredentialState(container, sas);
         }
+    }
+
+    /// <summary>
+    /// What the vault says about this container's secret, recorded on the container (#407).
+    ///
+    /// One vault read, no network. Called wherever the answer can change - the load, and the save
+    /// that stores or deletes a token - because the list is bound live and Save deliberately does
+    /// not reload it, so without this the dot would stay red after somebody had just fixed it.
+    /// </summary>
+    private void RecordCredentialState(BlobContainerConfig container, string? sas = null)
+    {
+        sas ??= _credentialStore.GetSasToken(container);
+
+        container.CredentialState =
+            !container.AuthMode.NeedsSasToken() ? ContainerCredentialState.Present
+            : sas == null ? ContainerCredentialState.Missing
+            : container.ReadSasExpiry(sas).IsExpired ? ContainerCredentialState.Expired
+            : ContainerCredentialState.Present;
     }
 
     /// <summary>
@@ -863,6 +883,10 @@ public partial class BlobConfigViewModel : ViewModelBase
         IsEditing = false;
         HasUnsavedChanges = false;
         UpdateSasExpiryStatus(container);
+
+        // The token may have just been stored or deleted, so the dot has to catch up (#407).
+        RecordCredentialState(container);
+
         SetStatus("Container saved successfully.");
     }
 

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -82,10 +82,31 @@
                             <DataTemplate>
                                 <StackPanel Margin="4,6">
                                     <StackPanel Orientation="Horizontal">
+                                        <!-- Says something (#407). This was SuccessBrush
+                                             unconditionally: a green light beside every
+                                             container whether or not it had a credential, in an
+                                             app whose premise is that nothing is fine until
+                                             something has proved it. A config import arrives
+                                             with no secrets by design, so a whole list of them
+                                             used to come up green and reach nothing. -->
                                         <Ellipse Width="8" Height="8"
-                                                 Fill="{DynamicResource SuccessBrush}"
                                                  VerticalAlignment="Center"
-                                                 Margin="0,0,8,0" />
+                                                 Margin="0,0,8,0"
+                                                 ToolTip="{Binding CredentialStateNote}">
+                                            <Ellipse.Style>
+                                                <Style TargetType="Ellipse">
+                                                    <Setter Property="Fill" Value="{DynamicResource SuccessBrush}" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding CredentialIsExpired}" Value="True">
+                                                            <Setter Property="Fill" Value="{DynamicResource WarningBrush}" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding CredentialIsMissing}" Value="True">
+                                                            <Setter Property="Fill" Value="{DynamicResource ErrorBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Ellipse.Style>
+                                        </Ellipse>
                                         <TextBlock Text="{Binding Name}"
                                                    FontWeight="SemiBold"
                                                    Foreground="{DynamicResource PrimaryTextBrush}" />
@@ -95,6 +116,23 @@
                                                TextTrimming="CharacterEllipsis"
                                                Margin="16,2,0,0"
                                                MaxWidth="220" />
+
+                                    <!-- In words as well as in colour. The selected-row style in
+                                         this app already carries a note that high contrast makes
+                                         a tinted fill nearly invisible, so meaning must not ride
+                                         on colour alone - an 8px dot is the worst case of it. -->
+                                    <TextBlock Text="no credential stored"
+                                               Style="{StaticResource SecondaryText}"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource ErrorBrush}"
+                                               Margin="16,2,0,0"
+                                               Visibility="{Binding CredentialIsMissing, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock Text="credential expired"
+                                               Style="{StaticResource SecondaryText}"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource WarningBrush}"
+                                               Margin="16,2,0,0"
+                                               Visibility="{Binding CredentialIsExpired, Converter={StaticResource BoolToVis}}" />
                                     <ItemsControl ItemsSource="{Binding TagChips}"
                                                   Style="{StaticResource TagChipList}"
                                                   Margin="16,2,0,0" />


### PR DESCRIPTION
Closes #407.

## What it was

`BlobConfigView.xaml`, in the saved-containers list item template:

```xaml
<Ellipse Width="8" Height="8" Fill="{DynamicResource SuccessBrush}" ... />
```

Unconditional. A green dot beside every container — whether it had a credential, whether it had ever been tested, whether it was anything more than a name. No tooltip, no legend, so the only available reading was "fine".

The SQL Servers screen had this right all along: its green dot sits behind `Visibility="{Binding IsConnected, ...}"`.

## Where it bites

The app has a documented flow that produces exactly the bad case. **Config export carries no secrets by design** — its own message says *"the file holds no secrets - credentials are re-entered on the importing machine"* — so the first thing somebody sees after importing on a new machine is a list of containers, every one green, **none of which can reach anything**. Same after restoring a profile, or after anything else clears a credential from Credential Manager.

For a tool whose premise is that a backup is not fine until something has proved it — a rehearsal verb, an exposure dashboard, a README note that path inference is "wrong in ways that stay invisible" — a decorative green light is the one ornament it should not have.

## The fix

The load loop was **already** reading each container's secret from the vault to cache it, so the answer was in hand and being discarded. The dot now reports present / expired / missing, with a tooltip that says which and what to do.

**In words as well as in colour.** This app's own selected-row style carries a note that high contrast makes a tinted fill nearly invisible and that meaning must not ride on colour alone; an 8px dot is the worst case of that. A missing or expired credential also says so in text.

**Entra containers report present, not missing.** They have no stored secret to be missing — that is the entire reason an organisation switches to them — and flagging one would send somebody hunting for a token that is not supposed to exist.

## One trap avoided

The list is bound live, and `Save` deliberately does not reload it. Recording the state only in the load path therefore left the dot **red on a container whose credential had just been fixed** — worse than the original bug, since it teaches people to ignore the marker. The state notifies, is recomputed on save, and a test walks exactly that sequence: missing → edit → save a token → marker off, and the list told about it.

## Effect

`-c Release -warnaserror` clean, **2,052 passed** (up 6). Rendered to check: a mixed list shows one green and two red with "no credential stored" beside them.
