### PR TITLE
Ignore local machine-specific instruction files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ publish/
 
 # Local staging for the publish/ swap while the app holds the exe lock - never shipped
 publish-staging/
+
+# Personal, machine-local editor and tooling notes. Each contributor keeps their own; the
+# shared conventions belong in CONTRIBUTING.md.
+CLAUDE.local.md


### PR DESCRIPTION
`CLAUDE.local.md` is per-contributor scratch — machine paths, personal preferences, notes someone keeps to hand while working. None of it is shared configuration (the conventions everyone follows live in CONTRIBUTING.md), and none of it should reach the repository.

Committed rather than left in a local `.git/info/exclude` so the protection travels: a clone on another machine picks it up without anyone remembering to set it up again.

One line plus a comment; no code, no behaviour.