### PR TITLE
Find the backups that never reached the container - engine half (#451)

### DIFF
--- a/src/NineLives.Core/Services/BackupGapAnalyser.cs
+++ b/src/NineLives.Core/Services/BackupGapAnalyser.cs
@@ -1,0 +1,183 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>One backup the source instance recorded that the container does not hold.</summary>
+public sealed record MissingBackup(BackupHistoryEntry Entry, string Folder)
+{
+    public BackupType Type => Entry.Type;
+    public DateTime TakenAt => Entry.StartedAt;
+    public IReadOnlyList<string> Files => Entry.Files;
+    public long SizeBytes => Entry.BackupSizeBytes ?? 0;
+}
+
+/// <summary>
+/// The missing backups that share one folder - what a copy script would be written against.
+/// </summary>
+public sealed class MissingLocation(string folder, IReadOnlyList<MissingBackup> backups)
+{
+    /// <summary>The directory the files were written to, as the source instance named it.</summary>
+    public string Folder { get; } = folder;
+
+    public IReadOnlyList<MissingBackup> Backups { get; } = backups;
+
+    public int FileCount => Backups.Sum(b => b.Files.Count);
+
+    public long TotalSizeBytes => Backups.Sum(b => b.SizeBytes);
+
+    public DateTime Earliest => Backups.Min(b => b.TakenAt);
+
+    public DateTime Latest => Backups.Max(b => b.TakenAt);
+
+    public string SizeDisplay => ByteSize.Format(TotalSizeBytes);
+
+    /// <summary>"23 log backups" / "1 differential backup" - counted by kind, in one phrase.</summary>
+    public string Summary
+    {
+        get
+        {
+            var byKind = Backups
+                .GroupBy(b => b.Type)
+                .OrderBy(g => g.Key)
+                .Select(g => $"{g.Count()} {Describe(g.Key, g.Count())}");
+
+            return string.Join(", ", byKind);
+        }
+    }
+
+    private static string Describe(BackupType type, int count) => type switch
+    {
+        BackupType.Full => count == 1 ? "full backup" : "full backups",
+        BackupType.Differential => count == 1 ? "differential backup" : "differential backups",
+        BackupType.TransactionLog => count == 1 ? "log backup" : "log backups",
+        _ => count == 1 ? "backup" : "backups"
+    };
+}
+
+/// <summary>
+/// What the source instance recorded, set against what is actually in the container (#451).
+///
+/// The estate shape this exists for: fulls and diffs go to blob, and the transaction logs go
+/// somewhere else - a local or cluster disk for throughput, or a share because log shipping
+/// already owns them. Pointed at the container, the app builds an honest chain out of what it can
+/// see, and that chain stops at the last differential. Nothing says the logs exist, where they
+/// went, or that the restore on offer is discarding hours of recoverable time.
+///
+/// Finding that out requires knowing to go and look, which is precisely the knowledge somebody
+/// does not have at 3am on a server they did not build. msdb knows, so this asks it.
+/// </summary>
+public static class BackupGapAnalyser
+{
+    /// <summary>
+    /// How far apart two timestamps can be and still describe the same backup, when LSNs are not
+    /// available on both sides.
+    ///
+    /// A container set's timestamp is parsed from its file name, which the writer stamps at the
+    /// START of the backup; msdb records the start too, so these agree exactly in the ordinary
+    /// case. The tolerance covers a writer that stamps a second late, not a genuinely different
+    /// backup - two backups of one database two seconds apart is not a real schedule.
+    /// </summary>
+    private static readonly TimeSpan SameBackupWindow = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Backups the instance recorded that the container does not hold, grouped by where they are.
+    ///
+    /// Matching is by LSN wherever both sides have one, because that is the only identifier that
+    /// is genuinely the backup rather than a description of it: a file can be renamed, moved, or
+    /// written to two places, and its LSN range still says which backup it is. Container sets only
+    /// carry LSNs once they have been audited, so the fallback is type plus timestamp - weaker,
+    /// and the reason a set that is present but renamed could be reported as missing. Reporting a
+    /// present backup as missing costs an unnecessary copy; the reverse would leave somebody
+    /// restoring to an hour earlier than they could have, so the bias is deliberate.
+    /// </summary>
+    public static IReadOnlyList<MissingLocation> Compare(
+        IReadOnlyList<BackupHistoryEntry> history,
+        IReadOnlyList<BackupSet> inContainer,
+        string database)
+    {
+        if (history.Count == 0) return [];
+
+        var mine = history
+            .Where(h => string.Equals(h.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Where(h => h.HasFiles)
+            .ToList();
+
+        var held = inContainer
+            .Where(s => string.Equals(s.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var missing = mine.Where(h => !IsHeld(h, held)).ToList();
+
+        return missing
+            .Select(h => new MissingBackup(h, FolderOf(h.Files[0])))
+            .GroupBy(m => m.Folder, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new MissingLocation(g.Key, g.OrderBy(m => m.TakenAt).ToList()))
+            .OrderBy(l => l.Earliest)
+            .ToList();
+    }
+
+    private static bool IsHeld(BackupHistoryEntry entry, List<BackupSet> held)
+    {
+        foreach (var set in held)
+        {
+            if (set.Type != entry.Type) continue;
+
+            // The reliable answer, when both sides have it.
+            if (entry.LastLsn is { } mine && set.LastLsn is { } theirs)
+            {
+                if (mine == theirs) return true;
+                continue;
+            }
+
+            if (Math.Abs((set.Timestamp - entry.StartedAt).TotalSeconds)
+                <= SameBackupWindow.TotalSeconds)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The directory part of a device path, handling both separators.
+    ///
+    /// Not Path.GetDirectoryName: these strings come from the SOURCE instance and describe its
+    /// file system, not this machine's. A UNC path read on a machine with different rules must
+    /// come back out unchanged, because it is about to be printed into a script that runs over
+    /// there.
+    /// </summary>
+    internal static string FolderOf(string devicePath)
+    {
+        var cut = devicePath.LastIndexOfAny(['\\', '/']);
+        return cut <= 0 ? devicePath : devicePath[..cut];
+    }
+
+    /// <summary>
+    /// How much recovery time the container's own chain is throwing away.
+    ///
+    /// The gap between the newest backup the container holds and the newest the instance recorded.
+    /// Null when the container is not behind - which includes the case where it holds MORE than
+    /// msdb knows about, as it will on any instance whose history has been trimmed.
+    /// </summary>
+    public static TimeSpan? RecoveryTimeNotInContainer(
+        IReadOnlyList<BackupHistoryEntry> history,
+        IReadOnlyList<BackupSet> inContainer,
+        string database)
+    {
+        var newestRecorded = history
+            .Where(h => string.Equals(h.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Select(h => (DateTime?)h.StartedAt)
+            .DefaultIfEmpty(null)
+            .Max();
+
+        var newestHeld = inContainer
+            .Where(s => string.Equals(s.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Select(s => (DateTime?)s.Timestamp)
+            .DefaultIfEmpty(null)
+            .Max();
+
+        if (newestRecorded is not { } recorded || newestHeld is not { } heldAt) return null;
+
+        var behind = recorded - heldAt;
+        return behind > TimeSpan.Zero ? behind : null;
+    }
+}

--- a/src/NineLives.Core/Services/MissingBackupCopyScript.cs
+++ b/src/NineLives.Core/Services/MissingBackupCopyScript.cs
@@ -1,0 +1,195 @@
+﻿using System.Text;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// The PowerShell that brings backups the container is missing into it (#451).
+///
+/// Runs on the SOURCE machine, because that is where the files are - a local or cluster disk this
+/// app has no route to. So it is a script somebody takes away and runs there, not something the
+/// app can do on their behalf.
+///
+/// It NEVER carries the credential. The whole point of the container's secret living in Windows
+/// Credential Manager is defeated by writing it into a .ps1 that then sits in a folder on a
+/// production server, and SECURITY.md states outright that a generated script contains none - a
+/// claim that has to stay true of every generator, not just the ones written when it was made.
+/// The credential arrives as a mandatory parameter at run time instead, which is also the form
+/// somebody can wire into a scheduled task without it touching disk.
+/// </summary>
+public static class MissingBackupCopyScript
+{
+    /// <summary>
+    /// One script per location, because a location is one folder and one command shape. Two
+    /// folders needing two runs is honest about what is happening; concatenating them into one
+    /// script with interleaved paths is what produces a half-finished copy nobody can unpick.
+    /// </summary>
+    public static string Build(MissingLocation location, BlobContainerConfig container)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("<#");
+        sb.AppendLine("    Nine Lives - copy backups into the container");
+        sb.AppendLine();
+        sb.AppendLine($"    Run this ON the machine that holds {location.Folder}.");
+        sb.AppendLine();
+        sb.AppendLine($"    {location.Summary} that this container does not have,");
+        sb.AppendLine($"    taken between {location.Earliest:yyyy-MM-dd HH:mm} and {location.Latest:yyyy-MM-dd HH:mm}.");
+        sb.AppendLine($"    {location.FileCount} file(s), {location.SizeDisplay}.");
+        sb.AppendLine();
+        sb.AppendLine("    The credential is a parameter, not a value in this file - so this script");
+        sb.AppendLine("    is safe to save, review and hand over. Supply it when you run it.");
+        sb.AppendLine("#>");
+        sb.AppendLine();
+
+        if (container.IsS3) AppendS3(sb, location, container);
+        else AppendAzure(sb, location, container);
+
+        return sb.ToString();
+    }
+
+    private static void AppendAzure(
+        StringBuilder sb, MissingLocation location, BlobContainerConfig container)
+    {
+        sb.AppendLine("param(");
+        sb.AppendLine("    # The container's SAS token, including the leading '?'.");
+        sb.AppendLine("    [Parameter(Mandatory = $true)]");
+        sb.AppendLine("    [string] $Sas");
+        sb.AppendLine(")");
+        sb.AppendLine();
+        sb.AppendLine("$ErrorActionPreference = 'Stop'");
+        sb.AppendLine();
+        sb.AppendLine($"$container = '{container.ContainerUrl.TrimEnd('/')}'");
+        sb.AppendLine();
+        sb.AppendLine("# azcopy is the fast path and resumes a part-finished copy. If it is not on this");
+        sb.AppendLine("# machine, the Az.Storage fallback below does the same job more slowly.");
+        sb.AppendLine("$azcopy = Get-Command azcopy -ErrorAction SilentlyContinue");
+        sb.AppendLine();
+
+        AppendFileList(sb, location);
+
+        sb.AppendLine("$failed = @()");
+        sb.AppendLine();
+        sb.AppendLine("foreach ($file in $files) {");
+        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file)) {");
+        sb.AppendLine("        Write-Warning \"Not on disk any more: $file\"");
+        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("        continue");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    $name = Split-Path -Leaf $file");
+        sb.AppendLine("    Write-Host \"Copying $name...\"");
+        sb.AppendLine();
+        sb.AppendLine("    try {");
+        sb.AppendLine("        if ($azcopy) {");
+        sb.AppendLine("            & azcopy copy $file \"$container/$name$Sas\" --overwrite=ifSourceNewer | Out-Null");
+        sb.AppendLine("            if ($LASTEXITCODE -ne 0) { throw \"azcopy exited $LASTEXITCODE\" }");
+        sb.AppendLine("        }");
+        sb.AppendLine("        else {");
+        sb.AppendLine("            $ctx = New-AzStorageContext -BlobEndpoint ($container -replace '/[^/]+$', '') -SasToken $Sas");
+        sb.AppendLine("            $containerName = Split-Path -Leaf $container");
+        sb.AppendLine("            Set-AzStorageBlobContent -File $file -Container $containerName -Blob $name -Context $ctx -Force | Out-Null");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine("    catch {");
+        sb.AppendLine("        Write-Warning \"Failed: $name - $_\"");
+        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        sb.AppendLine();
+
+        AppendEnding(sb);
+    }
+
+    private static void AppendS3(
+        StringBuilder sb, MissingLocation location, BlobContainerConfig container)
+    {
+        var url = S3Url.TryParse(container.ContainerUrl.TrimEnd('/'));
+        var bucket = url?.Bucket ?? "BUCKET";
+        var prefix = string.IsNullOrWhiteSpace(url?.BasePrefix) ? "" : url!.BasePrefix.Trim('/') + "/";
+        var endpoint = url?.Authority ?? "ENDPOINT";
+
+        sb.AppendLine("param(");
+        sb.AppendLine("    [Parameter(Mandatory = $true)] [string] $AccessKeyId,");
+        sb.AppendLine("    [Parameter(Mandatory = $true)] [string] $SecretAccessKey");
+        sb.AppendLine(")");
+        sb.AppendLine();
+        sb.AppendLine("$ErrorActionPreference = 'Stop'");
+        sb.AppendLine();
+        sb.AppendLine("# Set for this process only - nothing is written to the profile or the machine.");
+        sb.AppendLine("$env:AWS_ACCESS_KEY_ID = $AccessKeyId");
+        sb.AppendLine("$env:AWS_SECRET_ACCESS_KEY = $SecretAccessKey");
+
+        if (!string.IsNullOrWhiteSpace(container.S3Region))
+            sb.AppendLine($"$env:AWS_DEFAULT_REGION = '{container.S3Region}'");
+
+        sb.AppendLine();
+        sb.AppendLine($"$bucket = '{bucket}'");
+        sb.AppendLine($"$prefix = '{prefix}'");
+        sb.AppendLine($"$endpoint = 'https://{endpoint}'");
+        sb.AppendLine();
+
+        AppendFileList(sb, location);
+
+        sb.AppendLine("$failed = @()");
+        sb.AppendLine();
+        sb.AppendLine("foreach ($file in $files) {");
+        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file)) {");
+        sb.AppendLine("        Write-Warning \"Not on disk any more: $file\"");
+        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("        continue");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    $name = Split-Path -Leaf $file");
+        sb.AppendLine("    Write-Host \"Copying $name...\"");
+        sb.AppendLine();
+        sb.AppendLine("    & aws s3 cp $file \"s3://$bucket/$prefix$name\" --endpoint-url $endpoint");
+        sb.AppendLine("    if ($LASTEXITCODE -ne 0) {");
+        sb.AppendLine("        Write-Warning \"Failed: $name\"");
+        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        sb.AppendLine();
+
+        AppendEnding(sb);
+    }
+
+    /// <summary>
+    /// The files, named one by one rather than as a wildcard over the folder.
+    ///
+    /// A wildcard would copy whatever else is in there - other databases' backups, an unrelated
+    /// job's output, files somebody is midway through writing. This list is the answer to a
+    /// specific question (what is this chain missing), and copying anything else is both a
+    /// surprise and, on a metered egress link, a bill.
+    /// </summary>
+    private static void AppendFileList(StringBuilder sb, MissingLocation location)
+    {
+        sb.AppendLine("# Named individually, not a wildcard: only what this chain is actually missing.");
+        sb.AppendLine("$files = @(");
+
+        var paths = location.Backups.SelectMany(b => b.Files).ToList();
+        for (int i = 0; i < paths.Count; i++)
+        {
+            var comma = i < paths.Count - 1 ? "," : "";
+            sb.AppendLine($"    '{paths[i].Replace("'", "''")}'{comma}");
+        }
+
+        sb.AppendLine(")");
+        sb.AppendLine();
+    }
+
+    private static void AppendEnding(StringBuilder sb)
+    {
+        sb.AppendLine("if ($failed.Count -gt 0) {");
+        sb.AppendLine("    Write-Host \"\"");
+        sb.AppendLine("    Write-Warning \"$($failed.Count) file(s) did not copy:\"");
+        sb.AppendLine("    $failed | ForEach-Object { Write-Warning \"  $_\" }");
+        sb.AppendLine("    Write-Host \"\"");
+        sb.AppendLine("    Write-Host 'Rescan in Nine Lives to see what did arrive.'");
+        sb.AppendLine("    exit 1");
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine("Write-Host \"\"");
+        sb.AppendLine("Write-Host 'Done. Rescan the container in Nine Lives to pick them up.'");
+    }
+}

--- a/src/NineLives.Tests/BackupGapAnalyserTests.cs
+++ b/src/NineLives.Tests/BackupGapAnalyserTests.cs
@@ -1,0 +1,285 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Finding the backups the instance took that never reached the container (#451).
+///
+/// The estate this is for: fulls and diffs to blob, logs to a local or cluster disk. The container
+/// holds an honest chain that stops at the last differential, and nothing tells anybody the logs
+/// exist somewhere else - so a restore silently discards hours of recoverable time.
+/// </summary>
+public class BackupGapAnalyserTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 14, 22, 0, 0);
+
+    private static BackupHistoryEntry Recorded(
+        BackupType type, DateTime at, string folder, decimal? lastLsn = null, long size = 1024,
+        string database = "Sales", int stripes = 1)
+    {
+        var ext = type == BackupType.TransactionLog ? "trn" : "bak";
+        var stamp = at.ToString("yyyyMMdd_HHmmss");
+
+        var files = Enumerable.Range(1, stripes)
+            .Select(n => stripes == 1
+                ? $@"{folder}\{database}_{stamp}.{ext}"
+                : $@"{folder}\{database}_{stamp}_{n}.{ext}")
+            .ToList();
+
+        return new BackupHistoryEntry
+        {
+            DatabaseName = database,
+            Type = type,
+            StartedAt = at,
+            FinishedAt = at.AddMinutes(1),
+            Files = files,
+            LastLsn = lastLsn,
+            BackupSizeBytes = size,
+            FamilyCount = stripes
+        };
+    }
+
+    private static BackupSet InContainer(
+        BackupType type, DateTime at, decimal? lastLsn = null, string database = "Sales") => new()
+        {
+            SetId = at.ToString("yyyyMMdd_HHmmss"),
+            Type = type,
+            Timestamp = at,
+            DatabaseName = database,
+            LastLsn = lastLsn,
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = $"{database}_{at:yyyyMMdd_HHmmss}.bak",
+                    BlobUrl = $"https://acct.blob.core.windows.net/c/{database}_{at:yyyyMMdd_HHmmss}.bak",
+                    Type = type
+                }
+            ]
+        };
+
+    // ── the case the feature exists for ─────────────────────────────────────────
+
+    [Fact]
+    public void LogsWrittenToDiskAreReportedAsMissingFromTheContainer()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(2), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(3), @"E:\SQLLogs")
+        };
+
+        // The container has the full, and nothing else.
+        var container = new List<BackupSet> { InContainer(BackupType.Full, T0) };
+
+        var locations = BackupGapAnalyser.Compare(history, container, "Sales");
+
+        var logs = Assert.Single(locations);
+        Assert.Equal(@"E:\SQLLogs", logs.Folder);
+        Assert.Equal(3, logs.Backups.Count);
+        Assert.Equal("3 log backups", logs.Summary);
+        Assert.Equal(T0.AddHours(1), logs.Earliest);
+        Assert.Equal(T0.AddHours(3), logs.Latest);
+    }
+
+    [Fact]
+    public void TheRecoveryTimeTheContainerIsBehindIsReported()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(12), @"E:\SQLLogs")
+        };
+        var container = new List<BackupSet> { InContainer(BackupType.Full, T0) };
+
+        var behind = BackupGapAnalyser.RecoveryTimeNotInContainer(history, container, "Sales");
+
+        Assert.Equal(TimeSpan.FromHours(12), behind);
+    }
+
+    /// <summary>Two paths, two groups - a copy script is written per location.</summary>
+    [Fact]
+    public void MissingBackupsAreGroupedByTheFolderTheyWereWrittenTo()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(2), @"\\nas01\shipping"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(3), @"E:\SQLLogs")
+        };
+
+        var locations = BackupGapAnalyser.Compare(history, [], "Sales");
+
+        Assert.Equal(2, locations.Count);
+        Assert.Contains(locations, l => l.Folder == @"E:\SQLLogs" && l.Backups.Count == 2);
+        Assert.Contains(locations, l => l.Folder == @"\\nas01\shipping" && l.Backups.Count == 1);
+    }
+
+    // ── matching ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The reliable identifier. A file that was renamed or written to two places is still the same
+    /// backup, and its LSN range is the only thing that says so.
+    /// </summary>
+    [Fact]
+    public void ABackupHeldUnderADifferentNameIsMatchedByItsLsn()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"C:\Backups", lastLsn: 4200m)
+        };
+
+        // Same backup, different name and a timestamp that would not match.
+        var container = new List<BackupSet>
+        {
+            InContainer(BackupType.Full, T0.AddHours(9), lastLsn: 4200m)
+        };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, container, "Sales"));
+    }
+
+    /// <summary>
+    /// And two different backups that share a timestamp are not conflated, because the LSNs
+    /// disagree - a full and its log can start in the same second.
+    /// </summary>
+    [Fact]
+    public void DifferentLsnsAtTheSameInstantAreDifferentBackups()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs", lastLsn: 5000m)
+        };
+        var container = new List<BackupSet>
+        {
+            InContainer(BackupType.TransactionLog, T0, lastLsn: 4000m)
+        };
+
+        Assert.Single(BackupGapAnalyser.Compare(history, container, "Sales"));
+    }
+
+    /// <summary>
+    /// Without LSNs on both sides - a container that has never been audited - type and timestamp
+    /// are what is left.
+    /// </summary>
+    [Fact]
+    public void WithoutLsnsAMatchFallsBackToTypeAndTimestamp()
+    {
+        var history = new List<BackupHistoryEntry> { Recorded(BackupType.Full, T0, @"C:\Backups") };
+        var container = new List<BackupSet> { InContainer(BackupType.Full, T0) };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, container, "Sales"));
+    }
+
+    [Fact]
+    public void TheSameInstantButADifferentTypeIsNotAMatch()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs")
+        };
+        var container = new List<BackupSet> { InContainer(BackupType.Full, T0) };
+
+        Assert.Single(BackupGapAnalyser.Compare(history, container, "Sales"));
+    }
+
+    // ── things that must stay quiet ─────────────────────────────────────────────
+
+    [Fact]
+    public void AContainerHoldingEverythingReportsNoGap()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"C:\Backups")
+        };
+        var container = new List<BackupSet>
+        {
+            InContainer(BackupType.Full, T0),
+            InContainer(BackupType.TransactionLog, T0.AddHours(1))
+        };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, container, "Sales"));
+        Assert.Null(BackupGapAnalyser.RecoveryTimeNotInContainer(history, container, "Sales"));
+    }
+
+    /// <summary>Another database's backups are not this database's problem.</summary>
+    [Fact]
+    public void AnotherDatabasesBackupsAreIgnored()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs", database: "Payroll")
+        };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, [], "Sales"));
+    }
+
+    /// <summary>
+    /// A container ahead of msdb is not behind it. Instance history gets trimmed, so a container
+    /// holding backups older than anything msdb still remembers is the ordinary case, not a fault.
+    /// </summary>
+    [Fact]
+    public void AContainerAheadOfTheInstanceHistoryIsNotReportedAsBehind()
+    {
+        var history = new List<BackupHistoryEntry> { Recorded(BackupType.Full, T0, @"C:\Backups") };
+        var container = new List<BackupSet>
+        {
+            InContainer(BackupType.Full, T0),
+            InContainer(BackupType.TransactionLog, T0.AddHours(6))
+        };
+
+        Assert.Null(BackupGapAnalyser.RecoveryTimeNotInContainer(history, container, "Sales"));
+    }
+
+    [Fact]
+    public void AnEmptyHistoryReportsNothing()
+    {
+        Assert.Empty(BackupGapAnalyser.Compare([], [], "Sales"));
+        Assert.Null(BackupGapAnalyser.RecoveryTimeNotInContainer([], [], "Sales"));
+    }
+
+    /// <summary>A recorded backup with no files recorded against it has no path to report.</summary>
+    [Fact]
+    public void ARecordedBackupWithNoFilesIsSkipped()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            new() { DatabaseName = "Sales", Type = BackupType.TransactionLog, StartedAt = T0, Files = [] }
+        };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, [], "Sales"));
+    }
+
+    // ── the paths themselves ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// These strings describe the SOURCE instance's file system, not this machine's, and they are
+    /// about to be printed into a script that runs over there.
+    /// </summary>
+    [Theory]
+    [InlineData(@"E:\SQLLogs\Sales_20260814.trn", @"E:\SQLLogs")]
+    [InlineData(@"\\nas01\shipping\Sales.trn", @"\\nas01\shipping")]
+    [InlineData(@"/var/opt/mssql/backups/Sales.trn", "/var/opt/mssql/backups")]
+    [InlineData(@"Sales.trn", @"Sales.trn")]
+    public void TheFolderIsTakenFromThePathAsTheSourceWroteIt(string device, string expected)
+        => Assert.Equal(expected, BackupGapAnalyser.FolderOf(device));
+
+    /// <summary>A striped set is one missing backup with several files to copy, not several.</summary>
+    [Fact]
+    public void AStripedBackupIsOneEntryWithEveryFileNamed()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"E:\SQLLogs", stripes: 3)
+        };
+
+        var location = Assert.Single(BackupGapAnalyser.Compare(history, [], "Sales"));
+
+        Assert.Single(location.Backups);
+        Assert.Equal(3, location.FileCount);
+    }
+}

--- a/src/NineLives.Tests/MissingBackupCopyScriptTests.cs
+++ b/src/NineLives.Tests/MissingBackupCopyScriptTests.cs
@@ -1,0 +1,177 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The script that brings missing backups into the container (#451).
+///
+/// It runs on the source machine, so it is handed over rather than executed here - which makes
+/// what it contains a security question as much as a correctness one.
+/// </summary>
+public class MissingBackupCopyScriptTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 14, 22, 0, 0);
+
+    private static MissingLocation Location(string folder = @"E:\SQLLogs", int count = 3)
+    {
+        var backups = Enumerable.Range(1, count).Select(i =>
+        {
+            var at = T0.AddHours(i);
+            return new MissingBackup(
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "Sales",
+                    Type = BackupType.TransactionLog,
+                    StartedAt = at,
+                    Files = [$@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn"],
+                    BackupSizeBytes = 10 * 1024 * 1024
+                },
+                folder);
+        }).ToList();
+
+        return new MissingLocation(folder, backups);
+    }
+
+    private static BlobContainerConfig Azure() => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+    };
+
+    private static BlobContainerConfig Bucket() => new()
+    {
+        Id = "c2",
+        Name = "dr-bucket",
+        ContainerUrl = "s3://s3.eu-west-2.amazonaws.com/dr-bucket/sql",
+        S3Region = "eu-west-2"
+    };
+
+    // ── the security property ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// The one that must never regress. SECURITY.md states outright that a generated script
+    /// contains no credential, and this script is the most tempting place to break that: it would
+    /// be one string interpolation to embed the SAS, and the result would sit in a .ps1 on a
+    /// production server.
+    /// </summary>
+    [Fact]
+    public void TheAzureScriptTakesTheCredentialAsAParameterAndCarriesNone()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Azure());
+
+        Assert.Contains("[Parameter(Mandatory = $true)]", script);
+        Assert.Contains("$Sas", script);
+
+        // Nothing that looks like a token, and no query string on the container URL.
+        Assert.DoesNotContain("sig=", script);
+        Assert.DoesNotContain("?sv=", script);
+    }
+
+    [Fact]
+    public void TheS3ScriptTakesTheKeyPairAsParametersAndCarriesNone()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Bucket());
+
+        Assert.Contains("$AccessKeyId", script);
+        Assert.Contains("$SecretAccessKey", script);
+
+        // Set for the process, not written anywhere.
+        Assert.Contains("$env:AWS_ACCESS_KEY_ID = $AccessKeyId", script);
+        Assert.DoesNotContain("aws configure", script);
+    }
+
+    // ── what it copies ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Named individually. A wildcard over the folder would take other databases' backups, an
+    /// unrelated job's output, and whatever is half-written at that moment - a surprise, and on a
+    /// metered egress link a bill.
+    /// </summary>
+    [Fact]
+    public void EveryFileIsNamedAndNoWildcardIsUsed()
+    {
+        var script = MissingBackupCopyScript.Build(Location(count: 3), Azure());
+
+        Assert.Contains(@"'E:\SQLLogs\Sales_20260814_230000.trn'", script);
+        Assert.Contains(@"'E:\SQLLogs\Sales_20260815_000000.trn'", script);
+        Assert.Contains(@"'E:\SQLLogs\Sales_20260815_010000.trn'", script);
+
+        Assert.DoesNotContain("*.trn", script);
+        Assert.DoesNotContain("*.bak", script);
+    }
+
+    [Fact]
+    public void TheHeaderSaysWhatIsBeingCopiedAndFromWhere()
+    {
+        var script = MissingBackupCopyScript.Build(Location(count: 3), Azure());
+
+        Assert.Contains("3 log backups", script);
+        Assert.Contains(@"E:\SQLLogs", script);
+        Assert.Contains("30.0 MB", script);
+    }
+
+    [Fact]
+    public void TheS3ScriptTargetsTheBucketAndBasePathFromTheContainerUrl()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Bucket());
+
+        Assert.Contains("$bucket = 'dr-bucket'", script);
+        Assert.Contains("$prefix = 'sql/'", script);
+        Assert.Contains("$endpoint = 'https://s3.eu-west-2.amazonaws.com'", script);
+        Assert.Contains("$env:AWS_DEFAULT_REGION = 'eu-west-2'", script);
+    }
+
+    // ── what it does when things are not as expected ────────────────────────────
+
+    /// <summary>
+    /// A file that has been purged since the history was read is reported, not fatal. Retention
+    /// running between the scan and the copy is entirely ordinary, and stopping dead on the first
+    /// missing one would leave the rest uncopied for no reason.
+    /// </summary>
+    [Fact]
+    public void AFileThatHasGoneIsReportedAndTheRestStillCopy()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Azure());
+
+        Assert.Contains("Test-Path -LiteralPath $file", script);
+        Assert.Contains("Not on disk any more", script);
+        Assert.Contains("continue", script);
+        Assert.Contains("exit 1", script);
+    }
+
+    [Fact]
+    public void ItEndsByPointingBackAtTheRescan()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Azure());
+        Assert.Contains("Rescan", script);
+    }
+
+    /// <summary>
+    /// A path holding an apostrophe would otherwise close the PowerShell literal and turn the rest
+    /// of the line into commands - the same class of hole as an unescaped SQL literal.
+    /// </summary>
+    [Fact]
+    public void AnApostropheInAPathIsEscaped()
+    {
+        var folder = @"E:\Jake's Logs";
+        var location = new MissingLocation(folder,
+        [
+            new MissingBackup(
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "Sales",
+                    Type = BackupType.TransactionLog,
+                    StartedAt = T0,
+                    Files = [$@"{folder}\Sales.trn"]
+                },
+                folder)
+        ]);
+
+        var script = MissingBackupCopyScript.Build(location, Azure());
+
+        Assert.Contains(@"'E:\Jake''s Logs\Sales.trn'", script);
+    }
+}


### PR DESCRIPTION
The engine half of #451. **No screen uses this yet** — the UI is the next piece — but it is the part worth getting right on its own, and unlike the UI it is testable without one.

## The problem

Fulls and diffs go to blob; transaction logs go to a local or cluster disk for throughput, or to a share because log shipping already owns them. Pointed at the container, the app builds an honest chain out of what it can see — and that chain stops at the last differential. Nothing says the logs exist, where they went, or that the restore on offer is discarding hours of recoverable time.

Finding that out requires already knowing to look, which is precisely the knowledge somebody does not have at 3am on a server they did not build. msdb knows, so this asks it.

## `BackupGapAnalyser`

Sets msdb's record against the container's contents and reports what is missing, grouped by the folder it was written to — a folder being one copy script's worth of work. Also reports how far behind the container is in recovery time, which is the number that actually decides whether somebody cares.

**Matching is by LSN wherever both sides have one.** That is the only identifier which is the backup rather than a description of it: a file can be renamed, moved, or written to two places, and its LSN range still says which backup it is. Container sets only carry LSNs once they have been audited, so the fallback is type plus timestamp within five seconds.

That fallback is weaker, and **the bias is deliberate**: reporting a present backup as missing costs an unnecessary copy, while the reverse leaves somebody restoring to an hour earlier than they could have. Both directions are pinned.

## `MissingBackupCopyScript`

The PowerShell that brings them in — azcopy with an `Az.Storage` fallback for blob, `aws s3 cp` for a bucket. Per location, because a location is one folder and one command shape; concatenating two into one script is what produces a half-finished copy nobody can unpick.

Every file is **named individually rather than globbed**. A wildcard over the folder takes other databases' backups, an unrelated job's output, and whatever is half-written at that moment — a surprise, and on a metered egress link a bill.

### It carries no credential

Worth calling out because it would be one string interpolation away, and the result would sit in a `.ps1` on a production server. SECURITY.md states outright that a generated script contains none, and that has to stay true of every generator rather than only the ones written when the claim was made.

The SAS or key pair is a **mandatory parameter supplied at run time** — which is also the form somebody can wire into a scheduled task without it touching disk. Pinned in both provider shapes, including that the container URL carries no query string.

## Not in this PR

The Restore and Copy Database surfaces, the rescan-and-confirm loop, and the second remedy — restoring `WITH NORECOVERY` and rolling the logs forward from where they already are. That last one is smaller than it looks: `BackupDevice.Clause` already picks `DISK` or `URL` per file, so a chain holding a blob full and disk-resident logs already generates correct T-SQL. It has just never been possible to build one.

## Effect

`dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test` → **2,166 passed, 0 failed** (up 25). Nothing existing changes behaviour; this is all new and unreferenced until the UI lands.