### PR TITLE
Show the repo's vital signs at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Nine Lives 🐈‍⬛
 
-[![Build](https://github.com/jakemorgangit/NineLives/actions/workflows/build.yml/badge.svg)](https://github.com/jakemorgangit/NineLives/actions/workflows/build.yml)
+<p align="center">
+  <a href="https://github.com/jakemorgangit/NineLives/stargazers"><img src="https://img.shields.io/github/stars/jakemorgangit/NineLives?style=for-the-badge&logo=github&color=gold&logoColor=black" alt="GitHub Stars"></a>
+  <a href="https://github.com/jakemorgangit/NineLives/network/members"><img src="https://img.shields.io/github/forks/jakemorgangit/NineLives?style=for-the-badge&logo=github" alt="GitHub Forks"></a>
+  <a href="https://github.com/jakemorgangit/NineLives/actions/workflows/build.yml"><img src="https://img.shields.io/github/actions/workflow/status/jakemorgangit/NineLives/build.yml?branch=main&style=for-the-badge&label=Build" alt="Build"></a>
+  <a href="https://github.com/jakemorgangit/NineLives/releases/latest"><img src="https://img.shields.io/github/v/release/jakemorgangit/NineLives?style=for-the-badge&color=blueviolet" alt="Latest Release"></a>
+  <a href="https://github.com/jakemorgangit/NineLives/issues"><img src="https://img.shields.io/github/issues/jakemorgangit/NineLives?style=for-the-badge" alt="Open Issues"></a>
+  <a href="https://github.com/jakemorgangit/NineLives/issues?q=is%3Aissue+is%3Aclosed"><img src="https://img.shields.io/github/issues-closed/jakemorgangit/NineLives?style=for-the-badge&color=success" alt="Closed Issues"></a>
+  <a href="https://github.com/jakemorgangit/NineLives/commits/main"><img src="https://img.shields.io/github/last-commit/jakemorgangit/NineLives?style=for-the-badge" alt="Last Commit"></a>
+</p>
+<p align="center">
+  <a href="https://www.linkedin.com/in/ACoAAAIlOaYB5KQSv94bd4jyCl9Q4Mf505n40wk"><img src="https://img.shields.io/badge/LinkedIn-Connect-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn Connect"></a>
+  <a href="https://jakemorgan.co.uk"><img src="https://img.shields.io/badge/Website-jakemorgan.co.uk-FF6B35?style=for-the-badge&logo=aboutdotme&logoColor=white" alt="jakemorgan.co.uk"></a>
+  <a href="https://blackcat.wales"><img src="https://img.shields.io/badge/Blackcat_Data-blackcat.wales-black?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Blackcat Data Solutions"></a>
+</p>
 
 **Every database deserves nine lives.**
 


### PR DESCRIPTION
The only badge was the build status — which says whether CI is green, and nothing about whether the project is alive. That's the thing somebody weighing up an unfamiliar backup tool wants to know in the first two seconds.

**Row one, the repo:** stars, forks, build, latest release, open issues, closed issues, last commit.
**Row two, where to find me:** LinkedIn, jakemorgan.co.uk, blackcat.wales.

Two details worth naming:

- **Closed issues earns its place** next to open ones. 2 open against 169 closed says something about responsiveness that neither number says alone.
- **The build badge now pins `branch=main`**, so a red run on a topic branch can't make the front page of a released project look broken. The old badge didn't.

Every badge URL was fetched and checked before committing — all nine return live values (`BUILD: PASSING`, `RELEASE: V1.6.3`, `ISSUES: 2 OPEN`, `169 CLOSED`, `LAST COMMIT: TODAY`), none render an error state.