### PR TITLE
v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Recovery actions cannot be started on top of each other** (#411). The same defect as #401 on
+  the panel where it costs the most: the one somebody is looking at after a restore has failed,
+  trying to get a database back. Both "Run this" buttons stayed live while one was running - the
+  flag that would have disabled them existed and drove only a progress panel's visibility - and
+  the first thing the handler does is begin a new cancellation, so pressing the other button
+  abandoned the `RESTORE ... WITH RECOVERY` already in flight. That statement goes out with no
+  timeout on purpose, because it can take a long time; "nothing seems to be happening, press the
+  other one" is exactly how somebody would lose it.
+
 - **Connecting announces the server it actually proved** (#409). `ConnectAsync` read the list's
   selection again after its await, and so did every line after it - so clicking a different entry
   while a connection hung meant the app proved it could reach one server and then announced the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A fresh install says what is missing and where to fix it** (#406). Rendering every screen
+  with no containers and no servers found three that did not. Browse Backups said "Select a
+  container and click Load Backups to browse" when there were no containers to select - an
+  instruction nobody could follow, on the screen that is the natural thing to press when you want
+  to look before committing to anything. Back Up showed two empty dropdowns and no words at all;
+  Copy Database showed three, and since a copy needs two servers, somebody with one configured
+  hit the same wall. The Restore and Exposure screens already named the missing thing, named the
+  screen that fills it and said what would then happen; the other three now do too.
+
+- **Five screens now say what they just did** (#404). Four of them - Settings, SQL Servers,
+  Blob Storage and Exposure - carried an error banner and bound nothing to their status line, so
+  failures showed and every confirmation, instruction and consequence did not. A config import
+  reported what it had added and updated to nobody, and the sentence telling you where to go and
+  look went with it. An export's "the file holds no secrets" - the one thing worth knowing before
+  emailing it to a colleague - was never shown. "Enter the new SAS token below" never appeared
+  beside the box it was about. Pressing Stop on an exposure sweep looked like it had done
+  nothing. And on History, the one screen with no banner by design, an error was drawn in exactly
+  the same grey as a success, so a refusal to destroy a restore's evidence read like "Script
+  copied to clipboard".
+
 - **Execute is no longer live while a restore is running** (#401). The button took its enabled
   state from the same property that supplies the "why you cannot press this" sentence - and that
   sentence is deliberately empty during a run, because mid-restore the control anybody wants is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Connecting announces the server it actually proved** (#409). `ConnectAsync` read the list's
+  selection again after its await, and so did every line after it - so clicking a different entry
+  while a connection hung meant the app proved it could reach one server and then announced the
+  other: marked it connected, handed it to the rest of the app as the connected server, and wrote
+  the proved server's version banner onto the other one's saved entry. That object is what the
+  restore screen executes against, so the end of it was a restore - `WITH REPLACE`, dropping the
+  target - aimed at an instance the app had never tested, with every label on screen naming it as
+  the one that was. A connection attempt is exactly the operation slow enough for somebody to
+  click elsewhere while it runs. Four more places asked the same question after the await and now
+  capture first, including the one that decides the WITH MOVE directories.
+
 - **The dot beside a container says something** (#407). It was drawn in the success colour
   unconditionally - a green light beside every container whether or not it had a credential,
   whether or not it had ever been tested, with no tooltip and no legend, so the only reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
-## [Unreleased]
+## [1.6.2] - 2026-08-12
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Fixed
+
+- **Execute is no longer live while a restore is running** (#401). The button took its enabled
+  state from the same property that supplies the "why you cannot press this" sentence - and that
+  sentence is deliberately empty during a run, because mid-restore the control anybody wants is
+  Stop. Empty read as "not blocked", so the button stayed pressable, and two presses armed it and
+  called the run again: the first thing that does is begin a new cancellation, which abandons the
+  restore in flight and starts the chain over, leaving the target mid-restore in RESTORING. The
+  Backup and Copy Database screens both had this right already; this was the one where WITH
+  REPLACE has already dropped the target. The run itself now refuses to re-enter as well, since
+  the rehearsal path reaches it too.
+
+- **Verify Last Backup says it is running, and cannot be started twice** (#402). RESTORE
+  VERIFYONLY reads the whole backup - minutes on a real database - and the button looked exactly
+  as it had before, so the natural response was to press it again, which cancelled the verify and
+  started it over. The flag that would have said so existed and was bound to nothing.
+
 ## [1.6.1] - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Exposure is judged on the clock the dates came from** (#414). msdb records a backup's finish
+  time in the instance's own local time, and the sweep compared it against `DateTime.Now` on the
+  machine running the app - so every age on the dashboard was out by the offset between the two,
+  and with a one-hour warning threshold the offset decided the verdict. The dangerous direction is
+  a server ahead of the app: backups look newer than they are, so a database 28 hours without a
+  log computes as 23 and an alarm is downgraded to a warning - and where the offset exceeds the
+  real age the arithmetic goes negative and the row comes out green. The opposite offset produced
+  false alarms on healthy databases. Managing servers in another region is ordinary in exactly the
+  estates this tool is for, and it happens on its own twice a year where the two ends change to
+  daylight saving on different dates. Each server is now asked for its own clock in the same
+  query - no configuration, no extra round trip.
+
 - **Recovery actions cannot be started on top of each other** (#411). The same defect as #401 on
   the panel where it costs the most: the one somebody is looking at after a restore has failed,
   trying to get a database back. Both "Run this" buttons stayed live while one was running - the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **An S3 listing cannot loop forever on the last page** (#416). The paging loops stopped when
+  the continuation token was null, and the token was read straight off the XML - but an element
+  that is present and empty reads as `""`, not null. A provider that writes
+  `<NextContinuationToken/>` on the last page instead of omitting it therefore left a non-null
+  token, so the loop asked for another page with an empty continuation token, which means "start
+  again", got page one back, and went round for ever - accumulating duplicates until the process
+  ran out of memory. AWS omits the element, so this never fired against S3 proper; this feature
+  exists for the S3-compatible providers, which is exactly where that detail differs. `IsTruncated`,
+  which is the authoritative flag, was not being consulted at all. Both are now.
+
 - **Exposure is judged on the clock the dates came from** (#414). msdb records a backup's finish
   time in the instance's own local time, and the sweep compared it against `DateTime.Now` on the
   machine running the app - so every age on the dashboard was out by the offset between the two,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Ticking WITH MOVE no longer cancels a running chain verification** (#413). The server
+  operations on the Restore screen share one cancellation source so a single Stop button covers
+  them all, and starting one deliberately stops the last - which is right for the buttons, where
+  pressing another is a choice to do that instead. It was wrong for the checkbox: ticking WITH
+  MOVE fired the default-paths fetch as a convenience, and that threw away a chain verification
+  reading the header of every backup in the chain, for a value obtainable a moment later by
+  pressing Fetch from Server. The automatic trigger now defers when a query is in flight, and
+  says so rather than quietly leaving placeholder paths.
+
 - **Choosing a target on the Restore screen connects to it** (#420). Step 2 offers "otherwise
   pick a saved server here" as the alternative to connecting on the SQL Servers screen, and it
   set everything except the one flag that gates Execute - so every step ticked green, the script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Choosing a target on the Restore screen connects to it** (#420). Step 2 offers "otherwise
+  pick a saved server here" as the alternative to connecting on the SQL Servers screen, and it
+  set everything except the one flag that gates Execute - so every step ticked green, the script
+  generated, and the button said "Connect to a SQL Server instance (SQL Servers tab)", sending
+  somebody to another screen to do what they had just done. Picking a target now attempts the
+  connection and says what happened: reached, or the reason it was not, along with the reminder
+  that the script is still worth having - saved, exported as a runbook, or copied as an Agent job
+  for wherever the instance can be reached. A failed connection never blocks generation.
+
+- **The Restore screen stops claiming there are no restore points before anything is loaded**
+  (#419). Arriving at it put a red banner up saying there was no full backup, when the truth was
+  that nobody had pressed Load Backups yet - the check runs whenever the working set changes,
+  including on the path taken when nothing has been loaded at all. The same confusion as #368 and
+  #356, pointing the other way, and it was the first thing on the screen. It also appeared twice,
+  once in red and once in grey, which the shared status-line style from #404 now prevents.
+
 - **An S3 listing cannot loop forever on the last page** (#416). The paging loops stopped when
   the continuation token was null, and the token was read straight off the XML - but an element
   that is present and empty reads as `""`, not null. A provider that writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The dot beside a container says something** (#407). It was drawn in the success colour
+  unconditionally - a green light beside every container whether or not it had a credential,
+  whether or not it had ever been tested, with no tooltip and no legend, so the only reading
+  available was "fine". The case that makes it matter is one the app creates itself: a config
+  export carries no secrets by design, so the first thing somebody saw after importing on a new
+  machine was a list of green dots on containers that could not reach anything. It now reports
+  what the vault actually holds - present, expired or missing - in words as well as in colour,
+  since this app's own styles already note that meaning must not ride on colour alone. Entra
+  containers are not reported as missing anything, having no stored secret to miss.
+
 - **A fresh install says what is missing and where to fix it** (#406). Rendering every screen
   with no containers and no servers found three that did not. Browse Backups said "Select a
   container and click Load Backups to browse" when there were no containers to select - an

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.6.1</Version>
+    <Version>1.6.2</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/Models/BlobContainerConfig.cs
+++ b/src/NineLives.Core/Models/BlobContainerConfig.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Globalization;
@@ -242,6 +242,63 @@ public class BlobContainerConfig : INotifyPropertyChanged
     /// </summary>
     public bool IsExpired => AuthMode.NeedsSasToken() && ReadSasExpiry().IsExpired;
 
+    /// <summary>
+    /// Whether this container has the secret it needs, as far as can be known without asking the
+    /// network (#407).
+    ///
+    /// The list used to draw a green dot beside every container unconditionally - a status light
+    /// that never checked anything, in an app whose whole premise is that a backup is not fine
+    /// until something has proved it. The case that makes it matter is one the app creates
+    /// itself: a config export carries no secrets by design, so the first thing somebody sees
+    /// after importing on a new machine is a list of green dots on containers that cannot reach
+    /// anything.
+    ///
+    /// Set by whoever loaded the container from the vault; Unknown until then, so nothing claims
+    /// an answer it has not looked up.
+    /// </summary>
+    public ContainerCredentialState CredentialState
+    {
+        get => _credentialState;
+        set
+        {
+            if (_credentialState == value) return;
+            _credentialState = value;
+
+            // Notifying, so fixing a credential repaints the dot rather than leaving it red until
+            // the screen is rebuilt - the list is bound live and Save does not reload it.
+            OnPropertyChanged(nameof(CredentialState));
+            OnPropertyChanged(nameof(CredentialStateNote));
+            OnPropertyChanged(nameof(CredentialIsMissing));
+            OnPropertyChanged(nameof(CredentialIsExpired));
+        }
+    }
+
+    private ContainerCredentialState _credentialState = ContainerCredentialState.Unknown;
+
+    /// <summary>What the dot means, in words, for its tooltip.</summary>
+    public string CredentialStateNote => CredentialState switch
+    {
+        ContainerCredentialState.Present => AuthMode.IsEntra()
+            ? $"Signs in with {AuthMode.Describe()} - no stored secret to go stale."
+            : IsS3
+                ? "An access key pair is stored for this bucket."
+                : "A SAS token is stored for this container.",
+        ContainerCredentialState.Expired =>
+            "The stored SAS token has passed its expiry. Refresh it before restoring - the " +
+            "listing and the restore will both be refused.",
+        ContainerCredentialState.Missing => IsS3
+            ? "No access key pair is stored for this bucket. Nothing here can be listed or " +
+              "restored until one is added - a config imported from another machine arrives " +
+              "this way, by design."
+            : "No SAS token is stored for this container. Nothing here can be listed or " +
+              "restored until one is added - a config imported from another machine arrives " +
+              "this way, by design.",
+        _ => "Not checked yet."
+    };
+
+    public bool CredentialIsMissing => CredentialState == ContainerCredentialState.Missing;
+    public bool CredentialIsExpired => CredentialState == ContainerCredentialState.Expired;
+
     public DateTime? SasExpiry => GetSasExpiry();
 
     public string? StorageAccountName
@@ -427,4 +484,22 @@ public class PathElement
 
     public static string BuildPattern(IEnumerable<PathElement> elements)
         => string.Join("/", elements.Select(e => $"{{{e.Token}}}"));
+}
+
+/// <summary>
+/// What is known about a container's stored secret, without touching the network (#407).
+/// </summary>
+public enum ContainerCredentialState
+{
+    /// <summary>Nobody has asked the vault yet. Claims nothing.</summary>
+    Unknown,
+
+    /// <summary>The secret is there - or none is needed, under Entra.</summary>
+    Present,
+
+    /// <summary>Stored, and past its expiry. Reads and restores will both be refused.</summary>
+    Expired,
+
+    /// <summary>Not in the vault. The state a config import leaves behind, by design.</summary>
+    Missing
 }

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.6.1</Version>
+    <Version>1.6.2</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/Services/ExposureAdvisor.cs
+++ b/src/NineLives.Core/Services/ExposureAdvisor.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -25,6 +25,20 @@ public sealed class ExposureRow
     /// database (#287). A property rather than a magic string compared in two places.
     /// </summary>
     public bool IsUnreachable { get; init; }
+
+    /// <summary>
+    /// The instance's OWN clock when this row was read (#414).
+    ///
+    /// msdb records backup_finish_date in the server's local time, and the app used to judge it
+    /// against DateTime.Now on this machine - so every age was out by the offset between the two,
+    /// and with a one-hour warning threshold the offset dominated the verdict. Worse in the
+    /// direction that matters: a server ahead of the app made backups look NEWER than they were,
+    /// downgrading an alarm to a warning, or to nothing at all when the offset exceeded the age.
+    ///
+    /// Read from the same query, so it costs nothing and is per-server rather than per-estate.
+    /// Null only for a row the app fabricated because the server would not answer.
+    /// </summary>
+    public DateTime? ServerNow { get; init; }
 
     public DateTime? LastFull { get; init; }
     public DateTime? LastDifferential { get; init; }
@@ -76,6 +90,13 @@ public static class ExposureAdvisor
 
     public static void Judge(ExposureRow row, DateTime now)
     {
+        // The server's own clock when it answered, not this machine's (#414). msdb records
+        // backup_finish_date in the instance's local time, so judging it against DateTime.Now
+        // here was out by the offset between the two - and with a one-hour warning threshold the
+        // offset decided the verdict. The caller's clock is the fallback for a row no server
+        // answered for, where there is nothing to compare anyway.
+        now = row.ServerNow ?? now;
+
         // No full, no recovery - everything else is arithmetic on top of a full that must exist.
         if (row.LastFull == null)
         {

--- a/src/NineLives.Core/Services/S3ListingClient.cs
+++ b/src/NineLives.Core/Services/S3ListingClient.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Net.Http;
 using System.Xml.Linq;
 
@@ -170,7 +170,27 @@ public static class S3ListingClient
             }
         }
 
-        return new S3ListPage(objects, prefixes, Element(root, "NextContinuationToken"));
+        // Two independent reasons there is no next page, because relying on one of them alone is
+        // what made this loop forever (#416).
+        //
+        // IsTruncated is the authoritative flag in ListObjectsV2 and was not being consulted at
+        // all - the token's presence was standing in for it. And "present" was the wrong test:
+        // XElement.Value on an empty element is "", not null, so a provider that emits
+        // <NextContinuationToken/> rather than omitting it left a non-null token. The loop then
+        // asked for another page with an empty continuation-token, which means "from the start",
+        // got page one back, and went round again - accumulating duplicates until the process
+        // ran out of memory.
+        //
+        // AWS omits the element, so this never fires against S3 proper. This feature exists for
+        // the S3-COMPATIBLE providers, which is exactly where empty-versus-omitted differs, and
+        // none of them have been run against.
+        var truncated = string.Equals(
+            Element(root, "IsTruncated"), "true", StringComparison.OrdinalIgnoreCase);
+
+        var token = Element(root, "NextContinuationToken");
+        if (!truncated || string.IsNullOrWhiteSpace(token)) token = null;
+
+        return new S3ListPage(objects, prefixes, token);
     }
 
     private static string? Element(XElement? parent, string localName)

--- a/src/NineLives.Core/Services/SqlServerService.cs
+++ b/src/NineLives.Core/Services/SqlServerService.cs
@@ -277,7 +277,8 @@ public class SqlServerService : ISqlServerService
         // excludes master/tempdb/model/msdb; snapshots and restoring states still list, because
         // "it exists and is not backed up" is true of them too and the state column says why.
         cmd.CommandText = @"
-            SELECT d.name                 AS DatabaseName,
+            SELECT SYSDATETIME()          AS ServerNow,
+                   d.name                 AS DatabaseName,
                    d.recovery_model_desc  AS RecoveryModel,
                    d.state_desc           AS StateDescription,
                    MAX(CASE WHEN b.type = 'D' THEN b.backup_finish_date END) AS LastFull,
@@ -300,6 +301,11 @@ public class SqlServerService : ISqlServerService
                 DatabaseName = reader["DatabaseName"]?.ToString() ?? string.Empty,
                 RecoveryModel = reader["RecoveryModel"]?.ToString() ?? string.Empty,
                 StateDescription = reader["StateDescription"]?.ToString() ?? string.Empty,
+
+                // The instance's own clock, read in the same breath as the dates it is compared
+                // with (#414). Both are the server's local time; this machine's is not.
+                ServerNow = GetDateTimeFromReader(reader, "ServerNow"),
+
                 LastFull = GetDateTimeFromReader(reader, "LastFull"),
                 LastDifferential = GetDateTimeFromReader(reader, "LastDifferential"),
                 LastLog = GetDateTimeFromReader(reader, "LastLog")

--- a/src/NineLives.Tests/ACheckboxDoesNotCancelAQueryTests.cs
+++ b/src/NineLives.Tests/ACheckboxDoesNotCancelAQueryTests.cs
@@ -1,0 +1,99 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Ticking a checkbox does not cancel somebody's work (#413).
+///
+/// Fetching the target's default directories is one of the mutually exclusive server operations
+/// on this screen: they share a cancellation source so one Stop button covers them all, and
+/// starting one deliberately stops the last. That doctrine is right for the BUTTONS - pressing
+/// "Fetch from Server" while a chain verification runs is a choice to do the other thing instead.
+///
+/// It was wrong for the automatic trigger. Ticking WITH MOVE is a request to see the move
+/// options; it fired the fetch as a convenience, and that cancelled a chain verification which
+/// reads the header of every backup in the chain - several minutes' work - for a value the user
+/// can ask for explicitly a moment later.
+/// </summary>
+public class ACheckboxDoesNotCancelAQueryTests
+{
+    private static (RestoreViewModel Vm, FakeSqlServerService Sql) Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), sql, new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeRestoreHistoryStore());
+
+        vm.ConnectedServer = store.Config.Servers[0];
+        vm.IsConnectedToServer = true;
+        return (vm, sql);
+    }
+
+    [Fact]
+    public async Task WithNothingRunningTheTickStillFetches()
+    {
+        var (vm, sql) = Screen();
+
+        vm.UseWithMove = true;
+        await Settle();
+
+        Assert.True(sql.DefaultPathsAsked > 0);
+        Assert.Contains("detected from", vm.PathSourceText);
+    }
+
+    /// <summary>
+    /// The rule. A query is in flight, so the tick defers instead of cancelling it - and says
+    /// what it did, rather than silently leaving placeholder paths.
+    /// </summary>
+    [Fact]
+    public async Task WithAQueryRunningTheTickDefersAndSaysSo()
+    {
+        var (vm, sql) = Screen();
+
+        // A query in flight on the shared source, started by a button - held open, the way a
+        // chain verification reading every header would be.
+        var gate = new TaskCompletionSource();
+        sql.HoldDefaultPaths = gate;
+        var running = vm.FetchDefaultPathsCommand.ExecuteAsync(null);
+
+        var asked = sql.DefaultPathsAsked;
+        vm.UseWithMove = true;
+        await Settle();
+
+        Assert.Equal(asked, sql.DefaultPathsAsked);
+        Assert.Contains("already running", vm.PathSourceText);
+        Assert.Contains("Fetch from Server", vm.PathSourceText);
+
+        gate.SetResult();
+        await running;
+    }
+
+    /// <summary>Unticking never fetched anything and still does not.</summary>
+    [Fact]
+    public async Task UntickingFetchesNothing()
+    {
+        var (vm, sql) = Screen();
+
+        vm.UseWithMove = true;
+        await Settle();
+        var asked = sql.DefaultPathsAsked;
+
+        vm.UseWithMove = false;
+        await Settle();
+
+        Assert.Equal(asked, sql.DefaultPathsAsked);
+    }
+
+    private static async Task Settle()
+    {
+        for (int i = 0; i < 20; i++) await Task.Yield();
+        await Task.Delay(20);
+    }
+}

--- a/src/NineLives.Tests/CapturedBeforeTheAwaitTests.cs
+++ b/src/NineLives.Tests/CapturedBeforeTheAwaitTests.cs
@@ -1,0 +1,125 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// An answer belongs to the thing that was asked (#409).
+///
+/// `ConnectAsync` read `SelectedServer` again after its await, and so did every consequential
+/// line after it. A connection attempt is exactly the operation slow enough for somebody to click
+/// another entry in the list beside it - the full timeout against an unreachable host - so the
+/// app could prove it could reach one server and then announce the other: mark it connected, hand
+/// it out as `ConnectedServer`, and write the proved server's version banner onto the other one's
+/// saved entry.
+///
+/// `ConnectedServer` is the object the restore screen EXECUTES against. `RestoreViewModel` carries
+/// a comment about a bug of exactly this shape, fixed at the consuming end while the end that
+/// produces the value still had it: "so the restore ran under credentials the user never connected
+/// with or tested."
+/// </summary>
+public class CapturedBeforeTheAwaitTests
+{
+    private static (ServerManagerViewModel Vm, FakeSqlServerService Sql) Screen()
+    {
+        var store = new FakeCredentialStore();
+        foreach (var name in new[] { "SRV01", "SRV02" })
+        {
+            store.Config.Servers.Add(new ServerConnection
+            { Id = ServerConnection.NewId(), Name = name, ServerName = name });
+        }
+
+        var sql = new FakeSqlServerService();
+        var vm = new ServerManagerViewModel(store, sql);
+        return (vm, sql);
+    }
+
+    [Fact]
+    public async Task ConnectingAnnouncesTheServerItActuallyProved()
+    {
+        var (vm, sql) = Screen();
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV01");
+
+        var gate = new TaskCompletionSource();
+        sql.HoldConnection = gate;
+
+        var connecting = vm.ConnectCommand.ExecuteAsync(null);
+
+        // What a person does while a connection hangs: click the other one.
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV02");
+
+        gate.SetResult();
+        await connecting;
+
+        // It proved SRV01 ...
+        Assert.Equal(["SRV01"], sql.Connected);
+
+        // ... so SRV01 is what it must say, and what it must hand out.
+        Assert.True(vm.IsConnected);
+        Assert.Contains("SRV01", vm.ConnectedServerDisplay);
+        Assert.Contains("SRV01", vm.TestResult);
+    }
+
+    /// <summary>
+    /// The one with teeth: this object is what the restore screen runs its script against.
+    /// </summary>
+    [Fact]
+    public async Task TheServerHandedToTheRestScreenIsTheOneThatWasProved()
+    {
+        var (vm, sql) = Screen();
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV01");
+
+        ServerConnection? announced = null;
+        vm.ConnectionChanged += (_, e) => announced = e.ConnectedServer;
+
+        var gate = new TaskCompletionSource();
+        sql.HoldConnection = gate;
+
+        var connecting = vm.ConnectCommand.ExecuteAsync(null);
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV02");
+        gate.SetResult();
+        await connecting;
+
+        Assert.NotNull(announced);
+        Assert.Equal("SRV01", announced!.ServerName);
+    }
+
+    /// <summary>
+    /// DetectedVersion is saved to config and is what the S3 capability gate and the
+    /// version-compatibility preflight are decided on, so writing one server's banner onto
+    /// another's entry outlives the mistake.
+    /// </summary>
+    [Fact]
+    public async Task TheDetectedVersionLandsOnTheServerItWasReadFrom()
+    {
+        var (vm, sql) = Screen();
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV01");
+
+        var gate = new TaskCompletionSource();
+        sql.HoldConnection = gate;
+
+        var connecting = vm.ConnectCommand.ExecuteAsync(null);
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV02");
+        gate.SetResult();
+        await connecting;
+
+        var srv01 = vm.Servers.First(s => s.ServerName == "SRV01");
+        var srv02 = vm.Servers.First(s => s.ServerName == "SRV02");
+
+        Assert.NotNull(srv01.DetectedVersion);
+        Assert.Null(srv02.DetectedVersion);
+    }
+
+    [Fact]
+    public async Task NothingChangesWhenTheSelectionStaysPut()
+    {
+        var (vm, sql) = Screen();
+        vm.SelectedServer = vm.Servers.First(s => s.ServerName == "SRV02");
+
+        await vm.ConnectCommand.ExecuteAsync(null);
+
+        Assert.Equal(["SRV02"], sql.Connected);
+        Assert.Contains("SRV02", vm.ConnectedServerDisplay);
+    }
+}

--- a/src/NineLives.Tests/ContainerCredentialStateTests.cs
+++ b/src/NineLives.Tests/ContainerCredentialStateTests.cs
@@ -1,0 +1,186 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The dot beside a container says something (#407).
+///
+/// It was `Fill="{DynamicResource SuccessBrush}"` unconditionally: a green light beside every
+/// container whether or not it had a credential, whether or not it had ever been tested. No
+/// tooltip, no legend, so the only reading available was "fine".
+///
+/// The case that makes it matter is one the app creates itself. A config export carries no
+/// secrets - its own message says credentials are re-entered on the importing machine - so the
+/// first thing somebody sees after importing on a new machine was a list of green dots on
+/// containers that could not reach anything.
+///
+/// The SQL Servers screen had this right all along: its green dot sits behind IsConnected.
+/// </summary>
+public class ContainerCredentialStateTests
+{
+    private static (BlobConfigViewModel Vm, FakeCredentialStore Store) Screen(
+        params (string Name, string Url)[] containers)
+    {
+        var store = new FakeCredentialStore();
+        foreach (var (name, url) in containers)
+        {
+            store.Config.BlobContainers.Add(new BlobContainerConfig
+            {
+                Id = BlobContainerConfig.NewId(),
+                Name = name,
+                ContainerUrl = url
+            });
+        }
+
+        return (new BlobConfigViewModel(store, new FakeBlobStorageService()), store);
+    }
+
+    [Fact]
+    public void AContainerWithNoStoredSecretSaysSo()
+    {
+        var (vm, _) = Screen(("prod", "https://acct.blob.core.windows.net/prod"));
+
+        var container = vm.Containers.Single();
+
+        Assert.Equal(ContainerCredentialState.Missing, container.CredentialState);
+        Assert.True(container.CredentialIsMissing);
+        Assert.Contains("No SAS token is stored", container.CredentialStateNote);
+    }
+
+    [Fact]
+    public void AContainerWithAStoredSecretIsPresent()
+    {
+        var store = new FakeCredentialStore();
+        var config = new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "prod",
+            ContainerUrl = "https://acct.blob.core.windows.net/prod"
+        };
+        store.Config.BlobContainers.Add(config);
+        store.SaveSasToken(config, "sv=2022-11-02&sig=abc");
+
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+
+        var container = vm.Containers.Single();
+        Assert.Equal(ContainerCredentialState.Present, container.CredentialState);
+        Assert.False(container.CredentialIsMissing);
+    }
+
+    /// <summary>
+    /// The case that would have gone stale. The list is bound live and Save deliberately does not
+    /// reload it, so without recomputing on save the dot stayed red on a container whose
+    /// credential had just been fixed - which would have been a worse bug than the one being
+    /// fixed, since it would teach people to ignore the marker.
+    /// </summary>
+    [Fact]
+    public void FixingTheCredentialTurnsTheMarkerOff()
+    {
+        var (vm, _) = Screen(("prod", "https://acct.blob.core.windows.net/prod"));
+
+        var container = vm.Containers.Single();
+        Assert.True(container.CredentialIsMissing);
+
+        var raised = new List<string>();
+        container.PropertyChanged += (_, e) => raised.Add(e.PropertyName ?? "");
+
+        vm.SelectedContainer = container;
+        vm.EditCommand.Execute(null);
+        vm.EditSasToken = "sv=2022-11-02&sig=abc";
+        vm.SaveCommand.Execute(null);
+
+        Assert.False(vm.Containers.Single().CredentialIsMissing);
+
+        // And the list is told, or the dot would not repaint until the screen was rebuilt.
+        Assert.Contains(nameof(BlobContainerConfig.CredentialIsMissing), raised);
+    }
+
+    /// <summary>
+    /// Entra has no stored secret to be missing - which is the entire reason an organisation
+    /// switches to it - so it must not be reported as a gap.
+    /// </summary>
+    [Fact]
+    public void AnEntraContainerIsNotReportedAsMissingACredential()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "prod",
+            ContainerUrl = "https://acct.blob.core.windows.net/prod",
+            AuthMode = BlobAuthMode.EntraInteractive
+        });
+
+        var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+        var container = vm.Containers.Single();
+
+        Assert.Equal(ContainerCredentialState.Present, container.CredentialState);
+        Assert.Contains("no stored secret", container.CredentialStateNote);
+    }
+
+    /// <summary>An S3 bucket's missing secret is named for what it is.</summary>
+    [Fact]
+    public void AnS3BucketNamesTheKeyPair()
+    {
+        var (vm, _) = Screen(("dr", "s3://s3.eu-west-2.amazonaws.com/dr"));
+
+        var container = vm.Containers.Single();
+        Assert.True(container.CredentialIsMissing);
+        Assert.Contains("access key pair", container.CredentialStateNote);
+    }
+
+    /// <summary>
+    /// In words, not only in colour. The selected-row style in this app already carries a note
+    /// that high contrast makes a tinted fill nearly invisible, so meaning must not ride on
+    /// colour alone - and an 8px dot is the worst case of that.
+    /// </summary>
+    [Collection(WpfCollection.Name)]
+    public class Rendered(WpfFixture wpf)
+    {
+        [Fact]
+        public void TheListSaysItInWordsAsWellAsInColour()
+        {
+            wpf.Invoke(() =>
+            {
+                var store = new FakeCredentialStore();
+                store.Config.BlobContainers.Add(new BlobContainerConfig
+                {
+                    Id = BlobContainerConfig.NewId(),
+                    Name = "imported",
+                    ContainerUrl = "https://acct.blob.core.windows.net/imported"
+                });
+
+                var vm = new BlobConfigViewModel(store, new FakeBlobStorageService());
+                var view = new BlobConfigView { DataContext = vm };
+
+                view.Measure(new Size(1280, 900));
+                view.Arrange(new Rect(0, 0, 1280, 900));
+                view.UpdateLayout();
+
+                var shown = FindAll<TextBlock>(view)
+                    .Where(t => t.Visibility == Visibility.Visible)
+                    .Select(t => t.Text)
+                    .ToList();
+
+                Assert.Contains("no credential stored", shown);
+            });
+        }
+
+        private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+        {
+            int count = VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < count; i++)
+            {
+                var node = VisualTreeHelper.GetChild(root, i);
+                if (node is T match) yield return match;
+                foreach (var descendant in FindAll<T>(node)) yield return descendant;
+            }
+        }
+    }
+}

--- a/src/NineLives.Tests/EveryScreenSaysWhatItDidTests.cs
+++ b/src/NineLives.Tests/EveryScreenSaysWhatItDidTests.cs
@@ -1,0 +1,149 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A screen that reports a failure also reports a success (#404).
+///
+/// The mirror image of #356. Four screens carried an ErrorBanner and bound no StatusMessage, so
+/// their failures showed and every confirmation, instruction and consequence did not: a config
+/// import told nobody what it had changed, "Enter the new SAS token below" never appeared beside
+/// the box it was about, and pressing Stop on an exposure sweep looked like it had done nothing.
+///
+/// And History, the one view with no banner - deliberately, because SetError writes the status
+/// line too so an error there is not silent - drew that error in the same grey as everything
+/// else. A refusal to destroy a restore's evidence looked exactly like "Script copied to
+/// clipboard".
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class EveryScreenSaysWhatItDidTests(WpfFixture wpf)
+{
+    private static (FrameworkElement View, ViewModelBase Vm) Screen(string name)
+    {
+        var store = new FakeCredentialStore();
+
+        return name switch
+        {
+            "Settings" => Pair(new SettingsView(), new SettingsViewModel(store, TestLogs.Temp())),
+            "Servers" => Pair(new ServerManagerView(), new ServerManagerViewModel(store, new FakeSqlServerService())),
+            "Blob" => Pair(new BlobConfigView(), new BlobConfigViewModel(store, new FakeBlobStorageService())),
+            "Exposure" => Pair(new ExposureView(), new ExposureViewModel(store, new FakeSqlServerService(), new FakeRestoreHistoryStore())),
+            "History" => Pair(new HistoryView(), new HistoryViewModel(new FakeRestoreHistoryStore())),
+            _ => throw new ArgumentOutOfRangeException(nameof(name))
+        };
+
+        static (FrameworkElement, ViewModelBase) Pair(FrameworkElement v, ViewModelBase vm)
+        {
+            v.DataContext = vm;
+            return (v, vm);
+        }
+    }
+
+    [Theory]
+    [InlineData("Settings")]
+    [InlineData("Servers")]
+    [InlineData("Blob")]
+    [InlineData("Exposure")]
+    [InlineData("History")]
+    public void AStatusMessageReachesTheScreen(string name)
+    {
+        wpf.Invoke(() =>
+        {
+            var (view, vm) = Screen(name);
+            const string said = "Nine Lives status probe sentence.";
+
+            Layout(view);
+            Assert.DoesNotContain(said, Shown(view));
+
+            vm.SetStatusForTests(said);
+            Layout(view);
+
+            Assert.Contains(said, Shown(view));
+        });
+    }
+
+    /// <summary>
+    /// SetError writes the status line as well as the banner, because not every screen surfaces
+    /// both. On the four that surface both, the same sentence must not appear twice - once in red
+    /// and once in grey reads as two separate things having gone wrong.
+    /// </summary>
+    [Theory]
+    [InlineData("Settings")]
+    [InlineData("Servers")]
+    [InlineData("Blob")]
+    [InlineData("Exposure")]
+    public void AnErrorIsNotAlsoPrintedOnTheStatusLine(string name)
+    {
+        wpf.Invoke(() =>
+        {
+            var (view, vm) = Screen(name);
+            const string wrong = "Nine Lives error probe sentence.";
+
+            vm.SetErrorForTests(wrong);
+            Layout(view);
+
+            var appearances = Shown(view).Count(t => t == wrong);
+
+            Assert.True(appearances == 1,
+                $"{name} shows the same error {appearances} times.");
+        });
+    }
+
+    /// <summary>
+    /// History is the exception and stays visible - it has no banner, so collapsing its status
+    /// line on error is exactly the silence the arrangement exists to prevent. It carries the
+    /// error appearance instead.
+    /// </summary>
+    [Fact]
+    public void HistoryShowsItsErrorAndMarksItAsOne()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new HistoryViewModel(new FakeRestoreHistoryStore { CouldNotRead = true });
+            var view = new HistoryView { DataContext = vm };
+
+            vm.Refresh();
+            Layout(view);
+
+            var line = FindAll<TextBlock>(view)
+                .FirstOrDefault(t => t.Visibility == Visibility.Visible
+                                     && t.Text.Contains("could not be read"));
+
+            Assert.True(line != null, "History does not show its own refusal.");
+
+            var error = (SolidColorBrush)Application.Current!.Resources["ErrorBrush"];
+            Assert.Equal(error.Color, ((SolidColorBrush)line!.Foreground).Color);
+        });
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<string> Shown(DependencyObject view) =>
+        FindAll<TextBlock>(view)
+            .Where(t => t.Visibility == Visibility.Visible)
+            .Select(t => t.Text)
+            .ToList();
+
+    private static void Layout(FrameworkElement element)
+    {
+        element.Measure(new Size(1280, 900));
+        element.Arrange(new Rect(0, 0, 1280, 900));
+        element.UpdateLayout();
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        int count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var node = VisualTreeHelper.GetChild(root, i);
+            if (node is T match) yield return match;
+            foreach (var descendant in FindAll<T>(node)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
+++ b/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
@@ -56,14 +56,40 @@ public class ExecuteBlockedReasonTests
         return vm;
     }
 
+    /// <summary>
+    /// With no target chosen at all, the instruction is to choose one - here, on this screen
+    /// (#420). It used to say "Connect to a SQL Server", which sent somebody to a different
+    /// screen to do what step 2 offers to do for them.
+    /// </summary>
     [Fact]
-    public async Task NotConnectedSaysSo()
+    public async Task NoTargetChosenSaysToChooseOne()
     {
         var vm = await Loaded();
         vm.TargetDatabaseName = "MyDb_Restored";
 
+        Assert.Null(vm.SelectedTargetServer);
         Assert.False(vm.CanPressExecute);
-        Assert.Contains("Connect", vm.ExecuteBlockedReason);
+        Assert.Contains("Choose the target instance", vm.ExecuteBlockedReason);
+    }
+
+    /// <summary>
+    /// A target chosen and unreachable is a different state, and the sentence for it says so -
+    /// including that the script is still worth having.
+    /// </summary>
+    [Fact]
+    public async Task AnUnreachableTargetSaysTheScriptIsStillValid()
+    {
+        var vm = await Loaded();
+        vm.TargetDatabaseName = "MyDb_Restored";
+        vm.SelectedTargetServer = new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SQLEXPRESS", ServerName = "SQLEXPRESS" };
+        vm.IsConnectedToServer = false;
+        vm.IsConnectingToTarget = false;
+
+        Assert.False(vm.CanPressExecute);
+        Assert.Contains("SQLEXPRESS", vm.ExecuteBlockedReason);
+        Assert.Contains("could not be reached", vm.ExecuteBlockedReason);
+        Assert.Contains("still valid", vm.ExecuteBlockedReason);
     }
 
     [Fact]
@@ -108,7 +134,7 @@ public class ExecuteBlockedReasonTests
         var vm = await Loaded();
         vm.TargetDatabaseName = "MyDb_Restored";
 
-        Assert.Contains("Connect", vm.ExecuteBlockedReason);
+        Assert.Contains("Choose the target instance", vm.ExecuteBlockedReason);
 
         vm.IsConnectedToServer = true;
         Assert.Empty(vm.ExecuteBlockedReason);

--- a/src/NineLives.Tests/ExecuteDuringARunTests.cs
+++ b/src/NineLives.Tests/ExecuteDuringARunTests.cs
@@ -1,0 +1,188 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A screen that is running something does not offer to run it again (#401, #402).
+///
+/// Backup and Copy Database both had this right - `HasScript &amp;&amp; !IsRunning` - and Restore,
+/// the screen where WITH REPLACE has already dropped the target, did not. Its Execute button took
+/// its enablement from `ExecuteBlockedReason`, which is deliberately EMPTY during a run because
+/// there is nothing to nag about mid-restore. Empty read as "not blocked", so the button stayed
+/// live.
+///
+/// Two presses then armed it and called `RunAsync` again, whose first act is a cancellation
+/// `Begin()` - abandoning the restore in flight, leaving its target mid-chain in RESTORING, and
+/// starting the whole thing over.
+///
+/// The same shape on the backup screen's Verify: RESTORE VERIFYONLY reads the entire backup, the
+/// button looked unchanged throughout, and a second press cancelled and restarted it.
+/// </summary>
+public class ExecuteDuringARunTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 1, 22, 0, 0);
+
+    // ── the restore screen ──────────────────────────────────────────────────────
+
+    private static async Task<RestoreViewModel> LoadedRestore()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = "FULL/SRV01/Sales/20260801_220000.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/SRV01/Sales/20260801_220000.bak",
+                    Type = BackupType.Full,
+                    InferredServerName = "SRV01",
+                    InferredDatabaseName = "Sales",
+                    SizeBytes = 1000,
+                    LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+                }
+            ]
+        };
+
+        var vm = new RestoreViewModel(
+            blob, new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store,
+            new OperationLog(System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), "ninelives-exec", Guid.NewGuid().ToString("n"))),
+            new FakeRestoreHistoryStore());
+
+        vm.SelectedContainer = store.Config.BlobContainers[0];
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        RestoreSetup.ChooseADatabaseAndAPoint(vm);
+        vm.TargetDatabaseName = "Sales_Restored";
+        return vm;
+    }
+
+    [Fact]
+    public async Task ExecuteIsNotPressableWhileARestoreRuns()
+    {
+        var vm = await LoadedRestore();
+
+        vm.Execution.SetExecutingForTests(true);
+
+        Assert.True(vm.IsExecuting);
+        Assert.False(vm.CanPressExecute);
+    }
+
+    /// <summary>
+    /// The reason line stays empty on purpose - mid-restore the wanted control is Stop, not an
+    /// explanation - so this pins that the two questions are answered separately rather than one
+    /// being derived from the other.
+    /// </summary>
+    [Fact]
+    public async Task TheBlockedReasonStaysQuietDuringTheRun()
+    {
+        var vm = await LoadedRestore();
+
+        vm.Execution.SetExecutingForTests(true);
+
+        Assert.Equal(string.Empty, vm.ExecuteBlockedReason);
+        Assert.False(vm.CanPressExecute);
+    }
+
+    /// <summary>And the button comes back when the run ends.</summary>
+    [Fact]
+    public async Task ExecuteIsPressableAgainOnceTheRunEnds()
+    {
+        var vm = await LoadedRestore();
+        vm.IsConnectedToServer = true;
+
+        vm.Execution.SetExecutingForTests(true);
+        Assert.False(vm.CanPressExecute);
+
+        vm.Execution.SetExecutingForTests(false);
+        Assert.True(vm.CanPressExecute);
+    }
+
+    /// <summary>
+    /// The last line of defence. RunAsync is reachable from the rehearsal path too, and its first
+    /// act is a cancellation Begin() - so re-entering it does not waste a call, it abandons a
+    /// restore that is running.
+    /// </summary>
+    [Fact]
+    public async Task RunAsyncRefusesToStartASecondRun()
+    {
+        var vm = await LoadedRestore();
+        vm.Execution.SetExecutingForTests(true);
+
+        await vm.Execution.RunAsync(
+            new RestoreRun(
+                new ServerConnection { Name = "SRV01", ServerName = "SRV01" },
+                "RESTORE DATABASE [x] FROM DISK = N'y' WITH RECOVERY;",
+                "Sales_Restored", "Sales", "backups", "1 Full", null, "options"),
+            _ => Task.FromResult(CredentialPreflight.Proceed));
+
+        Assert.True(vm.Execution.HasError);
+        Assert.Contains("already running", vm.Execution.ErrorMessage);
+    }
+
+    // ── the backup screen's verify ──────────────────────────────────────────────
+
+    [Fact]
+    public void VerifyIsNotPressableWhileVerifying()
+    {
+        var vm = new BackupViewModel(new FakeCredentialStore(), new FakeSqlServerService())
+        {
+            CanVerifyLastBackup = true
+        };
+
+        Assert.True(vm.CanVerify);
+        Assert.True(vm.VerifyLastBackupCommand.CanExecute(null));
+
+        vm.IsVerifying = true;
+
+        Assert.False(vm.CanVerify);
+        Assert.False(vm.VerifyLastBackupCommand.CanExecute(null));
+    }
+
+    /// <summary>Nothing written means nothing to verify, running or not.</summary>
+    [Fact]
+    public void VerifyIsNotOfferedBeforeAnythingHasBeenWritten()
+    {
+        var vm = new BackupViewModel(new FakeCredentialStore(), new FakeSqlServerService());
+
+        Assert.False(vm.CanVerify);
+        Assert.False(vm.VerifyLastBackupCommand.CanExecute(null));
+    }
+
+    // ── and the two screens that already had it right ───────────────────────────
+
+    [Fact]
+    public void TheBackupRunIsStillGatedOnNotAlreadyRunning()
+    {
+        var vm = new BackupViewModel(new FakeCredentialStore(), new FakeSqlServerService())
+        {
+            IsRunning = true
+        };
+
+        Assert.False(vm.CanExecute);
+    }
+
+    [Fact]
+    public void TheCopyRunIsStillGatedOnNotAlreadyRunning()
+    {
+        var vm = new CopyDatabaseViewModel(new FakeCredentialStore(), new FakeSqlServerService())
+        {
+            IsRunning = true
+        };
+
+        Assert.False(vm.CanRun);
+    }
+}

--- a/src/NineLives.Tests/ExposureUsesTheServersClockTests.cs
+++ b/src/NineLives.Tests/ExposureUsesTheServersClockTests.cs
@@ -1,0 +1,109 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Exposure is judged on the clock the dates came from (#414).
+///
+/// msdb records `backup_finish_date` in the INSTANCE's local time, and both callers judged it
+/// against `DateTime.Now` on the machine running the app. So every age was out by the offset
+/// between the two - and with a one-hour warning threshold, the offset decided the verdict.
+///
+/// The dangerous direction is a server ahead of the app: backups look NEWER than they are, so an
+/// alarm is downgraded to a warning, or - when the offset exceeds the real age - the arithmetic
+/// goes negative and the row comes out green. This screen's own summary says a dashboard that
+/// hides the bad row "reads as all clear at the exact moment it should not".
+/// </summary>
+public class ExposureUsesTheServersClockTests
+{
+    /// <summary>A machine in New York looking at a server in London: the server is 5h ahead.</summary>
+    private static readonly DateTime AppNow = new(2026, 8, 12, 09, 00, 00);
+    private static readonly DateTime ServerNow = new(2026, 8, 12, 14, 00, 00);
+
+    private static ExposureRow Row(DateTime lastLog, DateTime? serverNow) => new()
+    {
+        ServerName = "SRV01",
+        DatabaseName = "Sales",
+        RecoveryModel = "FULL",
+        StateDescription = "ONLINE",
+        ServerNow = serverNow,
+        LastFull = lastLog.AddDays(-1),
+        LastLog = lastLog
+    };
+
+    /// <summary>
+    /// 28 hours without a log, on a server five hours ahead. Judged on this machine's clock it
+    /// computes as 23 hours and lands under the 24-hour alarm; judged on the server's own clock
+    /// it is what it is.
+    /// </summary>
+    [Fact]
+    public void AnAlarmIsNotDowngradedByTheOffset()
+    {
+        var row = Row(ServerNow.AddHours(-28), ServerNow);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        Assert.Equal(ExposureLevel.Alarm, row.Level);
+    }
+
+    /// <summary>
+    /// The extreme of the same error: when the offset exceeds the age the subtraction goes
+    /// negative, which is below every threshold, and a database that has not been backed up for
+    /// hours comes out green.
+    /// </summary>
+    [Fact]
+    public void TheArithmeticDoesNotGoNegative()
+    {
+        var row = Row(ServerNow.AddHours(-3), ServerNow);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        // Three hours without a log is past the one-hour warning, and must say so.
+        Assert.Equal(ExposureLevel.Warning, row.Level);
+    }
+
+    /// <summary>
+    /// And the other direction: a server BEHIND the app made healthy databases look old. Ten
+    /// minutes since the last log is fine, and must not be reported as a warning because the app
+    /// machine's clock is five hours ahead of the instance's.
+    /// </summary>
+    [Fact]
+    public void AHealthyDatabaseIsNotFalselyWarnedAbout()
+    {
+        var serverNow = AppNow.AddHours(-5);
+        var row = Row(serverNow.AddMinutes(-10), serverNow);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        Assert.Equal(ExposureLevel.Ok, row.Level);
+    }
+
+    /// <summary>
+    /// One clock, no offset: the answer is the same either way. This is the case that passed
+    /// before and must keep passing - the whole estate on one machine's time zone.
+    /// </summary>
+    [Fact]
+    public void NothingChangesWhenTheClocksAgree()
+    {
+        var row = Row(AppNow.AddHours(-28), AppNow);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        Assert.Equal(ExposureLevel.Alarm, row.Level);
+    }
+
+    /// <summary>
+    /// A row the app fabricated because the server would not answer has no server clock, and
+    /// falls back to the caller's rather than throwing.
+    /// </summary>
+    [Fact]
+    public void ARowWithNoServerClockStillJudges()
+    {
+        var row = Row(AppNow.AddHours(-28), serverNow: null);
+
+        ExposureAdvisor.Judge(row, AppNow);
+
+        Assert.Equal(ExposureLevel.Alarm, row.Level);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -413,8 +413,19 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.FromResult(VolumeFreeSpace);
     }
 
-    public Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(ServerConnection server, CancellationToken ct = default)
-        => Task.FromResult((@"D:\Data", @"D:\Logs"));
+    /// <summary>How many times the default directories were asked for (#413).</summary>
+    public int DefaultPathsAsked { get; private set; }
+
+    /// <summary>Holds the call open, so a test can have a query in flight while it does something else.</summary>
+    public TaskCompletionSource? HoldDefaultPaths { get; set; }
+
+    public async Task<(string DataPath, string LogPath)> GetDefaultPathsAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        DefaultPathsAsked++;
+        if (HoldDefaultPaths != null) await HoldDefaultPaths.Task.WaitAsync(ct);
+        return (@"D:\Data", @"D:\Logs");
+    }
 
     public Task<DatabaseRecoveryState> GetDatabaseRecoveryStateAsync(
         ServerConnection server, string databaseName, CancellationToken ct = default)

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -256,10 +256,24 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Refuse the connection, for the screens that have to explain one (#357).</summary>
     public Exception? TestConnectionThrows { get; set; }
 
-    public Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default)
-        => TestConnectionThrows != null
-            ? Task.FromException<bool>(TestConnectionThrows)
-            : Task.FromResult(true);
+    /// <summary>
+    /// Holds the connection open, so a test can do what a user does while one is slow: click
+    /// something else (#409). Set it, start the connect, change the selection, then release.
+    /// </summary>
+    public TaskCompletionSource? HoldConnection { get; set; }
+
+    /// <summary>Which server each call was actually made against, in order.</summary>
+    public List<string> Connected { get; } = [];
+
+    public async Task<bool> TestConnectionAsync(ServerConnection server, CancellationToken ct = default)
+    {
+        Connected.Add(server.ServerName);
+
+        if (HoldConnection != null) await HoldConnection.Task;
+        if (TestConnectionThrows != null) throw TestConnectionThrows;
+
+        return true;
+    }
 
     public Task<bool?> WouldConnectWithCertificateValidationAsync(ServerConnection server, CancellationToken ct = default)
         => Task.FromResult<bool?>(true);

--- a/src/NineLives.Tests/NothingToPickFromTests.cs
+++ b/src/NineLives.Tests/NothingToPickFromTests.cs
@@ -1,0 +1,186 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A fresh install says what is missing and where to fix it (#406).
+///
+/// Rendering every screen with no containers and no servers showed three that did not. Browse
+/// Backups said "Select a container and click Load Backups to browse" when there were no
+/// containers to select - an instruction nobody could follow, on the screen that is the natural
+/// thing to press when you want to LOOK before committing. Back Up showed two empty dropdowns and
+/// no words; Copy Database showed three, and a copy needs two servers, so somebody with one hits
+/// the same wall.
+///
+/// Restore and Exposure already had the sentence. These tests hold all five to it.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class NothingToPickFromTests(WpfFixture wpf)
+{
+    private static FakeCredentialStore Furnished()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+        return store;
+    }
+
+    // ── Back Up ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BackUpNamesBothMissingThings()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BackupViewModel(new FakeCredentialStore(), new FakeSqlServerService());
+            var view = new BackupView { DataContext = vm };
+            Layout(view);
+
+            Assert.True(vm.HasNoServers);
+            Assert.True(vm.HasNoContainers);
+
+            var shown = string.Join(" | ", Shown(view));
+            Assert.Contains("SQL Servers screen", shown);
+            Assert.Contains("Blob Storage screen", shown);
+        });
+    }
+
+    [Fact]
+    public void BackUpSaysNothingOnceThereIsSomethingToPick()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new BackupViewModel(Furnished(), new FakeSqlServerService());
+            var view = new BackupView { DataContext = vm };
+            Layout(view);
+
+            Assert.False(vm.HasNoServers);
+            Assert.False(vm.HasNoContainers);
+
+            var shown = string.Join(" | ", Shown(view));
+            Assert.DoesNotContain("No saved servers yet", shown);
+            Assert.DoesNotContain("No storage configured yet", shown);
+        });
+    }
+
+    // ── Copy Database ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CopySaysACopyNeedsTwoServers()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = new CopyDatabaseViewModel(new FakeCredentialStore(), new FakeSqlServerService());
+            var view = new CopyDatabaseView { DataContext = vm };
+            Layout(view);
+
+            var shown = string.Join(" | ", Shown(view));
+            Assert.Contains("a copy needs two", shown);
+            Assert.Contains("Blob Storage screen", shown);
+        });
+    }
+
+    // ── Browse Backups ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The one that was actively wrong rather than merely absent: an instruction to select
+    /// something that does not exist.
+    /// </summary>
+    [Fact]
+    public void BrowseDoesNotAskForAContainerWhenThereAreNone()
+    {
+        var vm = new BlobBrowserViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new FakeCredentialStore());
+
+        Assert.True(vm.MediumIsBlob);
+        Assert.DoesNotContain("Select a container", vm.BrowseHint);
+        Assert.Contains("Blob Storage screen", vm.BrowseHint);
+    }
+
+    [Fact]
+    public void BrowseAsksForAContainerOnceThereIsOne()
+    {
+        var vm = new BlobBrowserViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), Furnished());
+        vm.RefreshContainers();
+
+        Assert.Contains("Select a container", vm.BrowseHint);
+    }
+
+    [Fact]
+    public void BrowseSwitchesTheSentenceWithTheMedium()
+    {
+        var vm = new BlobBrowserViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new FakeCredentialStore())
+        {
+            SelectedMedium = BackupMedium.SharedPath
+        };
+
+        Assert.Contains("SQL Servers screen", vm.BrowseHint);
+        Assert.DoesNotContain("Blob Storage", vm.BrowseHint);
+    }
+
+    // ── and the two that already had it ─────────────────────────────────────────
+
+    [Fact]
+    public void RestoreStillSaysItAboutServers()
+    {
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), new FakeCredentialStore(),
+            TestLogs.Temp(), new FakeRestoreHistoryStore());
+
+        Assert.True(vm.HasNoTargetServers);
+    }
+
+    [Fact]
+    public async Task ExposureStillSaysItAboutServers()
+    {
+        var vm = new ExposureViewModel(
+            new FakeCredentialStore(), new FakeSqlServerService(), new FakeRestoreHistoryStore());
+
+        await vm.RefreshCommand.ExecuteAsync(null);
+
+        Assert.Contains("No servers configured", vm.Summary);
+        Assert.Contains("SQL Servers screen", vm.Summary);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static List<string> Shown(DependencyObject view) =>
+        FindAll<TextBlock>(view)
+            .Where(t => t.Visibility == Visibility.Visible)
+            .Select(t => t.Text)
+            .ToList();
+
+    private static void Layout(FrameworkElement element)
+    {
+        element.Measure(new Size(1280, 1400));
+        element.Arrange(new Rect(0, 0, 1280, 1400));
+        element.UpdateLayout();
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        int count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var node = VisualTreeHelper.GetChild(root, i);
+            if (node is T match) yield return match;
+            foreach (var descendant in FindAll<T>(node)) yield return descendant;
+        }
+    }
+}

--- a/src/NineLives.Tests/OneRecoveryActionAtATimeTests.cs
+++ b/src/NineLives.Tests/OneRecoveryActionAtATimeTests.cs
@@ -1,0 +1,74 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// One recovery action at a time (#411).
+///
+/// The same defect as #401, on the panel where it costs the most: the one somebody is looking at
+/// after a restore has FAILED, trying to get a database back. `IsRunningAction` existed and drove
+/// only a progress panel's visibility, so both "Run this" buttons stayed live - and the first
+/// thing the handler does is begin a new cancellation, which abandons the action already running.
+///
+/// The method's own comment explains why it is cancellable: RESTORE ... WITH RECOVERY can take a
+/// long time and goes out at CommandTimeout = 0. The same reasoning says an accidental cancel is
+/// expensive, and "nothing seems to be happening, press the other button" is how it happens.
+/// </summary>
+public class OneRecoveryActionAtATimeTests
+{
+    private static RestoreExecutionViewModel Panel(FakeSqlServerService sql) =>
+        new(sql, new FakeRestoreHistoryStore(), TestLogs.Temp(),
+            new OperationCancellation(), new FakeRunNotifier());
+
+    [Fact]
+    public void AnActionIsOfferedWhenNothingIsRunning()
+    {
+        var vm = Panel(new FakeSqlServerService());
+
+        Assert.True(vm.CanRunRecoveryAction);
+        Assert.True(vm.RunRecoveryActionCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void NoSecondActionIsOfferedWhileOneRuns()
+    {
+        var vm = Panel(new FakeSqlServerService());
+        vm.IsRunningAction = true;
+
+        Assert.False(vm.CanRunRecoveryAction);
+        Assert.False(vm.RunRecoveryActionCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void TheButtonsComeBackWhenTheActionEnds()
+    {
+        var vm = Panel(new FakeSqlServerService());
+        vm.IsRunningAction = true;
+        Assert.False(vm.RunRecoveryActionCommand.CanExecute(null));
+
+        vm.IsRunningAction = false;
+
+        Assert.True(vm.RunRecoveryActionCommand.CanExecute(null));
+    }
+
+    /// <summary>
+    /// And the handler refuses even if something reaches it directly - re-entering here does not
+    /// waste a call, it cancels a running RESTORE ... WITH RECOVERY.
+    /// </summary>
+    [Fact]
+    public async Task TheHandlerItselfRefusesToStartASecondAction()
+    {
+        var sql = new FakeSqlServerService();
+        var vm = Panel(sql);
+        vm.IsRunningAction = true;
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(
+            new RecoveryAction("Bring the database online",
+                               "RESTORE DATABASE [Sales] WITH RECOVERY", "..."));
+
+        Assert.Empty(sql.PolledScripts);
+    }
+}

--- a/src/NineLives.Tests/RestoreScreenOnArrivalTests.cs
+++ b/src/NineLives.Tests/RestoreScreenOnArrivalTests.cs
@@ -1,0 +1,221 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// What the Restore screen says before it has been asked anything (#419), and what choosing a
+/// target actually does (#420). Both reported from the app.
+/// </summary>
+public class RestoreScreenOnArrivalTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 9, 19, 51, 26);
+
+    private static (RestoreViewModel Vm, FakeSqlServerService Sql) Screen(
+        params BackupFileInfo[] files)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SQLEXPRESS", ServerName = "SQLEXPRESS" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService { Files = files.ToList() }, sql,
+            new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            TestLogs.Temp(), new FakeRestoreHistoryStore());
+
+        return (vm, sql);
+    }
+
+    private static BackupFileInfo Full(string db) => new()
+    {
+        BlobName = $"FULL/SRV01/{db}/20260809_195126.bak",
+        BlobUrl = $"https://acct.blob.core.windows.net/backups/FULL/SRV01/{db}/20260809_195126.bak",
+        Type = BackupType.Full,
+        InferredServerName = "SRV01",
+        InferredDatabaseName = db,
+        SizeBytes = 1024,
+        LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+    };
+
+    // ── nothing loaded, nothing to say (#419) ───────────────────────────────────
+
+    [Fact]
+    public void ArrivingSaysNothingAboutRestorePoints()
+    {
+        var (vm, _) = Screen();
+
+        Assert.False(vm.HasError);
+        Assert.DoesNotContain("No valid restore points", vm.ErrorMessage);
+        Assert.DoesNotContain("No valid restore points", vm.StatusMessage);
+    }
+
+    /// <summary>
+    /// Selecting a container is not loading from it. This is the exact sequence reported: the
+    /// dropdown has a container in it, Load Backups has not been pressed, and the screen was
+    /// already claiming there was no full backup.
+    /// </summary>
+    [Fact]
+    public void ChoosingAContainerWithoutLoadingSaysNothingEither()
+    {
+        var (vm, _) = Screen(Full("COaaS"));
+
+        vm.SelectedContainer = vm.Containers.FirstOrDefault();
+
+        Assert.False(vm.HasError);
+        Assert.DoesNotContain("No valid restore points", vm.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Loaded, but no database picked yet - still nothing to judge, because the working set is
+    /// empty by choice rather than by absence.
+    /// </summary>
+    [Fact]
+    public async Task LoadedButWithNoDatabaseChosenSaysNothing()
+    {
+        var (vm, _) = Screen(Full("COaaS"));
+        vm.SelectedContainer = vm.Containers.FirstOrDefault();
+
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        Assert.False(vm.HasError);
+    }
+
+    /// <summary>
+    /// And the finding still fires when it is a finding: backups loaded, a database chosen, and
+    /// genuinely nothing restorable - here a lone log with no full to base it on.
+    /// </summary>
+    [Fact]
+    public async Task ADatabaseWithNoFullStillReportsIt()
+    {
+        var log = new BackupFileInfo
+        {
+            BlobName = "LOG/SRV01/Orphan/20260809_200000.trn",
+            BlobUrl = "https://acct.blob.core.windows.net/backups/LOG/SRV01/Orphan/20260809_200000.trn",
+            Type = BackupType.TransactionLog,
+            InferredServerName = "SRV01",
+            InferredDatabaseName = "Orphan",
+            SizeBytes = 1024,
+            LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+        };
+
+        var (vm, _) = Screen(log);
+        vm.SelectedContainer = vm.Containers.FirstOrDefault();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.Inventory.SelectedDatabaseName = "Orphan";
+
+        Assert.True(vm.HasError);
+        Assert.Contains("No valid restore points", vm.ErrorMessage);
+    }
+
+    // ── choosing a target proves it (#420) ──────────────────────────────────────
+
+    [Fact]
+    public async Task ChoosingATargetConnectsToIt()
+    {
+        var (vm, sql) = Screen(Full("COaaS"));
+
+        vm.SelectedTargetServer = vm.TargetServers.First();
+        await Settle();
+
+        Assert.Contains("SQLEXPRESS", sql.Connected);
+        Assert.True(vm.IsConnectedToServer);
+        Assert.Contains("Connected to SQLEXPRESS", vm.TargetConnectionState);
+    }
+
+    /// <summary>
+    /// A target that cannot be reached is a legitimate outcome, not a dead end: the script still
+    /// generates and the screen says so, rather than sending somebody to another tab.
+    /// </summary>
+    [Fact]
+    public async Task ATargetThatCannotBeReachedSaysSoAndDoesNotBlockGeneration()
+    {
+        var (vm, sql) = Screen(Full("COaaS"));
+        sql.TestConnectionThrows = new InvalidOperationException(
+            "A network-related or instance-specific error occurred.");
+
+        vm.SelectedTargetServer = vm.TargetServers.First();
+        await Settle();
+
+        Assert.False(vm.IsConnectedToServer);
+        Assert.Contains("Could not connect to SQLEXPRESS", vm.TargetConnectionState);
+        Assert.Contains("network-related", vm.TargetConnectionState);
+        Assert.Contains("runbook", vm.TargetConnectionState);
+    }
+
+    /// <summary>
+    /// Choosing a target COMPLETES step 2, which folds it away - so the failure has to reach the
+    /// collapsed header, or the screen shows a green tick against a server it could not reach
+    /// with the explanation hidden inside. Found by rendering it.
+    /// </summary>
+    [Fact]
+    public async Task TheCollapsedStepHeaderSaysTheTargetWasNotReached()
+    {
+        var (vm, sql) = Screen(Full("COaaS"));
+        sql.TestConnectionThrows = new InvalidOperationException("Login failed.");
+
+        vm.SelectedTargetServer = vm.TargetServers.First();
+        await Settle();
+
+        Assert.Contains("could not be reached", vm.Steps.Target.Summary);
+        Assert.Contains("SQLEXPRESS", vm.Steps.Target.Summary);
+    }
+
+    [Fact]
+    public async Task AReachedTargetLeavesTheHeaderSayingJustItsName()
+    {
+        var (vm, _) = Screen(Full("COaaS"));
+
+        vm.SelectedTargetServer = vm.TargetServers.First();
+        await Settle();
+
+        Assert.Equal("SQLEXPRESS", vm.Steps.Target.Summary);
+    }
+
+    /// <summary>
+    /// The answer belongs to the server that was asked (#409): a connection held open while the
+    /// user picks a different target must not report for the one they moved away from.
+    /// </summary>
+    [Fact]
+    public async Task AConnectionThatFinishesAfterTheChoiceMovedOnIsDiscarded()
+    {
+        var store = new FakeCredentialStore();
+        foreach (var name in new[] { "SQLEXPRESS", "SRV02" })
+            store.Config.Servers.Add(new ServerConnection
+            { Id = ServerConnection.NewId(), Name = name, ServerName = name });
+
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), sql, new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeRestoreHistoryStore());
+
+        var gate = new TaskCompletionSource();
+        sql.HoldConnection = gate;
+
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.ServerName == "SQLEXPRESS");
+
+        // Moved on while the first connection hangs.
+        sql.HoldConnection = null;
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.ServerName == "SRV02");
+        gate.SetResult();
+        await Settle();
+
+        Assert.DoesNotContain("SQLEXPRESS", vm.TargetConnectionState);
+    }
+
+    /// <summary>Lets the fire-and-forget connection attempt finish.</summary>
+    private static async Task Settle()
+    {
+        for (int i = 0; i < 20; i++) await Task.Yield();
+        await Task.Delay(20);
+    }
+}

--- a/src/NineLives.Tests/S3PagingTerminatorTests.cs
+++ b/src/NineLives.Tests/S3PagingTerminatorTests.cs
@@ -1,0 +1,92 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// When an S3 listing stops (#416).
+///
+/// The paging loops terminate on `token != null`, and the token was taken straight off the XML
+/// element. `XElement.Value` on a PRESENT BUT EMPTY element is "", not null - so a provider that
+/// emits `&lt;NextContinuationToken/&gt;` on the last page instead of omitting it left a non-null
+/// token, the loop asked for another page with an empty continuation-token (which means "from the
+/// start"), got page one back, and went round again. An infinite loop accumulating duplicates
+/// until the process ran out of memory.
+///
+/// AWS omits the element, so this never fires against S3 proper. The feature exists for the
+/// S3-COMPATIBLE providers - Wasabi, B2, R2, MinIO, storage appliances - which is exactly where
+/// empty-versus-omitted differs, and none of them have been run against.
+///
+/// `IsTruncated` is the authoritative flag and was not consulted at all.
+/// </summary>
+public class S3PagingTerminatorTests
+{
+    private const string OneObject = """
+        <Contents>
+          <Key>FULL/SRV01/Sales/20260801_220000.bak</Key>
+          <Size>1024</Size>
+          <LastModified>2026-08-01T22:00:00.000Z</LastModified>
+          <ETag>"abc"</ETag>
+        </Contents>
+        """;
+
+    private static string Page(string truncated, string? tokenElement) => $"""
+        <ListBucketResult>
+          {OneObject}
+          <IsTruncated>{truncated}</IsTruncated>
+          {tokenElement}
+        </ListBucketResult>
+        """;
+
+    // ── the last page, in every shape a provider writes it ──────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("<NextContinuationToken></NextContinuationToken>")]
+    [InlineData("<NextContinuationToken/>")]
+    [InlineData("<NextContinuationToken>   </NextContinuationToken>")]
+    public void TheLastPageEndsTheLoopHoweverTheProviderWritesIt(string? tokenElement)
+    {
+        var page = S3ListingClient.ParsePage(Page("false", tokenElement));
+
+        Assert.Null(page.NextContinuationToken);
+        Assert.Single(page.Objects);
+    }
+
+    /// <summary>
+    /// IsTruncated is the authoritative flag: a stale token alongside "not truncated" must not
+    /// start another round.
+    /// </summary>
+    [Fact]
+    public void NotTruncatedEndsTheLoopEvenWithATokenPresent()
+    {
+        var page = S3ListingClient.ParsePage(
+            Page("false", "<NextContinuationToken>abc123</NextContinuationToken>"));
+
+        Assert.Null(page.NextContinuationToken);
+    }
+
+    // ── and a real next page still pages ────────────────────────────────────────
+
+    [Fact]
+    public void ATruncatedPageWithATokenCarriesOn()
+    {
+        var page = S3ListingClient.ParsePage(
+            Page("true", "<NextContinuationToken>abc123</NextContinuationToken>"));
+
+        Assert.Equal("abc123", page.NextContinuationToken);
+        Assert.Single(page.Objects);
+    }
+
+    /// <summary>
+    /// Truncated but with no usable token is the one genuinely broken response. Stopping is the
+    /// only safe reading: continuing would send an empty token and restart the listing.
+    /// </summary>
+    [Fact]
+    public void TruncatedWithNoTokenStopsRatherThanRestarting()
+    {
+        var page = S3ListingClient.ParsePage(Page("true", null));
+
+        Assert.Null(page.NextContinuationToken);
+    }
+}

--- a/src/NineLives.Tests/S3SignedRequestIsWhatIsSentTests.cs
+++ b/src/NineLives.Tests/S3SignedRequestIsWhatIsSentTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Net.Http;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// What was signed is what goes on the wire.
+///
+/// SigV4's characteristic failure is not a wrong algorithm - the signer is already pinned stage by
+/// stage against AWS's published test vectors - but a mismatch between the canonical string the
+/// signature was computed over and the bytes that actually arrive. The server re-derives the
+/// canonical form from the request it receives; if anything re-escapes, unescapes or reorders the
+/// query in between, the signatures differ and the provider answers SignatureDoesNotMatch, which
+/// reads as "your key is wrong" rather than "your URL was rewritten".
+///
+/// The gap this closes is real: the client hands a STRING to HttpRequestMessage, which builds a
+/// System.Uri from it, and Uri normalises. The AWS vectors cannot catch that - they end at the
+/// canonical string. These cases are the ones a base path actually contains: spaces, brackets
+/// round a region name, a plus, an already-percent-encoded sequence, an accent.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class S3SignedRequestIsWhatIsSentTests
+{
+    [Theory]
+    [InlineData("FULL/SRV01/Sales/")]
+    [InlineData("SQL Backups/SRV01/")]
+    [InlineData("Prod (EU)/SRV01/")]
+    [InlineData("a+b/SRV01/")]
+    [InlineData("~arch*ive/SRV01/")]
+    [InlineData("50%25/SRV01/")]
+    [InlineData("sauvegardes-é/SRV01/")]
+    public async Task TheQueryOnTheWireIsTheQueryThatWasSigned(string prefix)
+    {
+        string? sent = null;
+
+        S3ListingClient.SenderForTests = (req, _) =>
+        {
+            sent = req.RequestUri!.Query.TrimStart('?');
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>")
+            });
+        };
+
+        try
+        {
+            var url = S3Url.TryParse("s3://s3.eu-west-2.amazonaws.com/dr-bucket")!;
+
+            await S3ListingClient.ListPageAsync(
+                url, "AKIAEXAMPLE", "secret", "eu-west-2",
+                prefix: prefix, delimiter: "/", maxKeys: null, continuationToken: null);
+
+            var signed = S3RequestSigner.CanonicalQuery(
+            [
+                ("list-type", "2"),
+                ("delimiter", "/"),
+                ("prefix", prefix)
+            ]);
+
+            Assert.Equal(signed, sent);
+        }
+        finally
+        {
+            S3ListingClient.SenderForTests = null;
+        }
+    }
+
+    /// <summary>
+    /// And the bucket in the path, for the same reason - a bucket name is more constrained than a
+    /// prefix, but the path is signed too and goes through the same construction.
+    /// </summary>
+    [Fact]
+    public async Task TheBucketPathSurvivesTheTripToo()
+    {
+        string? path = null;
+
+        S3ListingClient.SenderForTests = (req, _) =>
+        {
+            path = req.RequestUri!.AbsolutePath;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>")
+            });
+        };
+
+        try
+        {
+            var url = S3Url.TryParse("s3://s3.eu-west-2.amazonaws.com/dr-bucket")!;
+
+            await S3ListingClient.ListPageAsync(
+                url, "AKIAEXAMPLE", "secret", "eu-west-2",
+                prefix: null, delimiter: "/", maxKeys: null, continuationToken: null);
+
+            Assert.Equal("/" + S3RequestSigner.UriEncode("dr-bucket", keepSlash: true), path);
+        }
+        finally
+        {
+            S3ListingClient.SenderForTests = null;
+        }
+    }
+}

--- a/src/NineLives.Tests/SavedExecutionLogTests.cs
+++ b/src/NineLives.Tests/SavedExecutionLogTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -50,6 +50,12 @@ public class SavedExecutionLogTests
         vm.TargetDatabaseName = "Sales_Restored";
         vm.Execution.Console.Append("RESTORE DATABASE ... 10 percent processed.");
 
+        // Append BUFFERS - it drains on a 60ms dispatcher timer, and only flushes inline when the
+        // calling thread has no dispatcher at all. Which thread xUnit hands this test therefore
+        // decided whether it passed, and it passed here and failed on CI. Flush, then read, is
+        // what ConsoleBuffer.Flush's own comment tells callers to do.
+        vm.Execution.Console.Flush();
+
         var saved = vm.Execution.BuildSavedDocument!();
 
         Assert.Contains("Nine Lives - restore execution log", saved);
@@ -71,6 +77,7 @@ public class SavedExecutionLogTests
         vm.TargetDatabaseName = "Sales_Restored";
         vm.Execution.Console.Append(
             "RESTORE FROM URL = N'https://acct.blob.core.windows.net/b/x.bak?sv=2022-11-02&sig=SECRETSIGNATUREVALUE'");
+        vm.Execution.Console.Flush();
 
         var saved = vm.Execution.BuildSavedDocument!();
 

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.6.1</Version>
+    <Version>1.6.2</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/Themes/Controls.xaml
+++ b/src/NineLives/Themes/Controls.xaml
@@ -243,6 +243,52 @@
         <Setter Property="Foreground" Value="{DynamicResource SecondaryTextBrush}" />
     </Style>
 
+    <!--
+        The screen's own status line: what it just did, or is doing (#404).
+
+        Four screens had an ErrorBanner and nothing bound to StatusMessage, so their failures
+        showed and every confirmation, instruction and consequence did not - a config import
+        reported what it had changed to nobody, and "Enter the new SAS token below" never appeared
+        beside the box it was talking about.
+
+        Collapses while there is an error. SetError deliberately writes the status line as well as
+        the banner, because not every screen surfaces both, so on a screen that surfaces both the
+        same sentence would appear twice - once in red and once in grey, which reads as two
+        separate things having gone wrong.
+    -->
+    <Style x:Key="StatusLine" TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+        <Setter Property="TextWrapping" Value="Wrap" />
+        <Setter Property="Margin" Value="0,8,0,0" />
+        <Setter Property="Visibility" Value="Visible" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding StatusMessage}" Value="">
+                <Setter Property="Visibility" Value="Collapsed" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding HasError}" Value="True">
+                <Setter Property="Visibility" Value="Collapsed" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <!--
+        The same line for the one screen that has no banner (#404).
+
+        History renders only a status line, by design - SetError writes it too, precisely so an
+        error there is not silent. But it was drawn in the same grey as everything else, so
+        "This history could not be read, so there is no telling what clearing it would destroy"
+        looked exactly like "Script copied to clipboard". This one stays visible during an error
+        and turns red for it.
+    -->
+    <Style x:Key="StatusLineNoBanner" TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+        <Setter Property="TextWrapping" Value="Wrap" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding HasError}" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ErrorBrush}" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="LabelText" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="Segoe UI" />
         <Setter Property="FontSize" Value="12" />

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -240,6 +240,24 @@ public partial class BackupViewModel : ViewModelBase
 
     [ObservableProperty]
     private ObservableCollection<BlobContainerConfig> _containers = [];
+    /// <summary>
+    /// Nothing to pick from, and where to go and fix that (#406).
+    ///
+    /// A fresh install put empty "Select..." dropdowns on this screen with no words at all, while
+    /// the Restore and Exposure screens both already named the missing thing, named the screen
+    /// that fills it, and said what would then happen. The app knows exactly what is absent; it
+    /// simply was not saying.
+    /// </summary>
+    public bool HasNoServers => Servers.Count == 0;
+
+    public bool HasNoContainers => Containers.Count == 0;
+
+    partial void OnServersChanged(ObservableCollection<ServerConnection> value) =>
+        OnPropertyChanged(nameof(HasNoServers));
+
+    partial void OnContainersChanged(ObservableCollection<BlobContainerConfig> value) =>
+        OnPropertyChanged(nameof(HasNoContainers));
+
 
     [ObservableProperty]
     private BlobContainerConfig? _container;

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -770,7 +770,31 @@ public partial class BackupViewModel : ViewModelBase
     /// WITH CHECKSUM follows the backup's own setting - verifying checksums that were never
     /// written fails the verify for a backup that is fine.
     /// </summary>
-    [RelayCommand]
+    /// <summary>
+    /// Pressable only when there is something to verify and nothing being verified (#402).
+    ///
+    /// The second half is what was missing. RESTORE VERIFYONLY reads the whole backup - minutes,
+    /// on a real database - and the button looked exactly as it had before, so the natural
+    /// response was to press it again. That call begins a new cancellation, which cancels the
+    /// verify in flight: every minute of reading thrown away, and a console reading "Verify
+    /// cancelled." immediately followed by "Verifying...", which looks like the app changed its
+    /// mind rather than like a button that should have been disabled.
+    /// </summary>
+    public bool CanVerify => CanVerifyLastBackup && !IsVerifying;
+
+    partial void OnIsVerifyingChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanVerify));
+        VerifyLastBackupCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnCanVerifyLastBackupChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanVerify));
+        VerifyLastBackupCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanVerify))]
     private async Task VerifyLastBackupAsync()
     {
         if (Server == null || _lastWrittenDevices.Count == 0) return;

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -160,13 +160,17 @@ public partial class BackupViewModel : ViewModelBase
             return;
         }
 
+        // Captured before the await (#409): the list belongs to the server that was asked, and
+        // this dropdown is a click away from the one that produced it.
+        var server = Server;
+
         var ct = _listCancellation.Begin();
         IsBusy = true;
         ClearStatus();
 
         try
         {
-            var names = await _sql.GetDatabaseListAsync(Server, ct);
+            var names = await _sql.GetDatabaseListAsync(server, ct);
 
             Databases = new ObservableCollection<string>(names);
             DatabasePicks = new ObservableCollection<DatabasePick>(
@@ -177,7 +181,7 @@ public partial class BackupViewModel : ViewModelBase
             try
             {
                 EncryptionCertificates = new ObservableCollection<string>(
-                    await _sql.ListBackupCertificatesAsync(Server, ct));
+                    await _sql.ListBackupCertificatesAsync(server, ct));
             }
             catch
             {
@@ -189,7 +193,7 @@ public partial class BackupViewModel : ViewModelBase
             // the wrong choice means a production database read at full speed for several minutes.
             SelectedDatabase = null;
 
-            SetStatus($"{Server.ServerName} has {names.Count} database(s).");
+            SetStatus($"{server.ServerName} has {names.Count} database(s).");
         }
         catch (OperationCanceledException)
         {

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -42,6 +42,30 @@ public partial class BlobBrowserViewModel : ViewModelBase
 
     [ObservableProperty]
     private ObservableCollection<BlobContainerConfig> _containers = [];
+    /// <summary>
+    /// Nothing to pick from, and where to go and fix that (#406).
+    ///
+    /// A fresh install put empty "Select..." dropdowns on this screen with no words at all, while
+    /// the Restore and Exposure screens both already named the missing thing, named the screen
+    /// that fills it, and said what would then happen. The app knows exactly what is absent; it
+    /// simply was not saying.
+    /// </summary>
+    public bool HasNoServers => Servers.Count == 0;
+
+    public bool HasNoContainers => Containers.Count == 0;
+
+    partial void OnServersChanged(ObservableCollection<ServerConnection> value)
+    {
+        OnPropertyChanged(nameof(HasNoServers));
+        OnPropertyChanged(nameof(BrowseHint));
+    }
+
+    partial void OnContainersChanged(ObservableCollection<BlobContainerConfig> value)
+    {
+        OnPropertyChanged(nameof(HasNoContainers));
+        OnPropertyChanged(nameof(BrowseHint));
+    }
+
 
     [ObservableProperty]
     private BlobContainerConfig? _selectedContainer;
@@ -112,10 +136,32 @@ public partial class BlobBrowserViewModel : ViewModelBase
     public bool MediumIsBlob => SelectedMedium == BackupMedium.AzureBlob;
     public bool MediumIsSharedPath => SelectedMedium == BackupMedium.SharedPath;
 
+    /// <summary>
+    /// The one line under the empty-state folder: what to do next, or why there is nothing to do
+    /// yet (#406).
+    ///
+    /// Four cases collapsed into one string rather than four TextBlocks and a MultiDataTrigger.
+    /// The bug it fixes is the fourth: on a fresh install this said "Select a container and click
+    /// Load Backups to browse" when there were no containers to select - an instruction nobody
+    /// could follow, on a screen that is one click from the sidebar and the natural thing to press
+    /// when you want to LOOK before committing to anything.
+    /// </summary>
+    public string BrowseHint =>
+        MediumIsBlob
+            ? HasNoContainers
+                ? "No storage configured yet. Add a container or bucket on the Blob Storage " +
+                  "screen, and what is in it can be browsed here."
+                : "Select a container and click Load Backups to browse."
+            : HasNoServers
+                ? "No saved servers yet. Add one on the SQL Servers screen, and what it has " +
+                  "recorded backing up can be read here."
+                : "Select a server and click Load Backups to read what it has backed up.";
+
     partial void OnSelectedMediumChanged(BackupMedium value)
     {
         OnPropertyChanged(nameof(MediumIsBlob));
         OnPropertyChanged(nameof(MediumIsSharedPath));
+        OnPropertyChanged(nameof(BrowseHint));
 
         // What is on screen came from the other source and no longer belongs to what is selected
         // above it. Leaving it there would put a container's files under a server's name.

--- a/src/NineLives/ViewModels/BlobConfigViewModel.cs
+++ b/src/NineLives/ViewModels/BlobConfigViewModel.cs
@@ -247,7 +247,27 @@ public partial class BlobConfigViewModel : ViewModelBase
         {
             var sas = _credentialStore.GetSasToken(container);
             if (sas != null) container.CacheSasToken(sas);
+
+            RecordCredentialState(container, sas);
         }
+    }
+
+    /// <summary>
+    /// What the vault says about this container's secret, recorded on the container (#407).
+    ///
+    /// One vault read, no network. Called wherever the answer can change - the load, and the save
+    /// that stores or deletes a token - because the list is bound live and Save deliberately does
+    /// not reload it, so without this the dot would stay red after somebody had just fixed it.
+    /// </summary>
+    private void RecordCredentialState(BlobContainerConfig container, string? sas = null)
+    {
+        sas ??= _credentialStore.GetSasToken(container);
+
+        container.CredentialState =
+            !container.AuthMode.NeedsSasToken() ? ContainerCredentialState.Present
+            : sas == null ? ContainerCredentialState.Missing
+            : container.ReadSasExpiry(sas).IsExpired ? ContainerCredentialState.Expired
+            : ContainerCredentialState.Present;
     }
 
     /// <summary>
@@ -863,6 +883,10 @@ public partial class BlobConfigViewModel : ViewModelBase
         IsEditing = false;
         HasUnsavedChanges = false;
         UpdateSasExpiryStatus(container);
+
+        // The token may have just been stored or deleted, so the dot has to catch up (#407).
+        RecordCredentialState(container);
+
         SetStatus("Container saved successfully.");
     }
 

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -74,6 +74,24 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
     [ObservableProperty]
     private ObservableCollection<BlobContainerConfig> _containers = [];
+    /// <summary>
+    /// Nothing to pick from, and where to go and fix that (#406).
+    ///
+    /// A fresh install put empty "Select..." dropdowns on this screen with no words at all, while
+    /// the Restore and Exposure screens both already named the missing thing, named the screen
+    /// that fills it, and said what would then happen. The app knows exactly what is absent; it
+    /// simply was not saying.
+    /// </summary>
+    public bool HasNoServers => Servers.Count == 0;
+
+    public bool HasNoContainers => Containers.Count == 0;
+
+    partial void OnServersChanged(ObservableCollection<ServerConnection> value) =>
+        OnPropertyChanged(nameof(HasNoServers));
+
+    partial void OnContainersChanged(ObservableCollection<BlobContainerConfig> value) =>
+        OnPropertyChanged(nameof(HasNoContainers));
+
 
     [ObservableProperty]
     private BlobContainerConfig? _container;

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -723,7 +723,14 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     // ── the console's own actions ───────────────────────────────────────────────
 
     [RelayCommand]
-    private void CopyConsole() => TryCopyToClipboard(Console.Text, "Execution log copied to clipboard.");
+    private void CopyConsole()
+    {
+        // Flush, then read - the rule Flush's own comment states. In practice the 60ms timer has
+        // long since drained by the time a human clicks, but that is a timing argument, and the
+        // cost of not relying on one is a single synchronous call.
+        Console.Flush();
+        TryCopyToClipboard(Console.Text, "Execution log copied to clipboard.");
+    }
 
     /// <summary>
     /// Builds the file Save output writes: the console, plus the context needed to read it a week
@@ -739,6 +746,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     [RelayCommand]
     private void SaveConsole()
     {
+        Console.Flush();
         if (string.IsNullOrEmpty(Console.Text)) return;
 
         var dialog = new SaveFileDialog

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -180,8 +180,24 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     /// The server-side credential check (#115 seam 5). A refusal has written nothing, so the run is
     /// abandoned without a history entry - it was never attempted.
     /// </param>
+    /// <summary>
+    /// Stage a run in progress without one, for the screens that have to behave differently
+    /// while a restore is running (#401). A real run needs a server.
+    /// </summary>
+    internal void SetExecutingForTests(bool value) => IsExecuting = value;
+
     public async Task RunAsync(RestoreRun run, Func<Action<string>, Task<CredentialPreflight>> preflight)
     {
+        // The last line of defence (#401). The screen's button is gated, but this is also reached
+        // from the rehearsal path, and the cost of re-entering is not a wasted call: the first
+        // thing below is a cancellation Begin(), which would abandon the restore already running
+        // and leave its target mid-chain in RESTORING.
+        if (IsExecuting)
+        {
+            SetError("A restore is already running. Stop it first, or wait for it to finish.");
+            return;
+        }
+
         // What the notifications call the run. A rehearsal's TARGET is the scratch copy, which
         // is an implementation detail - the thing being PROVEN is the source database, and that
         // is the name a Teams channel can recognise.

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -613,11 +613,32 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     [ObservableProperty]
     private string _actionOutcome = string.Empty;
 
+    /// <summary>
+    /// One at a time (#411). The flag existed and drove only the progress panel's visibility, so
+    /// every action button stayed live while one ran - and the first thing this method does is
+    /// begin a new cancellation, which abandons the action already running.
+    ///
+    /// This is the panel somebody is on after a restore has FAILED, with two buttons side by side
+    /// and a RESTORE ... WITH RECOVERY that goes out at CommandTimeout = 0. Pressing the other one
+    /// because nothing seemed to be happening threw away the recovery they were waiting for.
+    /// </summary>
+    public bool CanRunRecoveryAction => !IsRunningAction;
+
+    partial void OnIsRunningActionChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanRunRecoveryAction));
+        RunRecoveryActionCommand.NotifyCanExecuteChanged();
+    }
+
     /// <summary>Runs one remediation the user picked, then re-reads the state.</summary>
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanRunRecoveryAction))]
     private async Task RunRecoveryActionAsync(RecoveryAction? action)
     {
         if (action == null || _lastServer == null) return;
+
+        // The command is gated, but this is the one place where re-entering does damage rather
+        // than wasting a call, so it is checked here too.
+        if (IsRunningAction) return;
 
         // Cancellable, and it needs it more than most: this runs when a restore has already failed,
         // RESTORE ... WITH RECOVERY can take a long time on a large database, and it goes out at

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -395,8 +395,34 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnUseWithMoveChanged(bool value)
     {
         OnPropertyChanged(nameof(ShowMoveOptions));
+
+        // Ticking a checkbox does not cancel somebody's work (#413).
+        //
+        // Fetching the target's default directories is one of the mutually exclusive server
+        // operations on this screen - they share a cancellation source so that one Stop button
+        // covers them all, and starting one deliberately stops the last. That doctrine is right
+        // for the BUTTONS: pressing "Fetch from Server" while a chain verification runs is a
+        // choice to do the other thing instead.
+        //
+        // It is wrong here, because this is not a button. Ticking WITH MOVE is a request to see
+        // the move options, and it fired the fetch as a convenience - which cancelled a chain
+        // verification that reads the header of every backup in the chain, several minutes'
+        // work, for a value the user can ask for explicitly a moment later.
+        //
+        // So the automatic trigger defers, and says so. Deferring rather than queueing on
+        // purpose: a fetch that fires when the query finishes would answer for whatever is
+        // selected THEN, which is the stale-answer class fixed in #409.
         if (value)
-            _ = FetchDefaultPathsAsync();
+        {
+            if (_queryCancellation.CanCancel)
+                PathSourceText =
+                    "A server query is already running, so the default paths were not fetched - " +
+                    "stopping it for this would have been a poor trade. Press Fetch from Server " +
+                    "once it finishes, or type the paths in.";
+            else
+                _ = FetchDefaultPathsAsync();
+        }
+
         UpdateRestoreSummary();
     }
 

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -271,6 +271,89 @@ public partial class RestoreViewModel : ViewModelBase
         Steps.Target.Report(value != null, value?.Name ?? string.Empty);
         if (value != null && !ReferenceEquals(_connectedServer, value))
             ConnectedServer = value;
+
+        // Picking a target here PROVES it, rather than only naming it (#420).
+        //
+        // This step's own subtitle offers "otherwise pick a saved server here" as the equivalent
+        // of connecting on the SQL Servers screen. It set everything except the one flag that
+        // gates Execute - IsConnectedToServer, which only MainViewModel sets, and only when the
+        // Servers screen connects - so a user who did exactly what this screen invited them to do
+        // got every step ticked, a generated script, and "Connect to a SQL Server instance (SQL
+        // Servers tab)" telling them to go elsewhere and do it again.
+        if (value != null && !IsConnectedToServer)
+            _ = ConnectToTargetAsync(value);
+    }
+
+    /// <summary>
+    /// What the target connection is doing, or why it did not happen (#420).
+    ///
+    /// Failing is a legitimate outcome, not an error: generating a script for an instance this
+    /// machine cannot reach is exactly what Copy as Agent job, Export runbook and Save to File are
+    /// for. So a failure never blocks generation - it just stops being silent about why Execute is
+    /// unavailable.
+    /// </summary>
+    [ObservableProperty]
+    private string _targetConnectionState = string.Empty;
+
+    [ObservableProperty]
+    private bool _isConnectingToTarget;
+
+    partial void OnIsConnectingToTargetChanged(bool value) => RefreshExecuteBlockedReason();
+
+    /// <summary>Its own source: this is automatic, so it must not cancel a query somebody started.</summary>
+    private readonly OperationCancellation _targetConnectCancellation = new();
+
+    private async Task ConnectToTargetAsync(ServerConnection server)
+    {
+        var ct = _targetConnectCancellation.Begin();
+
+        IsConnectingToTarget = true;
+        TargetConnectionState = $"Connecting to {server.Name}...";
+
+        try
+        {
+            await _sqlService.TestConnectionAsync(server, ct);
+
+            // Captured before the await, and checked after it (#409): a connection attempt is
+            // slow enough for somebody to pick a different target while it runs, and the answer
+            // belongs to the server that was asked.
+            if (!ReferenceEquals(SelectedTargetServer, server)) return;
+
+            IsConnectedToServer = true;
+            ConnectedServerName = server.ServerName;
+            TargetConnectionState = $"Connected to {server.Name}. The restore can run from here.";
+
+            // The step collapses itself once answered, so the header is where this has to be
+            // legible - otherwise the outcome sits behind a chevron nobody has reason to open.
+            Steps.Target.Describe(server.Name);
+        }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a later selection, which will report for itself.
+        }
+        catch (Exception ex)
+        {
+            if (!ReferenceEquals(SelectedTargetServer, server)) return;
+
+            IsConnectedToServer = false;
+            TargetConnectionState =
+                $"Could not connect to {server.Name}: {ex.Message} The script still generates - " +
+                "save it, copy it as an Agent job or export a runbook and run it where the " +
+                "instance can be reached.";
+
+            // On the COLLAPSED header, because choosing a target completes the step and folds it
+            // away. Without this the screen showed a green tick against a server it had just
+            // failed to reach, with the explanation hidden inside - worse than the bug being
+            // fixed. Found by rendering it, not by reading it.
+            Steps.Target.Describe($"{server.Name} - could not be reached");
+        }
+        finally
+        {
+            if (ReferenceEquals(SelectedTargetServer, server))
+                IsConnectingToTarget = false;
+
+            _targetConnectCancellation.End();
+        }
     }
 
     /// <summary>
@@ -1238,6 +1321,19 @@ public partial class RestoreViewModel : ViewModelBase
 
         Timeline.Load(points);
 
+        // Only judge an inventory that exists (#419). This runs off WorkingSetChanged, which is
+        // raised on the path taken when NOTHING has been loaded and when no database has been
+        // picked - so arriving at the screen used to put a red banner up saying there is no full
+        // backup, when the truth was that nobody had pressed Load Backups yet.
+        //
+        // The same confusion as #368 and #356, pointing the other way: "not asked yet" reported
+        // as "asked, and the answer is bad". Here it was the first thing on the screen.
+        if (Inventory.AllSets.Count == 0 || string.IsNullOrEmpty(Inventory.SelectedDatabaseName))
+        {
+            ClearStatus();
+            return;
+        }
+
         if (points.Count == 0)
         {
             SetError("No valid restore points found. Ensure there is at least one full backup.");
@@ -1713,7 +1809,17 @@ public partial class RestoreViewModel : ViewModelBase
         get
         {
             if (IsExecuting) return string.Empty;
-            if (!IsConnectedToServer) return "Connect to a SQL Server to execute this restore.";
+            // Says which state it is actually in (#420). "Connect to a SQL Server" was written for
+            // somebody who had chosen no target at all; to somebody who HAS chosen one and could
+            // not be reached, it reads as an instruction they have already followed.
+            if (!IsConnectedToServer)
+                return IsConnectingToTarget
+                    ? $"Connecting to {SelectedTargetServer?.Name}..."
+                    : SelectedTargetServer != null
+                        ? $"{SelectedTargetServer.Name} could not be reached, so this restore " +
+                          "cannot run from here. The script above is still valid - save it, or " +
+                          "export it as a runbook or an Agent job."
+                        : "Choose the target instance above to execute this restore.";
             if (!HasScript) return "No script yet - pick a restore point and a target database name.";
             if (HasChainErrors) return "This chain cannot restore. See the problems listed above.";
             return string.Empty;

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -1274,11 +1274,20 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        PathSourceText = $"Querying {ConnectedServer.ServerName} for default paths...";
+        // Captured before the await (#409), like every other server call on this screen. Reading
+        // it again afterwards attributed one instance's default directories to another when the
+        // connection changed mid-query - and those directories go into the WITH MOVE clauses, so
+        // the restore would look correct and fail at run time with a directory-not-found, after
+        // WITH REPLACE had already dropped the target. Disconnecting mid-query threw a
+        // NullReferenceException that surfaced as "Could not fetch paths: Object reference not
+        // set to an instance of an object."
+        var server = ConnectedServer;
+
+        PathSourceText = $"Querying {server.ServerName} for default paths...";
         try
         {
             var (dataPath, logPath) = await _sqlService.GetDefaultPathsAsync(
-                ConnectedServer, _queryCancellation.Begin());
+                server, _queryCancellation.Begin());
             var dbName = string.IsNullOrWhiteSpace(TargetDatabaseName) ? "DatabaseName" : TargetDatabaseName;
 
             if (!string.IsNullOrEmpty(dataPath))
@@ -1290,7 +1299,7 @@ public partial class RestoreViewModel : ViewModelBase
                 MoveLogFilePath = Path.Combine(dataPath, $"{dbName}_log.ldf");
 
             PathsFromServer = true;
-            PathSourceText = $"Paths detected from {ConnectedServer.ServerName}. You can still override them.";
+            PathSourceText = $"Paths detected from {server.ServerName}. You can still override them.";
         }
         catch (Exception ex)
         {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -324,9 +324,6 @@ public partial class RestoreViewModel : ViewModelBase
     private string _moveLogFilePath = string.Empty;
 
     [ObservableProperty]
-    private bool _isFetchingPaths;
-
-    [ObservableProperty]
     private bool _pathsFromServer;
 
     [ObservableProperty]
@@ -1277,7 +1274,6 @@ public partial class RestoreViewModel : ViewModelBase
             return;
         }
 
-        IsFetchingPaths = true;
         PathSourceText = $"Querying {ConnectedServer.ServerName} for default paths...";
         try
         {
@@ -1304,10 +1300,6 @@ public partial class RestoreViewModel : ViewModelBase
             MoveLogFilePath = Path.Combine(fallbackDir, $"{dbName}_log.ldf");
             PathsFromServer = false;
             PathSourceText = $"Could not fetch paths: {ex.Message}. Using generic placeholders.";
-        }
-        finally
-        {
-            IsFetchingPaths = false;
         }
     }
 
@@ -1721,8 +1713,21 @@ public partial class RestoreViewModel : ViewModelBase
 
     public bool IsExecuteBlocked => ExecuteBlockedReason.Length > 0;
 
-    /// <summary>The button's own IsEnabled, so the reason and the enabled state cannot disagree.</summary>
-    public bool CanPressExecute => !IsExecuteBlocked;
+    /// <summary>
+    /// The button's own IsEnabled.
+    ///
+    /// NOT simply the inverse of the blocked reason (#401). That reason is deliberately empty
+    /// while a restore runs - there is nothing to nag about mid-run, the Stop button is what is
+    /// wanted then - and reading the enablement off it therefore left Execute LIVE during a
+    /// restore. Two presses armed it and called RunAsync again, whose cancellation source cancels
+    /// the run in flight: a production restore abandoned mid-chain, leaving the target in
+    /// RESTORING, and started over from the top.
+    ///
+    /// So the two questions are asked separately. Backup and Copy Database both had this right
+    /// already - CanExecute => HasScript &amp;&amp; !IsRunning - and this is the screen where
+    /// getting it wrong costs the most, because WITH REPLACE has already dropped the target.
+    /// </summary>
+    public bool CanPressExecute => !IsExecuteBlocked && !IsExecuting;
 
     private void RefreshExecuteBlockedReason()
     {

--- a/src/NineLives/ViewModels/ServerCredentialViewModel.cs
+++ b/src/NineLives/ViewModels/ServerCredentialViewModel.cs
@@ -314,7 +314,14 @@ public partial class ServerCredentialViewModel : ObservableObject
     {
         if (Server == null || Container == null) return;
 
-        var sasToken = _store.GetSasToken(Container);
+        // Captured before the awaits below (#409). This writes a CREDENTIAL onto an instance, so
+        // it must be the instance and container the user was looking at when they pressed the
+        // button - both are set from the screen above and can change while the write is in
+        // flight.
+        var server = Server;
+        var container = Container;
+
+        var sasToken = _store.GetSasToken(container);
 
         // Only a SAS credential needs one. A managed-identity credential carries no secret at all,
         // which is the entire point for an estate that forbids them.
@@ -324,7 +331,7 @@ public partial class ServerCredentialViewModel : ObservableObject
             // Says which secret is missing (#370). An S3 container stores an access key pair,
             // and being told to refresh a SAS token it never had is a wild goose chase.
             Reported?.Invoke(
-                Container.IsS3
+                container.IsS3
                     ? "No access key pair stored for this bucket. Add or refresh the key id and " +
                       "secret key in Blob Storage config."
                     : "No SAS token stored for this container. Add or refresh the token in " +
@@ -341,7 +348,7 @@ public partial class ServerCredentialViewModel : ObservableObject
         try
         {
             var change = await _sql.EnsureCredentialExistsAsync(
-                Server, Name, Container.ContainerUrl, sasToken ?? string.Empty,
+                server, Name, container.ContainerUrl, sasToken ?? string.Empty,
                 IdentityToCreate, _writeCancellation.Begin());
 
             await RefreshAsync();

--- a/src/NineLives/ViewModels/ServerManagerViewModel.cs
+++ b/src/NineLives/ViewModels/ServerManagerViewModel.cs
@@ -558,17 +558,26 @@ public partial class ServerManagerViewModel : ViewModelBase
     {
         if (SelectedServer == null) return;
 
+        // Captured BEFORE the await (#409). A connection attempt is exactly the operation slow
+        // enough for somebody to click another entry in the list beside it - the full timeout
+        // against an unreachable host - and every line below used to read SelectedServer again
+        // afterwards. So the app proved it could reach one server and then announced the other:
+        // marked it connected, handed it out as ConnectedServer (which is the object the restore
+        // screen EXECUTES against), and wrote the proved server's version banner onto the other
+        // one's saved entry.
+        var server = SelectedServer;
+
         TestResult = string.Empty;
         IsBusy = true;
         try
         {
-            await _sqlService.TestConnectionAsync(SelectedServer);
+            await _sqlService.TestConnectionAsync(server);
 
             // Derive the product-version tag from the connection we just proved works. Best
             // effort: a server that connects but will not answer @@VERSION should still connect.
             try
             {
-                RecordDetectedVersion(SelectedServer, await _sqlService.GetServerVersionAsync(SelectedServer));
+                RecordDetectedVersion(server, await _sqlService.GetServerVersionAsync(server));
             }
             catch
             {
@@ -576,18 +585,18 @@ public partial class ServerManagerViewModel : ViewModelBase
             }
 
             IsConnected = true;
-            ConnectedServerDisplay = SelectedServer.DisplayText;
-            MarkConnected(SelectedServer);
+            ConnectedServerDisplay = server.DisplayText;
+            MarkConnected(server);
             ConnectionChanged?.Invoke(this, new ServerConnectionChangedEventArgs
             {
                 IsConnected = true,
-                ServerName = SelectedServer.ServerName,
-                ConnectedServer = SelectedServer
+                ServerName = server.ServerName,
+                ConnectedServer = server
             });
-            SetStatus($"Connected to {SelectedServer.ServerName}");
+            SetStatus($"Connected to {server.ServerName}");
 
             TestSuccess = true;
-            TestResult = $"Connected to {SelectedServer.DisplayText}.";
+            TestResult = $"Connected to {server.DisplayText}.";
         }
         catch (Exception ex)
         {

--- a/src/NineLives/ViewModels/ViewModelBase.cs
+++ b/src/NineLives/ViewModels/ViewModelBase.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
@@ -46,6 +46,12 @@ public abstract partial class ViewModelBase : ObservableObject
     /// it.
     /// </summary>
     protected void SetStatus(string message) => StatusMessage = message;
+
+    /// <summary>Stage a status message without the operation that produces one.</summary>
+    internal void SetStatusForTests(string message) => SetStatus(message);
+
+    /// <summary>Stage an error without the failure that produces one.</summary>
+    internal void SetErrorForTests(string message) => SetError(message);
 
     /// <summary>
     /// Sticky: survives until another error supersedes it, the user dismisses it, or the next

--- a/src/NineLives/Views/BackupView.xaml
+++ b/src/NineLives/Views/BackupView.xaml
@@ -61,6 +61,11 @@
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
+                            <!-- Names the missing thing and the screen that fills it (#406). Restore and
+                                 Exposure already said this; the dropdowns here just sat empty. -->
+                            <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                       Text="No saved servers yet. Add one on the SQL Servers screen and it will appear here."
+                                       Visibility="{Binding HasNoServers, Converter={StaticResource BoolToVis}}" />
                         </StackPanel>
 
                         <Button Grid.Column="1"
@@ -153,6 +158,9 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
+                        <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                   Text="No storage configured yet. Add a container or bucket on the Blob Storage screen and it will appear here."
+                                   Visibility="{Binding HasNoContainers, Converter={StaticResource BoolToVis}}" />
                     </StackPanel>
 
                     <StackPanel Margin="0,12,0,0"

--- a/src/NineLives/Views/BackupView.xaml
+++ b/src/NineLives/Views/BackupView.xaml
@@ -286,6 +286,15 @@
                                 Visibility="{Binding CanVerifyLastBackup, Converter={StaticResource BoolToVis}}"
                                 Padding="16,8" Margin="0,0,8,8"
                                 ToolTip="RESTORE VERIFYONLY over the files the last run wrote. A backup nobody has verified is a hope, not a backup." />
+
+                        <!-- Says it is happening (#402). Reading a whole backup takes minutes, and
+                             the button used to look identical throughout - so it got pressed
+                             again, which cancelled the verify and started it over. -->
+                        <TextBlock Text="Verifying the backup..."
+                                   Style="{StaticResource SecondaryText}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,8,8"
+                                   Visibility="{Binding IsVerifying, Converter={StaticResource BoolToVis}}" />
                     </WrapPanel>
 
                     <!-- Where the files will land, readable before anything is written. -->

--- a/src/NineLives/Views/BlobBrowserView.xaml
+++ b/src/NineLives/Views/BlobBrowserView.xaml
@@ -275,17 +275,16 @@
                                Style="{StaticResource BodyText}"
                                HorizontalAlignment="Center" />
                     <!-- Names the thing actually being asked for. Telling somebody who has chosen a
-                         server to select a container is an instruction they cannot follow (#197). -->
-                    <TextBlock Text="Select a container and click Load Backups to browse."
+                         server to select a container is an instruction they cannot follow (#197) -
+                         and so is telling somebody with no containers at all to select one (#406).
+                         All four cases live in BrowseHint, as one sentence. -->
+                    <TextBlock Text="{Binding BrowseHint}"
                                Style="{StaticResource SecondaryText}"
                                HorizontalAlignment="Center"
-                               Margin="0,4,0,0"
-                               Visibility="{Binding MediumIsBlob, Converter={StaticResource BoolToVis}}" />
-                    <TextBlock Text="Select a server and click Load Backups to read what it has backed up."
-                               Style="{StaticResource SecondaryText}"
-                               HorizontalAlignment="Center"
-                               Margin="0,4,0,0"
-                               Visibility="{Binding MediumIsSharedPath, Converter={StaticResource BoolToVis}}" />
+                               TextWrapping="Wrap"
+                               MaxWidth="440"
+                               TextAlignment="Center"
+                               Margin="0,4,0,0" />
                 </StackPanel>
 
                 <!-- DataGrid -->

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -29,6 +29,9 @@
             <TextBlock Text="Configure the containers holding your backups - Azure Blob Storage, or any S3-compatible bucket."
                        Style="{StaticResource SecondaryText}"
                        Margin="0,4,0,0" />
+            <!-- What this screen just did. Its confirmations, instructions and
+                 consequences used to reach nothing at all (#404). -->
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" />
         </StackPanel>
 
         <Grid Grid.Row="1">

--- a/src/NineLives/Views/BlobConfigView.xaml
+++ b/src/NineLives/Views/BlobConfigView.xaml
@@ -82,10 +82,31 @@
                             <DataTemplate>
                                 <StackPanel Margin="4,6">
                                     <StackPanel Orientation="Horizontal">
+                                        <!-- Says something (#407). This was SuccessBrush
+                                             unconditionally: a green light beside every
+                                             container whether or not it had a credential, in an
+                                             app whose premise is that nothing is fine until
+                                             something has proved it. A config import arrives
+                                             with no secrets by design, so a whole list of them
+                                             used to come up green and reach nothing. -->
                                         <Ellipse Width="8" Height="8"
-                                                 Fill="{DynamicResource SuccessBrush}"
                                                  VerticalAlignment="Center"
-                                                 Margin="0,0,8,0" />
+                                                 Margin="0,0,8,0"
+                                                 ToolTip="{Binding CredentialStateNote}">
+                                            <Ellipse.Style>
+                                                <Style TargetType="Ellipse">
+                                                    <Setter Property="Fill" Value="{DynamicResource SuccessBrush}" />
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding CredentialIsExpired}" Value="True">
+                                                            <Setter Property="Fill" Value="{DynamicResource WarningBrush}" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding CredentialIsMissing}" Value="True">
+                                                            <Setter Property="Fill" Value="{DynamicResource ErrorBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Ellipse.Style>
+                                        </Ellipse>
                                         <TextBlock Text="{Binding Name}"
                                                    FontWeight="SemiBold"
                                                    Foreground="{DynamicResource PrimaryTextBrush}" />
@@ -95,6 +116,23 @@
                                                TextTrimming="CharacterEllipsis"
                                                Margin="16,2,0,0"
                                                MaxWidth="220" />
+
+                                    <!-- In words as well as in colour. The selected-row style in
+                                         this app already carries a note that high contrast makes
+                                         a tinted fill nearly invisible, so meaning must not ride
+                                         on colour alone - an 8px dot is the worst case of it. -->
+                                    <TextBlock Text="no credential stored"
+                                               Style="{StaticResource SecondaryText}"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource ErrorBrush}"
+                                               Margin="16,2,0,0"
+                                               Visibility="{Binding CredentialIsMissing, Converter={StaticResource BoolToVis}}" />
+                                    <TextBlock Text="credential expired"
+                                               Style="{StaticResource SecondaryText}"
+                                               FontWeight="SemiBold"
+                                               Foreground="{DynamicResource WarningBrush}"
+                                               Margin="16,2,0,0"
+                                               Visibility="{Binding CredentialIsExpired, Converter={StaticResource BoolToVis}}" />
                                     <ItemsControl ItemsSource="{Binding TagChips}"
                                                   Style="{StaticResource TagChipList}"
                                                   Margin="16,2,0,0" />

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -90,6 +90,12 @@
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
+                            <!-- Names the missing thing and the screen that fills it (#406). A copy needs
+                                 two servers and somewhere to put the backup, and a fresh install offered
+                                 three empty dropdowns with no words at all. -->
+                            <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                       Text="No saved servers yet. Add one on the SQL Servers screen and it will appear here - a copy needs two."
+                                       Visibility="{Binding HasNoServers, Converter={StaticResource BoolToVis}}" />
                         </StackPanel>
 
                         <Button Grid.Column="1"
@@ -143,6 +149,9 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
+                        <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                   Text="No storage configured yet. Add a container or bucket on the Blob Storage screen and it will appear here."
+                                   Visibility="{Binding HasNoContainers, Converter={StaticResource BoolToVis}}" />
                     </StackPanel>
 
                     <StackPanel Margin="0,12,0,0"
@@ -195,6 +204,9 @@
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
+                            <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
+                                       Text="No saved servers yet. Add one on the SQL Servers screen and it will appear here - a copy needs two."
+                                       Visibility="{Binding HasNoServers, Converter={StaticResource BoolToVis}}" />
                         </StackPanel>
 
                         <StackPanel Grid.Column="2">

--- a/src/NineLives/Views/ExposureView.xaml
+++ b/src/NineLives/Views/ExposureView.xaml
@@ -40,6 +40,10 @@
 
             <ContentControl Style="{StaticResource ErrorBanner}" Margin="0,0,0,12" />
 
+            <!-- "Cancelling..." and "Sweep cancelled." used to reach nothing, so pressing
+                 Stop on a long sweep looked like it had done nothing (#404). -->
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" />
+
             <ItemsControl ItemsSource="{Binding Rows}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>

--- a/src/NineLives/Views/HistoryView.xaml
+++ b/src/NineLives/Views/HistoryView.xaml
@@ -181,10 +181,13 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
+            <!-- This is the only view with no ErrorBanner, by design: SetError writes the
+                 status line too, precisely so an error here is not silent. But it was drawn in
+                 the same grey as everything else, so a refusal to destroy a restore's evidence
+                 looked exactly like "Script copied to clipboard" (#404). -->
             <TextBlock Grid.Column="0"
                        Text="{Binding StatusMessage}"
-                       Style="{StaticResource SecondaryText}"
-                       TextWrapping="Wrap"
+                       Style="{StaticResource StatusLineNoBanner}"
                        VerticalAlignment="Center" />
 
             <Button Grid.Column="1" Content="Keep it"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -662,6 +662,40 @@
                                    Visibility="{Binding HasNoTargetServers, Converter={StaticResource BoolToVis}}">
                             <Run Text="No saved servers yet. Add one on the SQL Servers screen and it will appear here." />
                         </TextBlock>
+
+                        <!-- Whether the target was actually reached (#420). Picking one here used
+                             to name the instance without ever proving it, so every step ticked and
+                             Execute still said "connect on the SQL Servers tab" - sending somebody
+                             elsewhere to do what they had just done. Failing is a legitimate
+                             outcome and says so: the script still generates for an instance this
+                             machine cannot reach, which is what the runbook and Agent job exports
+                             are for. -->
+                        <TextBlock TextWrapping="Wrap"
+                                   MaxWidth="640"
+                                   HorizontalAlignment="Left"
+                                   Margin="0,8,0,0"
+                                   Text="{Binding TargetConnectionState}"
+                                   Visibility="{Binding TargetConnectionState, Converter={StaticResource NullToVis}}">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                    <Style.Triggers>
+                                        <!-- Reached nothing, and no longer trying. Not an error
+                                             style: generating a script for an instance this
+                                             machine cannot reach is a supported workflow. -->
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding IsConnectingToTarget}" Value="False" />
+                                                <Condition Binding="{Binding IsConnectedToServer}" Value="False" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
+                                        </MultiDataTrigger>
+                                        <DataTrigger Binding="{Binding IsConnectedToServer}" Value="True">
+                                            <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
                     </StackPanel>
                 </StackPanel>
             </Border>
@@ -2214,11 +2248,12 @@
                 </StackPanel>
             </Border>
 
-            <!-- Status -->
+            <!-- Status. The shared style, so an error stops being printed twice (#419):
+                 SetError writes this line as well as the banner, because not every screen
+                 surfaces both, and this one surfaces both. Same wrinkle as #392 and #404. -->
             <TextBlock Text="{Binding StatusMessage}"
-                       Style="{StaticResource SecondaryText}"
-                       Margin="0,4,0,16"
-                       Visibility="{Binding StatusMessage, Converter={StaticResource NullToVis}}" />
+                       Style="{StaticResource StatusLine}"
+                       Margin="0,4,0,16" />
         </StackPanel>
         </ScrollViewer>
     </DockPanel>

--- a/src/NineLives/Views/ServerManagerView.xaml
+++ b/src/NineLives/Views/ServerManagerView.xaml
@@ -23,6 +23,9 @@
             <TextBlock Text="Manage SQL Server connections for executing restore scripts and reading backup metadata."
                        Style="{StaticResource SecondaryText}"
                        Margin="0,4,0,0" />
+            <!-- What this screen just did. Its confirmations, instructions and
+                 consequences used to reach nothing at all (#404). -->
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" />
         </StackPanel>
 
         <Grid Grid.Row="1">

--- a/src/NineLives/Views/SettingsView.xaml
+++ b/src/NineLives/Views/SettingsView.xaml
@@ -13,6 +13,10 @@
 
             <ContentControl Style="{StaticResource ErrorBanner}" />
 
+            <!-- Where an import says what it changed, and an export says where it went and
+                 that it holds no secrets. Both reported to nobody until #404. -->
+            <TextBlock Text="{Binding StatusMessage}" Style="{StaticResource StatusLine}" />
+
             <!-- Appearance -->
             <Border Style="{StaticResource CardBorder}" Margin="0,0,0,16">
                 <StackPanel>


### PR DESCRIPTION
Twelve fixes on top of 1.6.1. No breaking changes, no config or schema changes.

## The ones with real consequence

**Execute was live while a restore was running** (#401). The button took its enabled state from the same property that supplies the "why you cannot press this" sentence — and that sentence is deliberately empty mid-run. Empty read as "not blocked", so two presses would arm it and call the run again, whose first act is a new cancellation: the restore in flight abandoned mid-chain, target left in RESTORING, and the whole thing started over. Backup and Copy Database both had this right already.

**Connect announced a different server from the one it proved** (#409). `ConnectAsync` re-read the list selection after its await, so clicking another entry while a connection hung meant the app proved one server and then marked another connected — handing it out as `ConnectedServer`, which is the object the restore screen *executes against*. It also wrote the proved server's version banner onto the other one's saved entry.

**Exposure judged one clock against another** (#414). msdb records a backup's finish time in the instance's local time; the sweep compared it against this machine's. With a one-hour warning threshold, an offset in hours decided the verdict — and a server ahead of the app made backups look newer than they were, downgrading an alarm to a warning, or going negative and showing green.

**An S3 listing could loop forever** (#416). The paging loops stopped on a null continuation token, but a present-and-empty XML element reads as `""`, not null. A provider that writes `<NextContinuationToken/>` on the last page instead of omitting it sent the loop back for another page with an empty token — which means *start again* — re-listing the bucket until memory ran out.

**Recovery actions could be started on top of each other** (#411), on the panel you are looking at *after* a restore has failed: pressing the second button abandoned the `RESTORE ... WITH RECOVERY` you were waiting on.

## Screens that said the wrong thing

- The Restore screen claimed there were no restore points **before anything had been loaded**, and said it twice (#419)
- **Choosing a target never connected to it** (#420), so every step ticked green and Execute still told you to go to another tab and do what you had just done. It now connects, and says why if it cannot — without blocking script generation, since generating for an unreachable instance is what the runbook and Agent job exports are for
- Four screens showed errors but never confirmations, so a config import reported what it had changed to nobody (#404)
- Three screens told a fresh install to select things that did not exist (#406)
- Every container had a green dot regardless of whether it had a credential (#407) — which bites hardest right after a config import, since export carries no secrets by design
- Verify Last Backup had no busy state, and a second press restarted it (#402)
- Ticking WITH MOVE cancelled a running chain verification (#413)

Full detail in [CHANGELOG.md](CHANGELOG.md).

**Gate:** `dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test NineLives.sln -c Release` → **2,093 passed, 0 failed** (up 128 since v1.6.1).
