### PR TITLE
Prepare v1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
-## [Unreleased]
+## [1.6.4] - 2026-08-14
 
 ### Fixed
 
@@ -40,10 +40,6 @@ more detail on the user-facing changes; this file is the short history.
   run. Receipts are now written off the dispatcher, and still awaited one at a time: a run that
   dies on the sixth database leaves the first five receipts on disk, because that half-finished
   run is exactly the incident somebody opens the history for.
-
-## [Unreleased]
-
-### Fixed
 
 - **The Restore screen can no longer default its history store to the real file** (#440).
   Nothing a user sees changes. The store was an optional constructor argument defaulting to the

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.6.3</Version>
+    <Version>1.6.4</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.6.3</Version>
+    <Version>1.6.4</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.6.3</Version>
+    <Version>1.6.4</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>


### PR DESCRIPTION
Version bump to 1.6.4 across the three projects, and the CHANGELOG's Unreleased section dated. Two Unreleased headings had accumulated from parallel branches; merged into one.

Five fixes on top of 1.6.3, all from the code review of the audit-trail work. No breaking changes, no config or schema changes, so a patch release.

The two with user-visible consequence: recording a run no longer blocks the window — a fifty-database backup did fifty synchronous whole-file rewrites on the UI thread, and the same write in the cancellation handler meant Stop froze the app instead of stopping it (#437). And the recovery panel now records what it does: it runs RESTORE ... WITH RECOVERY and DBCC CHECKDB against production at the moment a restore has already failed, and wrote nothing to the history at all (#438).