### PR TITLE
Require the history store on the Restore screen (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The Restore screen can no longer default its history store to the real file** (#440).
+  Nothing a user sees changes. The store was an optional constructor argument defaulting to the
+  installed app's own `%LOCALAPPDATA%` audit trail, and this screen hands it straight to the
+  thing that writes - so a single forgotten argument meant a test appending invented runs to a
+  developer's real history, with the entry cap trimming genuine receipts off the end to make
+  room. The issue recorded this as latent because every call site passed a fake; one did not.
+  It is now required, which C# forces to sit ahead of the optional log, hence the call-site churn.
+
 - **A differential's file name no longer claims COPY_ONLY** (#441). COPY_ONLY is the default for
   backups this app takes, and the marker went into every destination name - but the generated
   statement omits the keyword on a differential, and rightly so: there is no copy-only

--- a/src/NineLives.Tests/ACheckboxDoesNotCancelAQueryTests.cs
+++ b/src/NineLives.Tests/ACheckboxDoesNotCancelAQueryTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -29,7 +29,7 @@ public class ACheckboxDoesNotCancelAQueryTests
         var sql = new FakeSqlServerService();
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), sql, new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeOperationHistoryStore());
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(), TestLogs.Temp());
 
         vm.ConnectedServer = store.Config.Servers[0];
         vm.IsConnectedToServer = true;

--- a/src/NineLives.Tests/AdHocFileRestoreTests.cs
+++ b/src/NineLives.Tests/AdHocFileRestoreTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -295,8 +295,8 @@ public class AdHocFileRestoreTests
 
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(),
-            new FakeOperationHistoryStore(), TestAuditStores.Temp())
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp(), TestAuditStores.Temp())
         {
             Mode = AppMode.Pro
         };

--- a/src/NineLives.Tests/AppModeTests.cs
+++ b/src/NineLives.Tests/AppModeTests.cs
@@ -414,8 +414,8 @@ public class AppModeTests
 
         return new RestoreViewModel(
             new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(),
-            new FakeOperationHistoryStore(), TestAuditStores.Temp())
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp(), TestAuditStores.Temp())
         {
             Mode = mode
         };

--- a/src/NineLives.Tests/AuditButtonComesAliveTests.cs
+++ b/src/NineLives.Tests/AuditButtonComesAliveTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -50,7 +50,7 @@ public class AuditButtonComesAliveTests
 
         return new RestoreViewModel(
             blob, new FakeSqlServerService(), new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeOperationHistoryStore(), TestAuditStores.Temp());
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(), TestLogs.Temp(), TestAuditStores.Temp());
     }
 
     private static void Connect(RestoreViewModel vm)

--- a/src/NineLives.Tests/AuditIsVisibleOnTheRowsTests.cs
+++ b/src/NineLives.Tests/AuditIsVisibleOnTheRowsTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -58,7 +58,7 @@ public class AuditIsVisibleOnTheRowsTests
                         : BackupType.Full)
             },
             new BackupChainBuilder(), new RestoreScriptGenerator(), store,
-            TestLogs.Temp(), new FakeOperationHistoryStore(), TestAuditStores.Temp());
+            new FakeOperationHistoryStore(), TestLogs.Temp(), TestAuditStores.Temp());
 
         vm.ConnectedServer = new ServerConnection
         { Id = ServerConnection.NewId(), Name = "SRV01", ServerName = "SRV01" };

--- a/src/NineLives.Tests/BrowseToRestoreHandoffTests.cs
+++ b/src/NineLives.Tests/BrowseToRestoreHandoffTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -108,8 +108,8 @@ public class BrowseToRestoreHandoffTests
     {
         var vm = new RestoreViewModel(
             blob, new FakeSqlServerService(), new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(),
-            new FakeOperationHistoryStore(), TestAuditStores.Temp())
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp(), TestAuditStores.Temp())
         {
             Mode = AppMode.Pro
         };

--- a/src/NineLives.Tests/BusyFeedbackTests.cs
+++ b/src/NineLives.Tests/BusyFeedbackTests.cs
@@ -22,9 +22,9 @@ public class ChainCheckStateTests
 
     private RestoreViewModel NewViewModel() => new(
         _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new FakeOperationHistoryStore(),
         new OperationLog(System.IO.Path.Combine(
-            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
-        new FakeOperationHistoryStore());
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))));
 
     private static BackupFileInfo File(string blobName, BackupType type, DateTime stamp) => new()
     {

--- a/src/NineLives.Tests/EncryptionPreflightTests.cs
+++ b/src/NineLives.Tests/EncryptionPreflightTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
@@ -120,8 +120,8 @@ public class EncryptionPreflightTests
 
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), sql, new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(),
-            new FakeOperationHistoryStore(), TestAuditStores.Temp())
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp(), TestAuditStores.Temp())
         {
             Mode = AppMode.Pro
         };

--- a/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
+++ b/src/NineLives.Tests/ExecuteBlockedReasonTests.cs
@@ -22,9 +22,9 @@ public class ExecuteBlockedReasonTests
 
     private RestoreViewModel NewViewModel() => new(
         _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new FakeOperationHistoryStore(),
         new OperationLog(System.IO.Path.Combine(
-            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
-        new FakeOperationHistoryStore());
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))));
 
     private async Task<RestoreViewModel> Loaded()
     {

--- a/src/NineLives.Tests/ExecuteDuringARunTests.cs
+++ b/src/NineLives.Tests/ExecuteDuringARunTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -59,9 +59,9 @@ public class ExecuteDuringARunTests
         var vm = new RestoreViewModel(
             blob, new FakeSqlServerService(), new BackupChainBuilder(),
             new RestoreScriptGenerator(), store,
+            new FakeOperationHistoryStore(),
             new OperationLog(System.IO.Path.Combine(
-                System.IO.Path.GetTempPath(), "ninelives-exec", Guid.NewGuid().ToString("n"))),
-            new FakeOperationHistoryStore());
+                System.IO.Path.GetTempPath(), "ninelives-exec", Guid.NewGuid().ToString("n"))));
 
         vm.SelectedContainer = store.Config.BlobContainers[0];
         await vm.LoadBackupsCommand.ExecuteAsync(null);

--- a/src/NineLives.Tests/HandoffHonestyTests.cs
+++ b/src/NineLives.Tests/HandoffHonestyTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -33,8 +33,8 @@ public class HandoffHonestyTests
 
     private static RestoreViewModel Restore(FakeCredentialStore store, FakeBlobStorageService blob) => new(
         blob, new FakeSqlServerService(), new BackupChainBuilder(),
-        new RestoreScriptGenerator(), store, TestLogs.Temp(),
-        new FakeOperationHistoryStore(), TestAuditStores.Temp())
+        new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+        TestLogs.Temp(), TestAuditStores.Temp())
     { Mode = AppMode.Pro };
 
     private static FakeCredentialStore Store(params BlobContainerConfig[] containers)

--- a/src/NineLives.Tests/LogGoesWhereItIsToldTests.cs
+++ b/src/NineLives.Tests/LogGoesWhereItIsToldTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
@@ -97,7 +97,7 @@ public class LogGoesWhereItIsToldTests
 
         var vm = new RestoreViewModel(
             blob, new FakeSqlServerService(), new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, log, new FakeOperationHistoryStore());
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(), log);
 
         vm.RefreshContainers();
         await vm.LoadBackupsCommand.ExecuteAsync(null);

--- a/src/NineLives.Tests/MultiContainerRestoreTests.cs
+++ b/src/NineLives.Tests/MultiContainerRestoreTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -229,8 +229,8 @@ public class MultiContainerRestoreTests
     {
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(),
-            new FakeOperationHistoryStore(), TestAuditStores.Temp())
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp(), TestAuditStores.Temp())
         {
             Mode = AppMode.Pro
         };

--- a/src/NineLives.Tests/NothingToPickFromTests.cs
+++ b/src/NineLives.Tests/NothingToPickFromTests.cs
@@ -1,4 +1,4 @@
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Blackcat.NineLives.Models;
@@ -141,7 +141,7 @@ public class NothingToPickFromTests(WpfFixture wpf)
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
             new RestoreScriptGenerator(), new FakeCredentialStore(),
-            TestLogs.Temp(), new FakeOperationHistoryStore());
+            new FakeOperationHistoryStore(), TestLogs.Temp());
 
         Assert.True(vm.HasNoTargetServers);
     }

--- a/src/NineLives.Tests/QueryCancellationTests.cs
+++ b/src/NineLives.Tests/QueryCancellationTests.cs
@@ -23,9 +23,9 @@ public class QueryCancellationTests
 
     private RestoreViewModel NewViewModel() => new(
         _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new FakeOperationHistoryStore(),
         new OperationLog(System.IO.Path.Combine(
-            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
-        new FakeOperationHistoryStore());
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))));
 
     private static BackupFileInfo File(string blobName, BackupType type, DateTime stamp)
         => new()

--- a/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionViewModelTests.cs
@@ -55,7 +55,7 @@ public class RestoreExecutionViewModelTests(WpfFixture wpf)
 
         var vm = new RestoreViewModel(
             blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store,
-            ThrowawayLog(), history ?? new FakeOperationHistoryStore())
+            history ?? new FakeOperationHistoryStore(), ThrowawayLog())
         {
             SelectedContainer = Container()
         };

--- a/src/NineLives.Tests/RestoreRehearsalTests.cs
+++ b/src/NineLives.Tests/RestoreRehearsalTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -135,8 +135,8 @@ public class RestoreRehearsalTests
         var history = new FakeOperationHistoryStore();
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), sql, new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(),
-            history, TestAuditStores.Temp(), notifier)
+            new RestoreScriptGenerator(), store, history,
+            TestLogs.Temp(), TestAuditStores.Temp(), notifier)
         {
             Mode = AppMode.Pro
         };

--- a/src/NineLives.Tests/RestoreScreenOnArrivalTests.cs
+++ b/src/NineLives.Tests/RestoreScreenOnArrivalTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -30,7 +30,7 @@ public class RestoreScreenOnArrivalTests
         var vm = new RestoreViewModel(
             new FakeBlobStorageService { Files = files.ToList() }, sql,
             new BackupChainBuilder(), new RestoreScriptGenerator(), store,
-            TestLogs.Temp(), new FakeOperationHistoryStore());
+            new FakeOperationHistoryStore(), TestLogs.Temp());
 
         return (vm, sql);
     }
@@ -196,7 +196,7 @@ public class RestoreScreenOnArrivalTests
         var sql = new FakeSqlServerService();
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), sql, new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeOperationHistoryStore());
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(), TestLogs.Temp());
 
         var gate = new TaskCompletionSource();
         sql.HoldConnection = gate;

--- a/src/NineLives.Tests/RestoreSummaryStaysPutTests.cs
+++ b/src/NineLives.Tests/RestoreSummaryStaysPutTests.cs
@@ -1,4 +1,4 @@
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Blackcat.NineLives.ViewModels;
@@ -88,7 +88,7 @@ public class RestoreSummaryStaysPutTests(WpfFixture wpf)
             new FakeBlobStorageService(), new FakeSqlServerService(),
             new Blackcat.NineLives.Services.BackupChainBuilder(),
             new Blackcat.NineLives.Services.RestoreScriptGenerator(),
-            store, TestLogs.Temp(), new FakeOperationHistoryStore(), TestAuditStores.Temp())
+            store, new FakeOperationHistoryStore(), TestLogs.Temp(), TestAuditStores.Temp())
         {
             // The banner is collapsed with nothing to say, and a collapsed element is not somewhere
             // a person can fail to see - so it needs something to say before any of this means

--- a/src/NineLives.Tests/RestoreTargetStepTests.cs
+++ b/src/NineLives.Tests/RestoreTargetStepTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -16,8 +16,8 @@ public class RestoreTargetStepTests
 {
     private static RestoreViewModel New(FakeCredentialStore? store = null) => new(
         new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
-        new RestoreScriptGenerator(), store ?? new FakeCredentialStore(), TestLogs.Temp(),
-        new FakeOperationHistoryStore(), TestAuditStores.Temp());
+        new RestoreScriptGenerator(), store ?? new FakeCredentialStore(), new FakeOperationHistoryStore(),
+        TestLogs.Temp(), TestAuditStores.Temp());
 
     private static ServerConnection Server(string id = "s1", string name = "SRV01") =>
         new() { Id = id, Name = name, ServerName = name };

--- a/src/NineLives.Tests/RestoreViewModelTests.cs
+++ b/src/NineLives.Tests/RestoreViewModelTests.cs
@@ -24,6 +24,7 @@ public class RestoreViewModelTests
 
     private RestoreViewModel NewViewModel() => new(
         _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new FakeOperationHistoryStore(),
         new OperationLog(System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))));
 
     private static readonly DateTime T0 = new(2026, 1, 10, 22, 0, 0);

--- a/src/NineLives.Tests/S3GuiPreflightTests.cs
+++ b/src/NineLives.Tests/S3GuiPreflightTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -65,8 +65,8 @@ public class S3GuiPreflightTests
 
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), sql, new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(),
-            new FakeOperationHistoryStore(), TestAuditStores.Temp())
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp(), TestAuditStores.Temp())
         {
             Mode = AppMode.Pro
         };

--- a/src/NineLives.Tests/SavedExecutionLogTests.cs
+++ b/src/NineLives.Tests/SavedExecutionLogTests.cs
@@ -29,9 +29,9 @@ public class SavedExecutionLogTests
         return new RestoreViewModel(
             new FakeBlobStorageService(), new FakeSqlServerService(),
             new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            new FakeOperationHistoryStore(),
             new OperationLog(System.IO.Path.Combine(
-                System.IO.Path.GetTempPath(), "ninelives-saved-log", Guid.NewGuid().ToString("n"))),
-            new FakeOperationHistoryStore());
+                System.IO.Path.GetTempPath(), "ninelives-saved-log", Guid.NewGuid().ToString("n"))));
     }
 
     [Fact]

--- a/src/NineLives.Tests/ScriptStaysInStepTests.cs
+++ b/src/NineLives.Tests/ScriptStaysInStepTests.cs
@@ -26,9 +26,9 @@ public class ScriptStaysInStepTests
 
     private RestoreViewModel NewViewModel() => new(
         _blob, _sql, new BackupChainBuilder(), new RestoreScriptGenerator(), _store,
+        new FakeOperationHistoryStore(),
         new OperationLog(System.IO.Path.Combine(
-            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
-        new FakeOperationHistoryStore());
+            System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))));
 
     private static BackupFileInfo FullBackup() => new()
     {

--- a/src/NineLives.Tests/SpaceCheckOnTheScreenTests.cs
+++ b/src/NineLives.Tests/SpaceCheckOnTheScreenTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -56,7 +56,7 @@ public class SpaceCheckOnTheScreenTests
 
         var vm = new RestoreViewModel(
             blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store,
-            TestLogs.Temp(), new FakeOperationHistoryStore(), TestAuditStores.Temp());
+            new FakeOperationHistoryStore(), TestLogs.Temp(), TestAuditStores.Temp());
 
         vm.RefreshContainers();
         vm.ConnectedServer = new ServerConnection

--- a/src/NineLives.Tests/VerifyWithMoveTests.cs
+++ b/src/NineLives.Tests/VerifyWithMoveTests.cs
@@ -137,9 +137,9 @@ public class VerifyWithMoveViewModelTests(WpfFixture wpf)
 
         var vm = new RestoreViewModel(
             blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(), store,
+            new FakeOperationHistoryStore(),
             new OperationLog(System.IO.Path.Combine(
-                System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))),
-            new FakeOperationHistoryStore())
+                System.IO.Path.GetTempPath(), "ninelives-vm-tests", Guid.NewGuid().ToString("n"))))
         {
             SelectedContainer = new BlobContainerConfig
             {

--- a/src/NineLives.Tests/VersionPreflightTests.cs
+++ b/src/NineLives.Tests/VersionPreflightTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -106,8 +106,8 @@ public class VersionPreflightTests
 
         var vm = new RestoreViewModel(
             new FakeBlobStorageService(), sql, new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(),
-            new FakeOperationHistoryStore(), TestAuditStores.Temp())
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp(), TestAuditStores.Temp())
         {
             Mode = AppMode.Pro
         };

--- a/src/NineLives.Tests/XamlLoadTests.cs
+++ b/src/NineLives.Tests/XamlLoadTests.cs
@@ -899,7 +899,7 @@ public class XamlLoadTests(WpfFixture wpf)
 
         var vm = new RestoreViewModel(
             blob, new FakeSqlServerService(), new BackupChainBuilder(),
-            new RestoreScriptGenerator(), store, TestLogs.Temp(), new FakeOperationHistoryStore(), TestAuditStores.Temp());
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(), TestLogs.Temp(), TestAuditStores.Temp());
 
         vm.RefreshContainers();
         vm.LoadBackupsCommand.Execute(null);
@@ -939,8 +939,8 @@ public class XamlLoadTests(WpfFixture wpf)
             var vm = new RestoreViewModel(
                 blob, new FakeSqlServerService(), new BackupChainBuilder(),
                 new RestoreScriptGenerator(), store,
-                TestLogs.Temp(),
-                new FakeOperationHistoryStore());
+                new FakeOperationHistoryStore(),
+                TestLogs.Temp());
 
             vm.RefreshContainers();
             vm.LoadBackupsCommand.Execute(null);
@@ -1593,8 +1593,8 @@ public class XamlLoadTests(WpfFixture wpf)
             new BackupChainBuilder(),
             new RestoreScriptGenerator(),
             store,
-            TestLogs.Temp(),
-            new FakeOperationHistoryStore());
+            new FakeOperationHistoryStore(),
+            TestLogs.Temp());
     }
 
     /// <summary>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -892,12 +892,23 @@ public partial class RestoreViewModel : ViewModelBase
         BackupChainBuilder chainBuilder,
         RestoreScriptGenerator scriptGenerator,
         ICredentialStore credentialStore,
+        // Required, and ahead of the optionals, matching RestoreExecutionViewModel (#440).
+        //
+        // It used to default to `new OperationHistoryStore()`, which resolves to the real
+        // %LOCALAPPDATA% file the installed app uses - and this instance is handed straight to
+        // RestoreExecutionViewModel, which is the thing that writes. So one forgotten argument
+        // meant a test appending invented runs to the developer's own audit trail, with the entry
+        // cap trimming real receipts off the end to make room. The same defaulted-store pattern on
+        // the Backup and Copy screens did exactly that once those screens started writing.
+        //
+        // C# forbids a required parameter after an optional one, so this cannot be fixed in place -
+        // it has to move ahead of `log`, which is why the call sites shift with it.
+        IOperationHistoryStore history,
         OperationLog? log = null,
-        IOperationHistoryStore? history = null,
         IBackupAuditStore? auditStore = null,
         IRunNotifier? notifier = null)
     {
-        _history = history ?? new OperationHistoryStore();
+        _history = history;
 
         _blobService = blobService;
         _sqlService = sqlService;


### PR DESCRIPTION
Closes #440.

`RestoreViewModel` took its history store as an optional argument defaulting to `new OperationHistoryStore()` — which resolves to `%LOCALAPPDATA%\NineLives\restore-history.json`, the same file the installed app writes. That instance goes straight into `RestoreExecutionViewModel`, which is the thing that writes.

So one forgotten argument meant a test appending invented runs to a developer's real audit trail, with the 200-entry cap trimming genuine receipts off the end to make room.

## The issue called this latent. It was armed.

> Every current call site already passes a fake — I checked all of them.

Not quite. `RestoreViewModelTests` passed six arguments and no history, so every `RestoreViewModel` it built held a store pointed at the real file — in the file that constructs this type more than any other. Nothing was lost, because that class never reaches the writing path, but it was one `await ExecuteScriptCommand` away rather than one refactor away.

That is also the answer to "why bother, it's latent": the same defaulted-store pattern on the Backup and Copy screens **did** fire once those screens started writing receipts.

## Why the churn

C# forbids a required parameter after an optional one, so `history` cannot be made required in place — it has to move ahead of `log`. That is the entire reason ~29 call sites shift. The resulting order now matches `RestoreExecutionViewModel`, which already had it right.

## Effect

`dotnet build -c Release -warnaserror` clean, `dotnet test` → **2,141 passed, 0 failed**.