### PR TITLE
The Copy screen says why it will not generate (#457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Copy screen says why it will not generate, and stops losing the database you chose**
+  (#457). Reported from the app: every field filled in, the overwrite banner naming the target,
+  and both buttons dead with nothing saying why. Two faults. The source database had been cleared
+  out from under the form - the screen re-reads its server list on every visit and re-assigns the
+  source server to a fresh object, which clears the database and reloads the list, while the
+  target server, container, name and overwrite tick all survive. So the form looked complete and
+  was not. Your own choice is now put back when the same server arrives again, though never when
+  you switch servers, because inventing a source database is the one thing this screen must not
+  do. And six things have to be true before Generate is live; the screen named none of them, and
+  now names the first one missing along with the step to go back to.
+
 ### Added
 
 - **The Restore screen can ask the source instance what this container is missing** (#451).

--- a/src/NineLives.Tests/CopyScreenSaysWhyItIsBlockedTests.cs
+++ b/src/NineLives.Tests/CopyScreenSaysWhyItIsBlockedTests.cs
@@ -1,0 +1,174 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The Copy screen explains itself, and stops losing the choice that was made (#457).
+///
+/// Reported from the app: every visible field filled in, the overwrite banner naming the target,
+/// and both buttons dead with nothing on screen saying why. Two faults behind it.
+///
+/// The source database had been cleared out from under the form. Refresh runs on every visit to
+/// this screen and re-assigns SourceServer to a fresh instance from the config - a different
+/// object every time, because the real store deserializes - which fires OnSourceServerChanged,
+/// which clears the database and reloads the list. The target server, container, target name and
+/// overwrite tick all survive that, so the form looked complete and was not.
+///
+/// And nothing said so. Six things have to be true before Generate is live and the screen named
+/// none of them.
+/// </summary>
+public class CopyScreenSaysWhyItIsBlockedTests
+{
+    private static (CopyDatabaseViewModel vm, FakeCredentialStore store, FakeSqlServerService sql) Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb", "Payroll", "Warehouse"] };
+        return (new CopyDatabaseViewModel(store, sql), store, sql);
+    }
+
+    private static async Task<CopyDatabaseViewModel> FullyAnsweredAsync()
+    {
+        var (vm, _, _) = Screen();
+        vm.Refresh();
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.Container = vm.Containers[0];
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb";
+
+        return vm;
+    }
+
+    // ── the sentence that was missing ───────────────────────────────────────────
+
+    [Fact]
+    public async Task AFullyAnsweredScreenIsNotBlockedAndSaysNothing()
+    {
+        var vm = await FullyAnsweredAsync();
+
+        Assert.True(vm.CanGenerate);
+        Assert.False(vm.IsGenerateBlocked);
+        Assert.Empty(vm.GenerateBlockedReason);
+    }
+
+    /// <summary>The reported case: everything else answered, no source database.</summary>
+    [Fact]
+    public async Task WithNoSourceDatabaseItNamesThatAndTheStepToGoBackTo()
+    {
+        var vm = await FullyAnsweredAsync();
+        vm.SourceDatabase = null;
+
+        Assert.False(vm.CanGenerate);
+        Assert.True(vm.IsGenerateBlocked);
+        Assert.Contains("database to copy", vm.GenerateBlockedReason);
+        Assert.Contains("step 1", vm.GenerateBlockedReason);
+    }
+
+    [Fact]
+    public async Task WithNoTargetNameItSaysSo()
+    {
+        var vm = await FullyAnsweredAsync();
+        vm.TargetDatabaseName = "";
+
+        Assert.Contains("restore as", vm.GenerateBlockedReason);
+        Assert.Contains("step 3", vm.GenerateBlockedReason);
+    }
+
+    [Fact]
+    public async Task WithNoContainerItSaysSo()
+    {
+        var vm = await FullyAnsweredAsync();
+        vm.Container = null;
+
+        Assert.Contains("container", vm.GenerateBlockedReason);
+        Assert.Contains("step 2", vm.GenerateBlockedReason);
+    }
+
+    /// <summary>
+    /// The order is the order the screen asks the questions, so somebody with three blanks is sent
+    /// to the first one rather than the last.
+    /// </summary>
+    [Fact]
+    public async Task WithSeveralBlanksItNamesTheEarliest()
+    {
+        var vm = await FullyAnsweredAsync();
+        vm.SourceDatabase = null;
+        vm.TargetDatabaseName = "";
+        vm.Container = null;
+
+        Assert.Contains("step 1", vm.GenerateBlockedReason);
+    }
+
+    // ── the choice survives a revisit ───────────────────────────────────────────
+
+    /// <summary>
+    /// The fault behind the report. Refresh re-assigns SourceServer to a fresh instance, which
+    /// clears the database and reloads - and everything the user filled in downstream survives, so
+    /// the form looks complete.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenKeepsTheDatabaseThatWasChosen()
+    {
+        var vm = await FullyAnsweredAsync();
+        Assert.True(vm.CanGenerate);
+
+        // What navigating away and back does.
+        vm.Refresh();
+        await Task.Delay(50);
+
+        Assert.Equal("MyDb", vm.SourceDatabase);
+        Assert.True(vm.CanGenerate);
+    }
+
+    /// <summary>
+    /// Putting back what the user chose is not the same as choosing for them. A source server they
+    /// have just switched to has no previous answer, and the app must not invent one - the wrong
+    /// choice here reads a production database at full speed and overwrites one on another server.
+    /// </summary>
+    [Fact]
+    public async Task SwitchingToADifferentSourceServerStillChoosesNothing()
+    {
+        var vm = await FullyAnsweredAsync();
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s2");
+        await Task.Delay(50);
+
+        Assert.Null(vm.SourceDatabase);
+        Assert.Contains("database to copy", vm.GenerateBlockedReason);
+    }
+
+    /// <summary>
+    /// And a database that has gone from the instance since is not put back. Restoring a selection
+    /// that no longer exists would arm the screen against a database nobody could back up.
+    /// </summary>
+    [Fact]
+    public async Task ADatabaseThatIsNoLongerThereIsNotRestored()
+    {
+        var (vm, _, sql) = Screen();
+        vm.Refresh();
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+
+        sql.DatabaseList = ["Payroll", "Warehouse"];
+        vm.Refresh();
+        await Task.Delay(50);
+
+        Assert.Null(vm.SourceDatabase);
+    }
+}

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -159,7 +159,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     private int _listGeneration;
 
     [RelayCommand(CanExecute = nameof(CanLoadSourceDatabases))]
-    private async Task LoadSourceDatabasesAsync()
+    private async Task LoadSourceDatabasesAsync(string? chosen = null)
     {
         if (SourceServer == null)
         {
@@ -186,9 +186,18 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
             SourceDatabases = new ObservableCollection<string>(names);
 
-            // Nothing is chosen for the user. Here the wrong choice reads a production database at
-            // full speed AND overwrites a database on another server.
-            SourceDatabase = null;
+            // Nothing is chosen FOR the user - here the wrong choice reads a production database
+            // at full speed AND overwrites a database on another server.
+            //
+            // But putting back what they chose themselves is not choosing for them, and not doing
+            // it was a live defect: Refresh runs on every visit to this screen and re-assigns
+            // SourceServer to a fresh instance from the config, which fires OnSourceServerChanged,
+            // which clears this and reloads. The target server, container, target name and
+            // overwrite tick all survive that, so navigating away and back left a form that looked
+            // complete, refused to generate, and said nothing about why.
+            SourceDatabase = chosen != null && names.Contains(chosen, StringComparer.OrdinalIgnoreCase)
+                ? names.First(n => string.Equals(n, chosen, StringComparison.OrdinalIgnoreCase))
+                : null;
 
             SetStatus($"{server.ServerName} has {names.Count} database(s).");
         }
@@ -214,16 +223,26 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         }
     }
 
-    partial void OnSourceServerChanged(ServerConnection? value)
+    partial void OnSourceServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
     {
+        // Carried across the reload ONLY when this is the same server arriving again - which is
+        // what Refresh does on every visit to the screen, because the config hands back a fresh
+        // instance each time and the assignment therefore always fires.
+        //
+        // A server the user has actually switched to has no previous answer, and inventing one
+        // would be the thing this screen most carefully does not do: the wrong choice here reads a
+        // production database at full speed and overwrites one on another server. Captured before
+        // the clear below wipes it.
+        var carry = oldValue?.Id == newValue?.Id ? SourceDatabase : null;
+
         SourceDatabases = [];
         SourceDatabase = null;
         Invalidate();
 
         // Choosing the source server is the request to see what it holds - same reasoning as the
         // Backup screen, and the same restraint mid-run.
-        if (value != null && CanLoadSourceDatabases)
-            _ = LoadSourceDatabasesAsync();
+        if (newValue != null && CanLoadSourceDatabases)
+            _ = LoadSourceDatabasesAsync(carry);
     }
 
     partial void OnTargetServerChanged(ServerConnection? value) => Invalidate();
@@ -345,11 +364,45 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         (MediumIsBlob ? Container != null : !string.IsNullOrWhiteSpace(SharedPathRoot)) &&
         !IsRefused;
 
+    /// <summary>
+    /// Why Generate scripts cannot be pressed, or empty when it can.
+    ///
+    /// The buttons went dead with nothing said. Six things have to be true and the screen named
+    /// none of them, so a form with five of them filled in - which is what one looks like after
+    /// the source database has been cleared out from under it - reads as complete and simply
+    /// refuses to work. The restore screen has had this sentence for a while; this screen is the
+    /// one where a person has typed a target name and ticked an overwrite box, so it is arguably
+    /// the one that needed it more.
+    ///
+    /// In the order the screen asks the questions, so the sentence points at the step to go back
+    /// to rather than just naming a field.
+    /// </summary>
+    public string GenerateBlockedReason =>
+        SourceServer == null
+            ? "Choose the server to copy from, in step 1."
+        : string.IsNullOrWhiteSpace(SourceDatabase)
+            ? "Choose the database to copy, in step 1."
+        : MediumIsBlob && Container == null
+            ? "Choose the container to copy through, in step 2."
+        : !MediumIsBlob && string.IsNullOrWhiteSpace(SharedPathRoot)
+            ? "Enter the folder both servers can reach, in step 2."
+        : TargetServer == null
+            ? "Choose the server to copy to, in step 3."
+        : string.IsNullOrWhiteSpace(TargetDatabaseName)
+            ? "Enter the name to restore as, in step 3."
+        : IsRefused
+            ? Refusal
+            : string.Empty;
+
+    public bool IsGenerateBlocked => GenerateBlockedReason.Length > 0;
+
     private void Invalidate()
     {
         OnPropertyChanged(nameof(Refusal));
         OnPropertyChanged(nameof(IsRefused));
         OnPropertyChanged(nameof(CanGenerate));
+        OnPropertyChanged(nameof(GenerateBlockedReason));
+        OnPropertyChanged(nameof(IsGenerateBlocked));
         OnPropertyChanged(nameof(WillOverwriteTheTarget));
         OnPropertyChanged(nameof(OverwriteWarning));
         OnPropertyChanged(nameof(WillResetTheDifferentialBase));

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -291,6 +291,19 @@
                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,4,0,12"
                                Text="Both statements are shown together, because what happens to each server is one decision - reading them one at a time is how somebody approves the half they were looking at." />
 
+                    <!-- Why the buttons are dead. They went out with nothing said, so a form with
+                         five of the six answers filled in read as complete and simply refused to
+                         work - which is exactly what a screen looks like after the source database
+                         has been cleared out from under it. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,12"
+                            Background="{DynamicResource WarningPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding IsGenerateBlocked, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding GenerateBlockedReason}"
+                                   Style="{StaticResource BodyText}" TextWrapping="Wrap" />
+                    </Border>
+
                     <WrapPanel>
                         <Button Content="Generate scripts"
                                 Command="{Binding GenerateCommand}"


### PR DESCRIPTION
Closes #457 — reported live from the app.

## What you saw

Every visible field filled in, the red overwrite banner naming the target database, and **both buttons dead with nothing saying why**.

## What was wrong

No source database was selected — the step 1 dropdown still said `Select...`, and that is one of six things `CanGenerate` requires.

It had been **cleared out from under the form**. `Refresh()` runs on every visit to this screen, rebuilds the server list from config, and re-assigns `SourceServer` to whichever entry matches by id — a *different object every time*, because the real store deserializes on each read rather than handing back what it holds. That assignment fires `OnSourceServerChanged`, which clears the database and reloads the list.

`TargetServer`, `Container`, `TargetDatabaseName` and the overwrite tick all survive that. So navigating away and back leaves a form that looks complete, refuses to work, and explains nothing.

Same root cause as #439 — the fake credential store returning cached objects is exactly what kept this invisible to the suite.

## The two fixes

**Put the choice back**, but only when the *same* server arrives again. Never on a switch: putting back what somebody chose is not the same as choosing for them, and inventing a source database is the one thing this screen must not do — the wrong choice reads a production database at full speed and overwrites one on another server.

My first attempt carried the name across regardless of which server arrived, and a test caught it, because the second server happened to hold a database of the same name. That distinction is now pinned in both directions.

**Say why the buttons are dead.** `GenerateBlockedReason` names the first unanswered question and the step to go back to — in the order the screen asks them, so somebody with three blanks is sent to the first rather than the last.

## Effect

`-c Release -warnaserror` clean, **2,192 passed** (up 8). Including a test that reproduces the report: fill everything in, call `Refresh()` as navigation does, and assert the screen is still armed.