### PR TITLE
One recovery action at a time (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Recovery actions cannot be started on top of each other** (#411). The same defect as #401 on
+  the panel where it costs the most: the one somebody is looking at after a restore has failed,
+  trying to get a database back. Both "Run this" buttons stayed live while one was running - the
+  flag that would have disabled them existed and drove only a progress panel's visibility - and
+  the first thing the handler does is begin a new cancellation, so pressing the other button
+  abandoned the `RESTORE ... WITH RECOVERY` already in flight. That statement goes out with no
+  timeout on purpose, because it can take a long time; "nothing seems to be happening, press the
+  other one" is exactly how somebody would lose it.
+
 - **Connecting announces the server it actually proved** (#409). `ConnectAsync` read the list's
   selection again after its await, and so did every line after it - so clicking a different entry
   while a connection hung meant the app proved it could reach one server and then announced the

--- a/src/NineLives.Tests/OneRecoveryActionAtATimeTests.cs
+++ b/src/NineLives.Tests/OneRecoveryActionAtATimeTests.cs
@@ -1,0 +1,74 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// One recovery action at a time (#411).
+///
+/// The same defect as #401, on the panel where it costs the most: the one somebody is looking at
+/// after a restore has FAILED, trying to get a database back. `IsRunningAction` existed and drove
+/// only a progress panel's visibility, so both "Run this" buttons stayed live - and the first
+/// thing the handler does is begin a new cancellation, which abandons the action already running.
+///
+/// The method's own comment explains why it is cancellable: RESTORE ... WITH RECOVERY can take a
+/// long time and goes out at CommandTimeout = 0. The same reasoning says an accidental cancel is
+/// expensive, and "nothing seems to be happening, press the other button" is how it happens.
+/// </summary>
+public class OneRecoveryActionAtATimeTests
+{
+    private static RestoreExecutionViewModel Panel(FakeSqlServerService sql) =>
+        new(sql, new FakeRestoreHistoryStore(), TestLogs.Temp(),
+            new OperationCancellation(), new FakeRunNotifier());
+
+    [Fact]
+    public void AnActionIsOfferedWhenNothingIsRunning()
+    {
+        var vm = Panel(new FakeSqlServerService());
+
+        Assert.True(vm.CanRunRecoveryAction);
+        Assert.True(vm.RunRecoveryActionCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void NoSecondActionIsOfferedWhileOneRuns()
+    {
+        var vm = Panel(new FakeSqlServerService());
+        vm.IsRunningAction = true;
+
+        Assert.False(vm.CanRunRecoveryAction);
+        Assert.False(vm.RunRecoveryActionCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void TheButtonsComeBackWhenTheActionEnds()
+    {
+        var vm = Panel(new FakeSqlServerService());
+        vm.IsRunningAction = true;
+        Assert.False(vm.RunRecoveryActionCommand.CanExecute(null));
+
+        vm.IsRunningAction = false;
+
+        Assert.True(vm.RunRecoveryActionCommand.CanExecute(null));
+    }
+
+    /// <summary>
+    /// And the handler refuses even if something reaches it directly - re-entering here does not
+    /// waste a call, it cancels a running RESTORE ... WITH RECOVERY.
+    /// </summary>
+    [Fact]
+    public async Task TheHandlerItselfRefusesToStartASecondAction()
+    {
+        var sql = new FakeSqlServerService();
+        var vm = Panel(sql);
+        vm.IsRunningAction = true;
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(
+            new RecoveryAction("Bring the database online",
+                               "RESTORE DATABASE [Sales] WITH RECOVERY", "..."));
+
+        Assert.Empty(sql.PolledScripts);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -613,11 +613,32 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     [ObservableProperty]
     private string _actionOutcome = string.Empty;
 
+    /// <summary>
+    /// One at a time (#411). The flag existed and drove only the progress panel's visibility, so
+    /// every action button stayed live while one ran - and the first thing this method does is
+    /// begin a new cancellation, which abandons the action already running.
+    ///
+    /// This is the panel somebody is on after a restore has FAILED, with two buttons side by side
+    /// and a RESTORE ... WITH RECOVERY that goes out at CommandTimeout = 0. Pressing the other one
+    /// because nothing seemed to be happening threw away the recovery they were waiting for.
+    /// </summary>
+    public bool CanRunRecoveryAction => !IsRunningAction;
+
+    partial void OnIsRunningActionChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanRunRecoveryAction));
+        RunRecoveryActionCommand.NotifyCanExecuteChanged();
+    }
+
     /// <summary>Runs one remediation the user picked, then re-reads the state.</summary>
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanRunRecoveryAction))]
     private async Task RunRecoveryActionAsync(RecoveryAction? action)
     {
         if (action == null || _lastServer == null) return;
+
+        // The command is gated, but this is the one place where re-entering does damage rather
+        // than wasting a call, so it is checked here too.
+        if (IsRunningAction) return;
 
         // Cancellable, and it needs it more than most: this runs when a restore has already failed,
         // RESTORE ... WITH RECOVERY can take a long time on a large database, and it goes out at


### PR DESCRIPTION
Closes #411. The same defect as #401, on the panel where it costs the most.

`RunRecoveryActionAsync` had no `CanExecute`, and the "Run this" buttons in `ExecutionWindow.xaml` had no `IsEnabled` binding. `IsRunningAction` existed and was set — but was bound only to a progress panel's **visibility**, never to whether the buttons worked.

So both stayed live while one ran, and the handler's first act is:

```csharp
var ct = _queryCancellation.Begin();   // Cancel(); Dispose(); new CancellationTokenSource();
```

Pressing the other button **abandons the action already in flight**.

## Why this panel

This is the screen somebody is on after a restore has *failed*, trying to get a database back. The method's own comment says why it is cancellable:

> this runs when a restore has already failed, `RESTORE ... WITH RECOVERY` can take a long time on a large database, and it goes out at `CommandTimeout = 0`. Without a Stop the only way out was killing the process - at the exact moment the user is trying to get their database back.

All true — and the same reasoning makes an *accidental* cancel expensive. `SuggestedActions` offers two at once when a database is both RESTORING and SINGLE_USER, so the buttons sit side by side, and the post-restore CHECKDB button shares the same command.

The realistic sequence: a restore fails, the panel offers to bring the database online, you press it, nothing visible changes fast enough on a large database, so you press the other button — and the recovery you were waiting for is thrown away.

## Fix

Gated on `!IsRunningAction`, notified when it changes, and refused on entry as well — re-entering here does damage rather than wasting a call.

## Effect

`-c Release -warnaserror` clean, **2,060 passed** (up 4).
