### PR TITLE
Record runs off the UI thread (#437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Fixed
+
+- **Recording a run no longer blocks the window** (#437). Writing a receipt is synchronous file
+  I/O - a cross-process lock whose backoff sleeps up to ten seconds when a scheduled CLI run
+  holds it, a whole-file read, a redaction pass over every script and log, then a serialize and
+  a replace - and the screens did it on the UI thread, once per database. A fifty-database
+  backup did fifty of them, so the window could stop repainting for minutes. The same write sat
+  in the cancellation handler, which meant pressing Stop froze the app instead of stopping the
+  run. Receipts are now written off the dispatcher, and still awaited one at a time: a run that
+  dies on the sixth database leaves the first five receipts on disk, because that half-finished
+  run is exactly the incident somebody opens the history for.
+
 ## [1.6.3] - 2026-08-13
 
 ### Fixed

--- a/src/NineLives.Core/Services/OperationHistoryStore.cs
+++ b/src/NineLives.Core/Services/OperationHistoryStore.cs
@@ -22,6 +22,27 @@ public interface IOperationHistoryStore
     /// <summary>Adds one execution. Never throws: recording history must not be able to fail a restore.</summary>
     void Append(OperationHistoryEntry entry);
 
+    /// <summary>
+    /// The same append, off the calling thread - what a UI caller must use (#437).
+    ///
+    /// <see cref="Append"/> is fully synchronous blocking I/O: a cross-process lock whose backoff
+    /// can sleep for ten seconds when a scheduled CLI run holds it, a whole-file read and
+    /// deserialize, a redaction pass over every script and log, then a serialize and a file
+    /// replace. On the dispatcher that stops the window repainting, and a backup records once per
+    /// database - fifty databases, fifty rewrites. The same call sits in the cancellation handler
+    /// too, so pressing Stop froze the app instead of stopping it.
+    ///
+    /// Awaited rather than fired and forgotten, deliberately. Ordering and per-database durability
+    /// are the whole point of one receipt per database: a run that dies on the sixth still leaves
+    /// the first five on disk, and that half-finished run is exactly the incident somebody opens
+    /// the history for.
+    ///
+    /// Defaulted here so a fake inherits it, and so a new UI call site cannot get it wrong by
+    /// forgetting - the fault it would reintroduce is invisible until somebody backs up fifty
+    /// databases at once.
+    /// </summary>
+    Task AppendAsync(OperationHistoryEntry entry) => Task.Run(() => Append(entry));
+
     void Clear();
 
     string FilePath { get; }

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -207,10 +207,22 @@ public sealed class FakeOperationHistoryStore : IOperationHistoryStore
     /// <summary>Set to play a store that cannot write - recording must never fail an operation.</summary>
     public Exception? AppendThrows { get; set; }
 
+    /// <summary>
+    /// The thread each Append ran on, in order (#437). A UI caller must not be one of them:
+    /// the real store's Append is blocking file I/O with a ten-second lock backoff.
+    /// </summary>
+    public List<int> AppendThreads { get; } = [];
+
     public void Append(OperationHistoryEntry entry)
     {
+        AppendThreads.Add(Environment.CurrentManagedThreadId);
+
         if (AppendThrows != null) throw AppendThrows;
-        Entries.Insert(0, entry);
+
+        // The real store serialises on its own lock, and callers may now arrive from the thread
+        // pool, so this has to be safe to call concurrently or the fake invents failures the
+        // product does not have.
+        lock (Entries) Entries.Insert(0, entry);
     }
 
     public void Clear() => Entries.Clear();

--- a/src/NineLives.Tests/HistoryWritesOffTheUiThreadTests.cs
+++ b/src/NineLives.Tests/HistoryWritesOffTheUiThreadTests.cs
@@ -1,0 +1,125 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Receipts are written off the thread that asked for them (#437).
+///
+/// <see cref="IOperationHistoryStore.Append"/> is blocking file I/O: a cross-process lock whose
+/// backoff sleeps up to ten seconds when a scheduled CLI run holds it, a whole-file read, a
+/// redaction pass, a serialize and a replace. The screens called it on the dispatcher, once per
+/// database - so a fifty-database backup did fifty of those on the UI thread, and the same call
+/// in the cancellation handler meant pressing Stop froze the window instead of stopping the run.
+///
+/// The property under test is *which thread ran the write*, so these assert on that directly
+/// rather than on a duration, which would be a timing test and therefore a flaky one.
+/// </summary>
+public class HistoryWritesOffTheUiThreadTests
+{
+    [Fact]
+    public async Task TheDefaultAppendAsyncLeavesTheCallingThread()
+    {
+        var store = new FakeOperationHistoryStore();
+        var caller = Environment.CurrentManagedThreadId;
+
+        // Through the interface deliberately: AppendAsync is a default interface method, so the
+        // implementation under test is the one every store inherits rather than any fake's own.
+        await ((IOperationHistoryStore)store).AppendAsync(
+            new OperationHistoryEntry { TargetDatabase = "Sales" });
+
+        Assert.Single(store.AppendThreads);
+        Assert.NotEqual(caller, store.AppendThreads[0]);
+    }
+
+    /// <summary>
+    /// Awaited, not fired and forgotten. One receipt per database only means anything if the
+    /// receipts are actually on disk when the run ends - a run that dies on the sixth database
+    /// has to leave the first five behind, because that half-finished run is the incident
+    /// somebody opens the history for.
+    /// </summary>
+    [Fact]
+    public async Task TheWriteHasCompletedByTheTimeTheCallReturns()
+    {
+        var store = new FakeOperationHistoryStore();
+
+        await ((IOperationHistoryStore)store).AppendAsync(
+            new OperationHistoryEntry { TargetDatabase = "Sales" });
+
+        Assert.Single(store.Entries);
+    }
+
+    /// <summary>
+    /// The store swallows its own failures, and the async path must not turn one into an
+    /// unobserved task exception - which would surface later, on a different thread, as a
+    /// crash nobody could trace back to a receipt.
+    /// </summary>
+    [Fact]
+    public async Task AStoreThatCannotWriteStillDoesNotThrowAtTheCaller()
+    {
+        var store = new FakeOperationHistoryStore
+        {
+            AppendThrows = new InvalidOperationException("history file is read-only")
+        };
+
+        // The real store catches internally; the fake throws to prove the caller's own guard
+        // holds, which is what every recording call site wraps this in.
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ((IOperationHistoryStore)store).AppendAsync(
+                new OperationHistoryEntry { TargetDatabase = "Sales" }));
+    }
+
+    /// <summary>
+    /// The one that would have caught this: a real backup run, checked for where it recorded.
+    ///
+    /// Deliberately NOT run on the fixture's dispatcher. Doing that deadlocks the test - Invoke
+    /// blocks the dispatcher thread, the run awaits a thread-pool write, and the continuation is
+    /// posted back to the thread that is sitting waiting for it. That is an artefact of blocking
+    /// inside Invoke rather than anything wrong with the product, where the message loop is free
+    /// to process the continuation.
+    ///
+    /// The property survives the simplification: the write must leave whichever thread ran the
+    /// backup. If a call site went back to the synchronous Append, this fails wherever it runs.
+    /// </summary>
+    [Fact]
+    public async Task ABackupRunRecordsOffTheThreadItRanOn()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var history = new FakeOperationHistoryStore();
+
+        var vm = new BackupViewModel(
+            store, new FakeSqlServerService { DatabaseList = ["Sales"] },
+            TestLogs.Temp(), notifier: null, history: history);
+
+        vm.Server = vm.Servers[0];
+        vm.Container = vm.Containers[0];
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.SelectedDatabase = "Sales";
+        vm.GenerateCommand.Execute(null);
+
+        var runner = Environment.CurrentManagedThreadId;
+
+        // Armed, then run - the button is a two-press control.
+        await vm.ExecuteCommand.ExecuteAsync(null);
+        await vm.ExecuteCommand.ExecuteAsync(null);
+
+        // The run has to have got as far as recording, or this proves nothing.
+        Assert.NotEmpty(history.AppendThreads);
+        Assert.DoesNotContain(runner, history.AppendThreads);
+    }
+}

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -161,13 +161,13 @@ public partial class BackupViewModel : ViewModelBase
     /// the restore screen: the backup has already happened by the time this is called, and
     /// throwing now would turn a completed backup into a reported failure.
     /// </summary>
-    private void Record(
+    private async Task Record(
         string database, string script, List<string> destinations,
         DateTime startedAt, OperationOutcome outcome, string? error)
     {
         try
         {
-            _history.Append(new OperationHistoryEntry
+            await _history.AppendAsync(new OperationHistoryEntry
             {
                 StartedAt = startedAt,
                 CompletedAt = DateTime.Now,
@@ -743,7 +743,7 @@ public partial class BackupViewModel : ViewModelBase
                     await _sql.ExecuteWithProgressAsync(Server, script, Append, ct);
                     Append($"{database}: done.");
                     succeededDevices.AddRange(destinations);
-                    Record(database, script, destinations, databaseStarted,
+                    await Record(database, script, destinations, databaseStarted,
                         OperationOutcome.Succeeded, null);
                 }
                 catch (OperationCanceledException)
@@ -751,7 +751,10 @@ public partial class BackupViewModel : ViewModelBase
                     // This one was in flight when the stop arrived, so it happened - and a partial
                     // file that cannot be restored from is precisely what somebody needs to find
                     // in the history later.
-                    Record(database, script, destinations, databaseStarted,
+                    // Awaited even though a stop is in flight: this write is why Stop used to
+                    // freeze the window, and it is also the receipt that says the file on disk is
+                    // a partial one. Off the dispatcher it is no longer felt.
+                    await Record(database, script, destinations, databaseStarted,
                         OperationOutcome.Cancelled,
                         "Cancelled by the user. Any file already written is incomplete.");
                     throw;
@@ -764,7 +767,7 @@ public partial class BackupViewModel : ViewModelBase
                     failed.Add(database);
                     lastFailureMessage = ex.Message;
                     _log.Error($"Backup failed: {database}: {ex.Message}");
-                    Record(database, script, destinations, databaseStarted,
+                    await Record(database, script, destinations, databaseStarted,
                         OperationOutcome.Failed, ex.Message);
 
                     // At the moment of the problem, not minutes later in the summary (#242): the

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -805,7 +805,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             IsRunning = false;
             OutcomeText = CopyOutcomeText.Describe(Outcome, run.Destinations.FirstOrDefault());
 
-            Record(run.Backup, run.Restore, run.Destinations, startedAt, ct.IsCancellationRequested);
+            await Record(run.Backup, run.Restore, run.Destinations, startedAt, ct.IsCancellationRequested);
 
             // Told, not interrupted (#289): same taskbar flash as the restore and the backup
             // when the copy finishes while the app is behind another window.
@@ -832,7 +832,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// Never allowed to throw. By the time this runs the copy is over, and a history write that
     /// failed here would surface as the copy failing.
     /// </summary>
-    private void Record(
+    private async Task Record(
         string backupScript, string restoreScript, IReadOnlyList<string> destinations,
         DateTime startedAt, bool wasCancelled)
     {
@@ -840,7 +840,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
         try
         {
-            _history.Append(new OperationHistoryEntry
+            await _history.AppendAsync(new OperationHistoryEntry
             {
                 StartedAt = startedAt,
                 CompletedAt = DateTime.Now,

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -386,7 +386,7 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             // After the flush, so the recorded log is the whole console rather than whatever had
             // made it out of the batching buffer. Recorded for every outcome including cancelled -
             // "I stopped it" is exactly the kind of thing a change ticket needs to say.
-            if (attempted) RecordHistory(run, startedAt, outcome, failure);
+            if (attempted) await RecordHistory(run, startedAt, outcome, failure);
         }
     }
 
@@ -394,8 +394,8 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     /// Files this execution in the history (#31). Never throws: the store swallows its own
     /// failures, and a restore must not be reported as failed because a record could not be kept.
     /// </summary>
-    private void RecordHistory(RestoreRun run, DateTime startedAt, OperationOutcome outcome, string? failure)
-        => _history.Append(new OperationHistoryEntry
+    private Task RecordHistory(RestoreRun run, DateTime startedAt, OperationOutcome outcome, string? failure)
+        => _history.AppendAsync(new OperationHistoryEntry
         {
             StartedAt = startedAt,
             CompletedAt = DateTime.Now,


### PR DESCRIPTION
Closes #437.

## What was happening

`OperationHistoryStore.Append` is synchronous blocking file I/O: a cross-process lock whose backoff sleeps up to ten seconds when a scheduled `9lives backup` holds it, a whole-file read and deserialize, a redaction pass over every script and log, then a serialize, temp write and `File.Replace`.

Three screens called it on the dispatcher. The backup screen calls it **once per database**, so a fifty-database run did fifty whole-file rewrites on the UI thread and the window could stop repainting for minutes.

The worst part is the one at the end of the issue: the same call sits in the `OperationCanceledException` handler. Pressing **Stop** — the one control whose entire purpose is to respond immediately — froze the app instead of stopping the run.

## The decision the issue asked for

It offered batching the run into a single `AppendRange`, or keeping per-database writes and moving them off the dispatcher. **This is the second.**

Batching loses per-database durability exactly when it matters most: if the app dies on database 6 of 50, the receipts for 1–5 never existed, and that crash is precisely the incident the audit trail is for. The receipts are per database because the run is — `Record`'s own doc comment argues that a failure on the sixth database is the sixth database's failure — and a single write at the end would have to summarise that away.

So each write is still awaited, in order. It just isn't on the UI thread.

## Where the rule lives

`AppendAsync` is a **default interface method**, not three offloading call sites. A convention spread across call sites is exactly what #438 is about, and this one would be reintroduced by the next screen that records something. A fake inherits it, so no test double has to be taught the rule.

## A note on the test

The end-to-end test deliberately does **not** run on the fixture's dispatcher. Doing that deadlocks: `Invoke` blocks the dispatcher thread, the run awaits a thread-pool write, and the continuation is posted back to the thread sitting waiting for it. That is an artefact of blocking inside `Invoke`, not a product defect — the real message loop is free to process the continuation. Asserting that the write leaves whichever thread ran the backup pins the same property without the artefact, and would fail just as loudly if a call site went back to synchronous `Append`.

## Effect

`dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test` → **2,123 passed, 0 failed** (up 4).