### PR TITLE
Ask the source instance what the container is missing (#451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Added
+
+- **The Restore screen can ask the source instance what this container is missing** (#451).
+  Logs often go somewhere the fulls do not - a local or cluster disk for throughput, or a share
+  because log shipping already owns them. Pointed at the container, the app built an honest chain
+  out of what it could see, and that chain stopped at the last differential with nothing to say
+  the rest existed. Under the advanced restore options there is now a source instance picker and
+  a check: it reads that instance's own record, sets it against what the container holds, and
+  names what is missing along with the path it went to and how much recovery time the container
+  is behind by. For anything on disk it writes the PowerShell to copy those exact files in -
+  named individually rather than globbed, and carrying no credential, because that script is
+  handed to somebody to run on a production server.
+
 ## [1.6.4] - 2026-08-14
 
 ### Fixed

--- a/src/NineLives.Tests/BackupGapViewModelTests.cs
+++ b/src/NineLives.Tests/BackupGapViewModelTests.cs
@@ -1,0 +1,288 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The panel that asks the source instance what the container is missing (#451).
+///
+/// It answers a question the restore screen cannot answer alone: is this chain short because that
+/// is all there ever was, or because the logs went somewhere else? Only the instance that took
+/// them knows.
+/// </summary>
+public class BackupGapViewModelTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 14, 22, 0, 0);
+
+    private static ServerConnection Server(string name = "SRV01") => new()
+    {
+        Id = ServerConnection.NewId(),
+        Name = name,
+        ServerName = name
+    };
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+    };
+
+    private static BackupHistoryEntry Recorded(BackupType type, DateTime at, string folder) => new()
+    {
+        DatabaseName = "Sales",
+        Type = type,
+        StartedAt = at,
+        Files = [$@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn"],
+        BackupSizeBytes = 10 * 1024 * 1024
+    };
+
+    private static BackupSet Held(BackupType type, DateTime at) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        Type = type,
+        Timestamp = at,
+        DatabaseName = "Sales",
+        Files = [new BackupFileInfo { BlobName = "x.bak", Type = type }]
+    };
+
+    private static (BackupGapViewModel vm, FakeSqlServerService sql) Panel(
+        params BackupHistoryEntry[] history)
+    {
+        var sql = new FakeSqlServerService { BackupHistory = history.ToList() };
+        var vm = new BackupGapViewModel(sql);
+        vm.Servers.Add(Server());
+        vm.SourceServer = vm.Servers[0];
+        return (vm, sql);
+    }
+
+    private static GapCheckRequest Ask(params BackupSet[] held)
+        => new("Sales", Container(), held);
+
+    // ── the case it exists for ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LogsTakenToDiskAreFoundAndTheirFolderNamed()
+    {
+        var (vm, _) = Panel(
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(2), @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0)));
+
+        Assert.True(vm.HasGap);
+        var row = Assert.Single(vm.Locations);
+        Assert.Equal(@"E:\SQLLogs", row.Folder);
+        Assert.Equal("2 log backups", row.Summary);
+        Assert.True(row.IsOnDisk);
+    }
+
+    [Fact]
+    public async Task ItSaysHowFarBehindTheContainerIs()
+    {
+        var (vm, _) = Panel(
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(12).AddMinutes(45), @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0)));
+
+        Assert.Equal("12 hours 45 minutes", vm.BehindBy);
+    }
+
+    /// <summary>
+    /// A clean answer has to be said out loud. "No locations" rendering as an empty panel is
+    /// indistinguishable from never having pressed the button.
+    /// </summary>
+    [Fact]
+    public async Task AContainerHoldingEverythingSaysSoRatherThanShowingNothing()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.Full, T0, @"C:\Backups"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0)));
+
+        Assert.False(vm.HasGap);
+        Assert.True(vm.FoundNothingMissing);
+        Assert.Contains("Everything the instance recorded", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void BeforeAnyCheckTheAllClearIsNotClaimed()
+    {
+        var (vm, _) = Panel();
+
+        Assert.False(vm.HasChecked);
+        Assert.False(vm.FoundNothingMissing);
+        Assert.False(vm.HasGap);
+    }
+
+    // ── what was compared ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The answer is only worth anything if somebody can see it was asked of the right instance
+    /// and the right database - this panel connects to a DIFFERENT server from the one the restore
+    /// runs on, which is exactly the confusion worth heading off.
+    /// </summary>
+    [Fact]
+    public async Task ItStatesWhatItCompared()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0.AddHours(-1))));
+
+        Assert.Contains("Sales on SRV01", vm.ComparedWhat);
+        Assert.Contains("sqlbackups", vm.ComparedWhat);
+    }
+
+    // ── refusals and failures ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WithNoDatabaseChosenItSaysSoRatherThanCheckingNothing()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(new GapCheckRequest("", Container(), []));
+
+        Assert.True(vm.HasError);
+        Assert.Contains("per database", vm.ErrorMessage);
+        Assert.False(vm.HasChecked);
+    }
+
+    [Fact]
+    public async Task AnUnreachableSourceNamesItselfInTheFailure()
+    {
+        var (vm, sql) = Panel();
+        sql.BackupHistoryThrows = new InvalidOperationException("Login failed for user 'sa'.");
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.True(vm.HasError);
+        Assert.Contains("SRV01", vm.ErrorMessage);
+        Assert.Contains("Login failed", vm.ErrorMessage);
+        Assert.False(vm.HasChecked);
+    }
+
+    [Fact]
+    public void TheCheckIsRefusedUntilASourceIsChosen()
+    {
+        var vm = new BackupGapViewModel(new FakeSqlServerService());
+        Assert.False(vm.CanCheck);
+
+        vm.Servers.Add(Server());
+        vm.SourceServer = vm.Servers[0];
+
+        Assert.True(vm.CanCheck);
+    }
+
+    /// <summary>
+    /// A previous answer describes a previous server. Leaving it on screen under a new selection
+    /// is the stale-result problem, and a panel whose whole job is to be believed cannot have it.
+    /// </summary>
+    [Fact]
+    public async Task ChangingTheSourceClearsThePreviousAnswer()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs"));
+        await vm.CheckCommand.ExecuteAsync(Ask());
+        Assert.True(vm.HasGap);
+
+        vm.Servers.Add(Server("SRV02"));
+        vm.SourceServer = vm.Servers[1];
+
+        Assert.False(vm.HasGap);
+        Assert.False(vm.HasChecked);
+        Assert.Empty(vm.BehindBy);
+    }
+
+    /// <summary>
+    /// A gap and a MEASURED gap are different things, and rendering the panel is what made that
+    /// obvious: a container holding nothing at all for this database has everything missing and no
+    /// interval to quote, because there is no newest-held backup to measure from. The banner
+    /// assumed the two went together and drew "This container is  behind what the instance
+    /// recorded" - a sentence with a hole in it.
+    /// </summary>
+    [Fact]
+    public async Task AContainerHoldingNothingHasAGapButNoIntervalToQuote()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.True(vm.HasGap);
+        Assert.False(vm.HasMeasuredGap);
+        Assert.Empty(vm.BehindBy);
+    }
+
+    [Fact]
+    public async Task AContainerThatIsMerelyBehindHasBoth()
+    {
+        var (vm, _) = Panel(
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(3), @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0)));
+
+        Assert.True(vm.HasGap);
+        Assert.True(vm.HasMeasuredGap);
+        Assert.Equal("3 hours", vm.BehindBy);
+    }
+
+    // ── the copy script ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TheCopyScriptIsBuiltForTheChosenLocationOnly()
+    {
+        var (vm, _) = Panel(
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(2), @"\\nas01\shipping"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+        Assert.Equal(2, vm.Locations.Count);
+
+        var first = vm.Locations.First(l => l.Folder == @"E:\SQLLogs");
+        Assert.False(first.HasScript);
+
+        vm.BuildScript(first, Container());
+
+        Assert.True(first.HasScript);
+        Assert.Contains(@"E:\SQLLogs", first.Script);
+        Assert.DoesNotContain(@"\\nas01\shipping", first.Script);
+
+        // And the other is untouched - one location, one script, one run.
+        Assert.False(vm.Locations.First(l => l.Folder == @"\\nas01\shipping").HasScript);
+    }
+
+    /// <summary>
+    /// A backup msdb recorded to a URL is not a file on the source machine, so there is nothing
+    /// for a copy script to pick up. That finding means the container listing did not see
+    /// something that WAS written to storage - a different problem with a different answer.
+    /// </summary>
+    [Fact]
+    public async Task ABackupRecordedToAUrlIsNotOfferedAsSomethingToCopy()
+    {
+        var (vm, _) = Panel(new BackupHistoryEntry
+        {
+            DatabaseName = "Sales",
+            Type = BackupType.TransactionLog,
+            StartedAt = T0,
+            Files = ["https://acct.blob.core.windows.net/sqlbackups/Sales_log.trn"]
+        });
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        var row = Assert.Single(vm.Locations);
+        Assert.False(row.IsOnDisk);
+    }
+
+    // ── the wording of the gap ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0, 0, 30, "30 minutes")]
+    [InlineData(0, 1, 0, "1 hour")]
+    [InlineData(0, 12, 45, "12 hours 45 minutes")]
+    [InlineData(2, 3, 0, "2 days 3 hours")]
+    [InlineData(0, 0, 0, "under a minute")]
+    public void TheGapIsQuotedInUnitsSomebodyDecidesOn(int d, int h, int m, string expected)
+        => Assert.Equal(expected, BackupGapViewModel.Humanise(new TimeSpan(d, h, m, 0)));
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -807,11 +807,17 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.FromResult(entries.ToList());
     }
 
+    /// <summary>Set to play an instance whose history cannot be read - a login failure, or no
+    /// rights on msdb, which is the ordinary reason a source refuses this (#451).</summary>
+    public Exception? BackupHistoryThrows { get; set; }
+
     public Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
         ServerConnection server, string? databaseName = null, CancellationToken ct = default)
-        => Task.FromResult(databaseName == null
-            ? BackupHistory
-            : BackupHistory.Where(h => h.DatabaseName == databaseName).ToList());
+        => BackupHistoryThrows != null
+            ? Task.FromException<List<BackupHistoryEntry>>(BackupHistoryThrows)
+            : Task.FromResult(databaseName == null
+                ? BackupHistory
+                : BackupHistory.Where(h => h.DatabaseName == databaseName).ToList());
 
     /// <summary>Set to make the target unreachable rather than merely unhelpful.</summary>
     public Exception? ThrowOnCheck { get; set; }

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -1,0 +1,227 @@
+﻿using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>One folder's worth of missing backups, as the screen shows it.</summary>
+public sealed partial class MissingLocationRow(MissingLocation location) : ObservableObject
+{
+    public MissingLocation Location { get; } = location;
+
+    public string Folder => Location.Folder;
+    public string Summary => Location.Summary;
+    public int FileCount => Location.FileCount;
+    public string SizeDisplay => Location.SizeDisplay;
+
+    public string Window =>
+        $"{Location.Earliest:yyyy-MM-dd HH:mm} to {Location.Latest:yyyy-MM-dd HH:mm}";
+
+    /// <summary>
+    /// Whether these can be copied at all. A backup msdb recorded to a URL is not a file on the
+    /// source machine, so there is nothing for a copy script to pick up - that finding means the
+    /// container listing did not see something that was written to storage, which is a different
+    /// problem with a different answer.
+    /// </summary>
+    public bool IsOnDisk => BackupDevice.IsPath(Location.Backups[0].Files.FirstOrDefault());
+
+    [ObservableProperty]
+    private string _script = string.Empty;
+
+    public bool HasScript => Script.Length > 0;
+
+    partial void OnScriptChanged(string value) => OnPropertyChanged(nameof(HasScript));
+}
+
+/// <summary>
+/// What the source instance recorded, against what the container actually holds (#451).
+///
+/// Answers the question the restore screen cannot answer on its own: is this chain short because
+/// that is all there ever was, or because the logs went somewhere else? The container cannot tell
+/// the difference - only the instance that took them knows - so this asks it, and it has to be
+/// asked deliberately because it means connecting to a second server.
+/// </summary>
+public partial class BackupGapViewModel : ViewModelBase
+{
+    private readonly ISqlServerService _sql;
+    private readonly OperationCancellation _cancellation = new();
+
+    public BackupGapViewModel(ISqlServerService sql) => _sql = sql;
+
+    /// <summary>The servers offered as the source. Filled by the screen that owns this.</summary>
+    public ObservableCollection<ServerConnection> Servers { get; } = [];
+
+    [ObservableProperty]
+    private ServerConnection? _sourceServer;
+
+    partial void OnSourceServerChanged(ServerConnection? value)
+    {
+        CheckCommand.NotifyCanExecuteChanged();
+
+        // A previous answer described a different server. Leaving it on screen under a new
+        // selection is the stale-result problem, and this panel's whole job is to be believed.
+        Clear();
+    }
+
+    public ObservableCollection<MissingLocationRow> Locations { get; } = [];
+
+    [ObservableProperty]
+    private bool _hasChecked;
+
+    [ObservableProperty]
+    private bool _isChecking;
+
+    /// <summary>How far behind the container is, in words, or empty when it is not behind.</summary>
+    [ObservableProperty]
+    private string _behindBy = string.Empty;
+
+    /// <summary>
+    /// Whether there is a measurable gap to quote (#451).
+    ///
+    /// A gap and a MEASURED gap are different things, which rendering the panel made obvious: a
+    /// container holding nothing at all for this database has everything missing and no interval
+    /// to state, because there is no newest-held backup to measure from. The banner assumed the
+    /// two went together and rendered "This container is  behind what the instance recorded".
+    /// </summary>
+    public bool HasMeasuredGap => BehindBy.Length > 0;
+
+    partial void OnBehindByChanged(string value) => OnPropertyChanged(nameof(HasMeasuredGap));
+
+    public bool HasGap => Locations.Count > 0;
+
+    public bool FoundNothingMissing => HasChecked && !IsChecking && Locations.Count == 0;
+
+    /// <summary>
+    /// What was compared, so the answer can be read without trusting it blindly - somebody has to
+    /// be able to see that the check was asked of the right database on the right instance.
+    /// </summary>
+    [ObservableProperty]
+    private string _comparedWhat = string.Empty;
+
+    public bool CanCheck => SourceServer != null && !IsChecking;
+
+    /// <summary>
+    /// Reads the source instance's own record and sets it against the container's contents.
+    ///
+    /// The container and the database name come from the screen at the moment of the press rather
+    /// than being held here, because both move while this panel is open and an answer about a
+    /// database nobody is looking at any more is worse than no answer.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanCheck))]
+    public async Task CheckAsync(GapCheckRequest? request)
+    {
+        if (SourceServer is not { } server || request is not { } ask) return;
+
+        if (string.IsNullOrWhiteSpace(ask.Database))
+        {
+            SetError("Pick a database on this screen first - the check is per database.");
+            return;
+        }
+
+        // Captured BEFORE the await: both can change while this runs, and the answer has to
+        // describe what was actually compared.
+        var database = ask.Database;
+        var container = ask.Container;
+        var held = ask.InContainer;
+
+        IsChecking = true;
+        ClearStatus();
+        Clear();
+
+        var ct = _cancellation.Begin();
+
+        try
+        {
+            var history = await _sql.ReadBackupHistoryAsync(server, database, ct);
+
+            var locations = BackupGapAnalyser.Compare(history, held, database);
+            foreach (var location in locations) Locations.Add(new MissingLocationRow(location));
+
+            var behind = BackupGapAnalyser.RecoveryTimeNotInContainer(history, held, database);
+            BehindBy = behind is { } gap ? Humanise(gap) : string.Empty;
+
+            ComparedWhat =
+                $"{database} on {server.ServerName}: {history.Count} backup(s) in its history, " +
+                $"{held.Count} set(s) in {container?.Name ?? "this container"}.";
+
+            HasChecked = true;
+
+            SetStatus(Locations.Count == 0
+                ? "Everything the instance recorded is in the container."
+                : $"{Locations.Count} location(s) hold backups this container does not.");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Check cancelled.");
+        }
+        catch (Exception ex)
+        {
+            // Naming the server, because the usual cause is that this one cannot be reached -
+            // and the reader is looking at a screen already connected to a different instance.
+            SetError($"Could not read {server.ServerName}'s backup history: {ex.Message}");
+        }
+        finally
+        {
+            IsChecking = false;
+            _cancellation.End();
+            RaiseDerived();
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cancellation.Cancel();
+
+    /// <summary>
+    /// Builds the copy script for one location, on demand rather than for every location up front.
+    /// Most checks find one location and nobody reads the others.
+    /// </summary>
+    public void BuildScript(MissingLocationRow row, BlobContainerConfig container)
+        => row.Script = MissingBackupCopyScript.Build(row.Location, container);
+
+    private void Clear()
+    {
+        Locations.Clear();
+        BehindBy = string.Empty;
+        ComparedWhat = string.Empty;
+        HasChecked = false;
+        RaiseDerived();
+    }
+
+    private void RaiseDerived()
+    {
+        OnPropertyChanged(nameof(HasGap));
+        OnPropertyChanged(nameof(FoundNothingMissing));
+        CheckCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// "12 hours 45 minutes" - the number somebody decides on. Rounded to minutes, because a
+    /// recovery window quoted to the second is false precision about a moving target.
+    /// </summary>
+    internal static string Humanise(TimeSpan gap)
+    {
+        if (gap.TotalMinutes < 1) return "under a minute";
+
+        var parts = new List<string>();
+        if (gap.Days > 0) parts.Add($"{gap.Days} day{(gap.Days == 1 ? "" : "s")}");
+        if (gap.Hours > 0) parts.Add($"{gap.Hours} hour{(gap.Hours == 1 ? "" : "s")}");
+        if (gap.Minutes > 0 && gap.Days == 0)
+            parts.Add($"{gap.Minutes} minute{(gap.Minutes == 1 ? "" : "s")}");
+
+        return string.Join(" ", parts);
+    }
+}
+
+/// <summary>
+/// What the screen hands the check at the moment it is pressed.
+///
+/// Passed in rather than held, because the database, the container and the listing all move while
+/// this panel is open, and an answer about a database nobody is looking at any more is worse than
+/// no answer at all.
+/// </summary>
+public sealed record GapCheckRequest(
+    string Database,
+    BlobContainerConfig? Container,
+    IReadOnlyList<BackupSet> InContainer);

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -76,6 +76,15 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     public RestoreTimelineViewModel Timeline { get; } = new();
 
+    /// <summary>
+    /// What the source instance recorded, against what this container holds (#451).
+    ///
+    /// Its own view model because it connects to a DIFFERENT server from the one the restore runs
+    /// on - the instance that TOOK the backups, which is routinely not the instance they are being
+    /// restored to - and conflating those two connections is the confusion worth designing out.
+    /// </summary>
+    public BackupGapViewModel Gap { get; }
+
     // Restore chain
     [ObservableProperty]
     private BackupChain? _restoreChain;
@@ -925,6 +934,7 @@ public partial class RestoreViewModel : ViewModelBase
         // finds the one in the user's profile - so a TEST run reads and writes the real cache, and
         // a stale entry from one test then decides the answer in another (#130).
         Inventory = new BackupInventoryViewModel(blobService, sqlService, _log, auditStore);
+        Gap = new BackupGapViewModel(sqlService);
 
         // The chain and the timeline are built from whatever the inventory currently holds, so a
         // change there is the one signal that rebuilds them.
@@ -1106,6 +1116,14 @@ public partial class RestoreViewModel : ViewModelBase
             var match = TargetServers.FirstOrDefault(x => x.Id == previousTarget);
             if (match != null) SelectedTargetServer = match;
         }
+
+        // The gap check offers the same saved list, and keeps its own selection: the instance that
+        // took the backups is a different question from the one being restored to (#451).
+        var previousGapSource = Gap.SourceServer?.Id;
+        Gap.Servers.Clear();
+        foreach (var server in config.Servers) Gap.Servers.Add(server);
+        if (previousGapSource != null)
+            Gap.SourceServer = Gap.Servers.FirstOrDefault(x => x.Id == previousGapSource);
 
         Containers = new ObservableCollection<BlobContainerConfig>(config.BlobContainers);
         foreach (var c in Containers)
@@ -2091,6 +2109,39 @@ public partial class RestoreViewModel : ViewModelBase
 
         GeneratedScript = _scriptGenerator.Generate(chain!, options);
         HasScript = true;
+    }
+
+    /// <summary>
+    /// Asks the source instance what this container is missing (#451).
+    ///
+    /// The database, the container and the listing are gathered HERE and handed over, rather than
+    /// the panel holding them: all three move while it is open, and an answer about a database
+    /// nobody is looking at any more is worse than no answer.
+    /// </summary>
+    [RelayCommand]
+    private async Task CheckForMissingBackupsAsync()
+        => await Gap.CheckAsync(new GapCheckRequest(
+            Inventory.SelectedDatabaseName ?? string.Empty,
+            SelectedContainer,
+            Inventory.AllSets));
+
+    /// <summary>
+    /// Writes the copy script for one location. On demand: most checks find one location, and
+    /// building every script up front is work nobody reads.
+    /// </summary>
+    [RelayCommand]
+    private void BuildCopyScript(MissingLocationRow? row)
+    {
+        if (row == null || SelectedContainer == null) return;
+        Gap.BuildScript(row, SelectedContainer);
+    }
+
+    /// <summary>Puts one location's script on the clipboard, ready to paste into a session on the source.</summary>
+    [RelayCommand]
+    private void CopyCopyScript(MissingLocationRow? row)
+    {
+        if (row is not { HasScript: true }) return;
+        TryCopyToClipboard(row.Script, "Copy script copied to clipboard.");
     }
 
     [RelayCommand]

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1582,6 +1582,165 @@
                                        Visibility="{Binding Options.ContinueAfterError, Converter={StaticResource BoolToVis}}"
                                        Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
 
+                            <!-- What the source instance recorded, against what this container
+                                 holds (#451). Behind the advanced options because it means
+                                 connecting to a SECOND server - the one that took the backups,
+                                 which is routinely not the one being restored to. -->
+                            <Border Style="{StaticResource CardBorder}"
+                                    Margin="0,4,0,16"
+                                    Visibility="{Binding ShowAdvancedOptions, Converter={StaticResource BoolToVis}}">
+                                <StackPanel>
+                                    <TextBlock Text="BACKUPS THIS CONTAINER IS MISSING"
+                                               Style="{StaticResource LabelText}" Margin="0,0,0,6" />
+
+                                    <TextBlock Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap" Margin="0,0,0,10"
+                                               Text="Logs often go somewhere else - a local or cluster disk for throughput, or a share because log shipping already owns them. The container cannot tell you that; the instance that took them can. Ask it, and anything written elsewhere shows up here with the path it went to." />
+
+                                    <Grid Margin="0,0,0,10">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <ComboBox Grid.Column="0"
+                                                  ItemsSource="{Binding Gap.Servers}"
+                                                  SelectedItem="{Binding Gap.SourceServer}"
+                                                  Style="{StaticResource DarkComboBox}"
+                                                  ToolTip="The instance that TOOK these backups - not necessarily the one being restored to.">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding DisplayText}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+
+                                        <Button Grid.Column="1"
+                                                Content="Check its history"
+                                                Command="{Binding CheckForMissingBackupsCommand}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="12,6" Margin="8,0,0,0"
+                                                IsEnabled="{Binding Gap.CanCheck}" />
+                                    </Grid>
+
+                                    <TextBlock Text="Reading the instance's own record..."
+                                               Style="{StaticResource SecondaryText}"
+                                               Margin="0,0,0,8"
+                                               Visibility="{Binding Gap.IsChecking, Converter={StaticResource BoolToVis}}" />
+
+                                    <ContentControl Style="{StaticResource ErrorBanner}"
+                                                    DataContext="{Binding Gap}" />
+
+                                    <!-- The all-clear, said out loud. An empty panel is
+                                         indistinguishable from never having pressed the button. -->
+                                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                                            Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                                            BorderBrush="{DynamicResource SuccessPanelBorderBrush}"
+                                            BorderThickness="1"
+                                            Visibility="{Binding Gap.FoundNothingMissing, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                                   Text="Everything the instance recorded is in this container. The chain on offer is the whole chain." />
+                                    </Border>
+
+                                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                                            Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                            BorderThickness="1"
+                                            Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}">
+                                        <StackPanel>
+                                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}}">
+                                                <Run Text="This container is" />
+                                                <Run Text="{Binding Gap.BehindBy, Mode=OneWay}" FontWeight="SemiBold" />
+                                                <Run Text="behind what the instance recorded. Restoring from it alone throws that away." />
+                                            </TextBlock>
+
+                                            <!-- A gap and a MEASURED gap are not the same thing: a
+                                                 container holding nothing for this database has
+                                                 everything missing and no interval to quote. -->
+                                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                                       Text="The instance recorded backups this container does not hold. Restoring from it alone leaves them out." />
+                                        </StackPanel>
+                                    </Border>
+
+                                    <ItemsControl ItemsSource="{Binding Gap.Locations}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border Background="{DynamicResource InputBackgroundBrush}"
+                                                        CornerRadius="4" Padding="10,8" Margin="0,0,0,8">
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding Folder}"
+                                                                   Style="{StaticResource BodyText}"
+                                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                                   TextWrapping="Wrap" />
+
+                                                        <TextBlock Style="{StaticResource SecondaryText}"
+                                                                   Margin="0,4,0,0" TextWrapping="Wrap">
+                                                            <Run Text="{Binding Summary, Mode=OneWay}" />
+                                                            <Run Text="-" />
+                                                            <Run Text="{Binding FileCount, Mode=OneWay}" />
+                                                            <Run Text="file(s)," />
+                                                            <Run Text="{Binding SizeDisplay, Mode=OneWay}" />
+                                                        </TextBlock>
+
+                                                        <TextBlock Text="{Binding Window}"
+                                                                   Style="{StaticResource SecondaryText}"
+                                                                   Margin="0,2,0,0" />
+
+                                                        <!-- A backup recorded to a URL is not a file on
+                                                             that machine, so there is nothing for a copy
+                                                             script to pick up. -->
+                                                        <TextBlock Style="{StaticResource SecondaryText}"
+                                                                   Margin="0,6,0,0" TextWrapping="Wrap"
+                                                                   Foreground="{DynamicResource WarningBrush}"
+                                                                   Text="Recorded as written to storage rather than to disk, so there is no file here to copy - the listing did not see something that should be in the container. Check its base path."
+                                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+
+                                                        <WrapPanel Margin="0,8,0,0"
+                                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}}">
+                                                            <Button Content="Write a copy script"
+                                                                    Command="{Binding DataContext.BuildCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                    CommandParameter="{Binding}"
+                                                                    Style="{StaticResource SecondaryButton}"
+                                                                    Padding="10,4" Margin="0,0,8,0" />
+
+                                                            <Button Content="Copy to clipboard"
+                                                                    Command="{Binding DataContext.CopyCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                    CommandParameter="{Binding}"
+                                                                    Style="{StaticResource SecondaryButton}"
+                                                                    Padding="10,4"
+                                                                    Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}" />
+                                                        </WrapPanel>
+
+                                                        <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                                                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                                                                BorderThickness="1" CornerRadius="4"
+                                                                Margin="0,8,0,0"
+                                                                Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
+                                                            <ScrollViewer MaxHeight="200"
+                                                                          VerticalScrollBarVisibility="Auto"
+                                                                          HorizontalScrollBarVisibility="Auto"
+                                                                          Padding="10,8">
+                                                                <TextBlock Text="{Binding Script}"
+                                                                           FontFamily="{StaticResource ConsoleFont}"
+                                                                           FontSize="11"
+                                                                           Foreground="{DynamicResource ConsoleTextBrush}" />
+                                                            </ScrollViewer>
+                                                        </Border>
+                                                    </StackPanel>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+
+                                    <TextBlock Text="{Binding Gap.ComparedWhat}"
+                                               Style="{StaticResource SecondaryText}"
+                                               FontSize="10" TextWrapping="Wrap" Margin="0,4,0,0"
+                                               Visibility="{Binding Gap.ComparedWhat, Converter={StaticResource NullToVis}}" />
+                                </StackPanel>
+                            </Border>
+
                             <CheckBox Content="WITH MOVE (relocate files)"
                                       Visibility="{Binding ShowFileRelocation, Converter={StaticResource BoolToVis}}"
                                       IsChecked="{Binding UseWithMove}"


### PR DESCRIPTION
The screen half of #451, on top of the engine that landed in #453.

## What it does

Under the advanced restore options: a **source instance** picker and a check. It reads that instance's own record, sets it against what the container holds, and reports what is missing — the folder it went to, how many files, how big, over what window, and how much recovery time the container is behind by. For anything on disk it writes the copy script for that location, on demand.

The source picker is deliberately separate from the target: it is the instance that **took** the backups, which is routinely not the one they are going back to.

## Its own view model

Rather than more surface on `RestoreViewModel` — which is already large — and for a reason beyond size: this panel connects to a *different server* from the one the restore runs on, and conflating those two connections is exactly the confusion worth designing out.

The database, container and listing are gathered by the screen and handed over at the moment of the press rather than held by the panel, because all three move while it is open and an answer about a database nobody is looking at any more is worse than no answer.

## Rendering caught a defect in my own work

Second time this week. **A gap and a measured gap are not the same thing.** A container holding nothing at all for that database has everything missing and *no interval to quote*, because there is no newest-held backup to measure from. The banner assumed the two went together and drew:

> This container is  behind what the instance recorded.

A sentence with a hole in the middle of it. It is now split — an interval when there is one, a plain statement when there is not — and both halves are pinned by tests that would have caught it.

## Honest about what it cannot offer

A backup msdb recorded to a **URL** is reported but *not* offered as something to copy. There is no file on that machine to pick up, and that finding means something different: the listing did not see something that is in storage. That is a base-path problem, and the panel says so rather than generating a script that would `Test-Path` a URL.

## Not yet

The Copy Database surface, the rescan-and-confirm loop, and the second remedy — restoring `WITH NORECOVERY` and rolling the logs forward from where they already are.

## Effect

`dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test` → **2,184 passed, 0 failed** (up 18). Rendered in all four states: idle, checking clean, gap found, and script written.