### PR TITLE
v1.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ publish/
 
 # Local staging for the publish/ swap while the app holds the exe lock - never shipped
 publish-staging/
+
+# Personal, machine-local editor and tooling notes. Each contributor keeps their own; the
+# shared conventions belong in CONTRIBUTING.md.
+CLAUDE.local.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ more detail on the user-facing changes; this file is the short history.
   named individually rather than globbed, and carrying no credential, because that script is
   handed to somebody to run on a production server.
 
+- **Or restore them from where they already are** (#451). The other way out, and the one for
+  mid-incident when uploading twenty-three files is time nobody has: fold them into the timeline
+  and leave the files alone. The restore point extends to the newest of them, and the script
+  reads the container by URL and those logs from their own path by DISK, in one run. The target
+  has to be able to open that path as its own service account - a different question from whether
+  the container is reachable, and one now asked in the preflight, before anything is dropped.
+
 ## [1.6.4] - 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Copy screen says why it will not generate, and stops losing the database you chose**
+  (#457). Reported from the app: every field filled in, the overwrite banner naming the target,
+  and both buttons dead with nothing saying why. Two faults. The source database had been cleared
+  out from under the form - the screen re-reads its server list on every visit and re-assigns the
+  source server to a fresh object, which clears the database and reloads the list, while the
+  target server, container, name and overwrite tick all survive. So the form looked complete and
+  was not. Your own choice is now put back when the same server arrives again, though never when
+  you switch servers, because inventing a source database is the one thing this screen must not
+  do. And six things have to be true before Generate is live; the screen named none of them, and
+  now names the first one missing along with the step to go back to.
+
 ### Added
 
 - **The script that carries a login across from the source instance** (#459). When a restored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Added
 
+- **The script that carries a login across from the source instance** (#459). When a restored
+  database holds a user with no matching login here, the app said to create the login first with
+  a password set by whoever owns the account - honest, and it still left a database whose users
+  could not log in. There is a third option beyond inventing a password or asking for one: go and
+  fetch the real one. Run the new script on the instance the backup came from and it prints the
+  `CREATE LOGIN` to run here, carrying the original password hash and the original SID. The hash
+  means applications keep the password they already have; the SID means the user is not orphaned
+  at all, so there is no `ALTER USER` to run afterwards. SQL logins only - a Windows login carries
+  no password and takes its SID from Active Directory, which the script says rather than quietly
+  finding nothing.
+
+
 - **The Restore screen can ask the source instance what this container is missing** (#451).
   Logs often go somewhere the fulls do not - a local or cluster disk for throughput, or a share
   because log shipping already owns them. Pointed at the container, the app built an honest chain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Added
+
+- **The Restore screen can ask the source instance what this container is missing** (#451).
+  Logs often go somewhere the fulls do not - a local or cluster disk for throughput, or a share
+  because log shipping already owns them. Pointed at the container, the app built an honest chain
+  out of what it could see, and that chain stopped at the last differential with nothing to say
+  the rest existed. Under the advanced restore options there is now a source instance picker and
+  a check: it reads that instance's own record, sets it against what the container holds, and
+  names what is missing along with the path it went to and how much recovery time the container
+  is behind by. For anything on disk it writes the PowerShell to copy those exact files in -
+  named individually rather than globbed, and carrying no credential, because that script is
+  handed to somebody to run on a production server.
+
 ## [1.6.4] - 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,7 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
-## [Unreleased]
-
-### Fixed
-
-- **The Copy screen says why it will not generate, and stops losing the database you chose**
-  (#457). Reported from the app: every field filled in, the overwrite banner naming the target,
-  and both buttons dead with nothing saying why. Two faults. The source database had been cleared
-  out from under the form - the screen re-reads its server list on every visit and re-assigns the
-  source server to a fresh object, which clears the database and reloads the list, while the
-  target server, container, name and overwrite tick all survive. So the form looked complete and
-  was not. Your own choice is now put back when the same server arrives again, though never when
-  you switch servers, because inventing a source database is the one thing this screen must not
-  do. And six things have to be true before Generate is live; the screen named none of them, and
-  now names the first one missing along with the step to go back to.
+## [1.7.0] - 2026-08-17
 
 ### Added
 
@@ -54,6 +41,19 @@ more detail on the user-facing changes; this file is the short history.
   reads the container by URL and those logs from their own path by DISK, in one run. The target
   has to be able to open that path as its own service account - a different question from whether
   the container is reachable, and one now asked in the preflight, before anything is dropped.
+
+### Fixed
+
+- **The Copy screen says why it will not generate, and stops losing the database you chose**
+  (#457). Reported from the app: every field filled in, the overwrite banner naming the target,
+  and both buttons dead with nothing saying why. Two faults. The source database had been cleared
+  out from under the form - the screen re-reads its server list on every visit and re-assigns the
+  source server to a fresh object, which clears the database and reloads the list, while the
+  target server, container, name and overwrite tick all survive. So the form looked complete and
+  was not. Your own choice is now put back when the same server arrives again, though never when
+  you switch servers, because inventing a source database is the one thing this screen must not
+  do. And six things have to be true before Generate is live; the screen named none of them, and
+  now names the first one missing along with the step to go back to.
 
 ## [1.6.4] - 2026-08-14
 

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.6.4</Version>
+    <Version>1.7.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.6.4</Version>
+    <Version>1.7.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/Services/BackupGapAnalyser.cs
+++ b/src/NineLives.Core/Services/BackupGapAnalyser.cs
@@ -1,0 +1,183 @@
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>One backup the source instance recorded that the container does not hold.</summary>
+public sealed record MissingBackup(BackupHistoryEntry Entry, string Folder)
+{
+    public BackupType Type => Entry.Type;
+    public DateTime TakenAt => Entry.StartedAt;
+    public IReadOnlyList<string> Files => Entry.Files;
+    public long SizeBytes => Entry.BackupSizeBytes ?? 0;
+}
+
+/// <summary>
+/// The missing backups that share one folder - what a copy script would be written against.
+/// </summary>
+public sealed class MissingLocation(string folder, IReadOnlyList<MissingBackup> backups)
+{
+    /// <summary>The directory the files were written to, as the source instance named it.</summary>
+    public string Folder { get; } = folder;
+
+    public IReadOnlyList<MissingBackup> Backups { get; } = backups;
+
+    public int FileCount => Backups.Sum(b => b.Files.Count);
+
+    public long TotalSizeBytes => Backups.Sum(b => b.SizeBytes);
+
+    public DateTime Earliest => Backups.Min(b => b.TakenAt);
+
+    public DateTime Latest => Backups.Max(b => b.TakenAt);
+
+    public string SizeDisplay => ByteSize.Format(TotalSizeBytes);
+
+    /// <summary>"23 log backups" / "1 differential backup" - counted by kind, in one phrase.</summary>
+    public string Summary
+    {
+        get
+        {
+            var byKind = Backups
+                .GroupBy(b => b.Type)
+                .OrderBy(g => g.Key)
+                .Select(g => $"{g.Count()} {Describe(g.Key, g.Count())}");
+
+            return string.Join(", ", byKind);
+        }
+    }
+
+    private static string Describe(BackupType type, int count) => type switch
+    {
+        BackupType.Full => count == 1 ? "full backup" : "full backups",
+        BackupType.Differential => count == 1 ? "differential backup" : "differential backups",
+        BackupType.TransactionLog => count == 1 ? "log backup" : "log backups",
+        _ => count == 1 ? "backup" : "backups"
+    };
+}
+
+/// <summary>
+/// What the source instance recorded, set against what is actually in the container (#451).
+///
+/// The estate shape this exists for: fulls and diffs go to blob, and the transaction logs go
+/// somewhere else - a local or cluster disk for throughput, or a share because log shipping
+/// already owns them. Pointed at the container, the app builds an honest chain out of what it can
+/// see, and that chain stops at the last differential. Nothing says the logs exist, where they
+/// went, or that the restore on offer is discarding hours of recoverable time.
+///
+/// Finding that out requires knowing to go and look, which is precisely the knowledge somebody
+/// does not have at 3am on a server they did not build. msdb knows, so this asks it.
+/// </summary>
+public static class BackupGapAnalyser
+{
+    /// <summary>
+    /// How far apart two timestamps can be and still describe the same backup, when LSNs are not
+    /// available on both sides.
+    ///
+    /// A container set's timestamp is parsed from its file name, which the writer stamps at the
+    /// START of the backup; msdb records the start too, so these agree exactly in the ordinary
+    /// case. The tolerance covers a writer that stamps a second late, not a genuinely different
+    /// backup - two backups of one database two seconds apart is not a real schedule.
+    /// </summary>
+    private static readonly TimeSpan SameBackupWindow = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Backups the instance recorded that the container does not hold, grouped by where they are.
+    ///
+    /// Matching is by LSN wherever both sides have one, because that is the only identifier that
+    /// is genuinely the backup rather than a description of it: a file can be renamed, moved, or
+    /// written to two places, and its LSN range still says which backup it is. Container sets only
+    /// carry LSNs once they have been audited, so the fallback is type plus timestamp - weaker,
+    /// and the reason a set that is present but renamed could be reported as missing. Reporting a
+    /// present backup as missing costs an unnecessary copy; the reverse would leave somebody
+    /// restoring to an hour earlier than they could have, so the bias is deliberate.
+    /// </summary>
+    public static IReadOnlyList<MissingLocation> Compare(
+        IReadOnlyList<BackupHistoryEntry> history,
+        IReadOnlyList<BackupSet> inContainer,
+        string database)
+    {
+        if (history.Count == 0) return [];
+
+        var mine = history
+            .Where(h => string.Equals(h.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Where(h => h.HasFiles)
+            .ToList();
+
+        var held = inContainer
+            .Where(s => string.Equals(s.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var missing = mine.Where(h => !IsHeld(h, held)).ToList();
+
+        return missing
+            .Select(h => new MissingBackup(h, FolderOf(h.Files[0])))
+            .GroupBy(m => m.Folder, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new MissingLocation(g.Key, g.OrderBy(m => m.TakenAt).ToList()))
+            .OrderBy(l => l.Earliest)
+            .ToList();
+    }
+
+    private static bool IsHeld(BackupHistoryEntry entry, List<BackupSet> held)
+    {
+        foreach (var set in held)
+        {
+            if (set.Type != entry.Type) continue;
+
+            // The reliable answer, when both sides have it.
+            if (entry.LastLsn is { } mine && set.LastLsn is { } theirs)
+            {
+                if (mine == theirs) return true;
+                continue;
+            }
+
+            if (Math.Abs((set.Timestamp - entry.StartedAt).TotalSeconds)
+                <= SameBackupWindow.TotalSeconds)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The directory part of a device path, handling both separators.
+    ///
+    /// Not Path.GetDirectoryName: these strings come from the SOURCE instance and describe its
+    /// file system, not this machine's. A UNC path read on a machine with different rules must
+    /// come back out unchanged, because it is about to be printed into a script that runs over
+    /// there.
+    /// </summary>
+    internal static string FolderOf(string devicePath)
+    {
+        var cut = devicePath.LastIndexOfAny(['\\', '/']);
+        return cut <= 0 ? devicePath : devicePath[..cut];
+    }
+
+    /// <summary>
+    /// How much recovery time the container's own chain is throwing away.
+    ///
+    /// The gap between the newest backup the container holds and the newest the instance recorded.
+    /// Null when the container is not behind - which includes the case where it holds MORE than
+    /// msdb knows about, as it will on any instance whose history has been trimmed.
+    /// </summary>
+    public static TimeSpan? RecoveryTimeNotInContainer(
+        IReadOnlyList<BackupHistoryEntry> history,
+        IReadOnlyList<BackupSet> inContainer,
+        string database)
+    {
+        var newestRecorded = history
+            .Where(h => string.Equals(h.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Select(h => (DateTime?)h.StartedAt)
+            .DefaultIfEmpty(null)
+            .Max();
+
+        var newestHeld = inContainer
+            .Where(s => string.Equals(s.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Select(s => (DateTime?)s.Timestamp)
+            .DefaultIfEmpty(null)
+            .Max();
+
+        if (newestRecorded is not { } recorded || newestHeld is not { } heldAt) return null;
+
+        var behind = recorded - heldAt;
+        return behind > TimeSpan.Zero ? behind : null;
+    }
+}

--- a/src/NineLives.Core/Services/MissingBackupCopyScript.cs
+++ b/src/NineLives.Core/Services/MissingBackupCopyScript.cs
@@ -1,0 +1,195 @@
+﻿using System.Text;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// The PowerShell that brings backups the container is missing into it (#451).
+///
+/// Runs on the SOURCE machine, because that is where the files are - a local or cluster disk this
+/// app has no route to. So it is a script somebody takes away and runs there, not something the
+/// app can do on their behalf.
+///
+/// It NEVER carries the credential. The whole point of the container's secret living in Windows
+/// Credential Manager is defeated by writing it into a .ps1 that then sits in a folder on a
+/// production server, and SECURITY.md states outright that a generated script contains none - a
+/// claim that has to stay true of every generator, not just the ones written when it was made.
+/// The credential arrives as a mandatory parameter at run time instead, which is also the form
+/// somebody can wire into a scheduled task without it touching disk.
+/// </summary>
+public static class MissingBackupCopyScript
+{
+    /// <summary>
+    /// One script per location, because a location is one folder and one command shape. Two
+    /// folders needing two runs is honest about what is happening; concatenating them into one
+    /// script with interleaved paths is what produces a half-finished copy nobody can unpick.
+    /// </summary>
+    public static string Build(MissingLocation location, BlobContainerConfig container)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("<#");
+        sb.AppendLine("    Nine Lives - copy backups into the container");
+        sb.AppendLine();
+        sb.AppendLine($"    Run this ON the machine that holds {location.Folder}.");
+        sb.AppendLine();
+        sb.AppendLine($"    {location.Summary} that this container does not have,");
+        sb.AppendLine($"    taken between {location.Earliest:yyyy-MM-dd HH:mm} and {location.Latest:yyyy-MM-dd HH:mm}.");
+        sb.AppendLine($"    {location.FileCount} file(s), {location.SizeDisplay}.");
+        sb.AppendLine();
+        sb.AppendLine("    The credential is a parameter, not a value in this file - so this script");
+        sb.AppendLine("    is safe to save, review and hand over. Supply it when you run it.");
+        sb.AppendLine("#>");
+        sb.AppendLine();
+
+        if (container.IsS3) AppendS3(sb, location, container);
+        else AppendAzure(sb, location, container);
+
+        return sb.ToString();
+    }
+
+    private static void AppendAzure(
+        StringBuilder sb, MissingLocation location, BlobContainerConfig container)
+    {
+        sb.AppendLine("param(");
+        sb.AppendLine("    # The container's SAS token, including the leading '?'.");
+        sb.AppendLine("    [Parameter(Mandatory = $true)]");
+        sb.AppendLine("    [string] $Sas");
+        sb.AppendLine(")");
+        sb.AppendLine();
+        sb.AppendLine("$ErrorActionPreference = 'Stop'");
+        sb.AppendLine();
+        sb.AppendLine($"$container = '{container.ContainerUrl.TrimEnd('/')}'");
+        sb.AppendLine();
+        sb.AppendLine("# azcopy is the fast path and resumes a part-finished copy. If it is not on this");
+        sb.AppendLine("# machine, the Az.Storage fallback below does the same job more slowly.");
+        sb.AppendLine("$azcopy = Get-Command azcopy -ErrorAction SilentlyContinue");
+        sb.AppendLine();
+
+        AppendFileList(sb, location);
+
+        sb.AppendLine("$failed = @()");
+        sb.AppendLine();
+        sb.AppendLine("foreach ($file in $files) {");
+        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file)) {");
+        sb.AppendLine("        Write-Warning \"Not on disk any more: $file\"");
+        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("        continue");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    $name = Split-Path -Leaf $file");
+        sb.AppendLine("    Write-Host \"Copying $name...\"");
+        sb.AppendLine();
+        sb.AppendLine("    try {");
+        sb.AppendLine("        if ($azcopy) {");
+        sb.AppendLine("            & azcopy copy $file \"$container/$name$Sas\" --overwrite=ifSourceNewer | Out-Null");
+        sb.AppendLine("            if ($LASTEXITCODE -ne 0) { throw \"azcopy exited $LASTEXITCODE\" }");
+        sb.AppendLine("        }");
+        sb.AppendLine("        else {");
+        sb.AppendLine("            $ctx = New-AzStorageContext -BlobEndpoint ($container -replace '/[^/]+$', '') -SasToken $Sas");
+        sb.AppendLine("            $containerName = Split-Path -Leaf $container");
+        sb.AppendLine("            Set-AzStorageBlobContent -File $file -Container $containerName -Blob $name -Context $ctx -Force | Out-Null");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine("    catch {");
+        sb.AppendLine("        Write-Warning \"Failed: $name - $_\"");
+        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        sb.AppendLine();
+
+        AppendEnding(sb);
+    }
+
+    private static void AppendS3(
+        StringBuilder sb, MissingLocation location, BlobContainerConfig container)
+    {
+        var url = S3Url.TryParse(container.ContainerUrl.TrimEnd('/'));
+        var bucket = url?.Bucket ?? "BUCKET";
+        var prefix = string.IsNullOrWhiteSpace(url?.BasePrefix) ? "" : url!.BasePrefix.Trim('/') + "/";
+        var endpoint = url?.Authority ?? "ENDPOINT";
+
+        sb.AppendLine("param(");
+        sb.AppendLine("    [Parameter(Mandatory = $true)] [string] $AccessKeyId,");
+        sb.AppendLine("    [Parameter(Mandatory = $true)] [string] $SecretAccessKey");
+        sb.AppendLine(")");
+        sb.AppendLine();
+        sb.AppendLine("$ErrorActionPreference = 'Stop'");
+        sb.AppendLine();
+        sb.AppendLine("# Set for this process only - nothing is written to the profile or the machine.");
+        sb.AppendLine("$env:AWS_ACCESS_KEY_ID = $AccessKeyId");
+        sb.AppendLine("$env:AWS_SECRET_ACCESS_KEY = $SecretAccessKey");
+
+        if (!string.IsNullOrWhiteSpace(container.S3Region))
+            sb.AppendLine($"$env:AWS_DEFAULT_REGION = '{container.S3Region}'");
+
+        sb.AppendLine();
+        sb.AppendLine($"$bucket = '{bucket}'");
+        sb.AppendLine($"$prefix = '{prefix}'");
+        sb.AppendLine($"$endpoint = 'https://{endpoint}'");
+        sb.AppendLine();
+
+        AppendFileList(sb, location);
+
+        sb.AppendLine("$failed = @()");
+        sb.AppendLine();
+        sb.AppendLine("foreach ($file in $files) {");
+        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file)) {");
+        sb.AppendLine("        Write-Warning \"Not on disk any more: $file\"");
+        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("        continue");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    $name = Split-Path -Leaf $file");
+        sb.AppendLine("    Write-Host \"Copying $name...\"");
+        sb.AppendLine();
+        sb.AppendLine("    & aws s3 cp $file \"s3://$bucket/$prefix$name\" --endpoint-url $endpoint");
+        sb.AppendLine("    if ($LASTEXITCODE -ne 0) {");
+        sb.AppendLine("        Write-Warning \"Failed: $name\"");
+        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        sb.AppendLine();
+
+        AppendEnding(sb);
+    }
+
+    /// <summary>
+    /// The files, named one by one rather than as a wildcard over the folder.
+    ///
+    /// A wildcard would copy whatever else is in there - other databases' backups, an unrelated
+    /// job's output, files somebody is midway through writing. This list is the answer to a
+    /// specific question (what is this chain missing), and copying anything else is both a
+    /// surprise and, on a metered egress link, a bill.
+    /// </summary>
+    private static void AppendFileList(StringBuilder sb, MissingLocation location)
+    {
+        sb.AppendLine("# Named individually, not a wildcard: only what this chain is actually missing.");
+        sb.AppendLine("$files = @(");
+
+        var paths = location.Backups.SelectMany(b => b.Files).ToList();
+        for (int i = 0; i < paths.Count; i++)
+        {
+            var comma = i < paths.Count - 1 ? "," : "";
+            sb.AppendLine($"    '{paths[i].Replace("'", "''")}'{comma}");
+        }
+
+        sb.AppendLine(")");
+        sb.AppendLine();
+    }
+
+    private static void AppendEnding(StringBuilder sb)
+    {
+        sb.AppendLine("if ($failed.Count -gt 0) {");
+        sb.AppendLine("    Write-Host \"\"");
+        sb.AppendLine("    Write-Warning \"$($failed.Count) file(s) did not copy:\"");
+        sb.AppendLine("    $failed | ForEach-Object { Write-Warning \"  $_\" }");
+        sb.AppendLine("    Write-Host \"\"");
+        sb.AppendLine("    Write-Host 'Rescan in Nine Lives to see what did arrive.'");
+        sb.AppendLine("    exit 1");
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine("Write-Host \"\"");
+        sb.AppendLine("Write-Host 'Done. Rescan the container in Nine Lives to pick them up.'");
+    }
+}

--- a/src/NineLives.Core/Services/PostRestoreAdvice.cs
+++ b/src/NineLives.Core/Services/PostRestoreAdvice.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -79,6 +79,90 @@ public static class PostRestoreAdvice
         "Create the login first - with a password set by whoever owns that account, not invented " +
         "here - then the ALTER USER line maps the user onto it.",
         Runnable: false);
+
+    /// <summary>
+    /// The script that carries a login across from the instance the backup came from (#459).
+    ///
+    /// The honest gap in ExplainUnmappableOrphan: it says create the login first, with a password
+    /// set by whoever owns the account, and leaves somebody holding a database whose users cannot
+    /// log in. Inventing a password here would be wrong, but there is a third option it did not
+    /// offer - go and fetch the real one.
+    ///
+    /// Run on the SOURCE, this emits a CREATE LOGIN carrying the original password HASH and the
+    /// original SID. Both matter, and for different reasons:
+    ///
+    ///   - the hash means applications authenticate with the password they already have, and
+    ///     nobody has to be told a new one
+    ///   - the SID means the restored user is not orphaned AT ALL. Its SID already matches, so
+    ///     there is no ALTER USER to run and no window where permissions are wrong
+    ///
+    /// Only SQL logins. A Windows login has no password here to carry and its SID comes from
+    /// Active Directory, so the target recreates it with CREATE LOGIN ... FROM WINDOWS and the
+    /// SIDs match by construction - the script says so rather than silently finding nothing.
+    ///
+    /// Nothing is executed by this app: it is read on one server and its OUTPUT is run on another,
+    /// which is also why the result carries a real password hash and this app never sees it.
+    /// </summary>
+    public static RecoveryAction CaptureLoginFromSource(string loginName) => new(
+        $"Copy the login {loginName} from the source instance",
+        BuildLoginCaptureScript(loginName),
+        "Run this on the instance the backup came FROM. It prints a CREATE LOGIN statement " +
+        "carrying that login's real password hash and its original SID - run that output on this " +
+        "server. Because the SID matches, the restored user stops being orphaned without an " +
+        "ALTER USER, and because the hash matches, applications keep the password they already " +
+        "have. Only SQL logins: a Windows login is recreated with CREATE LOGIN ... FROM WINDOWS, " +
+        "which carries its own SID from Active Directory.",
+        Runnable: false);
+
+    /// <summary>
+    /// The name is a LITERAL here, not an identifier - it is being compared against sys.sql_logins
+    /// rather than naming an object - so it is escaped as one. QUOTENAME inside the script does
+    /// the identifier quoting for the statement it emits, on the far side.
+    /// </summary>
+    internal static string BuildLoginCaptureScript(string loginName) =>
+        $"""
+        -- Run this on the instance the backup came FROM.
+        -- It prints a CREATE LOGIN statement to run on the target; it changes nothing here.
+        USE [master];
+        GO
+
+        DECLARE @LoginName sysname = N'{TSql.EscapeLiteral(loginName)}';
+        DECLARE @Command nvarchar(max);
+
+        IF NOT EXISTS (SELECT 1 FROM sys.sql_logins WHERE name = @LoginName)
+        BEGIN
+            THROW 50000, 'No SQL login of that name on this instance. A Windows login carries no password and takes its SID from Active Directory, so the target recreates it with CREATE LOGIN ... FROM WINDOWS instead.', 1;
+        END;
+
+        SELECT @Command =
+               N'CREATE LOGIN ' + QUOTENAME(sl.name)
+             + N' WITH PASSWORD = '
+             + CONVERT(nvarchar(max),
+                       CONVERT(varbinary(256),
+                               LOGINPROPERTY(sl.name, 'PasswordHash')), 1)
+             + N' HASHED'
+             + N', SID = ' + CONVERT(nvarchar(max), sl.sid, 1)
+             + N', DEFAULT_DATABASE = '
+             + QUOTENAME(COALESCE(sl.default_database_name, N'master'))
+             + N', DEFAULT_LANGUAGE = '
+             + QUOTENAME(COALESCE(sl.default_language_name, N'us_english'))
+             + N', CHECK_POLICY = '
+             + CASE sl.is_policy_checked WHEN 1 THEN N'ON' ELSE N'OFF' END
+             + N', CHECK_EXPIRATION = '
+             + CASE sl.is_expiration_checked WHEN 1 THEN N'ON' ELSE N'OFF' END
+             + N';'
+             + CASE
+                   WHEN sl.is_disabled = 1
+                   THEN CHAR(13) + CHAR(10)
+                      + N'ALTER LOGIN ' + QUOTENAME(sl.name) + N' DISABLE;'
+                   ELSE N''
+               END
+        FROM sys.sql_logins AS sl
+        WHERE sl.name = @LoginName;
+
+        SELECT @Command AS [RunThisOnTheTarget];
+        GO
+        """;
 
     /// <summary>What the orphan scan concluded, in one line.</summary>
     public static string DescribeOrphans(IReadOnlyList<OrphanedUser> orphans) => orphans.Count switch

--- a/src/NineLives.Tests/BackupGapAnalyserTests.cs
+++ b/src/NineLives.Tests/BackupGapAnalyserTests.cs
@@ -1,0 +1,285 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Finding the backups the instance took that never reached the container (#451).
+///
+/// The estate this is for: fulls and diffs to blob, logs to a local or cluster disk. The container
+/// holds an honest chain that stops at the last differential, and nothing tells anybody the logs
+/// exist somewhere else - so a restore silently discards hours of recoverable time.
+/// </summary>
+public class BackupGapAnalyserTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 14, 22, 0, 0);
+
+    private static BackupHistoryEntry Recorded(
+        BackupType type, DateTime at, string folder, decimal? lastLsn = null, long size = 1024,
+        string database = "Sales", int stripes = 1)
+    {
+        var ext = type == BackupType.TransactionLog ? "trn" : "bak";
+        var stamp = at.ToString("yyyyMMdd_HHmmss");
+
+        var files = Enumerable.Range(1, stripes)
+            .Select(n => stripes == 1
+                ? $@"{folder}\{database}_{stamp}.{ext}"
+                : $@"{folder}\{database}_{stamp}_{n}.{ext}")
+            .ToList();
+
+        return new BackupHistoryEntry
+        {
+            DatabaseName = database,
+            Type = type,
+            StartedAt = at,
+            FinishedAt = at.AddMinutes(1),
+            Files = files,
+            LastLsn = lastLsn,
+            BackupSizeBytes = size,
+            FamilyCount = stripes
+        };
+    }
+
+    private static BackupSet InContainer(
+        BackupType type, DateTime at, decimal? lastLsn = null, string database = "Sales") => new()
+        {
+            SetId = at.ToString("yyyyMMdd_HHmmss"),
+            Type = type,
+            Timestamp = at,
+            DatabaseName = database,
+            LastLsn = lastLsn,
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = $"{database}_{at:yyyyMMdd_HHmmss}.bak",
+                    BlobUrl = $"https://acct.blob.core.windows.net/c/{database}_{at:yyyyMMdd_HHmmss}.bak",
+                    Type = type
+                }
+            ]
+        };
+
+    // ── the case the feature exists for ─────────────────────────────────────────
+
+    [Fact]
+    public void LogsWrittenToDiskAreReportedAsMissingFromTheContainer()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(2), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(3), @"E:\SQLLogs")
+        };
+
+        // The container has the full, and nothing else.
+        var container = new List<BackupSet> { InContainer(BackupType.Full, T0) };
+
+        var locations = BackupGapAnalyser.Compare(history, container, "Sales");
+
+        var logs = Assert.Single(locations);
+        Assert.Equal(@"E:\SQLLogs", logs.Folder);
+        Assert.Equal(3, logs.Backups.Count);
+        Assert.Equal("3 log backups", logs.Summary);
+        Assert.Equal(T0.AddHours(1), logs.Earliest);
+        Assert.Equal(T0.AddHours(3), logs.Latest);
+    }
+
+    [Fact]
+    public void TheRecoveryTimeTheContainerIsBehindIsReported()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(12), @"E:\SQLLogs")
+        };
+        var container = new List<BackupSet> { InContainer(BackupType.Full, T0) };
+
+        var behind = BackupGapAnalyser.RecoveryTimeNotInContainer(history, container, "Sales");
+
+        Assert.Equal(TimeSpan.FromHours(12), behind);
+    }
+
+    /// <summary>Two paths, two groups - a copy script is written per location.</summary>
+    [Fact]
+    public void MissingBackupsAreGroupedByTheFolderTheyWereWrittenTo()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(2), @"\\nas01\shipping"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(3), @"E:\SQLLogs")
+        };
+
+        var locations = BackupGapAnalyser.Compare(history, [], "Sales");
+
+        Assert.Equal(2, locations.Count);
+        Assert.Contains(locations, l => l.Folder == @"E:\SQLLogs" && l.Backups.Count == 2);
+        Assert.Contains(locations, l => l.Folder == @"\\nas01\shipping" && l.Backups.Count == 1);
+    }
+
+    // ── matching ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The reliable identifier. A file that was renamed or written to two places is still the same
+    /// backup, and its LSN range is the only thing that says so.
+    /// </summary>
+    [Fact]
+    public void ABackupHeldUnderADifferentNameIsMatchedByItsLsn()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"C:\Backups", lastLsn: 4200m)
+        };
+
+        // Same backup, different name and a timestamp that would not match.
+        var container = new List<BackupSet>
+        {
+            InContainer(BackupType.Full, T0.AddHours(9), lastLsn: 4200m)
+        };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, container, "Sales"));
+    }
+
+    /// <summary>
+    /// And two different backups that share a timestamp are not conflated, because the LSNs
+    /// disagree - a full and its log can start in the same second.
+    /// </summary>
+    [Fact]
+    public void DifferentLsnsAtTheSameInstantAreDifferentBackups()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs", lastLsn: 5000m)
+        };
+        var container = new List<BackupSet>
+        {
+            InContainer(BackupType.TransactionLog, T0, lastLsn: 4000m)
+        };
+
+        Assert.Single(BackupGapAnalyser.Compare(history, container, "Sales"));
+    }
+
+    /// <summary>
+    /// Without LSNs on both sides - a container that has never been audited - type and timestamp
+    /// are what is left.
+    /// </summary>
+    [Fact]
+    public void WithoutLsnsAMatchFallsBackToTypeAndTimestamp()
+    {
+        var history = new List<BackupHistoryEntry> { Recorded(BackupType.Full, T0, @"C:\Backups") };
+        var container = new List<BackupSet> { InContainer(BackupType.Full, T0) };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, container, "Sales"));
+    }
+
+    [Fact]
+    public void TheSameInstantButADifferentTypeIsNotAMatch()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs")
+        };
+        var container = new List<BackupSet> { InContainer(BackupType.Full, T0) };
+
+        Assert.Single(BackupGapAnalyser.Compare(history, container, "Sales"));
+    }
+
+    // ── things that must stay quiet ─────────────────────────────────────────────
+
+    [Fact]
+    public void AContainerHoldingEverythingReportsNoGap()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"C:\Backups")
+        };
+        var container = new List<BackupSet>
+        {
+            InContainer(BackupType.Full, T0),
+            InContainer(BackupType.TransactionLog, T0.AddHours(1))
+        };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, container, "Sales"));
+        Assert.Null(BackupGapAnalyser.RecoveryTimeNotInContainer(history, container, "Sales"));
+    }
+
+    /// <summary>Another database's backups are not this database's problem.</summary>
+    [Fact]
+    public void AnotherDatabasesBackupsAreIgnored()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs", database: "Payroll")
+        };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, [], "Sales"));
+    }
+
+    /// <summary>
+    /// A container ahead of msdb is not behind it. Instance history gets trimmed, so a container
+    /// holding backups older than anything msdb still remembers is the ordinary case, not a fault.
+    /// </summary>
+    [Fact]
+    public void AContainerAheadOfTheInstanceHistoryIsNotReportedAsBehind()
+    {
+        var history = new List<BackupHistoryEntry> { Recorded(BackupType.Full, T0, @"C:\Backups") };
+        var container = new List<BackupSet>
+        {
+            InContainer(BackupType.Full, T0),
+            InContainer(BackupType.TransactionLog, T0.AddHours(6))
+        };
+
+        Assert.Null(BackupGapAnalyser.RecoveryTimeNotInContainer(history, container, "Sales"));
+    }
+
+    [Fact]
+    public void AnEmptyHistoryReportsNothing()
+    {
+        Assert.Empty(BackupGapAnalyser.Compare([], [], "Sales"));
+        Assert.Null(BackupGapAnalyser.RecoveryTimeNotInContainer([], [], "Sales"));
+    }
+
+    /// <summary>A recorded backup with no files recorded against it has no path to report.</summary>
+    [Fact]
+    public void ARecordedBackupWithNoFilesIsSkipped()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            new() { DatabaseName = "Sales", Type = BackupType.TransactionLog, StartedAt = T0, Files = [] }
+        };
+
+        Assert.Empty(BackupGapAnalyser.Compare(history, [], "Sales"));
+    }
+
+    // ── the paths themselves ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// These strings describe the SOURCE instance's file system, not this machine's, and they are
+    /// about to be printed into a script that runs over there.
+    /// </summary>
+    [Theory]
+    [InlineData(@"E:\SQLLogs\Sales_20260814.trn", @"E:\SQLLogs")]
+    [InlineData(@"\\nas01\shipping\Sales.trn", @"\\nas01\shipping")]
+    [InlineData(@"/var/opt/mssql/backups/Sales.trn", "/var/opt/mssql/backups")]
+    [InlineData(@"Sales.trn", @"Sales.trn")]
+    public void TheFolderIsTakenFromThePathAsTheSourceWroteIt(string device, string expected)
+        => Assert.Equal(expected, BackupGapAnalyser.FolderOf(device));
+
+    /// <summary>A striped set is one missing backup with several files to copy, not several.</summary>
+    [Fact]
+    public void AStripedBackupIsOneEntryWithEveryFileNamed()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Recorded(BackupType.Full, T0, @"E:\SQLLogs", stripes: 3)
+        };
+
+        var location = Assert.Single(BackupGapAnalyser.Compare(history, [], "Sales"));
+
+        Assert.Single(location.Backups);
+        Assert.Equal(3, location.FileCount);
+    }
+}

--- a/src/NineLives.Tests/BackupGapViewModelTests.cs
+++ b/src/NineLives.Tests/BackupGapViewModelTests.cs
@@ -1,0 +1,288 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The panel that asks the source instance what the container is missing (#451).
+///
+/// It answers a question the restore screen cannot answer alone: is this chain short because that
+/// is all there ever was, or because the logs went somewhere else? Only the instance that took
+/// them knows.
+/// </summary>
+public class BackupGapViewModelTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 14, 22, 0, 0);
+
+    private static ServerConnection Server(string name = "SRV01") => new()
+    {
+        Id = ServerConnection.NewId(),
+        Name = name,
+        ServerName = name
+    };
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+    };
+
+    private static BackupHistoryEntry Recorded(BackupType type, DateTime at, string folder) => new()
+    {
+        DatabaseName = "Sales",
+        Type = type,
+        StartedAt = at,
+        Files = [$@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn"],
+        BackupSizeBytes = 10 * 1024 * 1024
+    };
+
+    private static BackupSet Held(BackupType type, DateTime at) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        Type = type,
+        Timestamp = at,
+        DatabaseName = "Sales",
+        Files = [new BackupFileInfo { BlobName = "x.bak", Type = type }]
+    };
+
+    private static (BackupGapViewModel vm, FakeSqlServerService sql) Panel(
+        params BackupHistoryEntry[] history)
+    {
+        var sql = new FakeSqlServerService { BackupHistory = history.ToList() };
+        var vm = new BackupGapViewModel(sql);
+        vm.Servers.Add(Server());
+        vm.SourceServer = vm.Servers[0];
+        return (vm, sql);
+    }
+
+    private static GapCheckRequest Ask(params BackupSet[] held)
+        => new("Sales", Container(), held);
+
+    // ── the case it exists for ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LogsTakenToDiskAreFoundAndTheirFolderNamed()
+    {
+        var (vm, _) = Panel(
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(2), @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0)));
+
+        Assert.True(vm.HasGap);
+        var row = Assert.Single(vm.Locations);
+        Assert.Equal(@"E:\SQLLogs", row.Folder);
+        Assert.Equal("2 log backups", row.Summary);
+        Assert.True(row.IsOnDisk);
+    }
+
+    [Fact]
+    public async Task ItSaysHowFarBehindTheContainerIs()
+    {
+        var (vm, _) = Panel(
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(12).AddMinutes(45), @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0)));
+
+        Assert.Equal("12 hours 45 minutes", vm.BehindBy);
+    }
+
+    /// <summary>
+    /// A clean answer has to be said out loud. "No locations" rendering as an empty panel is
+    /// indistinguishable from never having pressed the button.
+    /// </summary>
+    [Fact]
+    public async Task AContainerHoldingEverythingSaysSoRatherThanShowingNothing()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.Full, T0, @"C:\Backups"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0)));
+
+        Assert.False(vm.HasGap);
+        Assert.True(vm.FoundNothingMissing);
+        Assert.Contains("Everything the instance recorded", vm.StatusMessage);
+    }
+
+    [Fact]
+    public void BeforeAnyCheckTheAllClearIsNotClaimed()
+    {
+        var (vm, _) = Panel();
+
+        Assert.False(vm.HasChecked);
+        Assert.False(vm.FoundNothingMissing);
+        Assert.False(vm.HasGap);
+    }
+
+    // ── what was compared ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The answer is only worth anything if somebody can see it was asked of the right instance
+    /// and the right database - this panel connects to a DIFFERENT server from the one the restore
+    /// runs on, which is exactly the confusion worth heading off.
+    /// </summary>
+    [Fact]
+    public async Task ItStatesWhatItCompared()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0.AddHours(-1))));
+
+        Assert.Contains("Sales on SRV01", vm.ComparedWhat);
+        Assert.Contains("sqlbackups", vm.ComparedWhat);
+    }
+
+    // ── refusals and failures ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WithNoDatabaseChosenItSaysSoRatherThanCheckingNothing()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(new GapCheckRequest("", Container(), []));
+
+        Assert.True(vm.HasError);
+        Assert.Contains("per database", vm.ErrorMessage);
+        Assert.False(vm.HasChecked);
+    }
+
+    [Fact]
+    public async Task AnUnreachableSourceNamesItselfInTheFailure()
+    {
+        var (vm, sql) = Panel();
+        sql.BackupHistoryThrows = new InvalidOperationException("Login failed for user 'sa'.");
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.True(vm.HasError);
+        Assert.Contains("SRV01", vm.ErrorMessage);
+        Assert.Contains("Login failed", vm.ErrorMessage);
+        Assert.False(vm.HasChecked);
+    }
+
+    [Fact]
+    public void TheCheckIsRefusedUntilASourceIsChosen()
+    {
+        var vm = new BackupGapViewModel(new FakeSqlServerService());
+        Assert.False(vm.CanCheck);
+
+        vm.Servers.Add(Server());
+        vm.SourceServer = vm.Servers[0];
+
+        Assert.True(vm.CanCheck);
+    }
+
+    /// <summary>
+    /// A previous answer describes a previous server. Leaving it on screen under a new selection
+    /// is the stale-result problem, and a panel whose whole job is to be believed cannot have it.
+    /// </summary>
+    [Fact]
+    public async Task ChangingTheSourceClearsThePreviousAnswer()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs"));
+        await vm.CheckCommand.ExecuteAsync(Ask());
+        Assert.True(vm.HasGap);
+
+        vm.Servers.Add(Server("SRV02"));
+        vm.SourceServer = vm.Servers[1];
+
+        Assert.False(vm.HasGap);
+        Assert.False(vm.HasChecked);
+        Assert.Empty(vm.BehindBy);
+    }
+
+    /// <summary>
+    /// A gap and a MEASURED gap are different things, and rendering the panel is what made that
+    /// obvious: a container holding nothing at all for this database has everything missing and no
+    /// interval to quote, because there is no newest-held backup to measure from. The banner
+    /// assumed the two went together and drew "This container is  behind what the instance
+    /// recorded" - a sentence with a hole in it.
+    /// </summary>
+    [Fact]
+    public async Task AContainerHoldingNothingHasAGapButNoIntervalToQuote()
+    {
+        var (vm, _) = Panel(Recorded(BackupType.TransactionLog, T0, @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.True(vm.HasGap);
+        Assert.False(vm.HasMeasuredGap);
+        Assert.Empty(vm.BehindBy);
+    }
+
+    [Fact]
+    public async Task AContainerThatIsMerelyBehindHasBoth()
+    {
+        var (vm, _) = Panel(
+            Recorded(BackupType.Full, T0, @"C:\Backups"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(3), @"E:\SQLLogs"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(BackupType.Full, T0)));
+
+        Assert.True(vm.HasGap);
+        Assert.True(vm.HasMeasuredGap);
+        Assert.Equal("3 hours", vm.BehindBy);
+    }
+
+    // ── the copy script ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TheCopyScriptIsBuiltForTheChosenLocationOnly()
+    {
+        var (vm, _) = Panel(
+            Recorded(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+            Recorded(BackupType.TransactionLog, T0.AddHours(2), @"\\nas01\shipping"));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+        Assert.Equal(2, vm.Locations.Count);
+
+        var first = vm.Locations.First(l => l.Folder == @"E:\SQLLogs");
+        Assert.False(first.HasScript);
+
+        vm.BuildScript(first, Container());
+
+        Assert.True(first.HasScript);
+        Assert.Contains(@"E:\SQLLogs", first.Script);
+        Assert.DoesNotContain(@"\\nas01\shipping", first.Script);
+
+        // And the other is untouched - one location, one script, one run.
+        Assert.False(vm.Locations.First(l => l.Folder == @"\\nas01\shipping").HasScript);
+    }
+
+    /// <summary>
+    /// A backup msdb recorded to a URL is not a file on the source machine, so there is nothing
+    /// for a copy script to pick up. That finding means the container listing did not see
+    /// something that WAS written to storage - a different problem with a different answer.
+    /// </summary>
+    [Fact]
+    public async Task ABackupRecordedToAUrlIsNotOfferedAsSomethingToCopy()
+    {
+        var (vm, _) = Panel(new BackupHistoryEntry
+        {
+            DatabaseName = "Sales",
+            Type = BackupType.TransactionLog,
+            StartedAt = T0,
+            Files = ["https://acct.blob.core.windows.net/sqlbackups/Sales_log.trn"]
+        });
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        var row = Assert.Single(vm.Locations);
+        Assert.False(row.IsOnDisk);
+    }
+
+    // ── the wording of the gap ──────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0, 0, 30, "30 minutes")]
+    [InlineData(0, 1, 0, "1 hour")]
+    [InlineData(0, 12, 45, "12 hours 45 minutes")]
+    [InlineData(2, 3, 0, "2 days 3 hours")]
+    [InlineData(0, 0, 0, "under a minute")]
+    public void TheGapIsQuotedInUnitsSomebodyDecidesOn(int d, int h, int m, string expected)
+        => Assert.Equal(expected, BackupGapViewModel.Humanise(new TimeSpan(d, h, m, 0)));
+}

--- a/src/NineLives.Tests/CarryTheLoginAcrossTests.cs
+++ b/src/NineLives.Tests/CarryTheLoginAcrossTests.cs
@@ -1,0 +1,119 @@
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Carrying a login across from the instance the backup came from (#459).
+///
+/// The honest gap in the unmappable-orphan advice: it says create the login first, with a password
+/// set by whoever owns the account, and leaves somebody holding a database whose users cannot log
+/// in. Inventing a password would be wrong - but there was a third option it never offered, which
+/// is to go and fetch the real one.
+///
+/// Run on the source, the script emits a CREATE LOGIN carrying the original password hash AND the
+/// original SID. The hash means applications keep the password they already have; the SID means
+/// the restored user is not orphaned at all, so there is no ALTER USER to run afterwards and no
+/// window where its permissions are wrong.
+/// </summary>
+public class CarryTheLoginAcrossTests
+{
+    [Fact]
+    public void TheScriptCarriesBothTheHashAndTheSid()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript("app_user");
+
+        // The hash, so nobody has to be told a new password.
+        Assert.Contains("LOGINPROPERTY(sl.name, 'PasswordHash')", sql);
+        Assert.Contains("HASHED", sql);
+
+        // The SID, which is what stops the user being orphaned in the first place.
+        Assert.Contains("SID = ", sql);
+        Assert.Contains("sl.sid", sql);
+    }
+
+    /// <summary>
+    /// The properties that make the recreated login behave like the original rather than merely
+    /// authenticate like it.
+    /// </summary>
+    [Fact]
+    public void ItCarriesTheLoginsOwnSettingsToo()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript("app_user");
+
+        Assert.Contains("DEFAULT_DATABASE", sql);
+        Assert.Contains("DEFAULT_LANGUAGE", sql);
+        Assert.Contains("CHECK_POLICY", sql);
+        Assert.Contains("CHECK_EXPIRATION", sql);
+
+        // A login disabled on the source must not arrive enabled on the target.
+        Assert.Contains("is_disabled", sql);
+        Assert.Contains("ALTER LOGIN ", sql);
+        Assert.Contains("DISABLE", sql);
+    }
+
+    /// <summary>
+    /// The name is compared against sys.sql_logins, so it is a LITERAL - and an apostrophe in it
+    /// would otherwise close the string and turn the rest into commands. QUOTENAME inside the
+    /// script does the identifier quoting for the statement it emits, on the far side.
+    /// </summary>
+    [Fact]
+    public void AnApostropheInTheLoginNameIsEscapedAsALiteral()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript("o'brien");
+
+        Assert.Contains("N'o''brien'", sql);
+        Assert.Contains("QUOTENAME(sl.name)", sql);
+    }
+
+    /// <summary>
+    /// A Windows login has no password here to carry and takes its SID from Active Directory, so
+    /// finding nothing is the expected answer for one - said out loud rather than returning an
+    /// empty result somebody has to interpret.
+    /// </summary>
+    [Fact]
+    public void AWindowsLoginIsExplainedRatherThanSilentlyFindingNothing()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript(@"DOMAIN\service");
+
+        Assert.Contains("THROW", sql);
+        Assert.Contains("FROM WINDOWS", sql);
+    }
+
+    /// <summary>It reads; it does not write. Run on a production source, that is the whole point.</summary>
+    [Fact]
+    public void ItChangesNothingOnTheInstanceItRunsOn()
+    {
+        var sql = PostRestoreAdvice.BuildLoginCaptureScript("app_user");
+
+        Assert.DoesNotContain("CREATE LOGIN [", sql);   // it BUILDS the text, never executes it
+        Assert.DoesNotContain("EXEC(", sql);
+        Assert.DoesNotContain("sp_executesql", sql);
+        Assert.Contains("SELECT @Command AS [RunThisOnTheTarget]", sql);
+    }
+
+    // ── how it is offered ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheActionSaysWhereToRunItAndIsNotRunnableHere()
+    {
+        var action = PostRestoreAdvice.CaptureLoginFromSource("app_user");
+
+        Assert.Contains("app_user", action.Title);
+        Assert.Contains("came FROM", action.Caution);
+        Assert.False(action.Runnable);
+    }
+
+    /// <summary>
+    /// And it says why this beats creating a login by hand: not just the password, but that the
+    /// matching SID removes the orphan rather than papering over it.
+    /// </summary>
+    [Fact]
+    public void ItExplainsWhyTheSidMatters()
+    {
+        var action = PostRestoreAdvice.CaptureLoginFromSource("app_user");
+
+        Assert.Contains("SID", action.Caution);
+        Assert.Contains("orphaned", action.Caution);
+    }
+}

--- a/src/NineLives.Tests/CopyScreenSaysWhyItIsBlockedTests.cs
+++ b/src/NineLives.Tests/CopyScreenSaysWhyItIsBlockedTests.cs
@@ -1,0 +1,174 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The Copy screen explains itself, and stops losing the choice that was made (#457).
+///
+/// Reported from the app: every visible field filled in, the overwrite banner naming the target,
+/// and both buttons dead with nothing on screen saying why. Two faults behind it.
+///
+/// The source database had been cleared out from under the form. Refresh runs on every visit to
+/// this screen and re-assigns SourceServer to a fresh instance from the config - a different
+/// object every time, because the real store deserializes - which fires OnSourceServerChanged,
+/// which clears the database and reloads the list. The target server, container, target name and
+/// overwrite tick all survive that, so the form looked complete and was not.
+///
+/// And nothing said so. Six things have to be true before Generate is live and the screen named
+/// none of them.
+/// </summary>
+public class CopyScreenSaysWhyItIsBlockedTests
+{
+    private static (CopyDatabaseViewModel vm, FakeCredentialStore store, FakeSqlServerService sql) Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb", "Payroll", "Warehouse"] };
+        return (new CopyDatabaseViewModel(store, sql), store, sql);
+    }
+
+    private static async Task<CopyDatabaseViewModel> FullyAnsweredAsync()
+    {
+        var (vm, _, _) = Screen();
+        vm.Refresh();
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.Container = vm.Containers[0];
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb";
+
+        return vm;
+    }
+
+    // ── the sentence that was missing ───────────────────────────────────────────
+
+    [Fact]
+    public async Task AFullyAnsweredScreenIsNotBlockedAndSaysNothing()
+    {
+        var vm = await FullyAnsweredAsync();
+
+        Assert.True(vm.CanGenerate);
+        Assert.False(vm.IsGenerateBlocked);
+        Assert.Empty(vm.GenerateBlockedReason);
+    }
+
+    /// <summary>The reported case: everything else answered, no source database.</summary>
+    [Fact]
+    public async Task WithNoSourceDatabaseItNamesThatAndTheStepToGoBackTo()
+    {
+        var vm = await FullyAnsweredAsync();
+        vm.SourceDatabase = null;
+
+        Assert.False(vm.CanGenerate);
+        Assert.True(vm.IsGenerateBlocked);
+        Assert.Contains("database to copy", vm.GenerateBlockedReason);
+        Assert.Contains("step 1", vm.GenerateBlockedReason);
+    }
+
+    [Fact]
+    public async Task WithNoTargetNameItSaysSo()
+    {
+        var vm = await FullyAnsweredAsync();
+        vm.TargetDatabaseName = "";
+
+        Assert.Contains("restore as", vm.GenerateBlockedReason);
+        Assert.Contains("step 3", vm.GenerateBlockedReason);
+    }
+
+    [Fact]
+    public async Task WithNoContainerItSaysSo()
+    {
+        var vm = await FullyAnsweredAsync();
+        vm.Container = null;
+
+        Assert.Contains("container", vm.GenerateBlockedReason);
+        Assert.Contains("step 2", vm.GenerateBlockedReason);
+    }
+
+    /// <summary>
+    /// The order is the order the screen asks the questions, so somebody with three blanks is sent
+    /// to the first one rather than the last.
+    /// </summary>
+    [Fact]
+    public async Task WithSeveralBlanksItNamesTheEarliest()
+    {
+        var vm = await FullyAnsweredAsync();
+        vm.SourceDatabase = null;
+        vm.TargetDatabaseName = "";
+        vm.Container = null;
+
+        Assert.Contains("step 1", vm.GenerateBlockedReason);
+    }
+
+    // ── the choice survives a revisit ───────────────────────────────────────────
+
+    /// <summary>
+    /// The fault behind the report. Refresh re-assigns SourceServer to a fresh instance, which
+    /// clears the database and reloads - and everything the user filled in downstream survives, so
+    /// the form looks complete.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenKeepsTheDatabaseThatWasChosen()
+    {
+        var vm = await FullyAnsweredAsync();
+        Assert.True(vm.CanGenerate);
+
+        // What navigating away and back does.
+        vm.Refresh();
+        await Task.Delay(50);
+
+        Assert.Equal("MyDb", vm.SourceDatabase);
+        Assert.True(vm.CanGenerate);
+    }
+
+    /// <summary>
+    /// Putting back what the user chose is not the same as choosing for them. A source server they
+    /// have just switched to has no previous answer, and the app must not invent one - the wrong
+    /// choice here reads a production database at full speed and overwrites one on another server.
+    /// </summary>
+    [Fact]
+    public async Task SwitchingToADifferentSourceServerStillChoosesNothing()
+    {
+        var vm = await FullyAnsweredAsync();
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s2");
+        await Task.Delay(50);
+
+        Assert.Null(vm.SourceDatabase);
+        Assert.Contains("database to copy", vm.GenerateBlockedReason);
+    }
+
+    /// <summary>
+    /// And a database that has gone from the instance since is not put back. Restoring a selection
+    /// that no longer exists would arm the screen against a database nobody could back up.
+    /// </summary>
+    [Fact]
+    public async Task ADatabaseThatIsNoLongerThereIsNotRestored()
+    {
+        var (vm, _, sql) = Screen();
+        vm.Refresh();
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+
+        sql.DatabaseList = ["Payroll", "Warehouse"];
+        vm.Refresh();
+        await Task.Delay(50);
+
+        Assert.Null(vm.SourceDatabase);
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -807,11 +807,17 @@ public sealed class FakeSqlServerService : ISqlServerService
         return Task.FromResult(entries.ToList());
     }
 
+    /// <summary>Set to play an instance whose history cannot be read - a login failure, or no
+    /// rights on msdb, which is the ordinary reason a source refuses this (#451).</summary>
+    public Exception? BackupHistoryThrows { get; set; }
+
     public Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
         ServerConnection server, string? databaseName = null, CancellationToken ct = default)
-        => Task.FromResult(databaseName == null
-            ? BackupHistory
-            : BackupHistory.Where(h => h.DatabaseName == databaseName).ToList());
+        => BackupHistoryThrows != null
+            ? Task.FromException<List<BackupHistoryEntry>>(BackupHistoryThrows)
+            : Task.FromResult(databaseName == null
+                ? BackupHistory
+                : BackupHistory.Where(h => h.DatabaseName == databaseName).ToList());
 
     /// <summary>Set to make the target unreachable rather than merely unhelpful.</summary>
     public Exception? ThrowOnCheck { get; set; }

--- a/src/NineLives.Tests/MissingBackupCopyScriptTests.cs
+++ b/src/NineLives.Tests/MissingBackupCopyScriptTests.cs
@@ -1,0 +1,177 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The script that brings missing backups into the container (#451).
+///
+/// It runs on the source machine, so it is handed over rather than executed here - which makes
+/// what it contains a security question as much as a correctness one.
+/// </summary>
+public class MissingBackupCopyScriptTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 14, 22, 0, 0);
+
+    private static MissingLocation Location(string folder = @"E:\SQLLogs", int count = 3)
+    {
+        var backups = Enumerable.Range(1, count).Select(i =>
+        {
+            var at = T0.AddHours(i);
+            return new MissingBackup(
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "Sales",
+                    Type = BackupType.TransactionLog,
+                    StartedAt = at,
+                    Files = [$@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn"],
+                    BackupSizeBytes = 10 * 1024 * 1024
+                },
+                folder);
+        }).ToList();
+
+        return new MissingLocation(folder, backups);
+    }
+
+    private static BlobContainerConfig Azure() => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+    };
+
+    private static BlobContainerConfig Bucket() => new()
+    {
+        Id = "c2",
+        Name = "dr-bucket",
+        ContainerUrl = "s3://s3.eu-west-2.amazonaws.com/dr-bucket/sql",
+        S3Region = "eu-west-2"
+    };
+
+    // ── the security property ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// The one that must never regress. SECURITY.md states outright that a generated script
+    /// contains no credential, and this script is the most tempting place to break that: it would
+    /// be one string interpolation to embed the SAS, and the result would sit in a .ps1 on a
+    /// production server.
+    /// </summary>
+    [Fact]
+    public void TheAzureScriptTakesTheCredentialAsAParameterAndCarriesNone()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Azure());
+
+        Assert.Contains("[Parameter(Mandatory = $true)]", script);
+        Assert.Contains("$Sas", script);
+
+        // Nothing that looks like a token, and no query string on the container URL.
+        Assert.DoesNotContain("sig=", script);
+        Assert.DoesNotContain("?sv=", script);
+    }
+
+    [Fact]
+    public void TheS3ScriptTakesTheKeyPairAsParametersAndCarriesNone()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Bucket());
+
+        Assert.Contains("$AccessKeyId", script);
+        Assert.Contains("$SecretAccessKey", script);
+
+        // Set for the process, not written anywhere.
+        Assert.Contains("$env:AWS_ACCESS_KEY_ID = $AccessKeyId", script);
+        Assert.DoesNotContain("aws configure", script);
+    }
+
+    // ── what it copies ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Named individually. A wildcard over the folder would take other databases' backups, an
+    /// unrelated job's output, and whatever is half-written at that moment - a surprise, and on a
+    /// metered egress link a bill.
+    /// </summary>
+    [Fact]
+    public void EveryFileIsNamedAndNoWildcardIsUsed()
+    {
+        var script = MissingBackupCopyScript.Build(Location(count: 3), Azure());
+
+        Assert.Contains(@"'E:\SQLLogs\Sales_20260814_230000.trn'", script);
+        Assert.Contains(@"'E:\SQLLogs\Sales_20260815_000000.trn'", script);
+        Assert.Contains(@"'E:\SQLLogs\Sales_20260815_010000.trn'", script);
+
+        Assert.DoesNotContain("*.trn", script);
+        Assert.DoesNotContain("*.bak", script);
+    }
+
+    [Fact]
+    public void TheHeaderSaysWhatIsBeingCopiedAndFromWhere()
+    {
+        var script = MissingBackupCopyScript.Build(Location(count: 3), Azure());
+
+        Assert.Contains("3 log backups", script);
+        Assert.Contains(@"E:\SQLLogs", script);
+        Assert.Contains("30.0 MB", script);
+    }
+
+    [Fact]
+    public void TheS3ScriptTargetsTheBucketAndBasePathFromTheContainerUrl()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Bucket());
+
+        Assert.Contains("$bucket = 'dr-bucket'", script);
+        Assert.Contains("$prefix = 'sql/'", script);
+        Assert.Contains("$endpoint = 'https://s3.eu-west-2.amazonaws.com'", script);
+        Assert.Contains("$env:AWS_DEFAULT_REGION = 'eu-west-2'", script);
+    }
+
+    // ── what it does when things are not as expected ────────────────────────────
+
+    /// <summary>
+    /// A file that has been purged since the history was read is reported, not fatal. Retention
+    /// running between the scan and the copy is entirely ordinary, and stopping dead on the first
+    /// missing one would leave the rest uncopied for no reason.
+    /// </summary>
+    [Fact]
+    public void AFileThatHasGoneIsReportedAndTheRestStillCopy()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Azure());
+
+        Assert.Contains("Test-Path -LiteralPath $file", script);
+        Assert.Contains("Not on disk any more", script);
+        Assert.Contains("continue", script);
+        Assert.Contains("exit 1", script);
+    }
+
+    [Fact]
+    public void ItEndsByPointingBackAtTheRescan()
+    {
+        var script = MissingBackupCopyScript.Build(Location(), Azure());
+        Assert.Contains("Rescan", script);
+    }
+
+    /// <summary>
+    /// A path holding an apostrophe would otherwise close the PowerShell literal and turn the rest
+    /// of the line into commands - the same class of hole as an unescaped SQL literal.
+    /// </summary>
+    [Fact]
+    public void AnApostropheInAPathIsEscaped()
+    {
+        var folder = @"E:\Jake's Logs";
+        var location = new MissingLocation(folder,
+        [
+            new MissingBackup(
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "Sales",
+                    Type = BackupType.TransactionLog,
+                    StartedAt = T0,
+                    Files = [$@"{folder}\Sales.trn"]
+                },
+                folder)
+        ]);
+
+        var script = MissingBackupCopyScript.Build(location, Azure());
+
+        Assert.Contains(@"'E:\Jake''s Logs\Sales.trn'", script);
+    }
+}

--- a/src/NineLives.Tests/RestoreFromWhereTheyAreTests.cs
+++ b/src/NineLives.Tests/RestoreFromWhereTheyAreTests.cs
@@ -1,0 +1,201 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Restoring the logs from where they already are, rather than copying them in first (#451).
+///
+/// The remedy for mid-incident, when uploading twenty-three files is time nobody has. It works
+/// because the script generator picks DISK or URL per FILE, from the device string rather than
+/// from an option - so a chain holding a blob full and disk-resident logs generates correct T-SQL
+/// with no further work. It has simply never been possible to BUILD one, because discovery only
+/// ever looked at a single medium.
+/// </summary>
+public class RestoreFromWhereTheyAreTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 14, 22, 0, 0);
+
+    private static BackupSet FromContainer(BackupType type, DateTime at) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        Type = type,
+        Timestamp = at,
+        DatabaseName = "Sales",
+        ServerName = "SRV01",
+        Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = $"Sales_{at:yyyyMMdd_HHmmss}.bak",
+                BlobUrl = $"https://acct.blob.core.windows.net/c/Sales_{at:yyyyMMdd_HHmmss}.bak",
+                Type = type,
+                InferredDatabaseName = "Sales",
+                InferredServerName = "SRV01"
+            }
+        ]
+    };
+
+    private static BackupSet FromDisk(BackupType type, DateTime at, string folder) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        Type = type,
+        Timestamp = at,
+        DatabaseName = "Sales",
+        ServerName = "SRV01",
+        Files =
+        [
+            new BackupFileInfo
+            {
+                BlobName = $"Sales_{at:yyyyMMdd_HHmmss}.trn",
+                LocalPath = $@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn",
+                Type = type,
+                InferredDatabaseName = "Sales",
+                InferredServerName = "SRV01"
+            }
+        ]
+    };
+
+    // ── the merge ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An inventory loaded from a container the ordinary way, so what these exercise is the real
+    /// load path rather than a seam that only tests use.
+    /// </summary>
+    private static BackupInventoryViewModel Inventory()
+    {
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = $"FULL/SRV01/Sales/Sales_{T0:yyyyMMdd_HHmmss}.bak",
+                    BlobUrl = $"https://acct.blob.core.windows.net/c/FULL/SRV01/Sales/Sales_{T0:yyyyMMdd_HHmmss}.bak",
+                    Type = BackupType.Full,
+                    InferredDatabaseName = "Sales",
+                    InferredServerName = "SRV01",
+                    SizeBytes = 1024,
+                    LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+                }
+            ]
+        };
+
+        var vm = new BackupInventoryViewModel(blob, new FakeSqlServerService(), TestLogs.Temp());
+
+        vm.LoadAsync(BackupLocation.Blob(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "sqlbackups",
+            ContainerUrl = "https://acct.blob.core.windows.net/c"
+        })).GetAwaiter().GetResult();
+
+        vm.SelectedDatabaseName = "Sales";
+        return vm;
+    }
+
+    [Fact]
+    public void SetsFromTheInstanceHistoryJoinTheWorkingSet()
+    {
+        var inv = Inventory();
+        Assert.Single(inv.WorkingSet);
+        Assert.False(inv.HasSetsFromInstanceHistory);
+
+        inv.IncludeFromInstanceHistory([FromDisk(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs")]);
+
+        Assert.Equal(2, inv.WorkingSet.Count);
+        Assert.True(inv.HasSetsFromInstanceHistory);
+    }
+
+    /// <summary>
+    /// Adding the same location twice - pressing the button again - must not double the timeline.
+    /// </summary>
+    [Fact]
+    public void IncludingTheSameSetTwiceAddsItOnce()
+    {
+        var inv = Inventory();
+        var log = FromDisk(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs");
+
+        inv.IncludeFromInstanceHistory([log]);
+        inv.IncludeFromInstanceHistory([log]);
+
+        Assert.Equal(2, inv.WorkingSet.Count);
+    }
+
+    /// <summary>
+    /// The same database and server filters apply to these as to everything else. A log from
+    /// another instance must not arrive through a side door the ordinary path would have refused -
+    /// mixing two servers' backups into one chain is a defect this codebase has already had once.
+    /// </summary>
+    [Fact]
+    public void ASetForAnotherDatabaseDoesNotReachTheWorkingSet()
+    {
+        var inv = Inventory();
+
+        var otherDatabase = FromDisk(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs");
+        otherDatabase.DatabaseName = "Payroll";
+        otherDatabase.Files[0].InferredDatabaseName = "Payroll";
+
+        inv.IncludeFromInstanceHistory([otherDatabase]);
+
+        Assert.Single(inv.WorkingSet);
+    }
+
+    [Fact]
+    public void IncludingNothingChangesNothing()
+    {
+        var inv = Inventory();
+
+        inv.IncludeFromInstanceHistory([]);
+
+        Assert.Single(inv.WorkingSet);
+        Assert.False(inv.HasSetsFromInstanceHistory);
+    }
+
+    // ── what the generator then produces ────────────────────────────────────────
+
+    /// <summary>
+    /// The point of the whole feature: one script, the full read from the container by URL and the
+    /// logs read from the path they are actually on by DISK.
+    /// </summary>
+    [Fact]
+    public void TheGeneratedScriptReadsTheContainerByUrlAndTheLogsByDisk()
+    {
+        var chain = new BackupChain
+        {
+            FullSet = FromContainer(BackupType.Full, T0),
+            LogSets =
+            [
+                FromDisk(BackupType.TransactionLog, T0.AddHours(1), @"E:\SQLLogs"),
+                FromDisk(BackupType.TransactionLog, T0.AddHours(2), @"E:\SQLLogs")
+            ]
+        };
+
+        var script = new RestoreScriptGenerator().Generate(chain, new RestoreOptions
+        {
+            TargetDatabaseName = "Sales_Restored",
+            RecoveryMode = RecoveryMode.Recovery
+        });
+
+        Assert.Contains("URL = N'https://acct.blob.core.windows.net/c/Sales_", script);
+        Assert.Contains(@"DISK = N'E:\SQLLogs\Sales_20260814_230000.trn'", script);
+        Assert.Contains(@"DISK = N'E:\SQLLogs\Sales_20260815_000000.trn'", script);
+
+        // And it still ends properly: NORECOVERY through the chain, RECOVERY once.
+        Assert.Contains("NORECOVERY", script);
+        Assert.Equal(1, CountOccurrences(script, "         RECOVERY,"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+}

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.6.4</Version>
+    <Version>1.7.0</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -1,0 +1,227 @@
+﻿using System.Collections.ObjectModel;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Blackcat.NineLives.ViewModels;
+
+/// <summary>One folder's worth of missing backups, as the screen shows it.</summary>
+public sealed partial class MissingLocationRow(MissingLocation location) : ObservableObject
+{
+    public MissingLocation Location { get; } = location;
+
+    public string Folder => Location.Folder;
+    public string Summary => Location.Summary;
+    public int FileCount => Location.FileCount;
+    public string SizeDisplay => Location.SizeDisplay;
+
+    public string Window =>
+        $"{Location.Earliest:yyyy-MM-dd HH:mm} to {Location.Latest:yyyy-MM-dd HH:mm}";
+
+    /// <summary>
+    /// Whether these can be copied at all. A backup msdb recorded to a URL is not a file on the
+    /// source machine, so there is nothing for a copy script to pick up - that finding means the
+    /// container listing did not see something that was written to storage, which is a different
+    /// problem with a different answer.
+    /// </summary>
+    public bool IsOnDisk => BackupDevice.IsPath(Location.Backups[0].Files.FirstOrDefault());
+
+    [ObservableProperty]
+    private string _script = string.Empty;
+
+    public bool HasScript => Script.Length > 0;
+
+    partial void OnScriptChanged(string value) => OnPropertyChanged(nameof(HasScript));
+}
+
+/// <summary>
+/// What the source instance recorded, against what the container actually holds (#451).
+///
+/// Answers the question the restore screen cannot answer on its own: is this chain short because
+/// that is all there ever was, or because the logs went somewhere else? The container cannot tell
+/// the difference - only the instance that took them knows - so this asks it, and it has to be
+/// asked deliberately because it means connecting to a second server.
+/// </summary>
+public partial class BackupGapViewModel : ViewModelBase
+{
+    private readonly ISqlServerService _sql;
+    private readonly OperationCancellation _cancellation = new();
+
+    public BackupGapViewModel(ISqlServerService sql) => _sql = sql;
+
+    /// <summary>The servers offered as the source. Filled by the screen that owns this.</summary>
+    public ObservableCollection<ServerConnection> Servers { get; } = [];
+
+    [ObservableProperty]
+    private ServerConnection? _sourceServer;
+
+    partial void OnSourceServerChanged(ServerConnection? value)
+    {
+        CheckCommand.NotifyCanExecuteChanged();
+
+        // A previous answer described a different server. Leaving it on screen under a new
+        // selection is the stale-result problem, and this panel's whole job is to be believed.
+        Clear();
+    }
+
+    public ObservableCollection<MissingLocationRow> Locations { get; } = [];
+
+    [ObservableProperty]
+    private bool _hasChecked;
+
+    [ObservableProperty]
+    private bool _isChecking;
+
+    /// <summary>How far behind the container is, in words, or empty when it is not behind.</summary>
+    [ObservableProperty]
+    private string _behindBy = string.Empty;
+
+    /// <summary>
+    /// Whether there is a measurable gap to quote (#451).
+    ///
+    /// A gap and a MEASURED gap are different things, which rendering the panel made obvious: a
+    /// container holding nothing at all for this database has everything missing and no interval
+    /// to state, because there is no newest-held backup to measure from. The banner assumed the
+    /// two went together and rendered "This container is  behind what the instance recorded".
+    /// </summary>
+    public bool HasMeasuredGap => BehindBy.Length > 0;
+
+    partial void OnBehindByChanged(string value) => OnPropertyChanged(nameof(HasMeasuredGap));
+
+    public bool HasGap => Locations.Count > 0;
+
+    public bool FoundNothingMissing => HasChecked && !IsChecking && Locations.Count == 0;
+
+    /// <summary>
+    /// What was compared, so the answer can be read without trusting it blindly - somebody has to
+    /// be able to see that the check was asked of the right database on the right instance.
+    /// </summary>
+    [ObservableProperty]
+    private string _comparedWhat = string.Empty;
+
+    public bool CanCheck => SourceServer != null && !IsChecking;
+
+    /// <summary>
+    /// Reads the source instance's own record and sets it against the container's contents.
+    ///
+    /// The container and the database name come from the screen at the moment of the press rather
+    /// than being held here, because both move while this panel is open and an answer about a
+    /// database nobody is looking at any more is worse than no answer.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanCheck))]
+    public async Task CheckAsync(GapCheckRequest? request)
+    {
+        if (SourceServer is not { } server || request is not { } ask) return;
+
+        if (string.IsNullOrWhiteSpace(ask.Database))
+        {
+            SetError("Pick a database on this screen first - the check is per database.");
+            return;
+        }
+
+        // Captured BEFORE the await: both can change while this runs, and the answer has to
+        // describe what was actually compared.
+        var database = ask.Database;
+        var container = ask.Container;
+        var held = ask.InContainer;
+
+        IsChecking = true;
+        ClearStatus();
+        Clear();
+
+        var ct = _cancellation.Begin();
+
+        try
+        {
+            var history = await _sql.ReadBackupHistoryAsync(server, database, ct);
+
+            var locations = BackupGapAnalyser.Compare(history, held, database);
+            foreach (var location in locations) Locations.Add(new MissingLocationRow(location));
+
+            var behind = BackupGapAnalyser.RecoveryTimeNotInContainer(history, held, database);
+            BehindBy = behind is { } gap ? Humanise(gap) : string.Empty;
+
+            ComparedWhat =
+                $"{database} on {server.ServerName}: {history.Count} backup(s) in its history, " +
+                $"{held.Count} set(s) in {container?.Name ?? "this container"}.";
+
+            HasChecked = true;
+
+            SetStatus(Locations.Count == 0
+                ? "Everything the instance recorded is in the container."
+                : $"{Locations.Count} location(s) hold backups this container does not.");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Check cancelled.");
+        }
+        catch (Exception ex)
+        {
+            // Naming the server, because the usual cause is that this one cannot be reached -
+            // and the reader is looking at a screen already connected to a different instance.
+            SetError($"Could not read {server.ServerName}'s backup history: {ex.Message}");
+        }
+        finally
+        {
+            IsChecking = false;
+            _cancellation.End();
+            RaiseDerived();
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel() => _cancellation.Cancel();
+
+    /// <summary>
+    /// Builds the copy script for one location, on demand rather than for every location up front.
+    /// Most checks find one location and nobody reads the others.
+    /// </summary>
+    public void BuildScript(MissingLocationRow row, BlobContainerConfig container)
+        => row.Script = MissingBackupCopyScript.Build(row.Location, container);
+
+    private void Clear()
+    {
+        Locations.Clear();
+        BehindBy = string.Empty;
+        ComparedWhat = string.Empty;
+        HasChecked = false;
+        RaiseDerived();
+    }
+
+    private void RaiseDerived()
+    {
+        OnPropertyChanged(nameof(HasGap));
+        OnPropertyChanged(nameof(FoundNothingMissing));
+        CheckCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// "12 hours 45 minutes" - the number somebody decides on. Rounded to minutes, because a
+    /// recovery window quoted to the second is false precision about a moving target.
+    /// </summary>
+    internal static string Humanise(TimeSpan gap)
+    {
+        if (gap.TotalMinutes < 1) return "under a minute";
+
+        var parts = new List<string>();
+        if (gap.Days > 0) parts.Add($"{gap.Days} day{(gap.Days == 1 ? "" : "s")}");
+        if (gap.Hours > 0) parts.Add($"{gap.Hours} hour{(gap.Hours == 1 ? "" : "s")}");
+        if (gap.Minutes > 0 && gap.Days == 0)
+            parts.Add($"{gap.Minutes} minute{(gap.Minutes == 1 ? "" : "s")}");
+
+        return string.Join(" ", parts);
+    }
+}
+
+/// <summary>
+/// What the screen hands the check at the moment it is pressed.
+///
+/// Passed in rather than held, because the database, the container and the listing all move while
+/// this panel is open, and an answer about a database nobody is looking at any more is worse than
+/// no answer at all.
+/// </summary>
+public sealed record GapCheckRequest(
+    string Database,
+    BlobContainerConfig? Container,
+    IReadOnlyList<BackupSet> InContainer);

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -483,6 +483,52 @@ public partial class BackupInventoryViewModel : ViewModelBase
     /// thousands of points on a real container, none of them meaningful, because a restore chain
     /// only exists within one database.
     /// </summary>
+    /// <summary>
+    /// Whether the working set holds anything that is not in the container (#451).
+    ///
+    /// Worth surfacing, because from here on the chain being offered restores from two places at
+    /// once - and a script naming a local path is a surprise to anybody who thought they were
+    /// restoring from blob.
+    /// </summary>
+    public bool HasSetsFromInstanceHistory { get; private set; }
+
+    /// <summary>
+    /// Folds backups the container does not hold into the working set, so the timeline and the
+    /// chain builder see them (#451).
+    ///
+    /// This is the whole of "restore them from where they are". The script generator already picks
+    /// DISK or URL per FILE, from the device string rather than from an option, so a chain holding
+    /// a blob full and disk-resident logs generates correct T-SQL with no further work - it has
+    /// simply never been possible to build one, because discovery only ever looked at one medium.
+    ///
+    /// Added to the whole-container list rather than the filtered one, so the same database and
+    /// server filters apply to these as to everything else: a log from another instance must not
+    /// arrive by a side door that the ordinary path would have refused.
+    ///
+    /// A reload drops them, deliberately. Reloading means "read the truth again", and if the files
+    /// were copied in they will be in the container by then anyway.
+    /// </summary>
+    public void IncludeFromInstanceHistory(IReadOnlyList<BackupSet> sets)
+    {
+        if (sets.Count == 0) return;
+
+        var known = _allSets.Select(Identity).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var added = sets.Where(s => known.Add(Identity(s))).ToList();
+        if (added.Count == 0) return;
+
+        _allSets.AddRange(added);
+        HasSetsFromInstanceHistory = true;
+        OnPropertyChanged(nameof(HasSetsFromInstanceHistory));
+
+        RebuildWorkingSet();
+    }
+
+    /// <summary>
+    /// What makes two sets the same one for the purpose of not adding it twice. The set id carries
+    /// the timestamp, and the type separates a full from the log that started in the same second.
+    /// </summary>
+    private static string Identity(BackupSet set) => $"{set.Type}|{set.DatabaseName}|{set.SetId}";
+
     private void RebuildWorkingSet()
     {
         if (string.IsNullOrEmpty(SelectedDatabaseName) || _allSets.Count == 0)

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -159,7 +159,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     private int _listGeneration;
 
     [RelayCommand(CanExecute = nameof(CanLoadSourceDatabases))]
-    private async Task LoadSourceDatabasesAsync()
+    private async Task LoadSourceDatabasesAsync(string? chosen = null)
     {
         if (SourceServer == null)
         {
@@ -186,9 +186,18 @@ public partial class CopyDatabaseViewModel : ViewModelBase
 
             SourceDatabases = new ObservableCollection<string>(names);
 
-            // Nothing is chosen for the user. Here the wrong choice reads a production database at
-            // full speed AND overwrites a database on another server.
-            SourceDatabase = null;
+            // Nothing is chosen FOR the user - here the wrong choice reads a production database
+            // at full speed AND overwrites a database on another server.
+            //
+            // But putting back what they chose themselves is not choosing for them, and not doing
+            // it was a live defect: Refresh runs on every visit to this screen and re-assigns
+            // SourceServer to a fresh instance from the config, which fires OnSourceServerChanged,
+            // which clears this and reloads. The target server, container, target name and
+            // overwrite tick all survive that, so navigating away and back left a form that looked
+            // complete, refused to generate, and said nothing about why.
+            SourceDatabase = chosen != null && names.Contains(chosen, StringComparer.OrdinalIgnoreCase)
+                ? names.First(n => string.Equals(n, chosen, StringComparison.OrdinalIgnoreCase))
+                : null;
 
             SetStatus($"{server.ServerName} has {names.Count} database(s).");
         }
@@ -214,16 +223,26 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         }
     }
 
-    partial void OnSourceServerChanged(ServerConnection? value)
+    partial void OnSourceServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
     {
+        // Carried across the reload ONLY when this is the same server arriving again - which is
+        // what Refresh does on every visit to the screen, because the config hands back a fresh
+        // instance each time and the assignment therefore always fires.
+        //
+        // A server the user has actually switched to has no previous answer, and inventing one
+        // would be the thing this screen most carefully does not do: the wrong choice here reads a
+        // production database at full speed and overwrites one on another server. Captured before
+        // the clear below wipes it.
+        var carry = oldValue?.Id == newValue?.Id ? SourceDatabase : null;
+
         SourceDatabases = [];
         SourceDatabase = null;
         Invalidate();
 
         // Choosing the source server is the request to see what it holds - same reasoning as the
         // Backup screen, and the same restraint mid-run.
-        if (value != null && CanLoadSourceDatabases)
-            _ = LoadSourceDatabasesAsync();
+        if (newValue != null && CanLoadSourceDatabases)
+            _ = LoadSourceDatabasesAsync(carry);
     }
 
     partial void OnTargetServerChanged(ServerConnection? value) => Invalidate();
@@ -345,11 +364,45 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         (MediumIsBlob ? Container != null : !string.IsNullOrWhiteSpace(SharedPathRoot)) &&
         !IsRefused;
 
+    /// <summary>
+    /// Why Generate scripts cannot be pressed, or empty when it can.
+    ///
+    /// The buttons went dead with nothing said. Six things have to be true and the screen named
+    /// none of them, so a form with five of them filled in - which is what one looks like after
+    /// the source database has been cleared out from under it - reads as complete and simply
+    /// refuses to work. The restore screen has had this sentence for a while; this screen is the
+    /// one where a person has typed a target name and ticked an overwrite box, so it is arguably
+    /// the one that needed it more.
+    ///
+    /// In the order the screen asks the questions, so the sentence points at the step to go back
+    /// to rather than just naming a field.
+    /// </summary>
+    public string GenerateBlockedReason =>
+        SourceServer == null
+            ? "Choose the server to copy from, in step 1."
+        : string.IsNullOrWhiteSpace(SourceDatabase)
+            ? "Choose the database to copy, in step 1."
+        : MediumIsBlob && Container == null
+            ? "Choose the container to copy through, in step 2."
+        : !MediumIsBlob && string.IsNullOrWhiteSpace(SharedPathRoot)
+            ? "Enter the folder both servers can reach, in step 2."
+        : TargetServer == null
+            ? "Choose the server to copy to, in step 3."
+        : string.IsNullOrWhiteSpace(TargetDatabaseName)
+            ? "Enter the name to restore as, in step 3."
+        : IsRefused
+            ? Refusal
+            : string.Empty;
+
+    public bool IsGenerateBlocked => GenerateBlockedReason.Length > 0;
+
     private void Invalidate()
     {
         OnPropertyChanged(nameof(Refusal));
         OnPropertyChanged(nameof(IsRefused));
         OnPropertyChanged(nameof(CanGenerate));
+        OnPropertyChanged(nameof(GenerateBlockedReason));
+        OnPropertyChanged(nameof(IsGenerateBlocked));
         OnPropertyChanged(nameof(WillOverwriteTheTarget));
         OnPropertyChanged(nameof(OverwriteWarning));
         OnPropertyChanged(nameof(WillResetTheDifferentialBase));

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -565,9 +565,20 @@ public partial class RestoreExecutionViewModel : ViewModelBase
 
             foreach (var orphan in orphans)
             {
-                actions.Add(orphan.HasSameNamedLogin
-                    ? PostRestoreAdvice.FixOrphan(targetDatabase, orphan)
-                    : PostRestoreAdvice.ExplainUnmappableOrphan(targetDatabase, orphan));
+                if (orphan.HasSameNamedLogin)
+                {
+                    actions.Add(PostRestoreAdvice.FixOrphan(targetDatabase, orphan));
+                    continue;
+                }
+
+                // Nothing here to re-attach to. Saying "create the login first, with a password
+                // somebody else owns" is honest and still leaves a database whose users cannot log
+                // in - so the other way out is offered beside it (#459): go and fetch the real
+                // login from the instance the backup came from, hash and SID intact. With the SID
+                // carried across the user is not orphaned at all, and there is no ALTER USER to
+                // run afterwards.
+                actions.Add(PostRestoreAdvice.ExplainUnmappableOrphan(targetDatabase, orphan));
+                actions.Add(PostRestoreAdvice.CaptureLoginFromSource(orphan.Name));
             }
         }
         catch (Exception ex)

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2136,6 +2136,33 @@ public partial class RestoreViewModel : ViewModelBase
         Gap.BuildScript(row, SelectedContainer);
     }
 
+    /// <summary>
+    /// Restores these where they already are, instead of copying them in first (#451).
+    ///
+    /// The remedy for mid-incident, when uploading twenty-three files is time nobody has. The sets
+    /// are folded into the working set, so the timeline extends to the newest of them and the
+    /// chain builder treats them like anything else - and the generator names them with DISK
+    /// rather than URL because it asks the device string, not an option.
+    ///
+    /// The target still has to be able to READ those paths, which is a different question from
+    /// whether this machine can. That is checked in the preflight, before anything is dropped.
+    /// </summary>
+    [RelayCommand]
+    private void RestoreFromWhereTheyAre(MissingLocationRow? row)
+    {
+        if (row is not { IsOnDisk: true }) return;
+
+        var sets = BackupHistoryInventory.ToSets(row.Location.Backups.Select(b => b.Entry));
+        if (sets.Count == 0) return;
+
+        Inventory.IncludeFromInstanceHistory(sets);
+
+        SetStatus(
+            $"Added {sets.Count} backup(s) from {row.Folder} to the timeline. The script will read " +
+            "them from that path - the target has to be able to reach it, which is checked before " +
+            "the restore runs.");
+    }
+
     /// <summary>Puts one location's script on the clipboard, ready to paste into a session on the source.</summary>
     [RelayCommand]
     private void CopyCopyScript(MissingLocationRow? row)
@@ -2788,6 +2815,12 @@ public partial class RestoreViewModel : ViewModelBase
             return await CheckVersionCompatibilityAsync(server, appendLog);
         }
 
+        // A blob chain can now hold disk-resident members (#451), and the target has to be able to
+        // read those paths - a different question from whether the container is reachable, and one
+        // the medium-based branch above never asks because the medium is still blob.
+        var onDisk = await CheckTargetCanReadAnyDiskMembersAsync(server, appendLog);
+        if (!onDisk.CanProceed) return onDisk;
+
         var primary = await Credential.PrepareForRestoreAsync(server, appendLog);
         if (!primary.CanProceed) return primary;
 
@@ -3040,6 +3073,57 @@ public partial class RestoreViewModel : ViewModelBase
     /// has no identity on the network and so cannot read ANY share. That is worth diagnosing rather
     /// than reporting as a missing file, because it sends people to check the wrong thing.
     /// </summary>
+    /// <summary>
+    /// The disk-resident members of an otherwise-blob chain (#451).
+    ///
+    /// Restoring logs from where they already are means the RESTORE names a path on some other
+    /// machine, and the instance running it has to be able to open that path as its own service
+    /// account. Nothing about the container being reachable says anything about that.
+    ///
+    /// Only the disk members: the URL members are covered by the credential checks, and asking
+    /// RESTORE HEADERONLY of every blob in a long chain would add a round trip per file to every
+    /// restore for no new information.
+    /// </summary>
+    private async Task<CredentialPreflight> CheckTargetCanReadAnyDiskMembersAsync(
+        ServerConnection server, Action<string> appendLog)
+    {
+        var paths = RestoreChain?.AllFiles
+            .Select(f => f.RestoreDevice)
+            .Where(BackupDevice.IsPath)
+            .Distinct()
+            .ToList() ?? [];
+
+        if (paths.Count == 0) return CredentialPreflight.Proceed;
+
+        appendLog(
+            $"This chain reads {paths.Count} file(s) from a path rather than the container. " +
+            $"Checking {server.ServerName} can open them...");
+
+        try
+        {
+            var checks = await _sqlService.CheckBackupFilesAsync(server, paths);
+            var failed = checks.FirstOrDefault(c => !c.CanBeRestored);
+
+            if (failed != null)
+            {
+                var refusal = failed.Explain(server.ServerName);
+                appendLog(refusal);
+                return CredentialPreflight.Stop(refusal);
+            }
+
+            appendLog($"{server.ServerName} can read all {checks.Count} of them.");
+            return CredentialPreflight.Proceed;
+        }
+        catch (Exception ex)
+        {
+            var refusal =
+                $"Could not confirm {server.ServerName} can read the files held outside the " +
+                $"container: {ex.Message}";
+            appendLog(refusal);
+            return CredentialPreflight.Stop(refusal);
+        }
+    }
+
     private async Task<CredentialPreflight> CheckTargetCanReadFilesAsync(
         ServerConnection server, Action<string> appendLog)
     {

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -76,6 +76,15 @@ public partial class RestoreViewModel : ViewModelBase
     /// </summary>
     public RestoreTimelineViewModel Timeline { get; } = new();
 
+    /// <summary>
+    /// What the source instance recorded, against what this container holds (#451).
+    ///
+    /// Its own view model because it connects to a DIFFERENT server from the one the restore runs
+    /// on - the instance that TOOK the backups, which is routinely not the instance they are being
+    /// restored to - and conflating those two connections is the confusion worth designing out.
+    /// </summary>
+    public BackupGapViewModel Gap { get; }
+
     // Restore chain
     [ObservableProperty]
     private BackupChain? _restoreChain;
@@ -925,6 +934,7 @@ public partial class RestoreViewModel : ViewModelBase
         // finds the one in the user's profile - so a TEST run reads and writes the real cache, and
         // a stale entry from one test then decides the answer in another (#130).
         Inventory = new BackupInventoryViewModel(blobService, sqlService, _log, auditStore);
+        Gap = new BackupGapViewModel(sqlService);
 
         // The chain and the timeline are built from whatever the inventory currently holds, so a
         // change there is the one signal that rebuilds them.
@@ -1106,6 +1116,14 @@ public partial class RestoreViewModel : ViewModelBase
             var match = TargetServers.FirstOrDefault(x => x.Id == previousTarget);
             if (match != null) SelectedTargetServer = match;
         }
+
+        // The gap check offers the same saved list, and keeps its own selection: the instance that
+        // took the backups is a different question from the one being restored to (#451).
+        var previousGapSource = Gap.SourceServer?.Id;
+        Gap.Servers.Clear();
+        foreach (var server in config.Servers) Gap.Servers.Add(server);
+        if (previousGapSource != null)
+            Gap.SourceServer = Gap.Servers.FirstOrDefault(x => x.Id == previousGapSource);
 
         Containers = new ObservableCollection<BlobContainerConfig>(config.BlobContainers);
         foreach (var c in Containers)
@@ -2091,6 +2109,39 @@ public partial class RestoreViewModel : ViewModelBase
 
         GeneratedScript = _scriptGenerator.Generate(chain!, options);
         HasScript = true;
+    }
+
+    /// <summary>
+    /// Asks the source instance what this container is missing (#451).
+    ///
+    /// The database, the container and the listing are gathered HERE and handed over, rather than
+    /// the panel holding them: all three move while it is open, and an answer about a database
+    /// nobody is looking at any more is worse than no answer.
+    /// </summary>
+    [RelayCommand]
+    private async Task CheckForMissingBackupsAsync()
+        => await Gap.CheckAsync(new GapCheckRequest(
+            Inventory.SelectedDatabaseName ?? string.Empty,
+            SelectedContainer,
+            Inventory.AllSets));
+
+    /// <summary>
+    /// Writes the copy script for one location. On demand: most checks find one location, and
+    /// building every script up front is work nobody reads.
+    /// </summary>
+    [RelayCommand]
+    private void BuildCopyScript(MissingLocationRow? row)
+    {
+        if (row == null || SelectedContainer == null) return;
+        Gap.BuildScript(row, SelectedContainer);
+    }
+
+    /// <summary>Puts one location's script on the clipboard, ready to paste into a session on the source.</summary>
+    [RelayCommand]
+    private void CopyCopyScript(MissingLocationRow? row)
+    {
+        if (row is not { HasScript: true }) return;
+        TryCopyToClipboard(row.Script, "Copy script copied to clipboard.");
     }
 
     [RelayCommand]

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -291,6 +291,19 @@
                     <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,4,0,12"
                                Text="Both statements are shown together, because what happens to each server is one decision - reading them one at a time is how somebody approves the half they were looking at." />
 
+                    <!-- Why the buttons are dead. They went out with nothing said, so a form with
+                         five of the six answers filled in read as complete and simply refused to
+                         work - which is exactly what a screen looks like after the source database
+                         has been cleared out from under it. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,12"
+                            Background="{DynamicResource WarningPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding IsGenerateBlocked, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding GenerateBlockedReason}"
+                                   Style="{StaticResource BodyText}" TextWrapping="Wrap" />
+                    </Border>
+
                     <WrapPanel>
                         <Button Content="Generate scripts"
                                 Command="{Binding GenerateCommand}"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1582,6 +1582,165 @@
                                        Visibility="{Binding Options.ContinueAfterError, Converter={StaticResource BoolToVis}}"
                                        Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
 
+                            <!-- What the source instance recorded, against what this container
+                                 holds (#451). Behind the advanced options because it means
+                                 connecting to a SECOND server - the one that took the backups,
+                                 which is routinely not the one being restored to. -->
+                            <Border Style="{StaticResource CardBorder}"
+                                    Margin="0,4,0,16"
+                                    Visibility="{Binding ShowAdvancedOptions, Converter={StaticResource BoolToVis}}">
+                                <StackPanel>
+                                    <TextBlock Text="BACKUPS THIS CONTAINER IS MISSING"
+                                               Style="{StaticResource LabelText}" Margin="0,0,0,6" />
+
+                                    <TextBlock Style="{StaticResource SecondaryText}"
+                                               TextWrapping="Wrap" Margin="0,0,0,10"
+                                               Text="Logs often go somewhere else - a local or cluster disk for throughput, or a share because log shipping already owns them. The container cannot tell you that; the instance that took them can. Ask it, and anything written elsewhere shows up here with the path it went to." />
+
+                                    <Grid Margin="0,0,0,10">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <ComboBox Grid.Column="0"
+                                                  ItemsSource="{Binding Gap.Servers}"
+                                                  SelectedItem="{Binding Gap.SourceServer}"
+                                                  Style="{StaticResource DarkComboBox}"
+                                                  ToolTip="The instance that TOOK these backups - not necessarily the one being restored to.">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding DisplayText}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+
+                                        <Button Grid.Column="1"
+                                                Content="Check its history"
+                                                Command="{Binding CheckForMissingBackupsCommand}"
+                                                Style="{StaticResource SecondaryButton}"
+                                                Padding="12,6" Margin="8,0,0,0"
+                                                IsEnabled="{Binding Gap.CanCheck}" />
+                                    </Grid>
+
+                                    <TextBlock Text="Reading the instance's own record..."
+                                               Style="{StaticResource SecondaryText}"
+                                               Margin="0,0,0,8"
+                                               Visibility="{Binding Gap.IsChecking, Converter={StaticResource BoolToVis}}" />
+
+                                    <ContentControl Style="{StaticResource ErrorBanner}"
+                                                    DataContext="{Binding Gap}" />
+
+                                    <!-- The all-clear, said out loud. An empty panel is
+                                         indistinguishable from never having pressed the button. -->
+                                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                                            Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                                            BorderBrush="{DynamicResource SuccessPanelBorderBrush}"
+                                            BorderThickness="1"
+                                            Visibility="{Binding Gap.FoundNothingMissing, Converter={StaticResource BoolToVis}}">
+                                        <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                                   Text="Everything the instance recorded is in this container. The chain on offer is the whole chain." />
+                                    </Border>
+
+                                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                                            Background="{DynamicResource WarningPanelBackgroundBrush}"
+                                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                                            BorderThickness="1"
+                                            Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}">
+                                        <StackPanel>
+                                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}}">
+                                                <Run Text="This container is" />
+                                                <Run Text="{Binding Gap.BehindBy, Mode=OneWay}" FontWeight="SemiBold" />
+                                                <Run Text="behind what the instance recorded. Restoring from it alone throws that away." />
+                                            </TextBlock>
+
+                                            <!-- A gap and a MEASURED gap are not the same thing: a
+                                                 container holding nothing for this database has
+                                                 everything missing and no interval to quote. -->
+                                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                                       Text="The instance recorded backups this container does not hold. Restoring from it alone leaves them out." />
+                                        </StackPanel>
+                                    </Border>
+
+                                    <ItemsControl ItemsSource="{Binding Gap.Locations}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border Background="{DynamicResource InputBackgroundBrush}"
+                                                        CornerRadius="4" Padding="10,8" Margin="0,0,0,8">
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding Folder}"
+                                                                   Style="{StaticResource BodyText}"
+                                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                                   TextWrapping="Wrap" />
+
+                                                        <TextBlock Style="{StaticResource SecondaryText}"
+                                                                   Margin="0,4,0,0" TextWrapping="Wrap">
+                                                            <Run Text="{Binding Summary, Mode=OneWay}" />
+                                                            <Run Text="-" />
+                                                            <Run Text="{Binding FileCount, Mode=OneWay}" />
+                                                            <Run Text="file(s)," />
+                                                            <Run Text="{Binding SizeDisplay, Mode=OneWay}" />
+                                                        </TextBlock>
+
+                                                        <TextBlock Text="{Binding Window}"
+                                                                   Style="{StaticResource SecondaryText}"
+                                                                   Margin="0,2,0,0" />
+
+                                                        <!-- A backup recorded to a URL is not a file on
+                                                             that machine, so there is nothing for a copy
+                                                             script to pick up. -->
+                                                        <TextBlock Style="{StaticResource SecondaryText}"
+                                                                   Margin="0,6,0,0" TextWrapping="Wrap"
+                                                                   Foreground="{DynamicResource WarningBrush}"
+                                                                   Text="Recorded as written to storage rather than to disk, so there is no file here to copy - the listing did not see something that should be in the container. Check its base path."
+                                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+
+                                                        <WrapPanel Margin="0,8,0,0"
+                                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}}">
+                                                            <Button Content="Write a copy script"
+                                                                    Command="{Binding DataContext.BuildCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                    CommandParameter="{Binding}"
+                                                                    Style="{StaticResource SecondaryButton}"
+                                                                    Padding="10,4" Margin="0,0,8,0" />
+
+                                                            <Button Content="Copy to clipboard"
+                                                                    Command="{Binding DataContext.CopyCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                    CommandParameter="{Binding}"
+                                                                    Style="{StaticResource SecondaryButton}"
+                                                                    Padding="10,4"
+                                                                    Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}" />
+                                                        </WrapPanel>
+
+                                                        <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                                                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                                                                BorderThickness="1" CornerRadius="4"
+                                                                Margin="0,8,0,0"
+                                                                Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
+                                                            <ScrollViewer MaxHeight="200"
+                                                                          VerticalScrollBarVisibility="Auto"
+                                                                          HorizontalScrollBarVisibility="Auto"
+                                                                          Padding="10,8">
+                                                                <TextBlock Text="{Binding Script}"
+                                                                           FontFamily="{StaticResource ConsoleFont}"
+                                                                           FontSize="11"
+                                                                           Foreground="{DynamicResource ConsoleTextBrush}" />
+                                                            </ScrollViewer>
+                                                        </Border>
+                                                    </StackPanel>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+
+                                    <TextBlock Text="{Binding Gap.ComparedWhat}"
+                                               Style="{StaticResource SecondaryText}"
+                                               FontSize="10" TextWrapping="Wrap" Margin="0,4,0,0"
+                                               Visibility="{Binding Gap.ComparedWhat, Converter={StaticResource NullToVis}}" />
+                                </StackPanel>
+                            </Border>
+
                             <CheckBox Content="WITH MOVE (relocate files)"
                                       Visibility="{Binding ShowFileRelocation, Converter={StaticResource BoolToVis}}"
                                       IsChecked="{Binding UseWithMove}"

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -1705,6 +1705,13 @@
                                                                     Style="{StaticResource SecondaryButton}"
                                                                     Padding="10,4" Margin="0,0,8,0" />
 
+                                                            <Button Content="Restore from where they are"
+                                                                    Command="{Binding DataContext.RestoreFromWhereTheyAreCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                    CommandParameter="{Binding}"
+                                                                    Style="{StaticResource SecondaryButton}"
+                                                                    Padding="10,4" Margin="0,0,8,0"
+                                                                    ToolTip="Adds these to the timeline and reads them from this path instead of copying them into the container. The target has to be able to reach it - checked before the restore runs." />
+
                                                             <Button Content="Copy to clipboard"
                                                                     Command="{Binding DataContext.CopyCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                                     CommandParameter="{Binding}"


### PR DESCRIPTION
Three new capabilities and one fix reported from the app. No breaking changes, no config or schema changes.

## Find the backups a container is missing, and do something about it (#451)

Logs often go somewhere the fulls do not — a local or cluster disk for throughput, or a share because log shipping already owns them. Pointed at the container, the app built an honest chain out of what it could see, that chain stopped at the last differential, and nothing said the rest existed.

Under the advanced restore options there is now a source instance picker and a check. It reads that instance's own record, sets it against what the container holds, and names what is missing — the folder it went to, how many files, how big, over what window, and how much recovery time the container is behind by.

Then **two ways out**, because both are legitimate:

- **Bring them in.** A PowerShell script to run on the source machine, naming each file individually rather than globbing the folder — a wildcard takes other databases' backups and whatever is half-written at that moment. It carries **no credential**: the SAS or key pair is a mandatory parameter supplied at run time, because that script gets saved on a production server.
- **Leave them where they are.** Fold them into the timeline and restore from that path. The restore point extends to the newest of them, and one script reads the container by URL and those logs from their own path by DISK. The target has to be able to open that path as its own service account, which is now checked in the preflight, before anything is dropped.

## Carry a login across from the source instance (#459)

When a restored database holds a user with no matching login here, the advice was to create the login first with a password set by whoever owns the account — honest, and it still left a database whose users could not log in.

There is a third option beyond inventing a password or asking for one: fetch the real one. Run the new script on the instance the backup came from and it prints the `CREATE LOGIN` to run here, carrying the original password hash **and the original SID**. The hash means applications keep the password they already have. The SID means the user is not orphaned at all — no `ALTER USER` afterwards, and no window where permissions are wrong.

SQL logins only. A Windows login carries no password and takes its SID from Active Directory, which the script says rather than quietly finding nothing.

## The Copy screen says why it will not generate (#457)

Reported from the app: every field filled in, the overwrite banner naming the target, and both buttons dead with nothing saying why.

The source database had been cleared out from under the form. The screen re-reads its server list on every visit and re-assigns the source server to a fresh object, which clears the database and reloads the list — while the target server, container, name and overwrite tick all survive. So the form looked complete and was not.

Your own choice is now put back when the same server arrives again, though never when you switch servers, because inventing a source database is the one thing that screen must not do. And six things have to be true before Generate is live; the screen named none of them, and now names the first one missing along with the step to go back to.

Full detail in [CHANGELOG.md](CHANGELOG.md).

**Gate:** `dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test` → **2,204 passed, 0 failed** (up 111 since v1.6.4).