### PR TITLE
Pressing Stop on a recovery step is a cancellation, not a severe error

### DIFF
--- a/src/NineLives.Core/Services/SqlServerService.cs
+++ b/src/NineLives.Core/Services/SqlServerService.cs
@@ -1025,7 +1025,11 @@ public class SqlServerService : ISqlServerService
         await using var cmd = conn.CreateCommand();
         cmd.CommandTimeout = 0;
         cmd.CommandText = sql;
-        await cmd.ExecuteNonQueryAsync(ct);
+
+        // No production caller today, but it is the same shape as the one that bit us in #427 -
+        // public, CommandTimeout = 0, takes a token - so it gets the trap now rather than the
+        // next time somebody reaches for it.
+        await CancellableAsync(() => cmd.ExecuteNonQueryAsync(ct), ct, "The statement");
     }
 
     public async Task ExecuteWithProgressAsync(
@@ -1432,9 +1436,25 @@ public class SqlServerService : ISqlServerService
         return marks;
     }
 
+    /// <summary>
+    /// Runs one statement with a percent bar, and reports a cancellation as a cancellation.
+    ///
+    /// The trap CancellableAsync exists for, caught a fourth time (#427). This method is what the
+    /// recovery panel runs, so it is the one place where getting it wrong is worst: a restore has
+    /// already failed, the user presses Stop on a RESTORE ... WITH RECOVERY, and SqlClient raises
+    /// the cancelled command as a SqlException. Untranslated, the panel reported "FAILED: A severe
+    /// error occurred" - telling somebody mid-recovery that their database is in a state it is
+    /// not, at the exact moment they need the truth about it.
+    /// </summary>
     public async Task ExecuteWithPercentPollingAsync(
         ServerConnection server, string sql, IProgress<double>? percent = null,
         CancellationToken ct = default)
+        => await CancellableAsync(
+            () => RunWithPercentPollingAsync(server, sql, percent, ct), ct, "The statement");
+
+    private async Task RunWithPercentPollingAsync(
+        ServerConnection server, string sql, IProgress<double>? percent,
+        CancellationToken ct)
     {
         await using var conn = CreateConnection(server);
         await conn.OpenAsync(ct);

--- a/src/NineLives.Tests/CancellationTests.cs
+++ b/src/NineLives.Tests/CancellationTests.cs
@@ -165,6 +165,33 @@ public class SqlCancellationTests
     }
 
     /// <summary>
+    /// The same pin for the polling execute, which is what the recovery panel runs (#427).
+    ///
+    /// That method was added after the three carrying the guard and never got one, so a cancelled
+    /// recovery step reached the panel as a raw SqlException and was reported as "FAILED: A severe
+    /// error occurred". Reported from the field. The test above proves the translation for the
+    /// statement-loop path; this proves it for the one the recovery panel actually calls.
+    /// </summary>
+    [RequiresSqlFact]
+    public async Task ACancelledPollingStatementIsAlsoACancellation()
+    {
+        using var cts = new CancellationTokenSource();
+
+        var started = Stopwatch.StartNew();
+        var run = Service().ExecuteWithPercentPollingAsync(
+            TestServer(), "WAITFOR DELAY '00:00:30'", null, cts.Token);
+
+        await Task.Delay(1000);
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run);
+        started.Stop();
+
+        Assert.True(started.Elapsed < TimeSpan.FromSeconds(15),
+            $"Cancellation did not reach the server - the statement ran for {started.Elapsed}.");
+    }
+
+    /// <summary>
     /// The other half of the translation: a genuine SqlException must still surface as a failure.
     /// Guarding only on the token means an unrelated severe error is not mislabelled as the user
     /// having pressed Stop.

--- a/src/NineLives.Tests/CancelledRecoveryStepTests.cs
+++ b/src/NineLives.Tests/CancelledRecoveryStepTests.cs
@@ -1,0 +1,125 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Pressing Stop on a recovery step is a cancellation, and must read as one (#427).
+///
+/// Reported from the field. A restore has already failed, the user is on the recovery panel with
+/// a RESTORE ... WITH RECOVERY running against a large database, and presses Stop. SqlClient
+/// raises a cancelled command as a SqlException - "A severe error occurred on the current
+/// command" - not an OperationCanceledException, so the panel's cancellation handler was stepped
+/// over and the general failure handler answered instead: "FAILED at HH:mm:ss: A severe error
+/// occurred". At the one moment somebody is trying to recover a broken database and needs to know
+/// its true state, the tool told them a step had failed when it had done exactly what they asked.
+///
+/// The same trap CancellableAsync was written for, and its doc comment predicted this: writing the
+/// guard out by hand at each call site is how sites come to be missing it. This was the fourth.
+///
+/// Fixed in two places, and pinned here in both:
+///   1. the service translates it, so every caller sees an OperationCanceledException;
+///   2. the panel also trusts the token, so nothing that reaches it can be called a failure when
+///      the user pressed Stop.
+/// </summary>
+public class CancelledRecoveryStepTests
+{
+    private static (RestoreExecutionViewModel vm, FakeSqlServerService sql, OperationCancellation queries)
+        NewAfterFailedRun()
+    {
+        var sql = new FakeSqlServerService();
+        var queries = new OperationCancellation();
+        var vm = new RestoreExecutionViewModel(
+            sql, new FakeRestoreHistoryStore(), TestLogs.Temp(), queries);
+
+        var run = new RestoreRun(
+            new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" },
+            "RESTORE DATABASE [MyDb] FROM DISK = N'D:\\b.bak' WITH REPLACE, RECOVERY;",
+            "MyDb", null, null, "1 full", null, "opts");
+        vm.RunAsync(run, _ => Task.FromResult(CredentialPreflight.Proceed)).GetAwaiter().GetResult();
+
+        return (vm, sql, queries);
+    }
+
+    private static RecoveryAction BringOnline() => new(
+        "Bring the database online",
+        "RESTORE DATABASE [MyDb] WITH RECOVERY",
+        "caution");
+
+    /// <summary>
+    /// The reported bug, in the shape it actually arrives: the token is signalled mid-statement
+    /// and what comes back is the driver's exception, not an OperationCanceledException.
+    /// </summary>
+    [Fact]
+    public async Task StoppingAStepReadsAsCancelledEvenWhenTheDriverThrowsItsOwnError()
+    {
+        var (vm, sql, queries) = NewAfterFailedRun();
+
+        // Exactly what the user saw. The type stands in for SqlException, which cannot be
+        // constructed here - what matters is that it is not an OperationCanceledException.
+        sql.DuringPollingExecute = queries.Cancel;
+        sql.PollingExecuteThrows = new InvalidOperationException(
+            "A severe error occurred on the current command. The results, if any, should be discarded.");
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(BringOnline());
+
+        Assert.Contains("Cancelled", vm.ActionOutcome);
+        Assert.Contains("unchanged by this step", vm.ActionOutcome);
+
+        // The words the report was actually about.
+        Assert.DoesNotContain("FAILED", vm.ActionOutcome);
+        Assert.DoesNotContain("severe error", vm.ActionOutcome);
+        Assert.False(vm.HasError);
+    }
+
+    /// <summary>The ordinary path the service now produces, once it has done the translation.</summary>
+    [Fact]
+    public async Task AnOperationCanceledExceptionStillReadsAsCancelled()
+    {
+        var (vm, sql, _) = NewAfterFailedRun();
+        sql.PollingExecuteThrows = new OperationCanceledException("The statement was cancelled.");
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(BringOnline());
+
+        Assert.Contains("Cancelled", vm.ActionOutcome);
+        Assert.False(vm.HasError);
+    }
+
+    /// <summary>
+    /// The other half, and the reason both guards are on the token rather than on the message: a
+    /// genuine failure with nobody pressing Stop must still be reported as the failure it is.
+    /// Mislabelling a real error as a cancellation on this panel would be the same defect pointing
+    /// the other way, and worse - it would tell somebody their database was untouched when a
+    /// recovery step had just failed against it.
+    /// </summary>
+    [Fact]
+    public async Task ARealFailureIsStillAFailure()
+    {
+        var (vm, sql, _) = NewAfterFailedRun();
+        sql.PollingExecuteThrows = new InvalidOperationException("Msg 3013: RESTORE DATABASE is terminating abnormally.");
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(BringOnline());
+
+        Assert.Contains("FAILED", vm.ActionOutcome);
+        Assert.Contains("Msg 3013", vm.ActionOutcome);
+        Assert.True(vm.HasError);
+    }
+
+    /// <summary>The panel must be usable again afterwards - a cancelled step is not a dead end.</summary>
+    [Fact]
+    public async Task ThePanelIsReadyForTheNextAttemptAfterACancelledStep()
+    {
+        var (vm, sql, queries) = NewAfterFailedRun();
+        sql.DuringPollingExecute = queries.Cancel;
+        sql.PollingExecuteThrows = new InvalidOperationException("A severe error occurred on the current command.");
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(BringOnline());
+
+        Assert.False(vm.IsRunningAction);
+        Assert.True(vm.CanRunRecoveryAction);
+        Assert.True(vm.RunRecoveryActionCommand.CanExecute(null));
+        Assert.True(vm.ActionPercentUnknown);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -626,6 +626,15 @@ public sealed class FakeSqlServerService : ISqlServerService
 
     public Exception? PollingExecuteThrows { get; set; }
 
+    /// <summary>
+    /// Runs once the statement is notionally in flight, before it throws (#427). It is how a test
+    /// reproduces the real sequence - the user presses Stop while the command is running, and what
+    /// comes back is the driver's own exception rather than an OperationCanceledException. Nothing
+    /// here can construct a SqlException, which has no public constructor, so the test supplies
+    /// the cancel through this and the exception through PollingExecuteThrows.
+    /// </summary>
+    public Action? DuringPollingExecute { get; set; }
+
     public List<string> PolledScripts { get; } = [];
 
     public Task ExecuteWithPercentPollingAsync(
@@ -634,6 +643,8 @@ public sealed class FakeSqlServerService : ISqlServerService
     {
         PolledScripts.Add(sql);
         ct.ThrowIfCancellationRequested();
+
+        DuringPollingExecute?.Invoke();
         if (PollingExecuteThrows != null) throw PollingExecuteThrows;
 
         if (percent != null)

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -685,7 +685,13 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             if (!HasRecoveryActions)
                 SetStatus($"[{_lastTarget}] is back to a usable state.");
         }
-        catch (OperationCanceledException)
+        // Two ways in, one answer (#427). The service translates a cancelled command into an
+        // OperationCanceledException, and this also trusts the token directly: if the user pressed
+        // Stop then, whatever the driver chose to throw on the way out, what happened is that they
+        // pressed Stop. Nothing reaching this panel should be able to call that a failure - it is
+        // the screen somebody is on when a restore has already gone wrong, and the one place where
+        // a wrong word about the database's state costs the most.
+        catch (Exception ex) when (ex is OperationCanceledException || ct.IsCancellationRequested)
         {
             // SQL Server rolls back the statement that was in flight, so the database is where it
             // was before this step - which is still whatever the failed restore left behind.


### PR DESCRIPTION
Closes #427. Reported from the field after the release announcement.

A restore has already failed. The user is on the recovery panel with a `RESTORE ... WITH RECOVERY` running against a large database, and presses **Stop**. The panel reported:

> FAILED at HH:mm:ss: A severe error occurred on the current command.

It did not fail. It did exactly what was asked — at the one moment somebody is trying to recover a broken database and needs to know its true state.

## Cause

SqlClient raises a command cancelled mid-flight as a `SqlException`, not an `OperationCanceledException`. `ExecuteWithPercentPollingAsync` — the only method the recovery panel calls — never translated it, so the panel's correct cancellation handler was stepped over and the general failure handler answered.

`CancellableAsync` was written for this trap, and its own doc comment predicted this one:

> Every call site that takes a token needs the same trap, and writing it out at each one is how three of them came to be missing it.

This was the fourth — and the one behind the highest-stakes screen in the product.

## Changes

- **Service.** The polling execute now routes through `CancellableAsync`, so every caller sees a cancellation as a cancellation.
- **Panel.** Also trusts the token directly. Whatever the driver throws on the way out, if the user pressed Stop then that is what happened, and nothing reaching this screen should be able to call it a failure.
- **`ExecuteNonQueryAsync`.** The one other public `CommandTimeout = 0` method without the guard. No caller today, but it is the identical shape and this is the second time that has mattered.
- **Audit.** The remaining token-taking execute sites are short metadata reads with nothing to press Stop on.

Both guards are on the token, never on the message. A genuine severe error still reports as the failure it is — the same defect pointing the other way would tell somebody their database was untouched when a recovery step had just failed against it.

## Tests

New `CancelledRecoveryStepTests` pins four cases, including the exact reported sequence: the driver's own exception arriving while the token is signalled. **That test fails without the fix** (verified by reverting the guard). Also a live-SQL pin beside the existing translation tests.

Full suite 2097 passed / 0 failed. Release `-warnaserror`: 0 warnings, 0 errors.