### PR TITLE
The Restore screen on arrival, and what choosing a target means (#419, #420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Choosing a target on the Restore screen connects to it** (#420). Step 2 offers "otherwise
+  pick a saved server here" as the alternative to connecting on the SQL Servers screen, and it
+  set everything except the one flag that gates Execute - so every step ticked green, the script
+  generated, and the button said "Connect to a SQL Server instance (SQL Servers tab)", sending
+  somebody to another screen to do what they had just done. Picking a target now attempts the
+  connection and says what happened: reached, or the reason it was not, along with the reminder
+  that the script is still worth having - saved, exported as a runbook, or copied as an Agent job
+  for wherever the instance can be reached. A failed connection never blocks generation.
+
+- **The Restore screen stops claiming there are no restore points before anything is loaded**
+  (#419). Arriving at it put a red banner up saying there was no full backup, when the truth was
+  that nobody had pressed Load Backups yet - the check runs whenever the working set changes,
+  including on the path taken when nothing has been loaded at all. The same confusion as #368 and
+  #356, pointing the other way, and it was the first thing on the screen. It also appeared twice,
+  once in red and once in grey, which the shared status-line style from #404 now prevents.
+
 - **An S3 listing cannot loop forever on the last page** (#416). The paging loops stopped when
   the continuation token was null, and the token was read straight off the XML - but an element
   that is present and empty reads as `""`, not null. A provider that writes

--- a/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
+++ b/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
@@ -56,14 +56,40 @@ public class ExecuteBlockedReasonTests
         return vm;
     }
 
+    /// <summary>
+    /// With no target chosen at all, the instruction is to choose one - here, on this screen
+    /// (#420). It used to say "Connect to a SQL Server", which sent somebody to a different
+    /// screen to do what step 2 offers to do for them.
+    /// </summary>
     [Fact]
-    public async Task NotConnectedSaysSo()
+    public async Task NoTargetChosenSaysToChooseOne()
     {
         var vm = await Loaded();
         vm.TargetDatabaseName = "MyDb_Restored";
 
+        Assert.Null(vm.SelectedTargetServer);
         Assert.False(vm.CanPressExecute);
-        Assert.Contains("Connect", vm.ExecuteBlockedReason);
+        Assert.Contains("Choose the target instance", vm.ExecuteBlockedReason);
+    }
+
+    /// <summary>
+    /// A target chosen and unreachable is a different state, and the sentence for it says so -
+    /// including that the script is still worth having.
+    /// </summary>
+    [Fact]
+    public async Task AnUnreachableTargetSaysTheScriptIsStillValid()
+    {
+        var vm = await Loaded();
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.SelectedTargetServer = new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SQLEXPRESS", ServerName = "SQLEXPRESS" };
+        vm.IsConnectedToServer = false;
+        vm.IsConnectingToTarget = false;
+
+        Assert.False(vm.CanPressExecute);
+        Assert.Contains("SQLEXPRESS", vm.ExecuteBlockedReason);
+        Assert.Contains("could not be reached", vm.ExecuteBlockedReason);
+        Assert.Contains("still valid", vm.ExecuteBlockedReason);
     }
 
     [Fact]
@@ -108,7 +134,7 @@ public class ExecuteBlockedReasonTests
         var vm = await Loaded();
         vm.TargetDatabaseName = "MyDb_Restored";
 
-        Assert.Contains("Connect", vm.ExecuteBlockedReason);
+        Assert.Contains("Choose the target instance", vm.ExecuteBlockedReason);
 
         vm.IsConnectedToServer = true;
         Assert.Empty(vm.ExecuteBlockedReason);

--- a/src/NineLives.Tests/RestoreScreenOnArrivalTests.cs
+++ b/src/NineLives.Tests/RestoreScreenOnArrivalTests.cs
@@ -1,0 +1,221 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// What the Restore screen says before it has been asked anything (#419), and what choosing a
+/// target actually does (#420). Both reported from the app.
+/// </summary>
+public class RestoreScreenOnArrivalTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 9, 19, 51, 26);
+
+    private static (RestoreViewModel Vm, FakeSqlServerService Sql) Screen(
+        params BackupFileInfo[] files)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SQLEXPRESS", ServerName = "SQLEXPRESS" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService { Files = files.ToList() }, sql,
+            new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            TestLogs.Temp(), new FakeRestoreHistoryStore());
+
+        return (vm, sql);
+    }
+
+    private static BackupFileInfo Full(string db) => new()
+    {
+        BlobName = $"FULL/SRV01/{db}/20260809_195126.bak",
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/FULL/SRV01/{db}/20260809_195126.bak",
+        Type = BackupType.Full,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = db,
+        SizeBytes = 1024,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    // ── nothing loaded, nothing to say (#419) ───────────────────────────────────
+
+    [Fact]
+    public void ArrivingSaysNothingAboutRestorePoints()
+    {
+        var (vm, _) = Screen();
+
+        Assert.False(vm.HasError);
+        Assert.DoesNotContain("No valid restore points", vm.ErrorMessage);
+        Assert.DoesNotContain("No valid restore points", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Selecting a container is not loading from it. This is the exact sequence reported: the
+    /// dropdown has a container in it, Load Backups has not been pressed, and the screen was
+    /// already claiming there was no full backup.
+    /// </summary>
+    [Fact]
+    public void ChoosingAContainerWithoutLoadingSaysNothingEither()
+    {
+        var (vm, _) = Screen(Full("COaaS"));
+
+        vm.SelectedContainer = vm.Containers.FirstOrDefault();
+
+        Assert.False(vm.HasError);
+        Assert.DoesNotContain("No valid restore points", vm.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Loaded, but no database picked yet - still nothing to judge, because the working set is
+    /// empty by choice rather than by absence.
+    /// </summary>
+    [Fact]
+    public async Task LoadedButWithNoDatabaseChosenSaysNothing()
+    {
+        var (vm, _) = Screen(Full("COaaS"));
+        vm.SelectedContainer = vm.Containers.FirstOrDefault();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.False(vm.HasError);
+    }
+
+    /// <summary>
+    /// And the finding still fires when it is a finding: backups loaded, a database chosen, and
+    /// genuinely nothing restorable - here a lone log with no full to base it on.
+    /// </summary>
+    [Fact]
+    public async Task ADatabaseWithNoFullStillReportsIt()
+    {
+        var log = new BackupFileInfo
+        {
+            BlobName = "LOG/SRV01/Orphan/20260809_200000.trn",
+            BlobUrl = "https://acct.blob.core.windows.net/backups/LOG/SRV01/Orphan/20260809_200000.trn",
+            Type = BackupType.TransactionLog,
+            InferredServerName = "SRV01",
+            InferredDatabaseName = "Orphan",
+            SizeBytes = 1024,
+            LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+        };
+
+        var (vm, _) = Screen(log);
+        vm.SelectedContainer = vm.Containers.FirstOrDefault();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.Inventory.SelectedDatabaseName = "Orphan";
+
+        Assert.True(vm.HasError);
+        Assert.Contains("No valid restore points", vm.ErrorMessage);
+    }
+
+    // ── choosing a target proves it (#420) ──────────────────────────────────────
+
+    [Fact]
+    public async Task ChoosingATargetConnectsToIt()
+    {
+        var (vm, sql) = Screen(Full("COaaS"));
+
+        vm.SelectedTargetServer = vm.TargetServers.First();
+        await Settle();
+
+        Assert.Contains("SQLEXPRESS", sql.Connected);
+        Assert.True(vm.IsConnectedToServer);
+        Assert.Contains("Connected to SQLEXPRESS", vm.TargetConnectionState);
+    }
+
+    /// <summary>
+    /// A target that cannot be reached is a legitimate outcome, not a dead end: the script still
+    /// generates and the screen says so, rather than sending somebody to another tab.
+    /// </summary>
+    [Fact]
+    public async Task ATargetThatCannotBeReachedSaysSoAndDoesNotBlockGeneration()
+    {
+        var (vm, sql) = Screen(Full("COaaS"));
+        sql.TestConnectionThrows = new InvalidOperationException(
+            "A network-related or instance-specific error occurred.");
+
+        vm.SelectedTargetServer = vm.TargetServers.First();
+        await Settle();
+
+        Assert.False(vm.IsConnectedToServer);
+        Assert.Contains("Could not connect to SQLEXPRESS", vm.TargetConnectionState);
+        Assert.Contains("network-related", vm.TargetConnectionState);
+        Assert.Contains("runbook", vm.TargetConnectionState);
+    }
+
+    /// <summary>
+    /// Choosing a target COMPLETES step 2, which folds it away - so the failure has to reach the
+    /// collapsed header, or the screen shows a green tick against a server it could not reach
+    /// with the explanation hidden inside. Found by rendering it.
+    /// </summary>
+    [Fact]
+    public async Task TheCollapsedStepHeaderSaysTheTargetWasNotReached()
+    {
+        var (vm, sql) = Screen(Full("COaaS"));
+        sql.TestConnectionThrows = new InvalidOperationException("Login failed.");
+
+        vm.SelectedTargetServer = vm.TargetServers.First();
+        await Settle();
+
+        Assert.Contains("could not be reached", vm.Steps.Target.Summary);
+        Assert.Contains("SQLEXPRESS", vm.Steps.Target.Summary);
+    }
+
+    [Fact]
+    public async Task AReachedTargetLeavesTheHeaderSayingJustItsName()
+    {
+        var (vm, _) = Screen(Full("COaaS"));
+
+        vm.SelectedTargetServer = vm.TargetServers.First();
+        await Settle();
+
+        Assert.Equal("SQLEXPRESS", vm.Steps.Target.Summary);
+    }
+
+    /// <summary>
+    /// The answer belongs to the server that was asked (#409): a connection held open while the
+    /// user picks a different target must not report for the one they moved away from.
+    /// </summary>
+    [Fact]
+    public async Task AConnectionThatFinishesAfterTheChoiceMovedOnIsDiscarded()
+    {
+        var store = new FakeCredentialStore();
+        foreach (var name in new[] { "SQLEXPRESS", "SRV02" })
+            store.Config.Servers.Add(new ServerConnection
+            { Id = ServerConnection.NewId(), Name = name, ServerName = name });
+
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), sql, new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeRestoreHistoryStore());
+
+        var gate = new TaskCompletionSource();
+        sql.HoldConnection = gate;
+
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.ServerName == "SQLEXPRESS");
+
+        // Moved on while the first connection hangs.
+        sql.HoldConnection = null;
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.ServerName == "SRV02");
+        gate.SetResult();
+        await Settle();
+
+        Assert.DoesNotContain("SQLEXPRESS", vm.TargetConnectionState);
+    }
+
+    /// <summary>Lets the fire-and-forget connection attempt finish.</summary>
+    private static async Task Settle()
+    {
+        for (int i = 0; i < 20; i++) await Task.Yield();
+        await Task.Delay(20);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -271,6 +271,89 @@ public partial class RestoreViewModel : ViewModelBase
         Steps.Target.Report(value != null, value?.Name ?? string.Empty);
         if (value != null && !ReferenceEquals(_connectedServer, value))
             ConnectedServer = value;
+
+        // Picking a target here PROVES it, rather than only naming it (#420).
+        //
+        // This step's own subtitle offers "otherwise pick a saved server here" as the equivalent
+        // of connecting on the SQL Servers screen. It set everything except the one flag that
+        // gates Execute - IsConnectedToServer, which only MainViewModel sets, and only when the
+        // Servers screen connects - so a user who did exactly what this screen invited them to do
+        // got every step ticked, a generated script, and "Connect to a SQL Server instance (SQL
+        // Servers tab)" telling them to go elsewhere and do it again.
+        if (value != null && !IsConnectedToServer)
+            _ = ConnectToTargetAsync(value);
+    }
+
+    /// <summary>
+    /// What the target connection is doing, or why it did not happen (#420).
+    ///
+    /// Failing is a legitimate outcome, not an error: generating a script for an instance this
+    /// machine cannot reach is exactly what Copy as Agent job, Export runbook and Save to File are
+    /// for. So a failure never blocks generation - it just stops being silent about why Execute is
+    /// unavailable.
+    /// </summary>
+    [ObservableProperty]
+    private string _targetConnectionState = string.Empty;
+
+    [ObservableProperty]
+    private bool _isConnectingToTarget;
+
+    partial void OnIsConnectingToTargetChanged(bool value) => RefreshExecuteBlockedReason();
+
+    /// <summary>Its own source: this is automatic, so it must not cancel a query somebody started.</summary>
+    private readonly OperationCancellation _targetConnectCancellation = new();
+
+    private async Task ConnectToTargetAsync(ServerConnection server)
+    {
+        var ct = _targetConnectCancellation.Begin();
+
+        IsConnectingToTarget = true;
+        TargetConnectionState = $"Connecting to {server.Name}...";
+
+        try
+        {
+            await _sqlService.TestConnectionAsync(server, ct);
+
+            // Captured before the await, and checked after it (#409): a connection attempt is
+            // slow enough for somebody to pick a different target while it runs, and the answer
+            // belongs to the server that was asked.
+            if (!ReferenceEquals(SelectedTargetServer, server)) return;
+
+            IsConnectedToServer = true;
+            ConnectedServerName = server.ServerName;
+            TargetConnectionState = $"Connected to {server.Name}. The restore can run from here.";
+
+            // The step collapses itself once answered, so the header is where this has to be
+            // legible - otherwise the outcome sits behind a chevron nobody has reason to open.
+            Steps.Target.Describe(server.Name);
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a later selection, which will report for itself.
+        }
+        catch (Exception ex)
+        {
+            if (!ReferenceEquals(SelectedTargetServer, server)) return;
+
+            IsConnectedToServer = false;
+            TargetConnectionState =
+                $"Could not connect to {server.Name}: {ex.Message} The script still generates - " +
+                "save it, copy it as an Agent job or export a runbook and run it where the " +
+                "instance can be reached.";
+
+            // On the COLLAPSED header, because choosing a target completes the step and folds it
+            // away. Without this the screen showed a green tick against a server it had just
+            // failed to reach, with the explanation hidden inside - worse than the bug being
+            // fixed. Found by rendering it, not by reading it.
+            Steps.Target.Describe($"{server.Name} - could not be reached");
+        }
+        finally
+        {
+            if (ReferenceEquals(SelectedTargetServer, server))
+                IsConnectingToTarget = false;
+
+            _targetConnectCancellation.End();
+        }
     }
 
     /// <summary>
@@ -1238,6 +1321,19 @@ public partial class RestoreViewModel : ViewModelBase
 
         Timeline.Load(points);
 
+        // Only judge an inventory that exists (#419). This runs off WorkingSetChanged, which is
+        // raised on the path taken when NOTHING has been loaded and when no database has been
+        // picked - so arriving at the screen used to put a red banner up saying there is no full
+        // backup, when the truth was that nobody had pressed Load Backups yet.
+        //
+        // The same confusion as #368 and #356, pointing the other way: "not asked yet" reported
+        // as "asked, and the answer is bad". Here it was the first thing on the screen.
+        if (Inventory.AllSets.Count == 0 || string.IsNullOrEmpty(Inventory.SelectedDatabaseName))
+        {
+            ClearStatus();
+            return;
+        }
+
         if (points.Count == 0)
         {
             SetError("No valid restore points found. Ensure there is at least one full backup.");
@@ -1713,7 +1809,17 @@ public partial class RestoreViewModel : ViewModelBase
         get
         {
             if (IsExecuting) return string.Empty;
-            if (!IsConnectedToServer) return "Connect to a SQL Server to execute this restore.";
+            // Says which state it is actually in (#420). "Connect to a SQL Server" was written for
+            // somebody who had chosen no target at all; to somebody who HAS chosen one and could
+            // not be reached, it reads as an instruction they have already followed.
+            if (!IsConnectedToServer)
+                return IsConnectingToTarget
+                    ? $"Connecting to {SelectedTargetServer?.Name}..."
+                    : SelectedTargetServer != null
+                        ? $"{SelectedTargetServer.Name} could not be reached, so this restore " +
+                          "cannot run from here. The script above is still valid - save it, or " +
+                          "export it as a runbook or an Agent job."
+                        : "Choose the target instance above to execute this restore.";
             if (!HasScript) return "No script yet - pick a restore point and a target database name.";
             if (HasChainErrors) return "This chain cannot restore. See the problems listed above.";
             return string.Empty;

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -662,6 +662,40 @@
                                    Visibility="{Binding HasNoTargetServers, Converter={StaticResource BoolToVis}}">
                             <Run Text="No saved servers yet. Add one on the SQL Servers screen and it will appear here." />
                         </TextBlock>
+
+                        <!-- Whether the target was actually reached (#420). Picking one here used
+                             to name the instance without ever proving it, so every step ticked and
+                             Execute still said "connect on the SQL Servers tab" - sending somebody
+                             elsewhere to do what they had just done. Failing is a legitimate
+                             outcome and says so: the script still generates for an instance this
+                             machine cannot reach, which is what the runbook and Agent job exports
+                             are for. -->
+                        <TextBlock TextWrapping="Wrap"
+                                   MaxWidth="640"
+                                   HorizontalAlignment="Left"
+                                   Margin="0,8,0,0"
+                                   Text="{Binding TargetConnectionState}"
+                                   Visibility="{Binding TargetConnectionState, Converter={StaticResource NullToVis}}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                    <Style.Triggers>
+                                        <!-- Reached nothing, and no longer trying. Not an error
+                                             style: generating a script for an instance this
+                                             machine cannot reach is a supported workflow. -->
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding IsConnectingToTarget}" Value="False" />
+                                                <Condition Binding="{Binding IsConnectedToServer}" Value="False" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
+                                        </MultiDataTrigger>
+                                        <DataTrigger Binding="{Binding IsConnectedToServer}" Value="True">
+                                            <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
                     </StackPanel>
                 </StackPanel>
             </Border>
@@ -2214,11 +2248,12 @@
                 </StackPanel>
             </Border>
 
-            <!-- Status -->
+            <!-- Status. The shared style, so an error stops being printed twice (#419):
+                 SetError writes this line as well as the banner, because not every screen
+                 surfaces both, and this one surfaces both. Same wrinkle as #392 and #404. -->
             <TextBlock Text="{Binding StatusMessage}"
-                       Style="{StaticResource SecondaryText}"
-                       Margin="0,4,0,16"
-                       Visibility="{Binding StatusMessage, Converter={StaticResource NullToVis}}" />
+                       Style="{StaticResource StatusLine}"
+                       Margin="0,4,0,16" />
         </StackPanel>
         </ScrollViewer>
     </DockPanel>


### PR DESCRIPTION
Closes #419 and #420. Both reported from the app.

## It claimed there were no restore points before anything was loaded

Opening the screen put a **red banner** up saying there was no full backup — before Load Backups had been pressed.

`ComputeAndDisplayRestorePoints` runs off `WorkingSetChanged`, and `RebuildWorkingSet` raises that event on its early-return path too — the one taken when nothing has been loaded, or no database is chosen. So the screen judged an inventory that did not exist. The same confusion as #368 and #356, pointing the other way: *not asked yet* reported as *asked, and the answer is bad* — as the first thing anybody sees on the screen.

It also said it **twice**, once in the banner and once in grey, because `SetError` writes the status line as well and this screen renders both. The shared `StatusLine` style from #404 already solved that; the Restore screen had not been given it.

## Choosing a target never connected to it

Step 2's own subtitle offers *"otherwise pick a saved server here"* as the equivalent of connecting on the SQL Servers screen. It set `ConnectedServer` — used for credential checks, file lists and preflights — but not `IsConnectedToServer`, which gates Execute and which only `MainViewModel` sets, and only when the Servers screen connects.

So somebody who did exactly what the screen invited got every step ticked green, a generated script, and a button telling them to go to another tab and do it again.

Picking a target now attempts the connection and reports either way. **Failing is a legitimate outcome rather than a dead end** — generating a script for an instance this machine cannot reach is what Copy as Agent job, Export runbook and Save to File are for — so a failure never blocks generation; it just stops being silent:

> Could not connect to SQLEXPRESS: A network-related or instance-specific error occurred while establishing a connection. The script still generates — save it, copy it as an Agent job or export a runbook and run it where the instance can be reached.

The attempt captures the server before its await and re-checks after (#409), and has its own cancellation source so an automatic connect cannot cancel a query somebody started (the #413 principle).

The Execute-blocked line now names the state it is actually in, rather than "Connect to a SQL Server" in every case: no target chosen, connecting, or chosen-and-unreachable each read differently.

## Rendering caught a flaw in my own fix

Choosing a target **completes** step 2, which folds it away — so the failure message went behind a green tick with the explanation hidden inside. That would have been worse than the bug being fixed. The collapsed header now carries the outcome too: `SQLEXPRESS - could not be reached`, and there is a test for it.

## Effect

`-c Release -warnaserror` clean, **2,090 passed** (up 11). Two existing tests in `ExecuteBlockedReasonTests` asserted the old "Connect" wording and were updated to pin the three distinct states instead.
