### PR TITLE
Pin that what SigV4 signed is what goes on the wire

### DIFF
--- a/src/NineLives.Tests/S3SignedRequestIsWhatIsSentTests.cs
+++ b/src/NineLives.Tests/S3SignedRequestIsWhatIsSentTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Net.Http;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// What was signed is what goes on the wire.
+///
+/// SigV4's characteristic failure is not a wrong algorithm - the signer is already pinned stage by
+/// stage against AWS's published test vectors - but a mismatch between the canonical string the
+/// signature was computed over and the bytes that actually arrive. The server re-derives the
+/// canonical form from the request it receives; if anything re-escapes, unescapes or reorders the
+/// query in between, the signatures differ and the provider answers SignatureDoesNotMatch, which
+/// reads as "your key is wrong" rather than "your URL was rewritten".
+///
+/// The gap this closes is real: the client hands a STRING to HttpRequestMessage, which builds a
+/// System.Uri from it, and Uri normalises. The AWS vectors cannot catch that - they end at the
+/// canonical string. These cases are the ones a base path actually contains: spaces, brackets
+/// round a region name, a plus, an already-percent-encoded sequence, an accent.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class S3SignedRequestIsWhatIsSentTests
+{
+    [Theory]
+    [InlineData("FULL/SRV01/Sales/")]
+    [InlineData("SQL Backups/SRV01/")]
+    [InlineData("Prod (EU)/SRV01/")]
+    [InlineData("a+b/SRV01/")]
+    [InlineData("~arch*ive/SRV01/")]
+    [InlineData("50%25/SRV01/")]
+    [InlineData("sauvegardes-é/SRV01/")]
+    public async Task TheQueryOnTheWireIsTheQueryThatWasSigned(string prefix)
+    {
+        string? sent = null;
+
+        S3ListingClient.SenderForTests = (req, _) =>
+        {
+            sent = req.RequestUri!.Query.TrimStart('?');
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>")
+            });
+        };
+
+        try
+        {
+            var url = S3Url.TryParse("s3://s3.eu-west-2.amazonaws.com/dr-bucket")!;
+
+            await S3ListingClient.ListPageAsync(
+                url, "AKIAEXAMPLE", "secret", "eu-west-2",
+                prefix: prefix, delimiter: "/", maxKeys: null, continuationToken: null);
+
+            var signed = S3RequestSigner.CanonicalQuery(
+            [
+                ("list-type", "2"),
+                ("delimiter", "/"),
+                ("prefix", prefix)
+            ]);
+
+            Assert.Equal(signed, sent);
+        }
+        finally
+        {
+            S3ListingClient.SenderForTests = null;
+        }
+    }
+
+    /// <summary>
+    /// And the bucket in the path, for the same reason - a bucket name is more constrained than a
+    /// prefix, but the path is signed too and goes through the same construction.
+    /// </summary>
+    [Fact]
+    public async Task TheBucketPathSurvivesTheTripToo()
+    {
+        string? path = null;
+
+        S3ListingClient.SenderForTests = (req, _) =>
+        {
+            path = req.RequestUri!.AbsolutePath;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>")
+            });
+        };
+
+        try
+        {
+            var url = S3Url.TryParse("s3://s3.eu-west-2.amazonaws.com/dr-bucket")!;
+
+            await S3ListingClient.ListPageAsync(
+                url, "AKIAEXAMPLE", "secret", "eu-west-2",
+                prefix: null, delimiter: "/", maxKeys: null, continuationToken: null);
+
+            Assert.Equal("/" + S3RequestSigner.UriEncode("dr-bucket", keepSlash: true), path);
+        }
+        finally
+        {
+            S3ListingClient.SenderForTests = null;
+        }
+    }
+}


### PR DESCRIPTION
No behaviour change — this closes a gap in what is *checked*.

The signer is already pinned stage by stage against AWS's published test vectors. But those vectors end at the canonical string, and SigV4's characteristic failure in practice is not a wrong algorithm — it is a **mismatch between the canonical string the signature was computed over and the bytes that actually arrive**. The server re-derives the canonical form from the request it receives, so anything that re-escapes, unescapes or reorders the query in between makes the two signatures differ.

The provider then answers `SignatureDoesNotMatch`, which reads as *"your key is wrong"* rather than *"your URL was rewritten on the way out"* — and the app has a friendly message for exactly that code, so somebody would go and regenerate a perfectly good key pair.

## Why the gap is real rather than theoretical

`ListPageAsync` hands a **string** to `HttpRequestMessage`, which builds a `System.Uri` from it, and `Uri` normalises. Nothing was checking that the string survived that.

It does — verified against every case a base path actually contains:

| prefix | result |
|---|---|
| `FULL/SRV01/Sales/` | match |
| `SQL Backups/SRV01/` | match |
| `Prod (EU)/SRV01/` | match |
| `a+b/SRV01/` | match |
| `~arch*ive/SRV01/` | match |
| `50%25/SRV01/` | match |
| `sauvegardes-é/SRV01/` | match |

So this is a test with no fix attached. Worth keeping regardless: it is one line of hand-rolled crypto wiring away from being wrong, the failure it produces blames the user's credentials, and the endpoint has **never been exercised live** — a recorded caveat of the S3 work, and the reason the cheap invariants are worth nailing down.

## Effect

`-c Release -warnaserror` clean, **2,080 passed** (up 8).
