### PR TITLE
Restore the missing logs from where they already are (#451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ more detail on the user-facing changes; this file is the short history.
   named individually rather than globbed, and carrying no credential, because that script is
   handed to somebody to run on a production server.
 
+- **Or restore them from where they already are** (#451). The other way out, and the one for
+  mid-incident when uploading twenty-three files is time nobody has: fold them into the timeline
+  and leave the files alone. The restore point extends to the newest of them, and the script
+  reads the container by URL and those logs from their own path by DISK, in one run. The target
+  has to be able to open that path as its own service account - a different question from whether
+  the container is reachable, and one now asked in the preflight, before anything is dropped.
+
 ## [1.6.4] - 2026-08-14
 
 ### Fixed

--- a/src/NineLives.Tests/RestoreFromWhereTheyAreTests.cs
+++ b/src/NineLives.Tests/RestoreFromWhereTheyAreTests.cs
@@ -1,0 +1,201 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Restoring the logs from where they already are, rather than copying them in first (#451).
+///
+/// The remedy for mid-incident, when uploading twenty-three files is time nobody has. It works
+/// because the script generator picks DISK or URL per FILE, from the device string rather than
+/// from an option - so a chain holding a blob full and disk-resident logs generates correct T-SQL
+/// with no further work. It has simply never been possible to BUILD one, because discovery only
+/// ever looked at a single medium.
+/// </summary>
+public class RestoreFromWhereTheyAreTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 14, 22, 0, 0);
+
+    private static BackupSet FromContainer(BackupType type, DateTime at) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        Type = type,
+        Timestamp = at,
+        DatabaseName = "Sales",
+        ServerName = "SRV01",
+        Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = $"Sales_{at:yyyyMMdd_HHmmss}.bak",
+                BlobUrl = $"https://acct.blob.core.windows.net/c/Sales_{at:yyyyMMdd_HHmmss}.bak",
+                Type = type,
+                InferredDatabaseName = "Sales",
+                InferredServerName = "SRV01"
+            }
+        ]
+    };
+
+    private static BackupSet FromDisk(BackupType type, DateTime at, string folder) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        Type = type,
+        Timestamp = at,
+        DatabaseName = "Sales",
+        ServerName = "SRV01",
+        Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = $"Sales_{at:yyyyMMdd_HHmmss}.trn",
+                LocalPath = $@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn",
+                Type = type,
+                InferredDatabaseName = "Sales",
+                InferredServerName = "SRV01"
+            }
+        ]
+    };
+
+    // ── the merge ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An inventory loaded from a container the ordinary way, so what these exercise is the real
+    /// load path rather than a seam that only tests use.
+    /// </summary>
+    private static BackupInventoryViewModel Inventory()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = $"FULL/SRV01/Sales/Sales_{T0:yyyyMMdd_HHmmss}.bak",
+                    BlobUrl = $"https://acct.blob.core.windows.net/c/FULL/SRV01/Sales/Sales_{T0:yyyyMMdd_HHmmss}.bak",
+                    Type = BackupType.Full,
+                    InferredDatabaseName = "Sales",
+                    InferredServerName = "SRV01",
+                    SizeBytes = 1024,
+                    LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+                }
+            ]
+        };
+
+        var vm = new BackupInventoryViewModel(blob, new FakeSqlServerService(), TestLogs.Temp());
+
+        vm.LoadAsync(BackupLocation.Blob(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "sqlbackups",
+            ContainerUrl = "https://acct.blob.core.windows.net/c"
+        })).GetAwaiter().GetResult();
+
+        vm.SelectedDatabaseName = "Sales";
+        return vm;
+    }
+
+    [Fact]
+    public void SetsFromTheInstanceHistoryJoinTheWorkingSet()
+    {
+        var inv = Inventory();
+        Assert.Single(inv.WorkingSet);
+        Assert.False(inv.HasSetsFromInstanceHistory);
+
+        inv.IncludeFromInstanceHistory([FromDisk(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs")]);
+
+        Assert.Equal(2, inv.WorkingSet.Count);
+        Assert.True(inv.HasSetsFromInstanceHistory);
+    }
+
+    /// <summary>
+    /// Adding the same location twice - pressing the button again - must not double the timeline.
+    /// </summary>
+    [Fact]
+    public void IncludingTheSameSetTwiceAddsItOnce()
+    {
+        var inv = Inventory();
+        var log = FromDisk(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs");
+
+        inv.IncludeFromInstanceHistory([log]);
+        inv.IncludeFromInstanceHistory([log]);
+
+        Assert.Equal(2, inv.WorkingSet.Count);
+    }
+
+    /// <summary>
+    /// The same database and server filters apply to these as to everything else. A log from
+    /// another instance must not arrive through a side door the ordinary path would have refused -
+    /// mixing two servers' backups into one chain is a defect this codebase has already had once.
+    /// </summary>
+    [Fact]
+    public void ASetForAnotherDatabaseDoesNotReachTheWorkingSet()
+    {
+        var inv = Inventory();
+
+        var otherDatabase = FromDisk(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs");
+        otherDatabase.DatabaseName = "Payroll";
+        otherDatabase.Files[0].InferredDatabaseName = "Payroll";
+
+        inv.IncludeFromInstanceHistory([otherDatabase]);
+
+        Assert.Single(inv.WorkingSet);
+    }
+
+    [Fact]
+    public void IncludingNothingChangesNothing()
+    {
+        var inv = Inventory();
+
+        inv.IncludeFromInstanceHistory([]);
+
+        Assert.Single(inv.WorkingSet);
+        Assert.False(inv.HasSetsFromInstanceHistory);
+    }
+
+    // ── what the generator then produces ────────────────────────────────────────
+
+    /// <summary>
+    /// The point of the whole feature: one script, the full read from the container by URL and the
+    /// logs read from the path they are actually on by DISK.
+    /// </summary>
+    [Fact]
+    public void TheGeneratedScriptReadsTheContainerByUrlAndTheLogsByDisk()
+    {
+        var chain = new BackupChain
+        {
+            FullSet = FromContainer(BackupType.Full, T0),
+            LogSets =
+            [
+                FromDisk(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+                FromDisk(BackupType.TransactionLog, T0.AddHours(2), @"E:\SQLLogs")
+            ]
+        };
+
+        var script = new RestoreScriptGenerator().Generate(chain, new RestoreOptions
+        {
+            TargetDatabaseName = "Sales_Restored",
+            RecoveryMode = RecoveryMode.Recovery
+        });
+
+        Assert.Contains("URL = N'https://acct.blob.core.windows.net/c/Sales_", script);
+        Assert.Contains(@"DISK = N'E:\SQLLogs\Sales_20260814_230000.trn'", script);
+        Assert.Contains(@"DISK = N'E:\SQLLogs\Sales_20260815_000000.trn'", script);
+
+        // And it still ends properly: NORECOVERY through the chain, RECOVERY once.
+        Assert.Contains("NORECOVERY", script);
+        Assert.Equal(1, CountOccurrences(script, "         RECOVERY,"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+}

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -483,6 +483,52 @@ public partial class BackupInventoryViewModel : ViewModelBase
     /// thousands of points on a real container, none of them meaningful, because a restore chain
     /// only exists within one database.
     /// </summary>
+    /// <summary>
+    /// Whether the working set holds anything that is not in the container (#451).
+    ///
+    /// Worth surfacing, because from here on the chain being offered restores from two places at
+    /// once - and a script naming a local path is a surprise to anybody who thought they were
+    /// restoring from blob.
+    /// </summary>
+    public bool HasSetsFromInstanceHistory { get; private set; }
+
+    /// <summary>
+    /// Folds backups the container does not hold into the working set, so the timeline and the
+    /// chain builder see them (#451).
+    ///
+    /// This is the whole of "restore them from where they are". The script generator already picks
+    /// DISK or URL per FILE, from the device string rather than from an option, so a chain holding
+    /// a blob full and disk-resident logs generates correct T-SQL with no further work - it has
+    /// simply never been possible to build one, because discovery only ever looked at one medium.
+    ///
+    /// Added to the whole-container list rather than the filtered one, so the same database and
+    /// server filters apply to these as to everything else: a log from another instance must not
+    /// arrive by a side door that the ordinary path would have refused.
+    ///
+    /// A reload drops them, deliberately. Reloading means "read the truth again", and if the files
+    /// were copied in they will be in the container by then anyway.
+    /// </summary>
+    public void IncludeFromInstanceHistory(IReadOnlyList<BackupSet> sets)
+    {
+        if (sets.Count == 0) return;
+
+        var known = _allSets.Select(Identity).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var added = sets.Where(s => known.Add(Identity(s))).ToList();
+        if (added.Count == 0) return;
+
+        _allSets.AddRange(added);
+        HasSetsFromInstanceHistory = true;
+        OnPropertyChanged(nameof(HasSetsFromInstanceHistory));
+
+        RebuildWorkingSet();
+    }
+
+    /// <summary>
+    /// What makes two sets the same one for the purpose of not adding it twice. The set id carries
+    /// the timestamp, and the type separates a full from the log that started in the same second.
+    /// </summary>
+    private static string Identity(BackupSet set) => $"{set.Type}|{set.DatabaseName}|{set.SetId}";
+
     private void RebuildWorkingSet()
     {
         if (string.IsNullOrEmpty(SelectedDatabaseName) || _allSets.Count == 0)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2136,6 +2136,33 @@ public partial class RestoreViewModel : ViewModelBase
         Gap.BuildScript(row, SelectedContainer);
     }
 
+    /// <summary>
+    /// Restores these where they already are, instead of copying them in first (#451).
+    ///
+    /// The remedy for mid-incident, when uploading twenty-three files is time nobody has. The sets
+    /// are folded into the working set, so the timeline extends to the newest of them and the
+    /// chain builder treats them like anything else - and the generator names them with DISK
+    /// rather than URL because it asks the device string, not an option.
+    ///
+    /// The target still has to be able to READ those paths, which is a different question from
+    /// whether this machine can. That is checked in the preflight, before anything is dropped.
+    /// </summary>
+    [RelayCommand]
+    private void RestoreFromWhereTheyAre(MissingLocationRow? row)
+    {
+        if (row is not { IsOnDisk: true }) return;
+
+        var sets = BackupHistoryInventory.ToSets(row.Location.Backups.Select(b => b.Entry));
+        if (sets.Count == 0) return;
+
+        Inventory.IncludeFromInstanceHistory(sets);
+
+        SetStatus(
+            $"Added {sets.Count} backup(s) from {row.Folder} to the timeline. The script will read " +
+            "them from that path - the target has to be able to reach it, which is checked before " +
+            "the restore runs.");
+    }
+
     /// <summary>Puts one location's script on the clipboard, ready to paste into a session on the source.</summary>
     [RelayCommand]
     private void CopyCopyScript(MissingLocationRow? row)
@@ -2788,6 +2815,12 @@ public partial class RestoreViewModel : ViewModelBase
             return await CheckVersionCompatibilityAsync(server, appendLog);
         }
 
+        // A blob chain can now hold disk-resident members (#451), and the target has to be able to
+        // read those paths - a different question from whether the container is reachable, and one
+        // the medium-based branch above never asks because the medium is still blob.
+        var onDisk = await CheckTargetCanReadAnyDiskMembersAsync(server, appendLog);
+        if (!onDisk.CanProceed) return onDisk;
+
         var primary = await Credential.PrepareForRestoreAsync(server, appendLog);
         if (!primary.CanProceed) return primary;
 
@@ -3040,6 +3073,57 @@ public partial class RestoreViewModel : ViewModelBase
     /// has no identity on the network and so cannot read ANY share. That is worth diagnosing rather
     /// than reporting as a missing file, because it sends people to check the wrong thing.
     /// </summary>
+    /// <summary>
+    /// The disk-resident members of an otherwise-blob chain (#451).
+    ///
+    /// Restoring logs from where they already are means the RESTORE names a path on some other
+    /// machine, and the instance running it has to be able to open that path as its own service
+    /// account. Nothing about the container being reachable says anything about that.
+    ///
+    /// Only the disk members: the URL members are covered by the credential checks, and asking
+    /// RESTORE HEADERONLY of every blob in a long chain would add a round trip per file to every
+    /// restore for no new information.
+    /// </summary>
+    private async Task<CredentialPreflight> CheckTargetCanReadAnyDiskMembersAsync(
+        ServerConnection server, Action<string> appendLog)
+    {
+        var paths = RestoreChain?.AllFiles
+            .Select(f => f.RestoreDevice)
+            .Where(BackupDevice.IsPath)
+            .Distinct()
+            .ToList() ?? [];
+
+        if (paths.Count == 0) return CredentialPreflight.Proceed;
+
+        appendLog(
+            $"This chain reads {paths.Count} file(s) from a path rather than the container. " +
+            $"Checking {server.ServerName} can open them...");
+
+        try
+        {
+            var checks = await _sqlService.CheckBackupFilesAsync(server, paths);
+            var failed = checks.FirstOrDefault(c => !c.CanBeRestored);
+
+            if (failed != null)
+            {
+                var refusal = failed.Explain(server.ServerName);
+                appendLog(refusal);
+                return CredentialPreflight.Stop(refusal);
+            }
+
+            appendLog($"{server.ServerName} can read all {checks.Count} of them.");
+            return CredentialPreflight.Proceed;
+        }
+        catch (Exception ex)
+        {
+            var refusal =
+                $"Could not confirm {server.ServerName} can read the files held outside the " +
+                $"container: {ex.Message}";
+            appendLog(refusal);
+            return CredentialPreflight.Stop(refusal);
+        }
+    }
+
     private async Task<CredentialPreflight> CheckTargetCanReadFilesAsync(
         ServerConnection server, Action<string> appendLog)
     {

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1705,6 +1705,13 @@
                                                                     Style="{StaticResource SecondaryButton}"
                                                                     Padding="10,4" Margin="0,0,8,0" />
 
+                                                            <Button Content="Restore from where they are"
+                                                                    Command="{Binding DataContext.RestoreFromWhereTheyAreCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                    CommandParameter="{Binding}"
+                                                                    Style="{StaticResource SecondaryButton}"
+                                                                    Padding="10,4" Margin="0,0,8,0"
+                                                                    ToolTip="Adds these to the timeline and reads them from this path instead of copying them into the container. The target has to be able to reach it - checked before the restore runs." />
+
                                                             <Button Content="Copy to clipboard"
                                                                     Command="{Binding DataContext.CopyCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                                     CommandParameter="{Binding}"


### PR DESCRIPTION
The second remedy in #451: leave the files where they are and restore from that path, instead of uploading twenty-three of them first. This is the one to reach for mid-incident.

(Replaces #455, which GitHub closed when its base branch was deleted on merge. Same commit, rebased onto `dev`.)

## Why it is small

`BackupDevice.Clause` already picks `DISK` or `URL` **per file**, from the device string rather than from an option. So a chain holding a blob full and disk-resident logs generates correct T-SQL with no further work — what has never been possible is *building* one, because discovery only ever looked at a single medium.

The button folds the missing sets into the inventory and everything downstream follows: `RebuildWorkingSet` applies the same database and server filters it applies to everything else, the timeline extends to the newest of them, and the chain builder treats them as ordinary members.

They go into the **whole-container list, not the filtered one**, deliberately. Adding them to the filtered list would let a log from another instance in through a side door the ordinary path refuses — and mixing two servers' backups into one chain is a defect this codebase has had once already (#362). Pinned.

## The preflight gained the question that goes with it

A blob chain can now hold disk members, and the target has to be able to open those paths **as its own service account**. That is a different question from whether the container is reachable, and the medium-based branch never asks it, because the medium is still blob.

Only the disk members are checked. The URL ones are covered by the credential checks, and a `RESTORE HEADERONLY` per blob would add a round trip per file to every restore for no new information.

## A reload drops them

Deliberately. Reloading means "read the truth again", and if the files were copied into the container by then they will be in the listing anyway.

## Effect

`-c Release -warnaserror` clean, **2,189 passed** (up 5). The test that matters asserts the generated script names `URL = N'https://...'` for the full and `DISK = N'E:\SQLLogs\...'` for the logs, in one script, still ending in exactly one `RECOVERY`.