### PR TITLE
Carry the login across instead of asking for a new password (#459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **The script that carries a login across from the source instance** (#459). When a restored
+  database holds a user with no matching login here, the app said to create the login first with
+  a password set by whoever owns the account - honest, and it still left a database whose users
+  could not log in. There is a third option beyond inventing a password or asking for one: go and
+  fetch the real one. Run the new script on the instance the backup came from and it prints the
+  `CREATE LOGIN` to run here, carrying the original password hash and the original SID. The hash
+  means applications keep the password they already have; the SID means the user is not orphaned
+  at all, so there is no `ALTER USER` to run afterwards. SQL logins only - a Windows login carries
+  no password and takes its SID from Active Directory, which the script says rather than quietly
+  finding nothing.
+
+
 - **The Restore screen can ask the source instance what this container is missing** (#451).
   Logs often go somewhere the fulls do not - a local or cluster disk for throughput, or a share
   because log shipping already owns them. Pointed at the container, the app built an honest chain

--- a/src/NineLives.Core/Services/PostRestoreAdvice.cs
+++ b/src/NineLives.Core/Services/PostRestoreAdvice.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -79,6 +79,90 @@ public static class PostRestoreAdvice
         "Create the login first - with a password set by whoever owns that account, not invented " +
         "here - then the ALTER USER line maps the user onto it.",
         Runnable: false);
+
+    /// <summary>
+    /// The script that carries a login across from the instance the backup came from (#459).
+    ///
+    /// The honest gap in ExplainUnmappableOrphan: it says create the login first, with a password
+    /// set by whoever owns the account, and leaves somebody holding a database whose users cannot
+    /// log in. Inventing a password here would be wrong, but there is a third option it did not
+    /// offer - go and fetch the real one.
+    ///
+    /// Run on the SOURCE, this emits a CREATE LOGIN carrying the original password HASH and the
+    /// original SID. Both matter, and for different reasons:
+    ///
+    ///   - the hash means applications authenticate with the password they already have, and
+    ///     nobody has to be told a new one
+    ///   - the SID means the restored user is not orphaned AT ALL. Its SID already matches, so
+    ///     there is no ALTER USER to run and no window where permissions are wrong
+    ///
+    /// Only SQL logins. A Windows login has no password here to carry and its SID comes from
+    /// Active Directory, so the target recreates it with CREATE LOGIN ... FROM WINDOWS and the
+    /// SIDs match by construction - the script says so rather than silently finding nothing.
+    ///
+    /// Nothing is executed by this app: it is read on one server and its OUTPUT is run on another,
+    /// which is also why the result carries a real password hash and this app never sees it.
+    /// </summary>
+    public static RecoveryAction CaptureLoginFromSource(string loginName) => new(
+        $"Copy the login {loginName} from the source instance",
+        BuildLoginCaptureScript(loginName),
+        "Run this on the instance the backup came FROM. It prints a CREATE LOGIN statement " +
+        "carrying that login's real password hash and its original SID - run that output on this " +
+        "server. Because the SID matches, the restored user stops being orphaned without an " +
+        "ALTER USER, and because the hash matches, applications keep the password they already " +
+        "have. Only SQL logins: a Windows login is recreated with CREATE LOGIN ... FROM WINDOWS, " +
+        "which carries its own SID from Active Directory.",
+        Runnable: false);
+
+    /// <summary>
+    /// The name is a LITERAL here, not an identifier - it is being compared against sys.sql_logins
+    /// rather than naming an object - so it is escaped as one. QUOTENAME inside the script does
+    /// the identifier quoting for the statement it emits, on the far side.
+    /// </summary>
+    internal static string BuildLoginCaptureScript(string loginName) =>
+        $"""
+        -- Run this on the instance the backup came FROM.
+        -- It prints a CREATE LOGIN statement to run on the target; it changes nothing here.
+        USE [master];
+        GO
+
+        DECLARE @LoginName sysname = N'{TSql.EscapeLiteral(loginName)}';
+        DECLARE @Command nvarchar(max);
+
+        IF NOT EXISTS (SELECT 1 FROM sys.sql_logins WHERE name = @LoginName)
+        BEGIN
+            THROW 50000, 'No SQL login of that name on this instance. A Windows login carries no password and takes its SID from Active Directory, so the target recreates it with CREATE LOGIN ... FROM WINDOWS instead.', 1;
+        END;
+
+        SELECT @Command =
+               N'CREATE LOGIN ' + QUOTENAME(sl.name)
+             + N' WITH PASSWORD = '
+             + CONVERT(nvarchar(max),
+                       CONVERT(varbinary(256),
+                               LOGINPROPERTY(sl.name, 'PasswordHash')), 1)
+             + N' HASHED'
+             + N', SID = ' + CONVERT(nvarchar(max), sl.sid, 1)
+             + N', DEFAULT_DATABASE = '
+             + QUOTENAME(COALESCE(sl.default_database_name, N'master'))
+             + N', DEFAULT_LANGUAGE = '
+             + QUOTENAME(COALESCE(sl.default_language_name, N'us_english'))
+             + N', CHECK_POLICY = '
+             + CASE sl.is_policy_checked WHEN 1 THEN N'ON' ELSE N'OFF' END
+             + N', CHECK_EXPIRATION = '
+             + CASE sl.is_expiration_checked WHEN 1 THEN N'ON' ELSE N'OFF' END
+             + N';'
+             + CASE
+                   WHEN sl.is_disabled = 1
+                   THEN CHAR(13) + CHAR(10)
+                      + N'ALTER LOGIN ' + QUOTENAME(sl.name) + N' DISABLE;'
+                   ELSE N''
+               END
+        FROM sys.sql_logins AS sl
+        WHERE sl.name = @LoginName;
+
+        SELECT @Command AS [RunThisOnTheTarget];
+        GO
+        """;
 
     /// <summary>What the orphan scan concluded, in one line.</summary>
     public static string DescribeOrphans(IReadOnlyList<OrphanedUser> orphans) => orphans.Count switch

--- a/src/NineLives.Tests/CarryTheLoginAcrossTests.cs
+++ b/src/NineLives.Tests/CarryTheLoginAcrossTests.cs
@@ -1,0 +1,119 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Carrying a login across from the instance the backup came from (#459).
+///
+/// The honest gap in the unmappable-orphan advice: it says create the login first, with a password
+/// set by whoever owns the account, and leaves somebody holding a database whose users cannot log
+/// in. Inventing a password would be wrong - but there was a third option it never offered, which
+/// is to go and fetch the real one.
+///
+/// Run on the source, the script emits a CREATE LOGIN carrying the original password hash AND the
+/// original SID. The hash means applications keep the password they already have; the SID means
+/// the restored user is not orphaned at all, so there is no ALTER USER to run afterwards and no
+/// window where its permissions are wrong.
+/// </summary>
+public class CarryTheLoginAcrossTests
+{
+    [Fact]
+    public void TheScriptCarriesBothTheHashAndTheSid()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript("app_user");
+
+        // The hash, so nobody has to be told a new password.
+        Assert.Contains("LOGINPROPERTY(sl.name, 'PasswordHash')", sql);
+        Assert.Contains("HASHED", sql);
+
+        // The SID, which is what stops the user being orphaned in the first place.
+        Assert.Contains("SID = ", sql);
+        Assert.Contains("sl.sid", sql);
+    }
+
+    /// <summary>
+    /// The properties that make the recreated login behave like the original rather than merely
+    /// authenticate like it.
+    /// </summary>
+    [Fact]
+    public void ItCarriesTheLoginsOwnSettingsToo()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript("app_user");
+
+        Assert.Contains("DEFAULT_DATABASE", sql);
+        Assert.Contains("DEFAULT_LANGUAGE", sql);
+        Assert.Contains("CHECK_POLICY", sql);
+        Assert.Contains("CHECK_EXPIRATION", sql);
+
+        // A login disabled on the source must not arrive enabled on the target.
+        Assert.Contains("is_disabled", sql);
+        Assert.Contains("ALTER LOGIN ", sql);
+        Assert.Contains("DISABLE", sql);
+    }
+
+    /// <summary>
+    /// The name is compared against sys.sql_logins, so it is a LITERAL - and an apostrophe in it
+    /// would otherwise close the string and turn the rest into commands. QUOTENAME inside the
+    /// script does the identifier quoting for the statement it emits, on the far side.
+    /// </summary>
+    [Fact]
+    public void AnApostropheInTheLoginNameIsEscapedAsALiteral()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript("o'brien");
+
+        Assert.Contains("N'o''brien'", sql);
+        Assert.Contains("QUOTENAME(sl.name)", sql);
+    }
+
+    /// <summary>
+    /// A Windows login has no password here to carry and takes its SID from Active Directory, so
+    /// finding nothing is the expected answer for one - said out loud rather than returning an
+    /// empty result somebody has to interpret.
+    /// </summary>
+    [Fact]
+    public void AWindowsLoginIsExplainedRatherThanSilentlyFindingNothing()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript(@"DOMAIN\service");
+
+        Assert.Contains("THROW", sql);
+        Assert.Contains("FROM WINDOWS", sql);
+    }
+
+    /// <summary>It reads; it does not write. Run on a production source, that is the whole point.</summary>
+    [Fact]
+    public void ItChangesNothingOnTheInstanceItRunsOn()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript("app_user");
+
+        Assert.DoesNotContain("CREATE LOGIN [", sql);   // it BUILDS the text, never executes it
+        Assert.DoesNotContain("EXEC(", sql);
+        Assert.DoesNotContain("sp_executesql", sql);
+        Assert.Contains("SELECT @Command AS [RunThisOnTheTarget]", sql);
+    }
+
+    // ── how it is offered ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheActionSaysWhereToRunItAndIsNotRunnableHere()
+    {
+        var action = PostRestoreAdvice.CaptureLoginFromSource("app_user");
+
+        Assert.Contains("app_user", action.Title);
+        Assert.Contains("came FROM", action.Caution);
+        Assert.False(action.Runnable);
+    }
+
+    /// <summary>
+    /// And it says why this beats creating a login by hand: not just the password, but that the
+    /// matching SID removes the orphan rather than papering over it.
+    /// </summary>
+    [Fact]
+    public void ItExplainsWhyTheSidMatters()
+    {
+        var action = PostRestoreAdvice.CaptureLoginFromSource("app_user");
+
+        Assert.Contains("SID", action.Caution);
+        Assert.Contains("orphaned", action.Caution);
+    }
+}

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -565,9 +565,20 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             foreach (var orphan in orphans)
             {
-                actions.Add(orphan.HasSameNamedLogin
-                    ? PostRestoreAdvice.FixOrphan(targetDatabase, orphan)
-                    : PostRestoreAdvice.ExplainUnmappableOrphan(targetDatabase, orphan));
+                if (orphan.HasSameNamedLogin)
+                {
+                    actions.Add(PostRestoreAdvice.FixOrphan(targetDatabase, orphan));
+                    continue;
+                }
+
+                // Nothing here to re-attach to. Saying "create the login first, with a password
+                // somebody else owns" is honest and still leaves a database whose users cannot log
+                // in - so the other way out is offered beside it (#459): go and fetch the real
+                // login from the instance the backup came from, hash and SID intact. With the SID
+                // carried across the user is not orphaned at all, and there is no ALTER USER to
+                // run afterwards.
+                actions.Add(PostRestoreAdvice.ExplainUnmappableOrphan(targetDatabase, orphan));
+                actions.Add(PostRestoreAdvice.CaptureLoginFromSource(orphan.Name));
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Closes #459.

## The gap

When a restored database holds a user with no matching login here, the advice was: create the login first, with a password set by whoever owns that account. Honest — inventing one would be worse — and it still leaves somebody holding a database whose users cannot log in, with no way forward that does not involve tracking down the account owner.

**There is a third option it never offered:** neither invent the password nor ask for it. Go and fetch the real one.

## What it does

Run on the instance the backup came from, the script prints the `CREATE LOGIN` to run here, carrying the original **password hash** and the original **SID**. Both halves earn their place:

- the **hash** means applications authenticate with the password they already have, and nobody has to be told a new one
- the **SID** means the restored user is not orphaned *at all*. Its SID already matches, so there is no `ALTER USER` to run afterwards and no window where its permissions are wrong

Offered *beside* the existing explanation rather than instead of it — creating the login by hand is still legitimate when somebody wants a fresh password.

## Details that matter

- The name is compared against `sys.sql_logins`, so it is a **literal** and escaped as one; `QUOTENAME` inside the script quotes the identifier for the statement it emits on the far side. An apostrophe in a login name is pinned.
- `DEFAULT_DATABASE`, `DEFAULT_LANGUAGE`, `CHECK_POLICY` and `CHECK_EXPIRATION` travel too, and a login **disabled on the source is re-disabled on the target** rather than arriving enabled.
- **SQL logins only.** A Windows login has no password here to carry and takes its SID from Active Directory, so the target recreates it with `CREATE LOGIN ... FROM WINDOWS` and the SIDs match by construction. The script throws with that explanation rather than returning an empty result somebody has to interpret.
- It reads and prints; it **executes nothing on either server**. That is what makes it safe to hand over for a production instance, and it is also why this app never sees the hash. Pinned — no `EXEC`, no `sp_executesql`.

## Effect

`-c Release -warnaserror` clean, **2,191 passed** (up 7).