### PR TITLE
List a server's databases when the server is chosen

### DIFF
--- a/src/NineLives.Tests/AutoListDatabasesTests.cs
+++ b/src/NineLives.Tests/AutoListDatabasesTests.cs
@@ -1,0 +1,190 @@
+using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Choosing a server is the request to see its databases.
+///
+/// Both screens made you pick a server and then press "List databases" - a second step whose
+/// answer was never in doubt, in front of the dropdown you cannot use until it runs. The listing
+/// now starts on selection, and the button stays as a refresh: a database created since, or a list
+/// the instance could not give the first time.
+///
+/// The cost of firing automatically is that being overtaken stops being exotic. Changing your mind
+/// about the server used to need a deliberate double press; now it is one dropdown click, and the
+/// superseded listing must neither write its answer over the newer one nor run the shared cleanup
+/// - OperationCancellation.End() disposes whatever source is current, which would be the live run's.
+/// </summary>
+public class AutoListDatabasesTests
+{
+    private static FakeCredentialStore StoreWithTwoServers()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+        return store;
+    }
+
+    // ── the step that went away ─────────────────────────────────────────────────
+
+    [Fact]
+    public void TheBackupScreenListsOnSelection()
+    {
+        var sql = new FakeSqlServerService { DatabaseList = ["Sales", "Archive"] };
+        var vm = new BackupViewModel(StoreWithTwoServers(), sql, TestLogs.Temp());
+
+        vm.Server = vm.Servers.First(s => s.Name == "SRV01");
+
+        Assert.Equal(["Sales", "Archive"], vm.Databases);
+        Assert.Null(vm.SelectedDatabase);   // listing is not choosing
+    }
+
+    [Fact]
+    public void TheCopyScreenListsOnSourceSelection()
+    {
+        var sql = new FakeSqlServerService { DatabaseList = ["Sales", "Archive"] };
+        var vm = new CopyDatabaseViewModel(StoreWithTwoServers(), sql, TestLogs.Temp());
+
+        vm.SourceServer = vm.Servers.First(s => s.Name == "SRV01");
+
+        Assert.Equal(["Sales", "Archive"], vm.SourceDatabases);
+        Assert.Null(vm.SourceDatabase);
+    }
+
+    /// <summary>Clearing the dropdown asks for nothing; it must not fire a listing at no server.</summary>
+    [Fact]
+    public void ClearingTheServerListsNothing()
+    {
+        var sql = new FakeSqlServerService { DatabaseList = ["Sales"] };
+        var vm = new BackupViewModel(StoreWithTwoServers(), sql, TestLogs.Temp());
+        vm.Server = vm.Servers.First();
+        Assert.NotEmpty(vm.Databases);
+
+        vm.Server = null;
+
+        Assert.Empty(vm.Databases);
+        Assert.False(vm.HasError);   // not "Choose the server to back up from"
+    }
+
+    // ── being overtaken ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The hazard the automatic trigger creates: pick a slow server, change your mind, and the
+    /// first listing lands after the second. The answer on screen must be the server on screen.
+    /// </summary>
+    [Fact]
+    public async Task ASupersededListingDoesNotWriteItsAnswer()
+    {
+        var sql = new FakeSqlServerService { DatabaseListIgnoresCancellation = true };
+        sql.DatabaseListByServer["SRV01"] = ["OldServerDb"];
+        sql.DatabaseListByServer["SRV02"] = ["NewServerDb"];
+
+        var vm = new BackupViewModel(StoreWithTwoServers(), sql, TestLogs.Temp());
+
+        // SRV01's listing is held open, then overtaken by SRV02.
+        var gate = new TaskCompletionSource<bool>();
+        sql.DatabaseListGate = gate;
+        vm.Server = vm.Servers.First(s => s.Name == "SRV01");
+
+        sql.DatabaseListGate = null;                 // SRV02 answers immediately
+        vm.Server = vm.Servers.First(s => s.Name == "SRV02");
+
+        gate.SetResult(true);                        // SRV01 answers anyway, too late
+        await Task.Delay(50);
+
+        Assert.Equal(["NewServerDb"], vm.Databases);
+        Assert.DoesNotContain("OldServerDb", vm.Databases);
+    }
+
+    /// <summary>
+    /// The subtler half. The superseded run's finally must not call End(), which disposes whatever
+    /// source is current - by then the live listing's. Left alone it would tear down a running
+    /// operation's cancellation and drop IsBusy while it was still going.
+    /// </summary>
+    [Fact]
+    public async Task ASupersededListingDoesNotTidyUpAfterTheLiveOne()
+    {
+        var sql = new FakeSqlServerService { DatabaseListIgnoresCancellation = true };
+        sql.DatabaseListByServer["SRV01"] = ["OldServerDb"];
+        sql.DatabaseListByServer["SRV02"] = ["NewServerDb"];
+
+        var vm = new BackupViewModel(StoreWithTwoServers(), sql, TestLogs.Temp());
+
+        var first = new TaskCompletionSource<bool>();
+        sql.DatabaseListGate = first;
+        vm.Server = vm.Servers.First(s => s.Name == "SRV01");
+
+        // SRV02's listing is still running when SRV01's lands.
+        var second = new TaskCompletionSource<bool>();
+        sql.DatabaseListGate = second;
+        vm.Server = vm.Servers.First(s => s.Name == "SRV02");
+
+        first.SetResult(true);
+        await Task.Delay(50);
+
+        // SRV02 is still in flight, and says so. Without the generation guard SRV01's finally has
+        // just dropped this and disposed SRV02's token source out from under it.
+        Assert.True(vm.IsBusy);
+
+        second.SetResult(true);
+        await Task.Delay(50);
+
+        Assert.False(vm.IsBusy);
+        Assert.Equal(["NewServerDb"], vm.Databases);
+    }
+
+    /// <summary>A listing that fails after being overtaken is not the new server's problem.</summary>
+    [Fact]
+    public async Task ASupersededFailureIsNotReportedOverTheNewServer()
+    {
+        var sql = new FakeSqlServerService { DatabaseListIgnoresCancellation = true };
+        sql.DatabaseListByServer["SRV02"] = ["NewServerDb"];
+
+        var vm = new BackupViewModel(StoreWithTwoServers(), sql, TestLogs.Temp());
+
+        var gate = new TaskCompletionSource<bool>();
+        sql.DatabaseListGate = gate;
+        vm.Server = vm.Servers.First(s => s.Name == "SRV01");
+
+        sql.DatabaseListGate = null;
+        vm.Server = vm.Servers.First(s => s.Name == "SRV02");
+
+        gate.SetException(new InvalidOperationException("SRV01 is unreachable"));
+        await Task.Delay(50);
+
+        Assert.False(vm.HasError);
+        Assert.Equal(["NewServerDb"], vm.Databases);
+    }
+
+    // ── the run still owns the screen ───────────────────────────────────────────
+
+    /// <summary>
+    /// The list is deliberately unfetchable mid-run (#281) - it can wait, the backup cannot re-run.
+    /// The automatic trigger must respect that rather than route around it.
+    /// </summary>
+    [Fact]
+    public void NothingIsListedWhileABackupIsRunning()
+    {
+        var sql = new FakeSqlServerService { DatabaseList = ["Sales"] };
+        var vm = new BackupViewModel(StoreWithTwoServers(), sql, TestLogs.Temp())
+        {
+            IsRunning = true
+        };
+
+        vm.Server = vm.Servers.First(s => s.Name == "SRV01");
+
+        Assert.False(vm.CanLoadDatabases);
+        Assert.Empty(vm.Databases);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -289,8 +289,44 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// </summary>
     public List<string> DatabaseList { get; set; } = [];
 
-    public Task<List<string>> GetDatabaseListAsync(ServerConnection server, CancellationToken ct = default)
-        => Task.FromResult(DatabaseList);
+    /// <summary>
+    /// Holds a listing open so a test can overtake it. Choosing a server now starts a listing by
+    /// itself, so one being superseded by the next selection is ordinary rather than exotic - and
+    /// the loser must neither write its answer nor tidy up after the winner.
+    /// </summary>
+    public TaskCompletionSource<bool>? DatabaseListGate { get; set; }
+
+    /// <summary>
+    /// Answer even though the token was signalled - the realistic case, and the one that matters.
+    ///
+    /// Cancelling a SQL command is not instantaneous: the attention has to reach the server and the
+    /// reply has to come back. A listing can finish normally in that window, so a superseded run
+    /// does not always unwind promptly at the moment it is replaced - it can land later, with its
+    /// finally running while the newer listing is mid-flight. Without this the fake cancels the
+    /// instant it is asked, which unwinds the loser before the winner has set anything up and hides
+    /// the whole class of bug.
+    /// </summary>
+    public bool DatabaseListIgnoresCancellation { get; set; }
+
+    /// <summary>Each server's answer, when a test needs the two listings to be distinguishable.</summary>
+    public Dictionary<string, List<string>> DatabaseListByServer { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public async Task<List<string>> GetDatabaseListAsync(
+        ServerConnection server, CancellationToken ct = default)
+    {
+        if (DatabaseListGate != null)
+        {
+            if (DatabaseListIgnoresCancellation) await DatabaseListGate.Task;
+            else await DatabaseListGate.Task.WaitAsync(ct);
+        }
+
+        if (!DatabaseListIgnoresCancellation) ct.ThrowIfCancellationRequested();
+
+        return DatabaseListByServer.TryGetValue(server.ServerName, out var forServer)
+            ? [.. forServer]
+            : [.. DatabaseList];
+    }
 
     /// <summary>What the fake instance says it has free, by mount point.</summary>
     public Dictionary<string, long> VolumeFreeSpace { get; set; } = [];

--- a/src/NineLives.Tests/StaleGeneratedStateTests.cs
+++ b/src/NineLives.Tests/StaleGeneratedStateTests.cs
@@ -52,22 +52,60 @@ public class StaleGeneratedStateTests
         Assert.False(vm.CanExecute);
     }
 
-    /// <summary>The multi-select ticks belonged to the previous instance too.</summary>
+    /// <summary>
+    /// The multi-select ticks belonged to the previous instance too (#278).
+    ///
+    /// Choosing a server now lists its databases automatically, so the list is no longer empty
+    /// after a switch - it holds the NEW server's databases. That is the point of the change, and
+    /// it does not weaken what #278 was protecting: what must not survive is the user's CHOICES,
+    /// because stale ticks satisfied CanGenerate and produced statements naming the old server's
+    /// databases against the new one's destinations. Every pick is rebuilt unticked, and nothing
+    /// is runnable until somebody chooses again.
+    /// </summary>
     [Fact]
     public async Task SwitchingServersClearsTheMultiSelectTicksAndCertificates()
     {
-        var (vm, _) = BackupStage();
+        var (vm, sql) = BackupStage();
+        sql.BackupCertificates = ["OldServerCert"];
         await vm.LoadDatabasesCommand.ExecuteAsync(null);
         vm.MultiSelect = true;
         vm.PickAllCommand.Execute(null);
+        vm.SelectedEncryptionCertificate = "OldServerCert";
         Assert.True(vm.CanGenerate);
+
+        // The new server has a different estate, so anything left from the old one is visible.
+        sql.DatabaseList = ["SomethingElse"];
+        sql.BackupCertificates = [];
 
         vm.Server = vm.Servers.First(s => s.Name == "SRV02");
 
-        Assert.Empty(vm.DatabasePicks);
-        Assert.Empty(vm.EncryptionCertificates);
+        // The choices did not survive - the part that made #278 dangerous.
+        Assert.DoesNotContain(vm.DatabasePicks, p => p.IsPicked);
+        Assert.Null(vm.SelectedDatabase);
         Assert.Null(vm.SelectedEncryptionCertificate);
         Assert.False(vm.CanGenerate);
+
+        // And nothing of the old server's estate is still on offer.
+        Assert.Equal(["SomethingElse"], vm.DatabasePicks.Select(p => p.Name));
+        Assert.Empty(vm.EncryptionCertificates);
+    }
+
+    /// <summary>
+    /// The step that used to be required: choosing a server is the request to see its databases,
+    /// so the list arrives without anyone pressing anything.
+    /// </summary>
+    [Fact]
+    public void ChoosingAServerListsItsDatabasesWithoutPressingAnything()
+    {
+        var (vm, _) = BackupStage();
+
+        // BackupStage sets Server, which is the whole trigger.
+        Assert.Equal(["MyDb", "OtherDb"], vm.Databases);
+        Assert.Equal(["MyDb", "OtherDb"], vm.DatabasePicks.Select(p => p.Name));
+
+        // Still nothing chosen for the user - listing is not selecting.
+        Assert.Null(vm.SelectedDatabase);
+        Assert.DoesNotContain(vm.DatabasePicks, p => p.IsPicked);
     }
 
     [Fact]

--- a/src/NineLives.Tests/ViewRenderHarness.cs
+++ b/src/NineLives.Tests/ViewRenderHarness.cs
@@ -1,0 +1,148 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Renders a screen to a PNG so somebody can look at it.
+///
+/// WPF fails a binding silently: a wrong path, a missing StaticResource on a template applied at
+/// runtime, a panel that collapses to nothing - the compiler is happy, every unit test passes, and
+/// the screen is simply wrong. This is the cheapest thing that catches that class, and it costs one
+/// command rather than a publish, a launch and a manual look.
+///
+/// Opt-in: set NINELIVES_RENDER to the output directory. It is not a CI gate - there is no
+/// assertion about what the pixels should be, and there should not be one. It exists to produce
+/// something a human can look at.
+///
+///     NINELIVES_RENDER=C:\temp\shots dotnet test --filter FullyQualifiedName~ViewRenderHarness
+/// </summary>
+public sealed class RequiresRenderFactAttribute : FactAttribute
+{
+    public RequiresRenderFactAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(ViewRenderHarness.OutputDirectory))
+            Skip = "Set NINELIVES_RENDER to an output directory to render the screens.";
+    }
+}
+
+public class ViewRenderHarness
+{
+    internal static string? OutputDirectory =>
+        Environment.GetEnvironmentVariable("NINELIVES_RENDER");
+
+    /// <summary>
+    /// Every screen in one test, on one thread, on purpose: WPF allows a single Application per
+    /// process and its resource dictionaries have thread affinity, so a test-per-screen renders the
+    /// first and then fails on the rest.
+    /// </summary>
+    [RequiresRenderFact]
+    public void RenderScreens() => Render(new Dictionary<string, Func<(UserControl, object)>>
+    {
+        ["backup-screen"] = () =>
+        {
+            var sql = new FakeSqlServerService { DatabaseList = ["Sales", "Archive", "Reporting"] };
+            var vm = new BackupViewModel(StoreWithAServer(), sql, TestLogs.Temp());
+            vm.Server = vm.Servers.First();
+            vm.Container = vm.Containers.First();
+            vm.SelectedDatabase = "Sales";
+            vm.GenerateCommand.Execute(null);
+            return (new BackupView(), vm);
+        },
+
+        ["copy-screen"] = () =>
+        {
+            var sql = new FakeSqlServerService { DatabaseList = ["Sales", "Archive"] };
+            var vm = new CopyDatabaseViewModel(StoreWithAServer(), sql, TestLogs.Temp());
+            vm.SourceServer = vm.Servers.First();
+            vm.TargetServer = vm.Servers.Last();
+            vm.Container = vm.Containers.First();
+            vm.SourceDatabase = "Sales";
+            vm.TargetDatabaseName = "Sales_Copy";
+            vm.GenerateCommand.Execute(null);
+            return (new CopyDatabaseView(), vm);
+        },
+    });
+
+    // Deliberately invented names. Nothing real belongs in a file that might be attached to an
+    // issue or a pull request.
+    private static FakeCredentialStore StoreWithAServer()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = ServerConnection.NewId(), Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+        return store;
+    }
+
+    private static void Render(Dictionary<string, Func<(UserControl View, object Model)>> screens)
+    {
+        var directory = OutputDirectory!;
+        Exception? failure = null;
+
+        // WPF needs an STA thread, and one Application for the merged theme dictionaries that
+        // every StaticResource in these views resolves against.
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                var app = Application.Current ?? new Application();
+                foreach (var source in new[] { "Palette.Dark", "Controls", "Logo" })
+                {
+                    app.Resources.MergedDictionaries.Add(new ResourceDictionary
+                    {
+                        Source = new Uri(
+                            $"pack://application:,,,/NineLives;component/Themes/{source}.xaml",
+                            UriKind.Absolute)
+                    });
+                }
+
+                Directory.CreateDirectory(directory);
+
+                foreach (var (name, build) in screens)
+                {
+                    var (view, model) = build();
+                    view.DataContext = model;
+
+                    var size = new Size(1500, 1400);
+                    view.Measure(size);
+                    view.Arrange(new Rect(size));
+                    view.UpdateLayout();
+
+                    var bitmap = new RenderTargetBitmap(
+                        (int)size.Width, (int)size.Height, 96, 96, PixelFormats.Pbgra32);
+                    bitmap.Render(view);
+
+                    var encoder = new PngBitmapEncoder();
+                    encoder.Frames.Add(BitmapFrame.Create(bitmap));
+                    using var stream = File.Create(Path.Combine(directory, $"{name}.png"));
+                    encoder.Save(stream);
+                }
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        if (failure != null) throw failure;
+    }
+}

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -150,6 +150,15 @@ public partial class BackupViewModel : ViewModelBase
     /// <summary>The list is not fetchable mid-run: it can wait; the backup cannot re-run (#281).</summary>
     public bool CanLoadDatabases => !IsRunning;
 
+    /// <summary>
+    /// Which listing owns the screen. Choosing a server now starts one automatically, so being
+    /// overtaken went from something you had to double-click to cause, to the ordinary result of
+    /// changing your mind about the server - and the loser must not write its answer, nor tidy up
+    /// after the winner. OperationCancellation.End() disposes unconditionally, so a superseded
+    /// run reaching its finally would dispose the live run's token source.
+    /// </summary>
+    private int _listGeneration;
+
     /// <summary>Asks the chosen instance what it has, rather than making somebody type a name.</summary>
     [RelayCommand(CanExecute = nameof(CanLoadDatabases))]
     private async Task LoadDatabasesAsync()
@@ -164,6 +173,7 @@ public partial class BackupViewModel : ViewModelBase
         // this dropdown is a click away from the one that produced it.
         var server = Server;
 
+        var generation = ++_listGeneration;
         var ct = _listCancellation.Begin();
         IsBusy = true;
         ClearStatus();
@@ -171,6 +181,10 @@ public partial class BackupViewModel : ViewModelBase
         try
         {
             var names = await _sql.GetDatabaseListAsync(server, ct);
+
+            // Overtaken while this was in flight: the newer selection owns the screen, and this
+            // answer is about a server the user has already moved on from.
+            if (generation != _listGeneration) return;
 
             Databases = new ObservableCollection<string>(names);
             DatabasePicks = new ObservableCollection<DatabasePick>(
@@ -197,16 +211,29 @@ public partial class BackupViewModel : ViewModelBase
         }
         catch (OperationCanceledException)
         {
-            SetStatus("Stopped.");
+            // A cancel here is almost always this run being replaced by a newer selection, and the
+            // newer one is about to say what it found. Only the current generation speaks.
+            if (generation == _listGeneration) SetStatus("Stopped.");
         }
-        catch (Exception ex)
+        catch (Exception ex) when (generation == _listGeneration)
         {
             SetError($"Could not list the databases: {ex.Message}");
         }
+        catch
+        {
+            // Superseded, and its server is no longer on screen - reporting it would put an error
+            // about the old server over the new server's list.
+        }
         finally
         {
-            _listCancellation.End();
-            IsBusy = false;
+            // Only the newest listing tidies up. End() disposes whatever source is current, so a
+            // superseded run doing this would dispose the live one's - the same shape as the
+            // cross-operation version of this bug in #281.
+            if (generation == _listGeneration)
+            {
+                _listCancellation.End();
+                IsBusy = false;
+            }
         }
     }
 
@@ -223,6 +250,16 @@ public partial class BackupViewModel : ViewModelBase
         EncryptionCertificates = [];
         SelectedEncryptionCertificate = null;
         Invalidate();
+
+        // Choosing the server IS the request to see its databases. Pressing a button afterwards to
+        // ask the obvious follow-up question was a step that only ever had one right answer.
+        //
+        // Unlike the automatic fetch in #413, this cancels nothing anyone would miss: the only
+        // thing sharing _listCancellation is a previous listing of this same dropdown, which the
+        // new selection has just made irrelevant. It stays out of the way mid-run, where the list
+        // is deliberately unfetchable (#281) and the backup must not be disturbed.
+        if (value != null && CanLoadDatabases)
+            _ = LoadDatabasesAsync();
     }
 
     partial void OnSelectedDatabaseChanged(string? value) => Invalidate();

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -153,6 +153,9 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// <summary>The list is not fetchable mid-run: it can wait; the copy cannot re-run (#281).</summary>
     public bool CanLoadSourceDatabases => !IsRunning;
 
+    /// <summary>Which listing owns the screen - see the note on the same field in BackupViewModel.</summary>
+    private int _listGeneration;
+
     [RelayCommand(CanExecute = nameof(CanLoadSourceDatabases))]
     private async Task LoadSourceDatabasesAsync()
     {
@@ -162,33 +165,50 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             return;
         }
 
+        // Captured before the await, the fix the Backup screen already had (#409). Read afterwards,
+        // the status line named whatever was selected by then rather than the server that answered
+        // - and threw outright if the selection had been cleared meanwhile.
+        var server = SourceServer;
+
+        var generation = ++_listGeneration;
         var ct = _listCancellation.Begin();
         IsBusy = true;
         ClearStatus();
 
         try
         {
-            var names = await _sql.GetDatabaseListAsync(SourceServer, ct);
+            var names = await _sql.GetDatabaseListAsync(server, ct);
+
+            // Overtaken while this was in flight; the newer selection owns the screen.
+            if (generation != _listGeneration) return;
+
             SourceDatabases = new ObservableCollection<string>(names);
 
             // Nothing is chosen for the user. Here the wrong choice reads a production database at
             // full speed AND overwrites a database on another server.
             SourceDatabase = null;
 
-            SetStatus($"{SourceServer.ServerName} has {names.Count} database(s).");
+            SetStatus($"{server.ServerName} has {names.Count} database(s).");
         }
         catch (OperationCanceledException)
         {
-            SetStatus("Stopped.");
+            if (generation == _listGeneration) SetStatus("Stopped.");
         }
-        catch (Exception ex)
+        catch (Exception ex) when (generation == _listGeneration)
         {
             SetError($"Could not list the databases: {ex.Message}");
         }
+        catch
+        {
+            // Superseded - an error about the old server does not belong over the new one's list.
+        }
         finally
         {
-            _listCancellation.End();
-            IsBusy = false;
+            if (generation == _listGeneration)
+            {
+                _listCancellation.End();
+                IsBusy = false;
+            }
         }
     }
 
@@ -197,6 +217,11 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         SourceDatabases = [];
         SourceDatabase = null;
         Invalidate();
+
+        // Choosing the source server is the request to see what it holds - same reasoning as the
+        // Backup screen, and the same restraint mid-run.
+        if (value != null && CanLoadSourceDatabases)
+            _ = LoadSourceDatabasesAsync();
     }
 
     partial void OnTargetServerChanged(ServerConnection? value) => Invalidate();

--- a/src/NineLives/Views/BackupView.xaml
+++ b/src/NineLives/Views/BackupView.xaml
@@ -68,12 +68,16 @@
                                        Visibility="{Binding HasNoServers, Converter={StaticResource BoolToVis}}" />
                         </StackPanel>
 
+                        <!-- Choosing a server now lists its databases by itself, so this is a
+                             refresh rather than the step it used to be: for a database created
+                             since, or a list the instance could not give the first time. -->
                         <Button Grid.Column="1"
-                                Content="List databases"
+                                Content="Refresh list"
                                 Command="{Binding LoadDatabasesCommand}"
                                 Style="{StaticResource SecondaryButton}"
                                 Padding="16,8"
-                                VerticalAlignment="Bottom" />
+                                VerticalAlignment="Bottom"
+                                ToolTip="Ask the server for its databases again - for one created since, or if the list could not be fetched." />
                     </Grid>
 
                     <StackPanel Margin="0,12,0,0">
@@ -305,22 +309,12 @@
                                    Visibility="{Binding IsVerifying, Converter={StaticResource BoolToVis}}" />
                     </WrapPanel>
 
-                    <!-- Where the files will land, readable before anything is written. -->
-                    <StackPanel Margin="0,8,0,0"
-                                Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="WRITING TO" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
-                        <ItemsControl ItemsSource="{Binding Destinations}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding}"
-                                               TextWrapping="Wrap"
-                                               FontFamily="{StaticResource ConsoleFont}"
-                                               FontSize="12"
-                                               Margin="0,0,0,2" />
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </StackPanel>
+                    <!-- The destination list used to be repeated here above the script, under
+                         "WRITING TO". The script itself names every file it writes, in the
+                         statement that writes it, so this said the same thing twice - and it
+                         appeared at exactly the moment the script did, which is when the reader is
+                         already looking at the authoritative copy. Destinations remains on the
+                         viewmodel: it drives the script, the too-long check, and the run. -->
 
                     <Border Background="{DynamicResource ConsoleBackgroundBrush}"
                             BorderBrush="{DynamicResource ConsoleBorderBrush}"

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -98,12 +98,14 @@
                                        Visibility="{Binding HasNoServers, Converter={StaticResource BoolToVis}}" />
                         </StackPanel>
 
+                        <!-- A refresh now, not a required step - the source server lists itself. -->
                         <Button Grid.Column="1"
-                                Content="List databases"
+                                Content="Refresh list"
                                 Command="{Binding LoadSourceDatabasesCommand}"
                                 Style="{StaticResource SecondaryButton}"
                                 Padding="16,8"
-                                VerticalAlignment="Bottom" />
+                                VerticalAlignment="Bottom"
+                                ToolTip="Ask the source server for its databases again - for one created since, or if the list could not be fetched." />
                     </Grid>
 
                     <StackPanel Margin="0,12,0,0">


### PR DESCRIPTION
Three things from using the app.

## Choosing a server lists its databases

Backup and Copy both made you pick a server and then press **List databases** - a second step whose answer was never in doubt, in front of the dropdown you cannot use until it runs. Choosing the server *is* the request to see what it holds.

The button stays, as a refresh: for a database created since, or a list the instance could not give the first time. Removing it entirely would strand both of those with no way back.

Unlike the automatic fetch in #413, this cancels nothing anyone would miss - the only thing sharing `_listCancellation` is a previous listing of the same dropdown, which the new selection has just made irrelevant. It stays out of the way mid-run, where the list is deliberately unfetchable (#281).

## What firing automatically costs, and what it needed

Being overtaken stops being exotic: it used to take a deliberate double press, now it is one dropdown click. So both screens track which listing owns the screen.

- A superseded listing does not write its answer, and does not report its failure over the new server's list.
- It does not run the shared cleanup either. `OperationCancellation.End()` disposes whatever source is current - by then the *live* listing's. Same shape as the cross-operation version of this in #281.
- Copy also captures its server before the await, the fix Backup already had from #409. Read afterwards, the status line named whatever was selected by then, and threw outright if the selection had been cleared meanwhile.

That third one was a live bug on the Copy screen before this change; the automatic trigger would have made it routine.

## "WRITING TO" is gone from the backup screen

It repeated what the generated script says, in the statement that writes it, and appeared at the same moment the script did - when the reader is already looking at the authoritative copy. `Destinations` stays on the viewmodel: it drives the script, the too-long check and the run.

## Tests

New `AutoListDatabasesTests` covers listing on selection for both screens, the three supersession cases, and that nothing lists mid-run.

The supersession pins needed the fake to answer *despite* a signalled token - the realistic case, since cancelling a SQL command is not instantaneous and a listing can finish before the attention lands. With the fake cancelling instantly, the loser unwound before the winner set anything up and the bug was invisible. Verified by reverting the guard: `ASupersededListingDoesNotTidyUpAfterTheLiveOne` fails without it.

`StaleGeneratedStateTests` was updated rather than deleted - the list is no longer empty after a switch, it holds the new server's databases. What #278 was protecting is the user's *choices*, and those are still asserted gone, plus the old server's estate is asserted absent.

## Render harness

New, opt-in via `NINELIVES_RENDER`. WPF fails bindings silently, so this removal-and-reword got looked at rather than assumed. Not a CI gate - it asserts nothing about pixels.

Full suite 2105 passed / 0 failed. Release `-warnaserror` clean.