### PR TITLE
Stop a differential's file name claiming COPY_ONLY (#441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@ more detail on the user-facing changes; this file is the short history.
   dies on the sixth database leaves the first five receipts on disk, because that half-finished
   run is exactly the incident somebody opens the history for.
 
+## [Unreleased]
+
+### Fixed
+
+- **A differential's file name no longer claims COPY_ONLY** (#441). COPY_ONLY is the default for
+  backups this app takes, and the marker went into every destination name - but the generated
+  statement omits the keyword on a differential, and rightly so: there is no copy-only
+  differential, because what COPY_ONLY protects is the differential base and a differential does
+  not move it. So the name asserted something about the statement that the statement did not.
+  That marker is load-bearing - the listing reads it back out of the name to classify what it
+  finds - and it read oddly in an audit, where the receipt said NOT copy-only beside a file
+  called `_COPY_ONLY_`. Backups already written keep their names and are still read correctly;
+  this only changes what gets written from here.
+
 ## [1.6.3] - 2026-08-13
 
 ### Fixed

--- a/src/NineLives.Core/Services/BackupDestinationBuilder.cs
+++ b/src/NineLives.Core/Services/BackupDestinationBuilder.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -47,7 +47,18 @@ public static class BackupDestinationBuilder
         // COPY_ONLY in the name as well as in the header. The listing reads it from the name (#49),
         // and a copy-only full that is not recognised as one becomes a differential's base - which
         // SQL Server then rejects with 3136.
-        var copy = copyOnly ? "_COPY_ONLY" : string.Empty;
+        //
+        // Never on a differential, matching the statement exactly (#441). The generator has the
+        // same condition, because there IS no copy-only differential: the keyword protects the
+        // differential base, and a differential does not move it. So the file name was claiming a
+        // property of a statement that never carried it - noise at best, and at worst read as
+        // meaningful by the listing, which uses this marker to classify what it finds. It also
+        // read oddly in an audit, where the receipt correctly said NOT copy-only beside a file
+        // called _COPY_ONLY_.
+        //
+        // Backups already on disk keep the old naming, so anything parsing the marker back out
+        // still has to tolerate it on a _DIFF_ file. This changes what gets written from here on.
+        var copy = copyOnly && type != BackupType.Differential ? "_COPY_ONLY" : string.Empty;
 
         return $"{Sanitise(databaseName)}_{FolderFor(type)}{copy}_{takenAt:yyyyMMdd_HHmmss}{suffix}" +
                ExtensionFor(type);

--- a/src/NineLives.Tests/CopyOnlyNamingTests.cs
+++ b/src/NineLives.Tests/CopyOnlyNamingTests.cs
@@ -1,0 +1,90 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The file name claims COPY_ONLY only when the statement carries it (#441).
+///
+/// COPY_ONLY is the default for backups this app takes, and the marker was written into every
+/// destination name regardless of type - but <c>BackupScriptGenerator</c> deliberately omits the
+/// keyword on a differential, and correctly: there is no copy-only differential, because what
+/// COPY_ONLY protects is the differential base and a differential does not move it.
+///
+/// So a name said something about the statement that the statement did not say about itself. That
+/// is not merely untidy: the marker is load-bearing. The listing reads it back out of the name to
+/// classify what it finds, and the receipt would say NOT copy-only beside a file called
+/// <c>_COPY_ONLY_</c>.
+/// </summary>
+public class CopyOnlyNamingTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 14, 15, 30, 0);
+
+    [Fact]
+    public void ADifferentialNeverCarriesTheMarker()
+    {
+        var name = BackupDestinationBuilder.FileName(
+            "Sales", BackupType.Differential, T0, copyOnly: true);
+
+        Assert.DoesNotContain("COPY_ONLY", name);
+        Assert.Contains("_DIFF_", name);
+    }
+
+    /// <summary>
+    /// The types that DO have a copy-only form still say so - this is a narrowing, not a removal,
+    /// and a copy-only full that stops being recognised as one becomes a differential's base,
+    /// which SQL Server rejects with 3136.
+    /// </summary>
+    [Theory]
+    [InlineData(BackupType.Full)]
+    [InlineData(BackupType.TransactionLog)]
+    public void TheTypesThatHaveACopyOnlyFormStillCarryIt(BackupType type)
+    {
+        Assert.Contains("_COPY_ONLY",
+            BackupDestinationBuilder.FileName("Sales", type, T0, copyOnly: true));
+    }
+
+    [Fact]
+    public void NothingCarriesTheMarkerWhenCopyOnlyIsOff()
+    {
+        foreach (var type in new[] { BackupType.Full, BackupType.Differential, BackupType.TransactionLog })
+            Assert.DoesNotContain("COPY_ONLY",
+                BackupDestinationBuilder.FileName("Sales", type, T0, copyOnly: false));
+    }
+
+    /// <summary>
+    /// The name and the statement now agree, which is the actual claim. Asked of both sides rather
+    /// than of the name alone, so the two cannot drift apart again in either direction.
+    /// </summary>
+    [Theory]
+    [InlineData(BackupType.Full)]
+    [InlineData(BackupType.Differential)]
+    [InlineData(BackupType.TransactionLog)]
+    public void TheNameAgreesWithTheStatement(BackupType type)
+    {
+        var script = new BackupScriptGenerator().Generate(new BackupOptions
+        {
+            DatabaseName = "Sales",
+            Type = type,
+            CopyOnly = true,
+            Destinations = ["https://acct.blob.core.windows.net/c/x.bak"]
+        });
+
+        var name = BackupDestinationBuilder.FileName("Sales", type, T0, copyOnly: true);
+
+        Assert.Equal(script.Contains("COPY_ONLY"), name.Contains("COPY_ONLY"));
+    }
+
+    /// <summary>
+    /// Backups already on disk carry the old naming, and this is a change to what gets written
+    /// from now on rather than a format migration - so a differential that was written with the
+    /// marker must still be read back as one, or an existing container's history changes shape
+    /// under somebody who only upgraded the app.
+    /// </summary>
+    [Fact]
+    public void ADifferentialAlreadyOnDiskWithTheOldNameIsStillReadAsCopyOnly()
+    {
+        Assert.True(BlobStorageService.IsCopyOnlyFileName("Sales_DIFF_COPY_ONLY_20260814_153000.bak"));
+    }
+}


### PR DESCRIPTION
Closes #441.

COPY_ONLY is the default for backups this app takes, and the marker went into every destination name regardless of type:

```
.../SRV01/Sales/Sales_DIFF_COPY_ONLY_20260814_15....bak
```

But `BackupScriptGenerator` omits the keyword on a differential, and rightly — `if (options.CopyOnly && options.Type != BackupType.Differential)`. There is no copy-only differential: what COPY_ONLY protects is the differential base, and a differential does not move it.

So the file name asserted a property of the statement that the statement did not have.

## Why it is worth fixing rather than tolerating

The marker is **load-bearing**. The listing reads it back out of the name to classify what it finds — a copy-only full that is not recognised as one becomes a differential's base, which SQL Server rejects with 3136. A differential carrying it is noise at best and read as meaningful at worst.

It also read oddly in an audit: the receipt correctly said *NOT copy-only* beside a file called `_COPY_ONLY_`.

## The compatibility half

Backups already on disk carry the old naming. This changes what gets **written** from here on, not the format, so a differential written with the marker must still be read back as copy-only — otherwise an existing container's history changes shape under somebody who only upgraded the app. That is pinned.

The agreement itself is pinned from both sides — name and statement asked the same question for all three types — so they cannot drift apart again in either direction.

## Effect

`dotnet build -c Release -warnaserror` clean, `dotnet test` → **2,136 passed, 0 failed** (up 8).