### PR TITLE
Make the config-store fake hand out copies, like the real one (#439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The test double for the config store now behaves like the real one** (#439). Nothing a user
+  sees changes today, but this is why a real defect reached `dev` with a fully green suite. The
+  real store re-reads and deserializes on every call, so every caller gets fresh objects; the
+  fake handed back its cached instances. That one difference meant a screen which rebuilds its
+  list and reselects by id saw "no change" in tests and a genuine change in production - so
+  every visit to the Backup or Copy screen silently opened a connection to a production instance
+  and wiped the user's selections, and no test could see it. The fake now hands out copies, and
+  five tests that were leaning on the old behaviour say what they mean instead.
+
 - **Recording a run no longer blocks the window** (#437). Writing a receipt is synchronous file
   I/O - a cross-process lock whose backoff sleeps up to ten seconds when a scheduled CLI run
   holds it, a whole-file read, a redaction pass over every script and log, then a serialize and

--- a/src/NineLives.Tests/FakeStoreFidelityTests.cs
+++ b/src/NineLives.Tests/FakeStoreFidelityTests.cs
@@ -1,0 +1,121 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The fake credential store behaves like the real one where it counts (#439).
+///
+/// A fake that diverges from production does not merely fail to catch a bug - it makes that bug
+/// invisible, which is worse than having no test at all. This one did exactly that:
+/// <c>CredentialStore.LoadConfig</c> reads and deserializes on every call, so every caller gets
+/// brand-new objects, while the fake handed back its cached instances.
+///
+/// What that hid: <c>BackupViewModel.Refresh</c> rebuilds its server list from the config and
+/// reselects by id. Against the real store that is always a different instance, so the setter
+/// raises a change and <c>OnServerChanged</c> runs - and once choosing a server started listing
+/// its databases, every navigation to Backup or Copy silently opened a connection to a production
+/// instance and wiped the user's ticks. Against identical instances the setter short-circuited
+/// and nothing fired. The suite was green throughout.
+///
+/// These pin the fidelity itself, so the next person to simplify this fake finds out here rather
+/// than in production.
+/// </summary>
+public class FakeStoreFidelityTests
+{
+    private static FakeCredentialStore Populated()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        {
+            Id = ServerConnection.NewId(),
+            Name = "SRV01",
+            ServerName = "SRV01"
+        });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = BlobContainerConfig.NewId(),
+            Name = "sqlbackups",
+            ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+        });
+        return store;
+    }
+
+    [Fact]
+    public void EveryLoadHandsBackFreshObjects()
+    {
+        var store = Populated();
+
+        var first = store.LoadConfig();
+        var second = store.LoadConfig();
+
+        Assert.NotSame(first, second);
+        Assert.NotSame(first.Servers[0], second.Servers[0]);
+        Assert.NotSame(first.BlobContainers[0], second.BlobContainers[0]);
+
+        // Different objects, same facts - a copy, not a blank.
+        Assert.Equal(first.Servers[0].Id, second.Servers[0].Id);
+        Assert.Equal("SRV01", second.Servers[0].ServerName);
+        Assert.Equal("sqlbackups", second.BlobContainers[0].Name);
+    }
+
+    /// <summary>
+    /// The identity question the hidden bug turned on: an object resolved out of a loaded config
+    /// is never the one sitting in the store, so an ObservableProperty setter sees a change.
+    /// </summary>
+    [Fact]
+    public void AServerResolvedFromALoadedConfigIsNotTheStoredInstance()
+    {
+        var store = Populated();
+        var stored = store.Config.Servers[0];
+
+        var resolved = store.LoadConfig().Servers.First(s => s.Id == stored.Id);
+
+        Assert.NotSame(stored, resolved);
+        Assert.Equal(stored.Id, resolved.Id);
+    }
+
+    [Fact]
+    public void MutatingALoadedConfigDoesNotReachTheStoreUntilItIsSaved()
+    {
+        var store = Populated();
+
+        var loaded = store.LoadConfig();
+        loaded.Servers[0].Name = "renamed in a copy";
+
+        Assert.Equal("SRV01", store.Config.Servers[0].Name);
+
+        store.SaveConfig(loaded);
+        Assert.Equal("renamed in a copy", store.Config.Servers[0].Name);
+    }
+
+    /// <summary>
+    /// LoadError is JsonIgnore'd, but the real store SETS it on the object it hands back when the
+    /// file existed and could not be read. So it has to survive the copy, or the fake can no
+    /// longer play an unreadable config and the rule that one is never overwritten - the shape of
+    /// the original config-loss defect - stops being testable.
+    /// </summary>
+    [Fact]
+    public void AConfigThatCouldNotBeReadStillSaysSoThroughTheCopy()
+    {
+        var store = Populated();
+        store.Config.LoadError = "config.json could not be read";
+
+        Assert.Equal("config.json could not be read", store.LoadConfig().LoadError);
+    }
+
+    /// <summary>
+    /// The in-memory secrets are JsonIgnore'd, and dropping them through the copy is FAITHFUL:
+    /// the real store deserializes from disk, where they were never written. Pinned so nobody
+    /// "fixes" the fake by carrying them across and quietly reintroduces a divergence.
+    /// </summary>
+    [Fact]
+    public void InMemorySecretsDoNotSurviveALoadEitherJustAsTheyDoNotInProduction()
+    {
+        var store = Populated();
+        store.Config.Servers[0].UnsavedPassword = "held in memory only";
+
+        Assert.Null(store.LoadConfig().Servers[0].UnsavedPassword);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -48,7 +48,39 @@ public sealed class FakeCredentialStore : ICredentialStore
     public string? GetSqlPassword(ServerConnection connection)
         => connection.UnsavedPassword ?? ReadSecret(SqlKey(connection)).secret;
 
-    public AppConfig LoadConfig() => Config;
+    /// <summary>
+    /// A fresh object graph on every call, the way the real store behaves (#439).
+    ///
+    /// CredentialStore.LoadConfig does File.ReadAllText plus Deserialize every time, so every
+    /// caller gets brand-new ServerConnection and BlobContainerConfig instances. This used to hand
+    /// back the cached Config - the same instances every time - and that one difference let a real
+    /// defect reach dev with a fully green suite.
+    ///
+    /// BackupViewModel.Refresh rebuilds its list from the config and reselects by id. Against the
+    /// real store that is always a DIFFERENT instance, so the ObservableProperty setter raises a
+    /// change and OnServerChanged runs; once choosing a server started listing its databases, every
+    /// navigation to the Backup or Copy screen silently opened a connection to a production
+    /// instance and wiped the user's ticks. Against identical instances the setter short-circuited
+    /// and nothing fired, so no test could see it.
+    ///
+    /// Round-tripped through JSON rather than hand-copied: a field added to AppConfig is carried
+    /// without anybody remembering to update this, and the JsonIgnore'd in-memory secrets
+    /// (UnsavedPassword, UnsavedSasToken) drop out exactly as they do when the real store reads
+    /// from disk.
+    /// </summary>
+    public AppConfig LoadConfig()
+    {
+        var fresh = System.Text.Json.JsonSerializer.Deserialize<AppConfig>(
+            System.Text.Json.JsonSerializer.Serialize(Config)) ?? new AppConfig();
+
+        // LoadError is JsonIgnore'd but the real store SETS it on the object it hands back, after
+        // deserializing, when the file existed and could not be read. So it has to survive the
+        // copy - without it this fake can no longer play an unreadable config, and the rule that
+        // such a config is never overwritten stops being testable at all.
+        fresh.LoadError = Config.LoadError;
+
+        return fresh;
+    }
 
     public void SaveConfig(AppConfig config)
     {

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -118,8 +118,14 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
             executedAgainst = Assert.Single(sql.ExecutedAgainst);
         });
 
-        Assert.Same(sqlAuthEntry, executedAgainst);
-        Assert.NotSame(windowsAuthEntry, executedAgainst);
+        // By identity rather than by reference (#439): the store now hands out fresh instances
+        // the way the real one does, so the object executed against is a COPY of the right entry.
+        // Which entry it is remains the whole point - the SQL-auth one that was connected, not
+        // the Windows-auth one a name lookup would find first.
+        Assert.Equal(sqlAuthEntry.Id, executedAgainst!.Id);
+        Assert.Equal(AuthMode.SqlAuth, executedAgainst.AuthMode);
+        Assert.Equal("restoreadmin", executedAgainst.Username);
+        Assert.NotEqual(windowsAuthEntry.Id, executedAgainst.Id);
     }
 
     /// <summary>

--- a/src/NineLives.Tests/WebhookHonestyTests.cs
+++ b/src/NineLives.Tests/WebhookHonestyTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -109,6 +109,13 @@ public class WebhookHonestyTests
             WebhookTransport.ResolveUrl(model, store));
     }
 
+    /// <summary>
+    /// The endpoint as the STORE holds it (#439). RecordDelivery loads fresh, stamps and saves,
+    /// so the stamp is on the saved config rather than on whichever instance the test handed in.
+    /// </summary>
+    private static WebhookEndpoint Saved(FakeCredentialStore store, string id) =>
+        store.Config.Webhooks.Single(w => w.Id == id);
+
     // ── every attempt stamps the endpoint (#292) ────────────────────────────────
 
     [Fact]
@@ -120,11 +127,15 @@ public class WebhookHonestyTests
 
         WebhookTransport.RecordDelivery(store, model.Id, null);
 
-        Assert.NotNull(model.LastDeliveryAt);
-        Assert.Equal("delivered", model.LastDeliveryOutcome);
+        // Read back OUT of the store rather than off the instance handed in (#439). RecordDelivery
+        // loads fresh, stamps, and saves - correctly, because the config may have moved on since
+        // the delivery started - so the stamp lands on the saved config, not on this object. The
+        // old assertion only passed because the fake handed back the very instance it was given.
+        Assert.NotNull(Saved(store, model.Id).LastDeliveryAt);
+        Assert.Equal("delivered", Saved(store, model.Id).LastDeliveryOutcome);
 
         WebhookTransport.RecordDelivery(store, model.Id, "410 Gone");
-        Assert.Equal("410 Gone", model.LastDeliveryOutcome);
+        Assert.Equal("410 Gone", Saved(store, model.Id).LastDeliveryOutcome);
     }
 
     [Fact]
@@ -153,8 +164,8 @@ public class WebhookHonestyTests
         notifier.Notify(new RunNotification(RunPhase.Succeeded, "Restore", "MyDb", "SRV01"));
         await notifier.DrainAsync(TimeSpan.FromSeconds(5));
 
-        Assert.NotNull(model.LastDeliveryAt);
-        Assert.Equal("delivered", model.LastDeliveryOutcome);
+        Assert.NotNull(Saved(store, model.Id).LastDeliveryAt);
+        Assert.Equal("delivered", Saved(store, model.Id).LastDeliveryOutcome);
     }
 
     /// <summary>Invokes the outcome callback the way the real notifier does after a post.</summary>


### PR DESCRIPTION
Closes #439.

## Why a test-only change is worth a PR

`CredentialStore.LoadConfig` does `File.ReadAllText` + `Deserialize` on **every call**, so every caller gets brand-new objects. `FakeCredentialStore.LoadConfig` handed back its cached `Config` — the same instances every time.

That one difference let a real defect reach `dev` with a fully green suite. `BackupViewModel.Refresh` rebuilds its list and reselects by id; against the real store that is always a *different* instance, so the setter raises a change and `OnServerChanged` runs. Once choosing a server started listing its databases, every navigation to Backup or Copy silently opened a connection to a production instance and wiped the user's ticks. Against identical instances the setter short-circuited and nothing fired.

A fake that diverges from production doesn't just fail to catch a bug — it makes that bug **invisible**, which is worse than having no test.

## The copy

A JSON round-trip, not a hand-written clone, so a field added to `AppConfig` is carried without anyone remembering to update it.

The `[JsonIgnore]` in-memory secrets (`UnsavedPassword`, `UnsavedSasToken`) drop out — and that is **faithful**, since the real store reads from disk where they were never written. Pinned, so nobody restores them and reintroduces a divergence in the other direction.

One thing does have to survive: `LoadError` is `[JsonIgnore]` but the real store *sets* it on the object it returns when the file existed and couldn't be read. Two tests failed exactly there — the fake catching its own gap on the first run.

## The five tests it surfaced

Predicted by the issue, and none of them a product bug:

- **Two webhook stamp tests** now read the endpoint back out of the store. `RecordDelivery` loads fresh, stamps and saves — correctly, since the config may have moved on since the delivery started — so the stamp was never on the instance the test handed in. Asserting through the store is the stronger claim anyway: it proves the stamp *persisted*.
- **Two config-not-overwritten tests** were the `LoadError` gap above.
- **The restore test** asserts identity by id and auth mode rather than by reference. It ran against a *copy of the correct* server — same `CredentialKey`, same `SqlAuth`, same username — so its intent (the connected SQL-auth entry, not the Windows-auth one a name lookup finds first) was never in doubt; only the way of expressing it depended on the fake.

## Effect

`dotnet build -c Release -warnaserror` clean, `dotnet test` → **2,128 passed, 0 failed** (up 5).