### PR TITLE
Prepare v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,7 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
-## [Unreleased]
-
-### Fixed
-
-- **The Copy screen says why it will not generate, and stops losing the database you chose**
-  (#457). Reported from the app: every field filled in, the overwrite banner naming the target,
-  and both buttons dead with nothing saying why. Two faults. The source database had been cleared
-  out from under the form - the screen re-reads its server list on every visit and re-assigns the
-  source server to a fresh object, which clears the database and reloads the list, while the
-  target server, container, name and overwrite tick all survive. So the form looked complete and
-  was not. Your own choice is now put back when the same server arrives again, though never when
-  you switch servers, because inventing a source database is the one thing this screen must not
-  do. And six things have to be true before Generate is live; the screen named none of them, and
-  now names the first one missing along with the step to go back to.
+## [1.7.0] - 2026-08-17
 
 ### Added
 
@@ -54,6 +41,19 @@ more detail on the user-facing changes; this file is the short history.
   reads the container by URL and those logs from their own path by DISK, in one run. The target
   has to be able to open that path as its own service account - a different question from whether
   the container is reachable, and one now asked in the preflight, before anything is dropped.
+
+### Fixed
+
+- **The Copy screen says why it will not generate, and stops losing the database you chose**
+  (#457). Reported from the app: every field filled in, the overwrite banner naming the target,
+  and both buttons dead with nothing saying why. Two faults. The source database had been cleared
+  out from under the form - the screen re-reads its server list on every visit and re-assigns the
+  source server to a fresh object, which clears the database and reloads the list, while the
+  target server, container, name and overwrite tick all survive. So the form looked complete and
+  was not. Your own choice is now put back when the same server arrives again, though never when
+  you switch servers, because inventing a source database is the one thing this screen must not
+  do. And six things have to be true before Generate is live; the screen named none of them, and
+  now names the first one missing along with the step to go back to.
 
 ## [1.6.4] - 2026-08-14
 

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.6.4</Version>
+    <Version>1.7.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.6.4</Version>
+    <Version>1.7.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.6.4</Version>
+    <Version>1.7.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>


### PR DESCRIPTION
Version bump to 1.7.0 across the three projects, and the Unreleased section dated.

A minor rather than a patch: three things are new, not just fixed - finding the backups a container is missing, restoring them from where they are, and the script that carries a login across from the source instance. No breaking changes, no config or schema changes.

Also reordered the section headings to Added before Fixed, which is the Keep a Changelog order the file says it follows.