### PR TITLE
Sync main: acknowledgement added after v1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,4 +640,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Acknowledgements
 
 - UI design inspired by [Erik Darling's SQL Performance tools](https://github.com/erikdarlingdata/PerformanceMonitor)
+- Hannah Vernon's [10 step Backup & Recovery from First Principles](https://www.sqlserverscience.com/basics/backup-recovery-part-1-recovery-models/)
 - Built with [CommunityToolkit.Mvvm](https://github.com/CommunityToolkit/dotnet)


### PR DESCRIPTION
Documentation only — no version bump, and no change to what v1.6.2 shipped.

`main` was two commits behind `dev` after the release: the acknowledgement of [Hannah Vernon's Backup & Recovery from First Principles](https://www.sqlserverscience.com/basics/backup-recovery-part-1-recovery-models/) (#425) landed after v1.6.2 was tagged. This brings `main` level so it is not sitting behind on a credit.

The version gate passes without a bump by design — the only file touched is `README.md`, so the check reports no code change and exits clean.

Nothing else changes: `dev` stays the default branch and the place work lands, `main` stays the released code.