### PR TITLE
An S3 listing that cannot end (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **An S3 listing cannot loop forever on the last page** (#416). The paging loops stopped when
+  the continuation token was null, and the token was read straight off the XML - but an element
+  that is present and empty reads as `""`, not null. A provider that writes
+  `<NextContinuationToken/>` on the last page instead of omitting it therefore left a non-null
+  token, so the loop asked for another page with an empty continuation token, which means "start
+  again", got page one back, and went round for ever - accumulating duplicates until the process
+  ran out of memory. AWS omits the element, so this never fired against S3 proper; this feature
+  exists for the S3-compatible providers, which is exactly where that detail differs. `IsTruncated`,
+  which is the authoritative flag, was not being consulted at all. Both are now.
+
 - **Exposure is judged on the clock the dates came from** (#414). msdb records a backup's finish
   time in the instance's own local time, and the sweep compared it against `DateTime.Now` on the
   machine running the app - so every age on the dashboard was out by the offset between the two,

--- a/src/NineLives.Core/Services/S3ListingClient.cs
+++ b/src/NineLives.Core/Services/S3ListingClient.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Net.Http;
 using System.Xml.Linq;
 
@@ -170,7 +170,27 @@ public static class S3ListingClient
             }
         }
 
-        return new S3ListPage(objects, prefixes, Element(root, "NextContinuationToken"));
+        // Two independent reasons there is no next page, because relying on one of them alone is
+        // what made this loop forever (#416).
+        //
+        // IsTruncated is the authoritative flag in ListObjectsV2 and was not being consulted at
+        // all - the token's presence was standing in for it. And "present" was the wrong test:
+        // XElement.Value on an empty element is "", not null, so a provider that emits
+        // <NextContinuationToken/> rather than omitting it left a non-null token. The loop then
+        // asked for another page with an empty continuation-token, which means "from the start",
+        // got page one back, and went round again - accumulating duplicates until the process
+        // ran out of memory.
+        //
+        // AWS omits the element, so this never fires against S3 proper. This feature exists for
+        // the S3-COMPATIBLE providers, which is exactly where empty-versus-omitted differs, and
+        // none of them have been run against.
+        var truncated = string.Equals(
+            Element(root, "IsTruncated"), "true", StringComparison.OrdinalIgnoreCase);
+
+        var token = Element(root, "NextContinuationToken");
+        if (!truncated || string.IsNullOrWhiteSpace(token)) token = null;
+
+        return new S3ListPage(objects, prefixes, token);
     }
 
     private static string? Element(XElement? parent, string localName)

--- a/src/NineLives.Tests/S3PagingTerminatorTests.cs
+++ b/src/NineLives.Tests/S3PagingTerminatorTests.cs
@@ -1,0 +1,92 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// When an S3 listing stops (#416).
+///
+/// The paging loops terminate on `token != null`, and the token was taken straight off the XML
+/// element. `XElement.Value` on a PRESENT BUT EMPTY element is "", not null - so a provider that
+/// emits `&lt;NextContinuationToken/&gt;` on the last page instead of omitting it left a non-null
+/// token, the loop asked for another page with an empty continuation-token (which means "from the
+/// start"), got page one back, and went round again. An infinite loop accumulating duplicates
+/// until the process ran out of memory.
+///
+/// AWS omits the element, so this never fires against S3 proper. The feature exists for the
+/// S3-COMPATIBLE providers - Wasabi, B2, R2, MinIO, storage appliances - which is exactly where
+/// empty-versus-omitted differs, and none of them have been run against.
+///
+/// `IsTruncated` is the authoritative flag and was not consulted at all.
+/// </summary>
+public class S3PagingTerminatorTests
+{
+    private const string OneObject = """
+        <Contents>
+          <Key>FULL/SRV01/Sales/20260801_220000.bak</Key>
+          <Size>1024</Size>
+          <LastModified>2026-08-01T22:00:00.000Z</LastModified>
+          <ETag>"abc"</ETag>
+        </Contents>
+        """;
+
+    private static string Page(string truncated, string? tokenElement) => $"""
+        <ListBucketResult>
+          {OneObject}
+          <IsTruncated>{truncated}</IsTruncated>
+          {tokenElement}
+        </ListBucketResult>
+        """;
+
+    // ── the last page, in every shape a provider writes it ──────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("<NextContinuationToken></NextContinuationToken>")]
+    [InlineData("<NextContinuationToken/>")]
+    [InlineData("<NextContinuationToken>   </NextContinuationToken>")]
+    public void TheLastPageEndsTheLoopHoweverTheProviderWritesIt(string? tokenElement)
+    {
+        var page = S3ListingClient.ParsePage(Page("false", tokenElement));
+
+        Assert.Null(page.NextContinuationToken);
+        Assert.Single(page.Objects);
+    }
+
+    /// <summary>
+    /// IsTruncated is the authoritative flag: a stale token alongside "not truncated" must not
+    /// start another round.
+    /// </summary>
+    [Fact]
+    public void NotTruncatedEndsTheLoopEvenWithATokenPresent()
+    {
+        var page = S3ListingClient.ParsePage(
+            Page("false", "<NextContinuationToken>abc123</NextContinuationToken>"));
+
+        Assert.Null(page.NextContinuationToken);
+    }
+
+    // ── and a real next page still pages ────────────────────────────────────────
+
+    [Fact]
+    public void ATruncatedPageWithATokenCarriesOn()
+    {
+        var page = S3ListingClient.ParsePage(
+            Page("true", "<NextContinuationToken>abc123</NextContinuationToken>"));
+
+        Assert.Equal("abc123", page.NextContinuationToken);
+        Assert.Single(page.Objects);
+    }
+
+    /// <summary>
+    /// Truncated but with no usable token is the one genuinely broken response. Stopping is the
+    /// only safe reading: continuing would send an empty token and restart the listing.
+    /// </summary>
+    [Fact]
+    public void TruncatedWithNoTokenStopsRatherThanRestarting()
+    {
+        var page = S3ListingClient.ParsePage(Page("true", null));
+
+        Assert.Null(page.NextContinuationToken);
+    }
+}


### PR DESCRIPTION
Closes #416.

Both paging loops in `BlobStorageService` terminate on `while (token != null)`, and `ParsePage` took the token straight off the element:

```csharp
return new S3ListPage(objects, prefixes, Element(root, "NextContinuationToken"));
```

`XElement.Value` on a **present but empty** element is `""` — not null.

Measured rather than reasoned about, by parsing the four shapes a last page actually takes:

| last page | token | loop |
|---|---|---|
| element omitted | `null` | ends |
| `<NextContinuationToken></NextContinuationToken>` | `""` | **continues** |
| `<NextContinuationToken/>` | `""` | **continues** |
| `<NextContinuationToken>   </NextContinuationToken>` | whitespace | **continues** |

So against such a provider the loop asks for another page with an empty `continuation-token` — which means *from the start* — gets page one back, and goes round again. **Infinite loop, accumulating duplicates** until the process runs out of memory. No `maxKeys` is set on these calls, so each turn re-lists the whole bucket.

## Why it matters despite AWS being fine

AWS omits the element, so this never fires against S3 proper. This feature exists for **S3-compatible** storage — the README names Wasabi, Backblaze B2, Cloudflare R2, MinIO and "a storage appliance speaking the S3 API" — which is exactly the population where empty-versus-omitted differs. And none of them have ever been run against: that is a recorded caveat of the S3 work, not an oversight here, which is precisely why the defensive reading is worth having.

`IsTruncated` is the authoritative flag in ListObjectsV2 and was not consulted at all; the token's presence was standing in for it.

## Fix

Both signals, in `ParsePage` — so the two loops are corrected without either being touched:

```csharp
var truncated = string.Equals(Element(root, "IsTruncated"), "true", StringComparison.OrdinalIgnoreCase);
var token = Element(root, "NextContinuationToken");
if (!truncated || string.IsNullOrWhiteSpace(token)) token = null;
```

"Truncated but no usable token" is the one genuinely broken response, and stopping is the only safe reading — continuing would restart the listing.

## Effect

`-c Release -warnaserror` clean, **2,072 passed** (up 7). Four of the seven new tests fail against the previous code, verified by reinstating it.
