### PR TITLE
Drop the "THROUGH" list from the copy screen

### DIFF
--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -324,20 +324,14 @@
                                    Style="{StaticResource BodyText}" />
                     </Border>
 
-                    <StackPanel Margin="0,12,0,0"
-                                Visibility="{Binding HasScripts, Converter={StaticResource BoolToVis}}">
-                        <TextBlock Text="THROUGH" Style="{StaticResource LabelText}" Margin="0,0,0,4" />
-                        <ItemsControl ItemsSource="{Binding Destinations}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding}"
-                                               TextWrapping="Wrap"
-                                               FontFamily="{StaticResource ConsoleFont}"
-                                               FontSize="12" />
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </StackPanel>
+                    <!-- The staging location used to be repeated here under "THROUGH", the same
+                         way the backup screen repeated it under "WRITING TO". Both scripts below
+                         name it in the statements that write and read it, and this appeared at
+                         exactly the moment they did - when the reader is already looking at the
+                         authoritative copy. Destinations remains on the viewmodel: it drives both
+                         scripts, the readability check and the run, and the outcome text still
+                         names the file when a copy half-works and the backup is worth restoring
+                         from. -->
 
                     <Border Background="{DynamicResource ConsoleBackgroundBrush}"
                             BorderBrush="{DynamicResource ConsoleBorderBrush}"


### PR DESCRIPTION
The same repetition removed from the backup screen in #433, on the other screen that had it.

Both generated scripts name the staging file in the statements that write and read it, and the list appeared at exactly the moment the scripts did — when the reader is already looking at the authoritative copy. It was also the harder of the two to read: dark console-font text under a label.

`Destinations` stays on the viewmodel. It drives both scripts, the readability check and the run — and the outcome text still names the file in the case where naming it matters most: a copy whose backup succeeded and whose restore did not, where the entire point of that distinction is that the backup is real, usable, and sitting *there*.

Rendered to confirm the panel is gone with no leftover gap, and that the destination URL is still on screen in the backup statement.

Full suite 2119 passed / 0 failed. Release `-warnaserror` clean.