### PR TITLE
Stop asserting a thread identity the runtime does not promise

### DIFF
--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -240,15 +240,24 @@ public sealed class FakeOperationHistoryStore : IOperationHistoryStore
     public Exception? AppendThrows { get; set; }
 
     /// <summary>
-    /// The thread each Append ran on, in order (#437). A UI caller must not be one of them:
-    /// the real store's Append is blocking file I/O with a ten-second lock backoff.
+    /// How many appends arrived through <see cref="AppendAsync"/> rather than the blocking
+    /// <see cref="Append"/> (#437).
+    ///
+    /// This is the observable difference between a call site that offloads and one that does not.
+    /// It replaced an assertion on thread identity, which was WRONG: Task.Run guarantees the work
+    /// is scheduled to the pool, not that it lands on a different thread - a loaded CI runner can
+    /// reuse the caller's own pool thread, and did.
     /// </summary>
-    public List<int> AppendThreads { get; } = [];
+    public int AsyncAppends { get; private set; }
+
+    public Task AppendAsync(OperationHistoryEntry entry)
+    {
+        AsyncAppends++;
+        return Task.Run(() => Append(entry));
+    }
 
     public void Append(OperationHistoryEntry entry)
     {
-        AppendThreads.Add(Environment.CurrentManagedThreadId);
-
         if (AppendThrows != null) throw AppendThrows;
 
         // The real store serialises on its own lock, and callers may now arrive from the thread

--- a/src/NineLives.Tests/HistoryWritesOffTheUiThreadTests.cs
+++ b/src/NineLives.Tests/HistoryWritesOffTheUiThreadTests.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
 using Xunit;
@@ -6,85 +6,114 @@ using Xunit;
 namespace Blackcat.NineLives.Tests;
 
 /// <summary>
-/// Receipts are written off the thread that asked for them (#437).
+/// Receipts are written without blocking the thread that asked for them (#437).
 ///
 /// <see cref="IOperationHistoryStore.Append"/> is blocking file I/O: a cross-process lock whose
 /// backoff sleeps up to ten seconds when a scheduled CLI run holds it, a whole-file read, a
 /// redaction pass, a serialize and a replace. The screens called it on the dispatcher, once per
-/// database - so a fifty-database backup did fifty of those on the UI thread, and the same call
-/// in the cancellation handler meant pressing Stop froze the window instead of stopping the run.
+/// database - so a fifty-database backup did fifty of those on the UI thread, and the same call in
+/// the cancellation handler meant pressing Stop froze the window instead of stopping the run.
 ///
-/// The property under test is *which thread ran the write*, so these assert on that directly
-/// rather than on a duration, which would be a timing test and therefore a flaky one.
+/// These first asserted the write ran on a DIFFERENT thread, which was not merely fragile but a
+/// claim the runtime never makes: Task.Run guarantees the work is queued to the thread pool, not
+/// which thread picks it up, and a loaded runner can hand it straight back to the caller's own
+/// pool thread. It did exactly that on CI, on a commit that was green locally.
+///
+/// They now assert the two things that are guaranteed and that actually matter: the caller is not
+/// held while the write happens, and the write has finished by the time the call is awaited.
 /// </summary>
 public class HistoryWritesOffTheUiThreadTests
 {
-    [Fact]
-    public async Task TheDefaultAppendAsyncLeavesTheCallingThread()
+    /// <summary>
+    /// A store whose Append blocks until released, and which deliberately does NOT implement
+    /// AppendAsync - so what these exercise is the default interface method every store inherits.
+    /// </summary>
+    private sealed class BlockingStore : IOperationHistoryStore
     {
-        var store = new FakeOperationHistoryStore();
-        var caller = Environment.CurrentManagedThreadId;
+        private readonly ManualResetEventSlim _release = new(false);
 
-        // Through the interface deliberately: AppendAsync is a default interface method, so the
-        // implementation under test is the one every store inherits rather than any fake's own.
-        await ((IOperationHistoryStore)store).AppendAsync(
-            new OperationHistoryEntry { TargetDatabase = "Sales" });
+        public ManualResetEventSlim Entered { get; } = new(false);
+        public List<OperationHistoryEntry> Written { get; } = [];
 
-        Assert.Single(store.AppendThreads);
-        Assert.NotEqual(caller, store.AppendThreads[0]);
+        public void Release() => _release.Set();
+
+        public void Append(OperationHistoryEntry entry)
+        {
+            Entered.Set();
+            _release.Wait(TimeSpan.FromSeconds(10));
+            lock (Written) Written.Add(entry);
+        }
+
+        public List<OperationHistoryEntry> Load() => [];
+        public bool CouldNotRead => false;
+        public void Clear() { }
+        public string FilePath => "(in memory)";
     }
 
     /// <summary>
-    /// Awaited, not fired and forgotten. One receipt per database only means anything if the
-    /// receipts are actually on disk when the run ends - a run that dies on the sixth database
-    /// has to leave the first five behind, because that half-finished run is the incident
-    /// somebody opens the history for.
+    /// The property the fix exists for: the caller gets on with its life while the write is still
+    /// inside the lock. Deterministic - it turns on a gate this test controls rather than on
+    /// which thread the scheduler happened to choose.
     /// </summary>
     [Fact]
-    public async Task TheWriteHasCompletedByTheTimeTheCallReturns()
+    public async Task AppendAsyncDoesNotHoldTheCallerWhileTheWriteHappens()
     {
-        var store = new FakeOperationHistoryStore();
+        var store = new BlockingStore();
+
+        var write = ((IOperationHistoryStore)store).AppendAsync(
+            new OperationHistoryEntry { TargetDatabase = "Sales" });
+
+        // The write is under way and the caller is here, not in it. Entered is an event, not a
+        // task, so waiting on it is not the blocking-a-task mistake this file is about.
+        Assert.True(store.Entered.Wait(TimeSpan.FromSeconds(10)));
+        Assert.False(write.IsCompleted);
+
+        store.Release();
+        await write.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    /// <summary>
+    /// Awaited, not fired and forgotten. One receipt per database only means something if the
+    /// receipts are on disk when the run ends - a run that dies on the sixth database has to leave
+    /// the first five behind, because that half-finished run is the incident somebody opens the
+    /// history for.
+    /// </summary>
+    [Fact]
+    public async Task TheWriteHasCompletedByTheTimeTheCallIsAwaited()
+    {
+        var store = new BlockingStore();
+        store.Release();
 
         await ((IOperationHistoryStore)store).AppendAsync(
             new OperationHistoryEntry { TargetDatabase = "Sales" });
 
-        Assert.Single(store.Entries);
+        Assert.Single(store.Written);
     }
 
     /// <summary>
     /// The store swallows its own failures, and the async path must not turn one into an
-    /// unobserved task exception - which would surface later, on a different thread, as a
-    /// crash nobody could trace back to a receipt.
+    /// unobserved task exception - which would surface later, on another thread, as a crash
+    /// nobody could trace back to a receipt.
     /// </summary>
     [Fact]
-    public async Task AStoreThatCannotWriteStillDoesNotThrowAtTheCaller()
+    public async Task AStoreThatCannotWriteFaultsTheTaskRatherThanTheProcess()
     {
         var store = new FakeOperationHistoryStore
         {
             AppendThrows = new InvalidOperationException("history file is read-only")
         };
 
-        // The real store catches internally; the fake throws to prove the caller's own guard
-        // holds, which is what every recording call site wraps this in.
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => ((IOperationHistoryStore)store).AppendAsync(
-                new OperationHistoryEntry { TargetDatabase = "Sales" }));
+            () => store.AppendAsync(new OperationHistoryEntry { TargetDatabase = "Sales" }));
     }
 
     /// <summary>
-    /// The one that would have caught this: a real backup run, checked for where it recorded.
-    ///
-    /// Deliberately NOT run on the fixture's dispatcher. Doing that deadlocks the test - Invoke
-    /// blocks the dispatcher thread, the run awaits a thread-pool write, and the continuation is
-    /// posted back to the thread that is sitting waiting for it. That is an artefact of blocking
-    /// inside Invoke rather than anything wrong with the product, where the message loop is free
-    /// to process the continuation.
-    ///
-    /// The property survives the simplification: the write must leave whichever thread ran the
-    /// backup. If a call site went back to the synchronous Append, this fails wherever it runs.
+    /// And the call site that matters takes the non-blocking route. Counted rather than inferred
+    /// from a thread id: a call site that reverted to the synchronous Append would record its
+    /// receipt just the same, and only this tells the two apart.
     /// </summary>
     [Fact]
-    public async Task ABackupRunRecordsOffTheThreadItRanOn()
+    public async Task ABackupRunRecordsThroughTheNonBlockingPath()
     {
         var store = new FakeCredentialStore();
         store.Config.Servers.Add(new ServerConnection
@@ -112,14 +141,11 @@ public class HistoryWritesOffTheUiThreadTests
         vm.SelectedDatabase = "Sales";
         vm.GenerateCommand.Execute(null);
 
-        var runner = Environment.CurrentManagedThreadId;
-
         // Armed, then run - the button is a two-press control.
         await vm.ExecuteCommand.ExecuteAsync(null);
         await vm.ExecuteCommand.ExecuteAsync(null);
 
-        // The run has to have got as far as recording, or this proves nothing.
-        Assert.NotEmpty(history.AppendThreads);
-        Assert.DoesNotContain(runner, history.AppendThreads);
+        Assert.NotEmpty(history.Entries);
+        Assert.Equal(history.Entries.Count, history.AsyncAppends);
     }
 }


### PR DESCRIPTION
Follow-up to #437, fixing a flaky test I introduced with it.

## What happened

The tests asserted the receipt write ran on a **different thread** from the caller. That is not merely fragile — it is a claim the runtime never makes. `Task.Run` guarantees the work is queued to the thread pool; it does not guarantee which thread picks it up, and a loaded runner can hand it straight back to the caller's own pool thread.

It did exactly that: `TheDefaultAppendAsyncLeavesTheCallingThread` failed on CI on the merge commit for #446 while passing locally every time — and the next commit went green, which is precisely how a flake survives to waste somebody's afternoon later instead of being dealt with now.

## What they assert instead

The two properties that are guaranteed, and that are what the fix is actually for:

- **The caller is not held while the write happens.** A store whose `Append` blocks on a gate the test controls; then assert the write has been *entered* and the returned task is *not complete*. Deterministic — it turns on the gate, not on scheduling luck.
- **The write has finished by the time the call is awaited**, which is what per-database durability rests on.

The backup path now proves it takes the non-blocking route by **counting** appends that arrived through `AppendAsync`, rather than inferring it from a thread id. A call site that reverted to the synchronous `Append` would record its receipt identically; only the count tells them apart.

## Confidence

Ran the four tests five times and the full suite twice — all green. The old assertion would not have survived that either locally; it needed a loaded runner, which is the point.

`dotnet build -c Release -warnaserror` clean, **2,141 passed, 0 failed**.