### PR TITLE
Exposure judged one clock against another (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Exposure is judged on the clock the dates came from** (#414). msdb records a backup's finish
+  time in the instance's own local time, and the sweep compared it against `DateTime.Now` on the
+  machine running the app - so every age on the dashboard was out by the offset between the two,
+  and with a one-hour warning threshold the offset decided the verdict. The dangerous direction is
+  a server ahead of the app: backups look newer than they are, so a database 28 hours without a
+  log computes as 23 and an alarm is downgraded to a warning - and where the offset exceeds the
+  real age the arithmetic goes negative and the row comes out green. The opposite offset produced
+  false alarms on healthy databases. Managing servers in another region is ordinary in exactly the
+  estates this tool is for, and it happens on its own twice a year where the two ends change to
+  daylight saving on different dates. Each server is now asked for its own clock in the same
+  query - no configuration, no extra round trip.
+
 - **Recovery actions cannot be started on top of each other** (#411). The same defect as #401 on
   the panel where it costs the most: the one somebody is looking at after a restore has failed,
   trying to get a database back. Both "Run this" buttons stayed live while one was running - the

--- a/src/NineLives.Core/Services/ExposureAdvisor.cs
+++ b/src/NineLives.Core/Services/ExposureAdvisor.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -25,6 +25,20 @@ public sealed class ExposureRow
     /// database (#287). A property rather than a magic string compared in two places.
     /// </summary>
     public bool IsUnreachable { get; init; }
+
+    /// <summary>
+    /// The instance's OWN clock when this row was read (#414).
+    ///
+    /// msdb records backup_finish_date in the server's local time, and the app used to judge it
+    /// against DateTime.Now on this machine - so every age was out by the offset between the two,
+    /// and with a one-hour warning threshold the offset dominated the verdict. Worse in the
+    /// direction that matters: a server ahead of the app made backups look NEWER than they were,
+    /// downgrading an alarm to a warning, or to nothing at all when the offset exceeded the age.
+    ///
+    /// Read from the same query, so it costs nothing and is per-server rather than per-estate.
+    /// Null only for a row the app fabricated because the server would not answer.
+    /// </summary>
+    public DateTime? ServerNow { get; init; }
 
     public DateTime? LastFull { get; init; }
     public DateTime? LastDifferential { get; init; }
@@ -76,6 +90,13 @@ public static class ExposureAdvisor
 
     public static void Judge(ExposureRow row, DateTime now)
     {
+        // The server's own clock when it answered, not this machine's (#414). msdb records
+        // backup_finish_date in the instance's local time, so judging it against DateTime.Now
+        // here was out by the offset between the two - and with a one-hour warning threshold the
+        // offset decided the verdict. The caller's clock is the fallback for a row no server
+        // answered for, where there is nothing to compare anyway.
+        now = row.ServerNow ?? now;
+
         // No full, no recovery - everything else is arithmetic on top of a full that must exist.
         if (row.LastFull == null)
         {

--- a/src/NineLives.Core/Services/SqlServerService.cs
+++ b/src/NineLives.Core/Services/SqlServerService.cs
@@ -277,7 +277,8 @@ public class SqlServerService : ISqlServerService
         // excludes master/tempdb/model/msdb; snapshots and restoring states still list, because
         // "it exists and is not backed up" is true of them too and the state column says why.
         cmd.CommandText = @"
-            SELECT d.name                 AS DatabaseName,
+            SELECT SYSDATETIME()          AS ServerNow,
+                   d.name                 AS DatabaseName,
                    d.recovery_model_desc  AS RecoveryModel,
                    d.state_desc           AS StateDescription,
                    MAX(CASE WHEN b.type = 'D' THEN b.backup_finish_date END) AS LastFull,
@@ -300,6 +301,11 @@ public class SqlServerService : ISqlServerService
                 DatabaseName = reader["DatabaseName"]?.ToString() ?? string.Empty,
                 RecoveryModel = reader["RecoveryModel"]?.ToString() ?? string.Empty,
                 StateDescription = reader["StateDescription"]?.ToString() ?? string.Empty,
+
+                // The instance's own clock, read in the same breath as the dates it is compared
+                // with (#414). Both are the server's local time; this machine's is not.
+                ServerNow = GetDateTimeFromReader(reader, "ServerNow"),
+
                 LastFull = GetDateTimeFromReader(reader, "LastFull"),
                 LastDifferential = GetDateTimeFromReader(reader, "LastDifferential"),
                 LastLog = GetDateTimeFromReader(reader, "LastLog")

--- a/src/NineLives.Tests/ExposureUsesTheServersClockTests.cs
+++ b/src/NineLives.Tests/ExposureUsesTheServersClockTests.cs
@@ -1,0 +1,109 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Exposure is judged on the clock the dates came from (#414).
+///
+/// msdb records `backup_finish_date` in the INSTANCE's local time, and both callers judged it
+/// against `DateTime.Now` on the machine running the app. So every age was out by the offset
+/// between the two - and with a one-hour warning threshold, the offset decided the verdict.
+///
+/// The dangerous direction is a server ahead of the app: backups look NEWER than they are, so an
+/// alarm is downgraded to a warning, or - when the offset exceeds the real age - the arithmetic
+/// goes negative and the row comes out green. This screen's own summary says a dashboard that
+/// hides the bad row "reads as all clear at the exact moment it should not".
+/// </summary>
+public class ExposureUsesTheServersClockTests
+{
+    /// <summary>A machine in New York looking at a server in London: the server is 5h ahead.</summary>
+    private static readonly DateTime AppNow = new(2026, 8, 12, 09, 00, 00);
+    private static readonly DateTime ServerNow = new(2026, 8, 12, 14, 00, 00);
+
+    private static ExposureRow Row(DateTime lastLog, DateTime? serverNow) => new()
+    {
+        ServerName = "SRV01",
+        DatabaseName = "Sales",
+        RecoveryModel = "FULL",
+        StateDescription = "ONLINE",
+        ServerNow = serverNow,
+        LastFull = lastLog.AddDays(-1),
+        LastLog = lastLog
+    };
+
+    /// <summary>
+    /// 28 hours without a log, on a server five hours ahead. Judged on this machine's clock it
+    /// computes as 23 hours and lands under the 24-hour alarm; judged on the server's own clock
+    /// it is what it is.
+    /// </summary>
+    [Fact]
+    public void AnAlarmIsNotDowngradedByTheOffset()
+    {
+        var row = Row(ServerNow.AddHours(-28), ServerNow);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        Assert.Equal(ExposureLevel.Alarm, row.Level);
+    }
+
+    /// <summary>
+    /// The extreme of the same error: when the offset exceeds the age the subtraction goes
+    /// negative, which is below every threshold, and a database that has not been backed up for
+    /// hours comes out green.
+    /// </summary>
+    [Fact]
+    public void TheArithmeticDoesNotGoNegative()
+    {
+        var row = Row(ServerNow.AddHours(-3), ServerNow);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        // Three hours without a log is past the one-hour warning, and must say so.
+        Assert.Equal(ExposureLevel.Warning, row.Level);
+    }
+
+    /// <summary>
+    /// And the other direction: a server BEHIND the app made healthy databases look old. Ten
+    /// minutes since the last log is fine, and must not be reported as a warning because the app
+    /// machine's clock is five hours ahead of the instance's.
+    /// </summary>
+    [Fact]
+    public void AHealthyDatabaseIsNotFalselyWarnedAbout()
+    {
+        var serverNow = AppNow.AddHours(-5);
+        var row = Row(serverNow.AddMinutes(-10), serverNow);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        Assert.Equal(ExposureLevel.Ok, row.Level);
+    }
+
+    /// <summary>
+    /// One clock, no offset: the answer is the same either way. This is the case that passed
+    /// before and must keep passing - the whole estate on one machine's time zone.
+    /// </summary>
+    [Fact]
+    public void NothingChangesWhenTheClocksAgree()
+    {
+        var row = Row(AppNow.AddHours(-28), AppNow);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        Assert.Equal(ExposureLevel.Alarm, row.Level);
+    }
+
+    /// <summary>
+    /// A row the app fabricated because the server would not answer has no server clock, and
+    /// falls back to the caller's rather than throwing.
+    /// </summary>
+    [Fact]
+    public void ARowWithNoServerClockStillJudges()
+    {
+        var row = Row(AppNow.AddHours(-28), serverNow: null);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        Assert.Equal(ExposureLevel.Alarm, row.Level);
+    }
+}

--- a/src/NineLives.Tests/SavedExecutionLogTests.cs
+++ b/src/NineLives.Tests/SavedExecutionLogTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -50,6 +50,12 @@ public class SavedExecutionLogTests
         vm.TargetDatabaseName = "Sales_Restored";
         vm.Execution.Console.Append("RESTORE DATABASE ... 10 percent processed.");
 
+        // Append BUFFERS - it drains on a 60ms dispatcher timer, and only flushes inline when the
+        // calling thread has no dispatcher at all. Which thread xUnit hands this test therefore
+        // decided whether it passed, and it passed here and failed on CI. Flush, then read, is
+        // what ConsoleBuffer.Flush's own comment tells callers to do.
+        vm.Execution.Console.Flush();
+
         var saved = vm.Execution.BuildSavedDocument!();
 
         Assert.Contains("Nine Lives - restore execution log", saved);
@@ -71,6 +77,7 @@ public class SavedExecutionLogTests
         vm.TargetDatabaseName = "Sales_Restored";
         vm.Execution.Console.Append(
             "RESTORE FROM URL = N'https://acct.blob.core.windows.net/b/x.bak?sv=2022-11-02&sig=SECRETSIGNATUREVALUE'");
+        vm.Execution.Console.Flush();
 
         var saved = vm.Execution.BuildSavedDocument!();
 

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -723,7 +723,14 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     // ── the console's own actions ───────────────────────────────────────────────
 
     [RelayCommand]
-    private void CopyConsole() => TryCopyToClipboard(Console.Text, "Execution log copied to clipboard.");
+    private void CopyConsole()
+    {
+        // Flush, then read - the rule Flush's own comment states. In practice the 60ms timer has
+        // long since drained by the time a human clicks, but that is a timing argument, and the
+        // cost of not relying on one is a single synchronous call.
+        Console.Flush();
+        TryCopyToClipboard(Console.Text, "Execution log copied to clipboard.");
+    }
 
     /// <summary>
     /// Builds the file Save output writes: the console, plus the context needed to read it a week
@@ -739,6 +746,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     [RelayCommand]
     private void SaveConsole()
     {
+        Console.Flush();
         if (string.IsNullOrEmpty(Console.Text)) return;
 
         var dialog = new SaveFileDialog


### PR DESCRIPTION
Closes #414.

`msdb.dbo.backupset.backup_finish_date` is stored in **the instance's own local time**. Both callers judged it against **this machine's**:

- `ExposureViewModel.cs:135` — `var now = DateTime.Now;` → `ExposureAdvisor.Judge(row, now)`
- `ExposureVerb.cs:99` — the same

Nothing anywhere asked a server for its clock: `grep -rn "SYSDATETIME\|GETDATE()" src/NineLives.Core` returned nothing.

## Why it decides the verdict rather than nudging it

```
LogWarnAfter    = 1 hour      <-- an offset in hours swamps this outright
LogAlarmAfter   = 24 hours
SimpleWarnAfter = 26 hours
SimpleAlarmAfter= 7 days
```

**Server behind the app** — healthy databases look old. A log backup taken ten minutes ago reads as 5h10m and goes **Warning**: a false alarm on the screen whose entire value is being believed when it turns red.

**Server ahead of the app** — backups look newer than they are, and this is the dangerous direction:

- 28 hours without a log computes as 23h → **Warning instead of Alarm**
- where the offset exceeds the real age the subtraction goes **negative**, falls below every threshold, and the row comes out **green**

The screen's own summary comment says a dashboard that hides the bad row *"reads as all clear at the exact moment it should not"*. The same wrong number is what `Age(...)` prints and what `exposure --notify` sends to Teams or Slack, so the text agrees with the wrong verdict.

## Not hypothetical

Managing servers in another region is ordinary, and more likely in exactly the estates this targets — DR sites, cloud instances away from the desk, migrations between data centres. It also arrives on its own twice a year where the two ends change to daylight saving on different dates; the UK and US changeovers are three weeks apart.

## Fix

`SYSDATETIME()` rides along in the query that was already being run, so it is per-server rather than per-estate, needs no configuration, and costs no extra round trip. `Judge` uses the row's own clock and falls back to the caller's for a row the app fabricated because a server would not answer.

The app already had this concept for the *blob* path — `BackupServerTimeZone`, `BackupTime.ToBackupServerTime` — but the msdb path never got it, and unlike the blob case it does not need configuring, because the instance can just be asked.

## Effect

`-c Release -warnaserror` clean, **2,065 passed** (up 5). Three of the five new tests fail against the previous code — verified by reinstating it.
