### PR TITLE
A checkbox does not cancel somebody's query (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Ticking WITH MOVE no longer cancels a running chain verification** (#413). The server
+  operations on the Restore screen share one cancellation source so a single Stop button covers
+  them all, and starting one deliberately stops the last - which is right for the buttons, where
+  pressing another is a choice to do that instead. It was wrong for the checkbox: ticking WITH
+  MOVE fired the default-paths fetch as a convenience, and that threw away a chain verification
+  reading the header of every backup in the chain, for a value obtainable a moment later by
+  pressing Fetch from Server. The automatic trigger now defers when a query is in flight, and
+  says so rather than quietly leaving placeholder paths.
+
 - **Choosing a target on the Restore screen connects to it** (#420). Step 2 offers "otherwise
   pick a saved server here" as the alternative to connecting on the SQL Servers screen, and it
   set everything except the one flag that gates Execute - so every step ticked green, the script

--- a/src/NineLives.Tests/ACheckboxDoesNotCancelAQueryTests.cs
+++ b/src/NineLives.Tests/ACheckboxDoesNotCancelAQueryTests.cs
@@ -1,0 +1,99 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Ticking a checkbox does not cancel somebody's work (#413).
+///
+/// Fetching the target's default directories is one of the mutually exclusive server operations
+/// on this screen: they share a cancellation source so one Stop button covers them all, and
+/// starting one deliberately stops the last. That doctrine is right for the BUTTONS - pressing
+/// "Fetch from Server" while a chain verification runs is a choice to do the other thing instead.
+///
+/// It was wrong for the automatic trigger. Ticking WITH MOVE is a request to see the move
+/// options; it fired the fetch as a convenience, and that cancelled a chain verification which
+/// reads the header of every backup in the chain - several minutes' work - for a value the user
+/// can ask for explicitly a moment later.
+/// </summary>
+public class ACheckboxDoesNotCancelAQueryTests
+{
+    private static (RestoreViewModel Vm, FakeSqlServerService Sql) Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), sql, new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeRestoreHistoryStore());
+
+        vm.ConnectedServer = store.Config.Servers[0];
+        vm.IsConnectedToServer = true;
+        return (vm, sql);
+    }
+
+    [Fact]
+    public async Task WithNothingRunningTheTickStillFetches()
+    {
+        var (vm, sql) = Screen();
+
+        vm.UseWithMove = true;
+        await Settle();
+
+        Assert.True(sql.DefaultPathsAsked > 0);
+        Assert.Contains("detected from", vm.PathSourceText);
+    }
+
+    /// <summary>
+    /// The rule. A query is in flight, so the tick defers instead of cancelling it - and says
+    /// what it did, rather than silently leaving placeholder paths.
+    /// </summary>
+    [Fact]
+    public async Task WithAQueryRunningTheTickDefersAndSaysSo()
+    {
+        var (vm, sql) = Screen();
+
+        // A query in flight on the shared source, started by a button - held open, the way a
+        // chain verification reading every header would be.
+        var gate = new TaskCompletionSource();
+        sql.HoldDefaultPaths = gate;
+        var running = vm.FetchDefaultPathsCommand.ExecuteAsync(null);
+
+        var asked = sql.DefaultPathsAsked;
+        vm.UseWithMove = true;
+        await Settle();
+
+        Assert.Equal(asked, sql.DefaultPathsAsked);
+        Assert.Contains("already running", vm.PathSourceText);
+        Assert.Contains("Fetch from Server", vm.PathSourceText);
+
+        gate.SetResult();
+        await running;
+    }
+
+    /// <summary>Unticking never fetched anything and still does not.</summary>
+    [Fact]
+    public async Task UntickingFetchesNothing()
+    {
+        var (vm, sql) = Screen();
+
+        vm.UseWithMove = true;
+        await Settle();
+        var asked = sql.DefaultPathsAsked;
+
+        vm.UseWithMove = false;
+        await Settle();
+
+        Assert.Equal(asked, sql.DefaultPathsAsked);
+    }
+
+    private static async Task Settle()
+    {
+        for (int i = 0; i < 20; i++) await Task.Yield();
+        await Task.Delay(20);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -413,8 +413,19 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.FromResult(VolumeFreeSpace);
     }
 
-    public Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(ServerConnection server, CancellationToken ct = default)
-        => Task.FromResult((@"D:\Data", @"D:\Logs"));
+    /// <summary>How many times the default directories were asked for (#413).</summary>
+    public int DefaultPathsAsked { get; private set; }
+
+    /// <summary>Holds the call open, so a test can have a query in flight while it does something else.</summary>
+    public TaskCompletionSource? HoldDefaultPaths { get; set; }
+
+    public async Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        DefaultPathsAsked++;
+        if (HoldDefaultPaths != null) await HoldDefaultPaths.Task.WaitAsync(ct);
+        return (@"D:\Data", @"D:\Logs");
+    }
 
     public Task<DatabaseRecoveryState> GetDatabaseRecoveryStateAsync(
         ServerConnection server, string databaseName, CancellationToken ct = default)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -395,8 +395,34 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnUseWithMoveChanged(bool value)
     {
         OnPropertyChanged(nameof(ShowMoveOptions));
+
+        // Ticking a checkbox does not cancel somebody's work (#413).
+        //
+        // Fetching the target's default directories is one of the mutually exclusive server
+        // operations on this screen - they share a cancellation source so that one Stop button
+        // covers them all, and starting one deliberately stops the last. That doctrine is right
+        // for the BUTTONS: pressing "Fetch from Server" while a chain verification runs is a
+        // choice to do the other thing instead.
+        //
+        // It is wrong here, because this is not a button. Ticking WITH MOVE is a request to see
+        // the move options, and it fired the fetch as a convenience - which cancelled a chain
+        // verification that reads the header of every backup in the chain, several minutes'
+        // work, for a value the user can ask for explicitly a moment later.
+        //
+        // So the automatic trigger defers, and says so. Deferring rather than queueing on
+        // purpose: a fetch that fires when the query finishes would answer for whatever is
+        // selected THEN, which is the stale-answer class fixed in #409.
         if (value)
-            _ = FetchDefaultPathsAsync();
+        {
+            if (_queryCancellation.CanCancel)
+                PathSourceText =
+                    "A server query is already running, so the default paths were not fetched - " +
+                    "stopping it for this would have been a poor trade. Press Fetch from Server " +
+                    "once it finishes, or type the paths in.";
+            else
+                _ = FetchDefaultPathsAsync();
+        }
+
         UpdateRestoreSummary();
     }
 


### PR DESCRIPTION
Closes #413, the one left open for a design call.

## The decision

The server operations on this screen share one `OperationCancellation` so a single Stop button covers them all, and `Begin()` is *cancel-then-restart* — so starting one stops the last. `CancelQuery`'s own comment says why: *"They share one source because they are mutually exclusive buttons."*

That is right for the buttons. Pressing "Fetch from Server" while a chain verification runs is a choice to do the other thing instead, and one Stop covering one running thing is a coherent model.

It is wrong for the **checkbox**. Ticking WITH MOVE is a request to see the move options; it fired the fetch as a convenience, and that cancelled a chain verification reading the header of every backup in the chain — minutes of work — for a value obtainable a moment later by pressing the button right next to it. The user had not asked to start anything.

So the automatic trigger defers, and says so:

> A server query is already running, so the default paths were not fetched — stopping it for this would have been a poor trade. Press Fetch from Server once it finishes, or type the paths in.

## Why not the alternatives

**Its own cancellation source** would also stop it clobbering a verify, but it changes the *button's* behaviour too, and the button was not broken. It also adds a second source to the cancel plumbing for one caller.

**Teaching `OperationCancellation` to hold several operations** would redesign a primitive used across the app — one whose own documentation says "the token source behind **one** cancellable operation" and "not thread-safe by design" — to fix one checkbox.

**Queueing the fetch for when the query finishes** was considered and rejected: it would answer for whatever is selected *then*, which is precisely the stale-answer class fixed in #409.

## Scope

This is the only instance. Every other operation on the shared source is a plain `[RelayCommand]` bound to a button; `FetchDefaultPathsAsync` is the sole one reachable from a property-changed handler.

## Effect

`-c Release -warnaserror` clean, **2,093 passed** (up 3). The deferral test fails against the previous code, verified by reinstating it.
