### PR TITLE
Prove both accounts against the shared folder before the backup (#452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Added
+
+- **Both service accounts are proven against the shared folder before anything is backed up**
+  (#452). The Copy screen has always said the source writes there as its own service account and
+  the target reads there as its own - two different accounts, routinely not the same one - but the
+  check ran on a *file*, so it could not run until a file was there. Which meant after a full
+  backup had been written. A share the target could not read cost you the whole backup first, and
+  the source's write was never checked ahead of time at all. Generating the scripts now asks each
+  instance about the folder as itself: can the source create in it, can the target see it. Two
+  verdicts kept apart, because the fix is a permission grant to a specific account and one
+  combined answer loses which. It stays honest about what it proves - the folder is reachable, not
+  that a backup inside it will open - so the file-level check after the backup remains the
+  authoritative one. An instance that never answers does not block the copy: not knowing is not
+  the same as refusing.
+
 ## [1.7.0] - 2026-08-17
 
 ### Added

--- a/src/NineLives.Core/Models/FolderAccessCheck.cs
+++ b/src/NineLives.Core/Models/FolderAccessCheck.cs
@@ -1,0 +1,113 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>What one instance's service account could do with a folder.</summary>
+public enum FolderAccess
+{
+    /// <summary>Not asked yet.</summary>
+    Unknown,
+
+    /// <summary>The folder is there and the account could do what was asked of it.</summary>
+    Ok,
+
+    /// <summary>
+    /// The account cannot see the folder at all.
+    ///
+    /// The one this check exists for. A SQL Server running as a local account, or as
+    /// NT SERVICE\MSSQLSERVER, has no identity on the network and so cannot reach ANY share -
+    /// which from the outside is indistinguishable from a path that does not exist, and is the
+    /// commonest way a copy through a shared folder fails.
+    /// </summary>
+    NotVisible,
+
+    /// <summary>Visible, and the account cannot create in it.</summary>
+    CannotWrite,
+
+    /// <summary>
+    /// The instance never answered.
+    ///
+    /// A UNC path whose host does not resolve does not come back as "not found": the statement
+    /// hangs while Windows looks for the machine, and the command timeout expires first.
+    /// </summary>
+    Unreachable,
+
+    /// <summary>Something else. The server's own words are in the message.</summary>
+    Other
+}
+
+/// <summary>
+/// Whether one instance can use a folder, asked of that instance (#452).
+///
+/// The distinction that makes it worth asking at all: a copy through a shared folder needs the
+/// SOURCE to write there as its own service account and the TARGET to read there as its own - two
+/// different accounts, routinely not the same one, and neither of them this app. A check from here
+/// would answer for the wrong identity entirely.
+///
+/// Asked BEFORE the backup, which is the whole point. The readability check that already exists
+/// runs on a file, so it cannot run until a file is there - by which time a full backup has been
+/// written and the wait is over. This one costs a round trip and answers the common failure in a
+/// second.
+/// </summary>
+/// <param name="Folder">The folder as it was asked about.</param>
+/// <param name="Access">What the account could do.</param>
+/// <param name="ServerMessage">What SQL Server said, verbatim, whatever the classification.</param>
+public sealed record FolderAccessCheck(
+    string Folder, FolderAccess Access, string? ServerMessage = null)
+{
+    public bool IsOk => Access == FolderAccess.Ok;
+
+    public static FolderAccessCheck Ok(string folder) => new(folder, FolderAccess.Ok);
+
+    /// <summary>
+    /// Turns what SQL Server said into which failure it was.
+    ///
+    /// The message is kept whatever the classification: the numbered error is what somebody
+    /// searches for, and a wrong guess here must not hide the server's own words.
+    /// </summary>
+    public static FolderAccessCheck FromError(string folder, string message)
+    {
+        var m = message ?? string.Empty;
+
+        var access =
+            Contains(m, "timeout") || Contains(m, "network path was not found")
+                ? FolderAccess.Unreachable
+            : Contains(m, "access is denied") || Contains(m, "permission")
+                ? FolderAccess.CannotWrite
+            : Contains(m, "cannot find") || Contains(m, "does not exist")
+                ? FolderAccess.NotVisible
+                : FolderAccess.Other;
+
+        return new FolderAccessCheck(folder, access, m);
+    }
+
+    private static bool Contains(string haystack, string needle)
+        => haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// What to tell somebody, naming the instance whose account could not do it.
+    ///
+    /// Names the ACCOUNT rather than just the failure, because the fix is a permission grant to a
+    /// specific identity and "access denied" on its own sends people to check the share from their
+    /// own logged-in session, where it works.
+    /// </summary>
+    public string Explain(string serverName, bool wasWriteCheck) => Access switch
+    {
+        FolderAccess.Ok => wasWriteCheck
+            ? $"{serverName} can write here as its own service account."
+            : $"{serverName} can see this folder as its own service account.",
+
+        FolderAccess.NotVisible =>
+            $"{serverName} cannot see {Folder} at all. Its SQL Server service account is the one " +
+            "that has to reach it, not your login - an instance running as a local account or as " +
+            "NT SERVICE\\MSSQLSERVER has no identity on the network and cannot open any share.",
+
+        FolderAccess.CannotWrite =>
+            $"{serverName} can see {Folder} but its service account cannot create files there. " +
+            "The backup would fail at the point of writing.",
+
+        FolderAccess.Unreachable =>
+            $"{serverName} never answered about {Folder}. A UNC path whose host does not resolve " +
+            "hangs rather than reporting a missing folder, so check the machine name first.",
+
+        _ => $"{serverName} could not use {Folder}: {ServerMessage}"
+    };
+}

--- a/src/NineLives.Core/Services/ISqlServerService.cs
+++ b/src/NineLives.Core/Services/ISqlServerService.cs
@@ -182,6 +182,21 @@ public interface ISqlServerService
     Task<BackupFileCheck> CheckBackupFileAsync(
         ServerConnection server, string path, CancellationToken ct = default);
 
+    /// <summary>
+    /// Whether THIS instance's service account can use a folder, asked before anything is written
+    /// (#452).
+    ///
+    /// The file-level check below cannot run until a file is there, which on the copy screen means
+    /// after a full backup has been taken - so a share the target cannot read costs the whole
+    /// backup first. This one costs a round trip.
+    ///
+    /// <paramref name="needsWrite"/> picks the question: whether the account can see the folder, or
+    /// whether it can create in it. Both are asked ON the instance, because the account that
+    /// matters is its service account and not this app.
+    /// </summary>
+    Task<FolderAccessCheck> CheckFolderAccessAsync(
+        ServerConnection server, string folder, bool needsWrite, CancellationToken ct = default);
+
     /// <summary>Checks every file a chain needs, stopping at the first that cannot be read.</summary>
     Task<List<BackupFileCheck>> CheckBackupFilesAsync(
         ServerConnection server, IEnumerable<string> paths, CancellationToken ct = default);

--- a/src/NineLives.Core/Services/SqlServerService.cs
+++ b/src/NineLives.Core/Services/SqlServerService.cs
@@ -554,6 +554,80 @@ public class SqlServerService : ISqlServerService
     /// cause - the service account having no access to the share - fails every file identically,
     /// so carrying on would produce a page of the same message.
     /// </summary>
+    /// <summary>
+    /// The name of the folder created to prove a write (#452).
+    ///
+    /// A write cannot be proven without writing, and SQL Server has no primitive for removing a
+    /// directory again - xp_delete_files takes files with an extension and a date filter. So this
+    /// leaves one empty folder behind, with a name that says what it is, and reuses it on every
+    /// later check because xp_create_subdir succeeds silently when the directory already exists.
+    ///
+    /// One obvious artefact beats the alternatives: writing a real backup to prove the write costs
+    /// minutes and megabytes, and proving nothing costs somebody a full backup before they find out.
+    /// </summary>
+    internal const string WriteProbeFolder = "_ninelives_write_check";
+
+    /// <inheritdoc />
+    public async Task<FolderAccessCheck> CheckFolderAccessAsync(
+        ServerConnection server, string folder, bool needsWrite, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(folder)) return FolderAccessCheck.Ok(folder);
+
+        var trimmed = folder.TrimEnd('\\', '/');
+
+        try
+        {
+            await using var conn = CreateConnection(server);
+            await conn.OpenAsync(ct);
+
+            // Shorter than the default: the failure this is most likely to hit is a UNC host that
+            // does not resolve, which hangs rather than answering, and the whole value of asking
+            // early is lost if the answer takes as long as the backup would have.
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandTimeout = 30;
+
+            if (needsWrite)
+            {
+                // Creating a subfolder is the cheapest thing that genuinely proves the account can
+                // write here, and it is what the maintenance scripts everybody already runs use for
+                // the same purpose. Idempotent, so the probe folder is created at most once.
+                cmd.CommandText = "EXEC master.sys.xp_create_subdir @probe";
+                cmd.Parameters.Add(new SqlParameter("@probe",
+                    trimmed + "\\" + WriteProbeFolder));
+
+                await cmd.ExecuteNonQueryAsync(ct);
+                return FolderAccessCheck.Ok(folder);
+            }
+
+            // Visible, and a directory rather than a file. xp_fileexist answers three columns:
+            // whether the path exists as a file, whether it is a directory, and whether its parent
+            // exists - and it answers as the SERVICE account, which is the whole point.
+            cmd.CommandText = "EXEC master.dbo.xp_fileexist @path";
+            cmd.Parameters.Add(new SqlParameter("@path", trimmed));
+
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+            if (!await reader.ReadAsync(ct))
+                return new FolderAccessCheck(folder, FolderAccess.Other,
+                    "xp_fileexist returned no rows.");
+
+            var isDirectory = !reader.IsDBNull(1) && reader.GetInt32(1) == 1;
+
+            return isDirectory
+                ? FolderAccessCheck.Ok(folder)
+                : new FolderAccessCheck(folder, FolderAccess.NotVisible,
+                    "xp_fileexist reported it is not a directory this account can see.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return FolderAccessCheck.FromError(folder, ex.Message);
+        }
+    }
+
     public async Task<List<BackupFileCheck>> CheckBackupFilesAsync(
         ServerConnection server, IEnumerable<string> paths, CancellationToken ct = default)
     {

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -822,6 +822,24 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Set to make the target unreachable rather than merely unhelpful.</summary>
     public Exception? ThrowOnCheck { get; set; }
 
+    /// <summary>What each folder check should answer, keyed by "serverName|folder|write" (#452).
+    /// Anything not listed answers Ok, so a test only has to state the failure it cares about.</summary>
+    public Dictionary<string, FolderAccessCheck> FolderAccess { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Every folder check asked for, so a test can prove BOTH sides were asked.</summary>
+    public List<string> FolderChecks { get; } = [];
+
+    public Task<FolderAccessCheck> CheckFolderAccessAsync(
+        ServerConnection server, string folder, bool needsWrite, CancellationToken ct = default)
+    {
+        var key = $"{server.ServerName}|{folder}|{(needsWrite ? "write" : "read")}";
+        FolderChecks.Add(key);
+
+        return Task.FromResult(FolderAccess.TryGetValue(key, out var answer)
+            ? answer
+            : FolderAccessCheck.Ok(folder));
+    }
+
     public Task<BackupFileCheck> CheckBackupFileAsync(
         ServerConnection server, string path, CancellationToken ct = default)
     {

--- a/src/NineLives.Tests/ProveTheShareBeforeTheBackupTests.cs
+++ b/src/NineLives.Tests/ProveTheShareBeforeTheBackupTests.cs
@@ -1,0 +1,209 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Both accounts are proven against the shared folder before anything is backed up (#452).
+///
+/// The screen's own text has always said it: the source writes here as its own service account and
+/// the target reads here as its own, two different accounts and routinely not the same one. But
+/// the check that existed ran on a FILE, so it could not run until a file was there - which meant
+/// after a full backup had been written. A share the target could not read cost the whole backup
+/// first, and the source's write was never checked ahead of time at all.
+/// </summary>
+public class ProveTheShareBeforeTheBackupTests
+{
+    private const string Folder = @"\\nas01\sql";
+
+    private static (CopyDatabaseViewModel vm, FakeSqlServerService sql) Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var vm = new CopyDatabaseViewModel(store, sql);
+        vm.Refresh();
+        return (vm, sql);
+    }
+
+    /// <summary>Everything answered, going through a folder rather than a container.</summary>
+    private static async Task<(CopyDatabaseViewModel vm, FakeSqlServerService sql)> ReadyAsync()
+    {
+        var (vm, sql) = Screen();
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.SharedPath;
+        vm.SharedPathRoot = Folder;
+
+        // The sweep runs on Generate, not on every keystroke - re-asking two production instances
+        // per character typed was the disease #285 cured. Still before anything is written.
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+        return (vm, sql);
+    }
+
+    private static string Key(string server, bool write)
+        => $"{server}|{Folder}|{(write ? "write" : "read")}";
+
+    // ── both sides are asked, as themselves ─────────────────────────────────────
+
+    [Fact]
+    public async Task BothAccountsAreAskedAndEachAboutItsOwnQuestion()
+    {
+        var (_, sql) = await ReadyAsync();
+
+        // The source has to CREATE here; the target only has to see it.
+        Assert.Contains(Key("SRV01", write: true), sql.FolderChecks);
+        Assert.Contains(Key("SRV02", write: false), sql.FolderChecks);
+    }
+
+    [Fact]
+    public async Task WhenBothCanUseItTheScreenSaysSoAndDoesNotRefuse()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        Assert.True(vm.SharedFolderProven);
+        Assert.Contains("SRV01", vm.SourceCanWriteHere);
+        Assert.Contains("SRV02", vm.TargetCanReadHere);
+        Assert.Empty(vm.SharedFolderRefusal);
+    }
+
+    // ── and refused when one of them cannot ─────────────────────────────────────
+
+    /// <summary>
+    /// The failure this exists for, and the reason the message names the ACCOUNT: an instance
+    /// running as a local account has no identity on the network, so it cannot open any share -
+    /// while the share opens perfectly from the operator's own logged-in session.
+    /// </summary>
+    [Fact]
+    public async Task ATargetThatCannotSeeTheFolderRefusesBeforeAnythingIsWritten()
+    {
+        var (vm, sql) = Screen();
+        sql.FolderAccess[Key("SRV02", write: false)] =
+            new FolderAccessCheck(Folder, FolderAccess.NotVisible, "Operating system error 5.");
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.SharedPath;
+        vm.SharedPathRoot = Folder;
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+
+        Assert.False(vm.SharedFolderProven);
+        Assert.True(vm.IsRefused);
+        Assert.Contains("SRV02", vm.Refusal);
+        Assert.Contains("service account", vm.Refusal);
+        Assert.False(vm.CanGenerate);
+    }
+
+    [Fact]
+    public async Task ASourceThatCannotWriteRefusesToo()
+    {
+        var (vm, sql) = Screen();
+        sql.FolderAccess[Key("SRV01", write: true)] =
+            new FolderAccessCheck(Folder, FolderAccess.CannotWrite, "Access is denied.");
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.SharedPath;
+        vm.SharedPathRoot = Folder;
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+
+        Assert.True(vm.IsRefused);
+        Assert.Contains("SRV01", vm.Refusal);
+        Assert.Contains("cannot create", vm.Refusal);
+    }
+
+    /// <summary>
+    /// A check that could not be COMPLETED is not a check that failed. An instance that never
+    /// answers - a UNC host that does not resolve, so the statement hangs until the timeout - must
+    /// not block a copy that would have worked. Same rule the space check follows.
+    /// </summary>
+    [Fact]
+    public async Task AnInstanceThatNeverAnsweredDoesNotBlockTheCopy()
+    {
+        var (vm, sql) = Screen();
+        sql.FolderAccess[Key("SRV02", write: false)] =
+            new FolderAccessCheck(Folder, FolderAccess.Unreachable, "Execution Timeout Expired.");
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.SharedPath;
+        vm.SharedPathRoot = Folder;
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+
+        Assert.False(vm.SharedFolderProven);
+        Assert.Empty(vm.SharedFolderRefusal);
+
+        // Said, though - not knowing is worth reporting even when it is not worth refusing over.
+        Assert.Contains("never answered", vm.TargetCanReadHere);
+    }
+
+    // ── it is a shared-folder question only ─────────────────────────────────────
+
+    [Fact]
+    public async Task GoingThroughACloudContainerAsksNothingAboutFolders()
+    {
+        var (vm, sql) = Screen();
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.AzureBlob;
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+
+        Assert.Empty(sql.FolderChecks);
+        Assert.Empty(vm.SourceCanWriteHere);
+    }
+
+    // ── what it does and does not prove ─────────────────────────────────────────
+
+    /// <summary>
+    /// The wording has to stay narrower than the check. xp_fileexist proves the folder is visible
+    /// to that account; it does not prove a backup inside it will be readable, because a share can
+    /// be traversable and still refuse the read. The file-level check after the backup is still
+    /// the authoritative one, and claiming more here would make it look redundant.
+    /// </summary>
+    [Fact]
+    public void TheVisibilityVerdictDoesNotClaimReadability()
+    {
+        var seen = new FolderAccessCheck(Folder, FolderAccess.Ok);
+
+        var said = seen.Explain("SRV02", wasWriteCheck: false);
+
+        Assert.Contains("can see", said);
+        Assert.DoesNotContain("readable", said);
+        Assert.DoesNotContain("can read the backup", said);
+    }
+
+    [Fact]
+    public void AnUnreachableFolderPointsAtTheMachineNameFirst()
+    {
+        var check = new FolderAccessCheck(
+            Folder, FolderAccess.Unreachable, "timeout");
+
+        Assert.Contains("machine name", check.Explain("SRV02", wasWriteCheck: false));
+    }
+}

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -278,6 +278,11 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             if (string.IsNullOrWhiteSpace(SourceDatabase)) return string.Empty;
             if (string.IsNullOrWhiteSpace(TargetDatabaseName)) return string.Empty;
 
+            // A folder one side cannot use (#452). Before the version and encryption verdicts,
+            // because there is no point discussing what the target can restore when the backup
+            // cannot be written in the first place.
+            if (SharedFolderRefusal.Length > 0) return SharedFolderRefusal;
+
             // Onto itself, under its own name. That is not a copy - it is a backup of a database
             // immediately restored over the top of the database it was taken from, which at best
             // is an expensive no-op and at worst destroys it when the restore fails halfway.
@@ -506,7 +511,45 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// <summary>The in-flight sweep, so the run can refuse to start before the verdicts are in.</summary>
     private Task _checksTask = Task.CompletedTask;
 
+    /// <summary>
+    /// Awaits the in-flight check sweep. For tests, so they turn on the sweep having finished
+    /// rather than on a sleep long enough to hope it has - a timing guess is how a test passes
+    /// locally and fails on a loaded runner.
+    /// </summary>
+    internal Task WaitForChecksForTests() => _checksTask;
+
     private readonly OperationCancellation _checksCancellation = new();
+
+    /// <summary>
+    /// What the SOURCE said about writing to the shared folder, and the TARGET about reading it
+    /// (#452).
+    ///
+    /// Two accounts, two answers, kept apart. The screen's own text has always said the source
+    /// writes as its service account and the target reads as its own - routinely not the same one -
+    /// and reporting them as one verdict loses the only thing that makes the message actionable,
+    /// which is WHICH permission grant is needed and to whom.
+    /// </summary>
+    [ObservableProperty]
+    private string _sourceCanWriteHere = string.Empty;
+
+    [ObservableProperty]
+    private string _targetCanReadHere = string.Empty;
+
+    [ObservableProperty]
+    private bool _sharedFolderProven;
+
+    /// <summary>
+    /// The folder problem, or empty. Feeds the refusal, because a copy through a folder one side
+    /// cannot use will not work and generating a script for it wastes the wait.
+    ///
+    /// A check that could not be COMPLETED is not a check that failed - an instance that refuses to
+    /// answer must not block a copy that would have worked, the same rule the space check follows.
+    /// So only a definite no counts.
+    /// </summary>
+    [ObservableProperty]
+    private string _sharedFolderRefusal = string.Empty;
+
+    partial void OnSharedFolderRefusalChanged(string value) => Invalidate();
 
     /// <summary>
     /// The three generation-time checks as one serialised sweep (#285): warnings cleared once
@@ -523,6 +566,12 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             SpaceWarning = string.Empty;
             VolumeSpace = [];
 
+            SourceCanWriteHere = string.Empty;
+            TargetCanReadHere = string.Empty;
+            SharedFolderRefusal = string.Empty;
+            SharedFolderProven = false;
+
+            await CheckSharedFolderAsync(ct);
             await CheckVersionAsync(ct);
             await CheckEncryptionAsync(ct);
             await CheckSpaceAsync(ct);
@@ -558,6 +607,51 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// STRONGEST terms, because unlike disk space nothing can change between generating and
     /// running that makes this legal.
     /// </summary>
+    /// <summary>
+    /// Asks both instances about the shared folder before anything is backed up (#452).
+    ///
+    /// The readability check that already exists runs on a FILE, so it cannot run until a file is
+    /// there - which on this screen is after a full backup has been written. A share the target
+    /// cannot read therefore cost the whole backup first. This costs two round trips.
+    ///
+    /// What it proves is narrower than what the file check proves, and the wording says so: that
+    /// the folder is visible to the target's account, not that a backup inside it will be
+    /// readable - a share can be traversable and still refuse the read. It catches the common
+    /// failure, which is an account with no access to the share at all, in a second.
+    /// </summary>
+    private async Task CheckSharedFolderAsync(CancellationToken ct)
+    {
+        if (MediumIsBlob) return;
+        if (string.IsNullOrWhiteSpace(SharedPathRoot)) return;
+        if (SourceServer == null || TargetServer == null) return;
+
+        try
+        {
+            // The source has to CREATE here; the target only has to see it.
+            var write = await _sql.CheckFolderAccessAsync(SourceServer, SharedPathRoot, true, ct);
+            SourceCanWriteHere = write.Explain(SourceServer.ServerName, wasWriteCheck: true);
+
+            var read = await _sql.CheckFolderAccessAsync(TargetServer, SharedPathRoot, false, ct);
+            TargetCanReadHere = read.Explain(TargetServer.ServerName, wasWriteCheck: false);
+
+            SharedFolderProven = write.IsOk && read.IsOk;
+
+            SharedFolderRefusal =
+                !write.IsOk && write.Access != FolderAccess.Unreachable ? SourceCanWriteHere
+                : !read.IsOk && read.Access != FolderAccess.Unreachable ? TargetCanReadHere
+                : string.Empty;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Never the reason a copy cannot be set up. Not knowing is not the same as refusing.
+            _log.Info($"[share] could not check {SharedPathRoot}: {ex.Message}");
+        }
+    }
+
     private async Task CheckVersionAsync(CancellationToken ct)
     {
         if (SourceServer == null || TargetServer == null) return;

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -164,7 +164,52 @@
                                  Margin="0,4,0,0"
                                  ToolTip="For example \\nas01\sql" />
                         <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
-                                   Text="The source has to WRITE here as its own service account, and the target has to READ here as its own - two different accounts, and routinely not the same one. Whether the target can read it is checked after the backup, before the restore." />
+                                   Text="The source has to WRITE here as its own service account, and the target has to READ here as its own - two different accounts, and routinely not the same one. Both are checked when you generate the scripts - before anything is written, rather than after the backup as it used to be." />
+
+                        <!-- The two verdicts, kept apart (#452). One combined answer loses the only
+                             thing that makes the message actionable: which permission grant is
+                             needed, and to which account. Coloured on the outcome, so a refusal
+                             does not read as reassurance. -->
+                        <StackPanel Margin="0,8,0,0"
+                                    Visibility="{Binding SourceCanWriteHere, Converter={StaticResource NullToVis}}">
+                            <TextBlock Text="{Binding SourceCanWriteHere}"
+                                       TextWrapping="Wrap" Margin="0,0,0,4">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                        <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding SharedFolderProven}" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
+                            <TextBlock Text="{Binding TargetCanReadHere}"
+                                       TextWrapping="Wrap"
+                                       Visibility="{Binding TargetCanReadHere, Converter={StaticResource NullToVis}}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                        <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding SharedFolderProven}" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
+                            <!-- What xp_fileexist actually proves, said rather than implied: the
+                                 folder is visible to that account, not that a backup inside it will
+                                 be readable. The file-level check after the backup is still the
+                                 authoritative one. -->
+                            <TextBlock Style="{StaticResource SecondaryText}"
+                                       FontSize="10" TextWrapping="Wrap" Margin="0,6,0,0"
+                                       Visibility="{Binding SharedFolderProven, Converter={StaticResource BoolToVis}}"
+                                       Text="That proves the folder is reachable by both accounts. Whether a backup inside it can be opened is checked again once it is written - a share can be visible and still refuse the read." />
+                        </StackPanel>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal" Margin="0,14,0,0">


### PR DESCRIPTION
Closes #452 — from your screenshot of the Via section.

## What it said, and why that was the problem

> The source has to WRITE here as its own service account, and the target has to READ here as its own — two different accounts, and routinely not the same one. **Whether the target can read it is checked after the backup, before the restore.**

Accurate, and that ordering is the defect. The check runs on a *file*, and there is no file until the backup has been written — so a share the target cannot read costs you the whole backup first. On a large database that is a long wait to be told something knowable in a second.

The source's write was never checked ahead of time at all. It was discovered by the backup failing.

## What it does now

Generating the scripts asks each instance about the folder **as itself**:

- `xp_create_subdir` on the source — proves it can create there
- `xp_fileexist` on the target — proves it can see it

Both run as the service account that will do the work, which is the only identity whose answer means anything. A check from this app answers for the wrong account entirely.

**The two verdicts are kept apart.** The fix for either is a permission grant to a specific identity, and one combined answer loses the only thing that makes the message actionable. Each names the instance, because "access denied" on its own sends people to check the share from their own logged-in session, where it works.

## Honest about what it proves

`xp_fileexist` says the folder is *visible* to that account. It does not say a backup inside it will open — a share can be traversable and still refuse the read. So the file-level check after the backup **stays** as the authoritative one, and the wording says so rather than making it look redundant.

An instance that never answers does not block the copy. A UNC host that does not resolve hangs rather than reporting a missing folder, and a check that could not be completed is not a check that failed — the same rule the space check follows. Reported, not refused over. Pinned.

## Two things the tests corrected

- The sweep runs on **Generate**, not per keystroke — re-asking two production instances six round trips per character typed was the disease #285 cured. So the UI text I first wrote, claiming the folder is checked as soon as it is named, was a claim the behaviour does not make. Reworded.
- The test wait seam awaits the sweep rather than sleeping. A timing guess is how a test passes locally and fails on a loaded runner, which this session has already paid for once.

## One artefact

The write proof leaves an empty folder called `_ninelives_write_check`. A write cannot be proven without writing, and SQL Server has no primitive for removing a directory again — `xp_delete_files` takes files with an extension and a date filter. The alternatives were writing a real backup to prove it, or proving nothing.

## Effect

`-c Release -warnaserror` clean, **2,212 passed** (up 8).