### PR TITLE
The recorded log is a prefix of the console, not equal to it (#461)

### DIFF
--- a/src/NineLives.Tests/RestoreExecutionSeamTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionSeamTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
@@ -119,19 +119,36 @@ public class RestoreExecutionSeamTests
     }
 
     /// <summary>
-    /// The recorded log is the WHOLE console, not whatever had made it out of the batching buffer
-    /// when the run ended - which is why the flush happens before the history entry is written.
+    /// The recorded log is the console as it stood when the run ended, from its first line - not
+    /// whatever had made it out of the batching buffer, which is why the flush happens before the
+    /// history entry is written.
+    ///
+    /// A PREFIX rather than equality, and the distinction is a real one rather than a way of making
+    /// a test pass (#461). Progress&lt;T&gt; POSTS its callbacks, so a report issued just before the
+    /// execution returned can still be queued when the run's finally block flushes and records -
+    /// and it then reaches the console after the receipt was taken. The receipt is one line short
+    /// of the console, on CI, perhaps one run in twenty.
+    ///
+    /// Prefix keeps everything worth keeping: nothing in the receipt that is not in the console, in
+    /// the same order, starting at the same place. A receipt truncated early, out of order, or
+    /// holding text the console never had all still fail. Only a trailing progress line arriving
+    /// late is tolerated, which is the one thing that is genuinely not guaranteed.
     /// </summary>
     [Fact]
-    public async Task TheRecordedLogIsTheWholeConsole()
+    public async Task TheRecordedLogIsTheConsoleAsItStoodWhenTheRunEnded()
     {
         var (vm, _, history) = New();
 
         await vm.RunAsync(Run(), Proceed);
 
         var entry = Assert.Single(history.Entries);
+
         Assert.Contains("Beginning restore execution", entry.Log);
-        Assert.Equal(vm.Console.Text, entry.Log);
+        Assert.StartsWith(entry.Log, vm.Console.Text);
+
+        // And it is the run, not a fragment of it: the outcome has to be in there, because that is
+        // what somebody opens a receipt to find.
+        Assert.Contains("Restore completed", entry.Log);
     }
 
     [Fact]

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -383,9 +383,18 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             Console.Flush();   // nothing buffered may outlive the run
             RaiseCancelStateChanged();
 
-            // After the flush, so the recorded log is the whole console rather than whatever had
-            // made it out of the batching buffer. Recorded for every outcome including cancelled -
-            // "I stopped it" is exactly the kind of thing a change ticket needs to say.
+            // After the flush, so the recorded log is the console as it stands rather than
+            // whatever had made it out of the batching buffer. Recorded for every outcome
+            // including cancelled - "I stopped it" is exactly the kind of thing a change ticket
+            // needs to say.
+            //
+            // Not quite the WHOLE console, and the gap is worth knowing about (#461): Progress<T>
+            // posts its callbacks, so a report issued just before the execution returned can still
+            // be queued here and reach the console after this receipt is taken. The receipt can be
+            // one trailing progress line short. Draining that would mean pumping the dispatcher
+            // mid-finally, which is a worse trade than a receipt missing "100 percent processed" -
+            // every line that carries meaning is already in it, because those are appended
+            // directly rather than through the progress channel.
             if (attempted) await RecordHistory(run, startedAt, outcome, failure);
         }
     }


### PR DESCRIPTION
Closes #461.

## Why it failed

`Progress<T>` **posts** its callbacks. A report issued just before the execution returned can still be queued when the run's `finally` flushes the console and writes the receipt — and it then reaches the console *after* the receipt was taken.

So the receipt is one trailing progress line short of the console. On CI, perhaps one run in twenty. It passed 8/8 locally in isolation, which is exactly how it survived being written.

The test asserted **equality between two reads of the console taken at different moments** — `entry.Log` from inside the run, `vm.Console.Text` from after it. That was only ever true by timing luck.

## Why a prefix rather than a looser assertion

`Assert.StartsWith(entry.Log, vm.Console.Text)` keeps everything worth keeping: nothing in the receipt that is not in the console, in the same order, from the same starting point. A receipt truncated early, out of order, or holding text the console never had all still fail it.

The only thing tolerated is a trailing progress line arriving late — which is the one thing genuinely not guaranteed. It also now asserts the outcome line is present, because that is what somebody opens a receipt to find.

## Why the product is not changed

Draining the progress channel would mean pumping the dispatcher inside the `finally`. That is a worse trade than a receipt missing `100 percent processed`: every line that carries meaning — the statements, the errors, the outcome — is appended directly rather than through the progress channel, so those are already in the receipt.

The limitation is now written down where the flush is, so the next person reading "the recorded log is the whole console" is not misled by it.

## Effect

`-c Release -warnaserror` clean, **2,204 passed**. The reworked test run six times locally, green each time.