### PR TITLE
An answer belongs to the thing that was asked (#409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Connecting announces the server it actually proved** (#409). `ConnectAsync` read the list's
+  selection again after its await, and so did every line after it - so clicking a different entry
+  while a connection hung meant the app proved it could reach one server and then announced the
+  other: marked it connected, handed it to the rest of the app as the connected server, and wrote
+  the proved server's version banner onto the other one's saved entry. That object is what the
+  restore screen executes against, so the end of it was a restore - `WITH REPLACE`, dropping the
+  target - aimed at an instance the app had never tested, with every label on screen naming it as
+  the one that was. A connection attempt is exactly the operation slow enough for somebody to
+  click elsewhere while it runs. Four more places asked the same question after the await and now
+  capture first, including the one that decides the WITH MOVE directories.
+
 - **The dot beside a container says something** (#407). It was drawn in the success colour
   unconditionally - a green light beside every container whether or not it had a credential,
   whether or not it had ever been tested, with no tooltip and no legend, so the only reading

--- a/src/NineLives.Tests/CapturedBeforeTheAwaitTests.cs
+++ b/src/NineLives.Tests/CapturedBeforeTheAwaitTests.cs
@@ -1,0 +1,125 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// An answer belongs to the thing that was asked (#409).
+///
+/// `ConnectAsync` read `SelectedServer` again after its await, and so did every consequential
+/// line after it. A connection attempt is exactly the operation slow enough for somebody to click
+/// another entry in the list beside it - the full timeout against an unreachable host - so the
+/// app could prove it could reach one server and then announce the other: mark it connected, hand
+/// it out as `ConnectedServer`, and write the proved server's version banner onto the other one's
+/// saved entry.
+///
+/// `ConnectedServer` is the object the restore screen EXECUTES against. `RestoreViewModel` carries
+/// a comment about a bug of exactly this shape, fixed at the consuming end while the end that
+/// produces the value still had it: "so the restore ran under credentials the user never connected
+/// with or tested."
+/// </summary>
+public class CapturedBeforeTheAwaitTests
+{
+    private static (ServerManagerViewModel Vm, FakeSqlServerService Sql) Screen()
+    {
+        var store = new FakeCredentialStore();
+        foreach (var name in new[] { "SRV01", "SRV02" })
+        {
+            store.Config.Servers.Add(new ServerConnection
+            { Id = ServerConnection.NewId(), Name = name, ServerName = name });
+        }
+
+        var sql = new FakeSqlServerService();
+        var vm = new ServerManagerViewModel(store, sql);
+        return (vm, sql);
+    }
+
+    [Fact]
+    public async Task ConnectingAnnouncesTheServerItActuallyProved()
+    {
+        var (vm, sql) = Screen();
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV01");
+
+        var gate = new TaskCompletionSource();
+        sql.HoldConnection = gate;
+
+        var connecting = vm.ConnectCommand.ExecuteAsync(null);
+
+        // What a person does while a connection hangs: click the other one.
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV02");
+
+        gate.SetResult();
+        await connecting;
+
+        // It proved SRV01 ...
+        Assert.Equal(["SRV01"], sql.Connected);
+
+        // ... so SRV01 is what it must say, and what it must hand out.
+        Assert.True(vm.IsConnected);
+        Assert.Contains("SRV01", vm.ConnectedServerDisplay);
+        Assert.Contains("SRV01", vm.TestResult);
+    }
+
+    /// <summary>
+    /// The one with teeth: this object is what the restore screen runs its script against.
+    /// </summary>
+    [Fact]
+    public async Task TheServerHandedToTheRestScreenIsTheOneThatWasProved()
+    {
+        var (vm, sql) = Screen();
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV01");
+
+        ServerConnection? announced = null;
+        vm.ConnectionChanged += (_, e) => announced = e.ConnectedServer;
+
+        var gate = new TaskCompletionSource();
+        sql.HoldConnection = gate;
+
+        var connecting = vm.ConnectCommand.ExecuteAsync(null);
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV02");
+        gate.SetResult();
+        await connecting;
+
+        Assert.NotNull(announced);
+        Assert.Equal("SRV01", announced!.ServerName);
+    }
+
+    /// <summary>
+    /// DetectedVersion is saved to config and is what the S3 capability gate and the
+    /// version-compatibility preflight are decided on, so writing one server's banner onto
+    /// another's entry outlives the mistake.
+    /// </summary>
+    [Fact]
+    public async Task TheDetectedVersionLandsOnTheServerItWasReadFrom()
+    {
+        var (vm, sql) = Screen();
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV01");
+
+        var gate = new TaskCompletionSource();
+        sql.HoldConnection = gate;
+
+        var connecting = vm.ConnectCommand.ExecuteAsync(null);
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV02");
+        gate.SetResult();
+        await connecting;
+
+        var srv01 = vm.Servers.First(s => s.ServerName == "SRV01");
+        var srv02 = vm.Servers.First(s => s.ServerName == "SRV02");
+
+        Assert.NotNull(srv01.DetectedVersion);
+        Assert.Null(srv02.DetectedVersion);
+    }
+
+    [Fact]
+    public async Task NothingChangesWhenTheSelectionStaysPut()
+    {
+        var (vm, sql) = Screen();
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV02");
+
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        Assert.Equal(["SRV02"], sql.Connected);
+        Assert.Contains("SRV02", vm.ConnectedServerDisplay);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -256,10 +256,24 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Refuse the connection, for the screens that have to explain one (#357).</summary>
     public Exception? TestConnectionThrows { get; set; }
 
-    public Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default)
-        => TestConnectionThrows != null
-            ? Task.FromException<bool>(TestConnectionThrows)
-            : Task.FromResult(true);
+    /// <summary>
+    /// Holds the connection open, so a test can do what a user does while one is slow: click
+    /// something else (#409). Set it, start the connect, change the selection, then release.
+    /// </summary>
+    public TaskCompletionSource? HoldConnection { get; set; }
+
+    /// <summary>Which server each call was actually made against, in order.</summary>
+    public List<string> Connected { get; } = [];
+
+    public async Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default)
+    {
+        Connected.Add(server.ServerName);
+
+        if (HoldConnection != null) await HoldConnection.Task;
+        if (TestConnectionThrows != null) throw TestConnectionThrows;
+
+        return true;
+    }
 
     public Task<bool?> WouldConnectWithCertificateValidationAsync(ServerConnection server, CancellationToken ct = default)
         => Task.FromResult<bool?>(true);

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -160,13 +160,17 @@ public partial class BackupViewModel : ViewModelBase
             return;
         }
 
+        // Captured before the await (#409): the list belongs to the server that was asked, and
+        // this dropdown is a click away from the one that produced it.
+        var server = Server;
+
         var ct = _listCancellation.Begin();
         IsBusy = true;
         ClearStatus();
 
         try
         {
-            var names = await _sql.GetDatabaseListAsync(Server, ct);
+            var names = await _sql.GetDatabaseListAsync(server, ct);
 
             Databases = new ObservableCollection<string>(names);
             DatabasePicks = new ObservableCollection<DatabasePick>(
@@ -177,7 +181,7 @@ public partial class BackupViewModel : ViewModelBase
             try
             {
                 EncryptionCertificates = new ObservableCollection<string>(
-                    await _sql.ListBackupCertificatesAsync(Server, ct));
+                    await _sql.ListBackupCertificatesAsync(server, ct));
             }
             catch
             {
@@ -189,7 +193,7 @@ public partial class BackupViewModel : ViewModelBase
             // the wrong choice means a production database read at full speed for several minutes.
             SelectedDatabase = null;
 
-            SetStatus($"{Server.ServerName} has {names.Count} database(s).");
+            SetStatus($"{server.ServerName} has {names.Count} database(s).");
         }
         catch (OperationCanceledException)
         {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1274,11 +1274,20 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        PathSourceText = $"Querying {ConnectedServer.ServerName} for default paths...";
+        // Captured before the await (#409), like every other server call on this screen. Reading
+        // it again afterwards attributed one instance's default directories to another when the
+        // connection changed mid-query - and those directories go into the WITH MOVE clauses, so
+        // the restore would look correct and fail at run time with a directory-not-found, after
+        // WITH REPLACE had already dropped the target. Disconnecting mid-query threw a
+        // NullReferenceException that surfaced as "Could not fetch paths: Object reference not
+        // set to an instance of an object."
+        var server = ConnectedServer;
+
+        PathSourceText = $"Querying {server.ServerName} for default paths...";
         try
         {
             var (dataPath, logPath) = await _sqlService.GetDefaultPathsAsync(
-                ConnectedServer, _queryCancellation.Begin());
+                server, _queryCancellation.Begin());
             var dbName = string.IsNullOrWhiteSpace(TargetDatabaseName) ? "DatabaseName" : TargetDatabaseName;
 
             if (!string.IsNullOrEmpty(dataPath))
@@ -1290,7 +1299,7 @@ public partial class RestoreViewModel : ViewModelBase
                 MoveLogFilePath = Path.Combine(dataPath, $"{dbName}_log.ldf");
 
             PathsFromServer = true;
-            PathSourceText = $"Paths detected from {ConnectedServer.ServerName}. You can still override them.";
+            PathSourceText = $"Paths detected from {server.ServerName}. You can still override them.";
         }
         catch (Exception ex)
         {

--- a/src/NineLives/ViewModels/ServerCredentialViewModel.cs
+++ b/src/NineLives/ViewModels/ServerCredentialViewModel.cs
@@ -314,7 +314,14 @@ public partial class ServerCredentialViewModel : ObservableObject
     {
         if (Server == null || Container == null) return;
 
-        var sasToken = _store.GetSasToken(Container);
+        // Captured before the awaits below (#409). This writes a CREDENTIAL onto an instance, so
+        // it must be the instance and container the user was looking at when they pressed the
+        // button - both are set from the screen above and can change while the write is in
+        // flight.
+        var server = Server;
+        var container = Container;
+
+        var sasToken = _store.GetSasToken(container);
 
         // Only a SAS credential needs one. A managed-identity credential carries no secret at all,
         // which is the entire point for an estate that forbids them.
@@ -324,7 +331,7 @@ public partial class ServerCredentialViewModel : ObservableObject
             // Says which secret is missing (#370). An S3 container stores an access key pair,
             // and being told to refresh a SAS token it never had is a wild goose chase.
             Reported?.Invoke(
-                Container.IsS3
+                container.IsS3
                     ? "No access key pair stored for this bucket. Add or refresh the key id and " +
                       "secret key in Blob Storage config."
                     : "No SAS token stored for this container. Add or refresh the token in " +
@@ -341,7 +348,7 @@ public partial class ServerCredentialViewModel : ObservableObject
         try
         {
             var change = await _sql.EnsureCredentialExistsAsync(
-                Server, Name, Container.ContainerUrl, sasToken ?? string.Empty,
+                server, Name, container.ContainerUrl, sasToken ?? string.Empty,
                 IdentityToCreate, _writeCancellation.Begin());
 
             await RefreshAsync();

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -558,17 +558,26 @@ public partial class ServerManagerViewModel : ViewModelBase
     {
         if (SelectedServer == null) return;
 
+        // Captured BEFORE the await (#409). A connection attempt is exactly the operation slow
+        // enough for somebody to click another entry in the list beside it - the full timeout
+        // against an unreachable host - and every line below used to read SelectedServer again
+        // afterwards. So the app proved it could reach one server and then announced the other:
+        // marked it connected, handed it out as ConnectedServer (which is the object the restore
+        // screen EXECUTES against), and wrote the proved server's version banner onto the other
+        // one's saved entry.
+        var server = SelectedServer;
+
         TestResult = string.Empty;
         IsBusy = true;
         try
         {
-            await _sqlService.TestConnectionAsync(SelectedServer);
+            await _sqlService.TestConnectionAsync(server);
 
             // Derive the product-version tag from the connection we just proved works. Best
             // effort: a server that connects but will not answer @@VERSION should still connect.
             try
             {
-                RecordDetectedVersion(SelectedServer, await _sqlService.GetServerVersionAsync(SelectedServer));
+                RecordDetectedVersion(server, await _sqlService.GetServerVersionAsync(server));
             }
             catch
             {
@@ -576,18 +585,18 @@ public partial class ServerManagerViewModel : ViewModelBase
             }
 
             IsConnected = true;
-            ConnectedServerDisplay = SelectedServer.DisplayText;
-            MarkConnected(SelectedServer);
+            ConnectedServerDisplay = server.DisplayText;
+            MarkConnected(server);
             ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs
             {
                 IsConnected = true,
-                ServerName = SelectedServer.ServerName,
-                ConnectedServer = SelectedServer
+                ServerName = server.ServerName,
+                ConnectedServer = server
             });
-            SetStatus($"Connected to {SelectedServer.ServerName}");
+            SetStatus($"Connected to {server.ServerName}");
 
             TestSuccess = true;
-            TestResult = $"Connected to {SelectedServer.DisplayText}.";
+            TestResult = $"Connected to {server.DisplayText}.";
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Closes #409.

## What happens

`ConnectAsync` read `SelectedServer` again **after** its await, and so did every consequential line after it. A connection attempt is exactly the operation slow enough for somebody to click another entry in the list beside it — the full timeout against an unreachable host, longer with retries.

Click one, and the app:

- proves it can reach **A**
- marks **B** connected and displays B
- hands **B** to the rest of the app through `ConnectionChanged` as `ConnectedServer`
- writes **A's** version banner onto **B's** saved entry, and persists it

## Why the middle one has teeth

`MainViewModel.OnSqlConnectionChanged` does `Restore.ConnectedServer = e.ConnectedServer`, and `RestoreViewModel.ExecuteScriptAsync` runs against that object rather than looking one up by name — with a comment explaining why:

> Execute against the server we are actually connected to, not one looked up by name. This used to re-read config.json and take the first entry whose ServerName matched … so the restore ran under credentials the user never connected with or tested.

That is a description of this bug, fixed at the consuming end and left live at the end that *produces* the value. The end of it is a restore — `WITH REPLACE`, so it drops the target — aimed at an instance the app never tested, with every label on screen naming it as the one that was.

The version write is quieter but persists: `DetectedVersion` is saved to config and is what the S3 capability gate and the version-compatibility preflight are decided on.

## The codebase already knew

Three sites carry `// Captured BEFORE the await` comments explaining this precise hazard — `FetchLogicalNamesAsync`, `InspectBackupMetadataAsync`, and `BlobBrowserViewModel`. A sweep for the same shape found five more. Fixed here:

- **`FetchDefaultPathsAsync`** — attributed one instance's default directories to another, and those go into the WITH MOVE clauses, so the restore looks correct and fails at run time with a directory-not-found after `WITH REPLACE` has dropped the target. Disconnecting mid-query threw a `NullReferenceException` that surfaced as *"Could not fetch paths: Object reference not set to an instance of an object."*
- **`LoadDatabasesAsync`** — could list one server's databases under another's name.
- **`CreateOnServerAsync`** — writes a `CREDENTIAL` onto an instance, so it had better be the instance and container the button was pressed for.

## The tests

They do what a person does: hold the connection open, click the other server while it hangs, then release. **Three of the four fail against the previous code** — verified by reinstating it.

## Effect

`-c Release -warnaserror` clean, **2,056 passed** (up 4).
