### PR TITLE
Put the gap check where somebody can find it (#466)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [1.7.0] - 2026-08-17
 
+### Fixed
+
+- **The gap check can be found** (#466). It shipped in 1.7.0 inside the restore options, which
+  meant behind a step you only reach after *confirming* a restore point - and which starts
+  collapsed. A feature whose whole purpose is telling you the chain is shorter than you think
+  cannot require you to already suspect it; that is the same fault as the bug it fixes, and the
+  first person to look for it could not find it. It now sits in step 1 beside the audit panel,
+  reachable as soon as a database is picked, with no target and no confirmed restore point needed.
+  It was also gated on a mode check that returns true for every mode, which did nothing except
+  imply it was a Pro-only tool. A test now asserts it is on screen with only a container chosen,
+  in every mode, because two placements have compiled and hidden it.
+
 ### Added
 
 - **The script that carries a login across from the source instance** (#459). When a restored

--- a/src/NineLives.Tests/TheGapCheckIsReachableTests.cs
+++ b/src/NineLives.Tests/TheGapCheckIsReachableTests.cs
@@ -1,0 +1,164 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The gap check can be found (#466).
+///
+/// It shipped in v1.7.0 inside the restore options - which is to say behind a step that only
+/// appears once a restore point has been confirmed, and which starts collapsed. A feature whose
+/// entire purpose is telling somebody the chain is shorter than they think cannot require them to
+/// already suspect it: that is the same fault as the bug it exists to fix. It was reported as
+/// missing by the first person to look for it, which is about as clear as evidence gets.
+///
+/// Pinned in the view rather than the view model, because the view model was never the problem.
+/// Every assertion here is about what is on screen and when.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class TheGapCheckIsReachableTests(WpfFixture wpf)
+{
+    private const string Header = "BACKUPS THIS CONTAINER IS MISSING";
+
+    private static RestoreViewModel Screen(AppMode mode)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = mode;
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "sqlbackups",
+            ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+        });
+
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp());
+
+        vm.Mode = mode;
+        vm.SelectedContainer = store.Config.BlobContainers[0];
+        return vm;
+    }
+
+    private static TextBlock? FindHeader(DependencyObject view) =>
+        FindAll<TextBlock>(view).FirstOrDefault(t => t.Text == Header);
+
+    /// <summary>
+    /// The one that would have caught the report: nothing chosen but a container, no target, no
+    /// confirmed restore point - and it is on screen.
+    /// </summary>
+    [Fact]
+    public void ItIsOnScreenBeforeATargetOrARestorePointIsChosen()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = Screen(AppMode.Pro);
+            var view = new RestoreView { DataContext = vm };
+            Layout(view);
+
+            Assert.Null(vm.SelectedTargetServer);
+            Assert.False(vm.Steps.Options.IsVisible);
+
+            var header = FindHeader(view);
+            Assert.NotNull(header);
+            Assert.Equal(Visibility.Visible, header!.Visibility);
+        });
+    }
+
+    /// <summary>
+    /// In every mode. It was gated on ShowAdvancedOptions, which happens to return true for all of
+    /// them - so the gate did nothing except imply this was a Pro-only tool to anybody reading it.
+    /// </summary>
+    [Theory]
+    [InlineData(AppMode.Basic)]
+    [InlineData(AppMode.Standard)]
+    [InlineData(AppMode.Pro)]
+    public void ItIsOnScreenInEveryMode(AppMode mode)
+    {
+        wpf.Invoke(() =>
+        {
+            var view = new RestoreView { DataContext = Screen(mode) };
+            Layout(view);
+
+            var header = FindHeader(view);
+            Assert.NotNull(header);
+            Assert.Equal(Visibility.Visible, header!.Visibility);
+        });
+    }
+
+    /// <summary>
+    /// And it sits in the SOURCE step, beside the other tool that asks an instance about these same
+    /// backups. Proven by walking up from the header to the step that contains it, rather than by
+    /// trusting a line number - the previous two placements both compiled and both hid it.
+    /// </summary>
+    [Fact]
+    public void ItSitsInTheSourceStepBesideTheAuditPanel()
+    {
+        wpf.Invoke(() =>
+        {
+            var view = new RestoreView { DataContext = Screen(AppMode.Pro) };
+            Layout(view);
+
+            var header = FindHeader(view);
+            Assert.NotNull(header);
+
+            var audit = FindAll<TextBlock>(view)
+                .FirstOrDefault(t => t.Text == "AUDIT THESE BACKUPS");
+            Assert.NotNull(audit);
+
+            // Both inside one container, which is the source step's own panel.
+            Assert.True(SharesAnAncestorWithin(header!, audit!, generations: 4),
+                "The gap check is no longer beside the audit panel - check which step it landed in.");
+        });
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static bool SharesAnAncestorWithin(
+        DependencyObject a, DependencyObject b, int generations)
+    {
+        var ancestors = new List<DependencyObject>();
+        var walk = a;
+        for (int i = 0; i < generations && walk != null; i++)
+        {
+            walk = VisualTreeHelper.GetParent(walk);
+            if (walk != null) ancestors.Add(walk);
+        }
+
+        walk = b;
+        for (int i = 0; i < generations && walk != null; i++)
+        {
+            walk = VisualTreeHelper.GetParent(walk);
+            if (walk != null && ancestors.Contains(walk)) return true;
+        }
+
+        return false;
+    }
+
+    private static void Layout(FrameworkElement element)
+    {
+        element.Measure(new Size(1400, 2400));
+        element.Arrange(new Rect(0, 0, 1400, 2400));
+        element.UpdateLayout();
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        int count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var node = VisualTreeHelper.GetChild(root, i);
+            if (node is T match) yield return match;
+            foreach (var d in FindAll<T>(node)) yield return d;
+        }
+    }
+}

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -574,6 +574,178 @@
                 </StackPanel>
             </Border>
 
+            <!-- Beside the audit panel, in SELECT SOURCE, and the placement took two goes to get
+                 right (#466). It began in the restore options: a feature whose entire point is
+                 telling somebody the chain is shorter than they think, behind a step reached only
+                 after confirming a restore point computed from that same short chain. Then step 3,
+                 which shows the chain but is not offered until a TARGET has been chosen - and this
+                 question is about the SOURCE. Here it is reachable the moment a database is picked,
+                 next to the other tool that asks an instance about these same backups. -->
+            <!-- What the source instance recorded, against what this container
+                 holds (#451). Behind the advanced options because it means
+                 connecting to a SECOND server - the one that took the backups,
+                 which is routinely not the one being restored to. -->
+            <Border Style="{StaticResource CardBorder}"
+                    Margin="0,4,0,16">
+                <StackPanel>
+                    <TextBlock Text="BACKUPS THIS CONTAINER IS MISSING"
+                               Style="{StaticResource LabelText}" Margin="0,0,0,6" />
+
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap" Margin="0,0,0,10"
+                               Text="Logs often go somewhere else - a local or cluster disk for throughput, or a share because log shipping already owns them. The container cannot tell you that; the instance that took them can. Ask it, and anything written elsewhere shows up here with the path it went to." />
+
+                    <Grid Margin="0,0,0,10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <ComboBox Grid.Column="0"
+                                  ItemsSource="{Binding Gap.Servers}"
+                                  SelectedItem="{Binding Gap.SourceServer}"
+                                  Style="{StaticResource DarkComboBox}"
+                                  ToolTip="The instance that TOOK these backups - not necessarily the one being restored to.">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding DisplayText}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+
+                        <Button Grid.Column="1"
+                                Content="Check its history"
+                                Command="{Binding CheckForMissingBackupsCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="12,6" Margin="8,0,0,0"
+                                IsEnabled="{Binding Gap.CanCheck}" />
+                    </Grid>
+
+                    <TextBlock Text="Reading the instance's own record..."
+                               Style="{StaticResource SecondaryText}"
+                               Margin="0,0,0,8"
+                               Visibility="{Binding Gap.IsChecking, Converter={StaticResource BoolToVis}}" />
+
+                    <ContentControl Style="{StaticResource ErrorBanner}"
+                                    DataContext="{Binding Gap}" />
+
+                    <!-- The all-clear, said out loud. An empty panel is
+                         indistinguishable from never having pressed the button. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                            Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource SuccessPanelBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding Gap.FoundNothingMissing, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                   Text="Everything the instance recorded is in this container. The chain on offer is the whole chain." />
+                    </Border>
+
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                            Background="{DynamicResource WarningPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}}">
+                                <Run Text="This container is" />
+                                <Run Text="{Binding Gap.BehindBy, Mode=OneWay}" FontWeight="SemiBold" />
+                                <Run Text="behind what the instance recorded. Restoring from it alone throws that away." />
+                            </TextBlock>
+
+                            <!-- A gap and a MEASURED gap are not the same thing: a
+                                 container holding nothing for this database has
+                                 everything missing and no interval to quote. -->
+                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                       Text="The instance recorded backups this container does not hold. Restoring from it alone leaves them out." />
+                        </StackPanel>
+                    </Border>
+
+                    <ItemsControl ItemsSource="{Binding Gap.Locations}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{DynamicResource InputBackgroundBrush}"
+                                        CornerRadius="4" Padding="10,8" Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Folder}"
+                                                   Style="{StaticResource BodyText}"
+                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                   TextWrapping="Wrap" />
+
+                                        <TextBlock Style="{StaticResource SecondaryText}"
+                                                   Margin="0,4,0,0" TextWrapping="Wrap">
+                                            <Run Text="{Binding Summary, Mode=OneWay}" />
+                                            <Run Text="-" />
+                                            <Run Text="{Binding FileCount, Mode=OneWay}" />
+                                            <Run Text="file(s)," />
+                                            <Run Text="{Binding SizeDisplay, Mode=OneWay}" />
+                                        </TextBlock>
+
+                                        <TextBlock Text="{Binding Window}"
+                                                   Style="{StaticResource SecondaryText}"
+                                                   Margin="0,2,0,0" />
+
+                                        <!-- A backup recorded to a URL is not a file on
+                                             that machine, so there is nothing for a copy
+                                             script to pick up. -->
+                                        <TextBlock Style="{StaticResource SecondaryText}"
+                                                   Margin="0,6,0,0" TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource WarningBrush}"
+                                                   Text="Recorded as written to storage rather than to disk, so there is no file here to copy - the listing did not see something that should be in the container. Check its base path."
+                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+
+                                        <WrapPanel Margin="0,8,0,0"
+                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}}">
+                                            <Button Content="Write a copy script"
+                                                    Command="{Binding DataContext.BuildCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Style="{StaticResource SecondaryButton}"
+                                                    Padding="10,4" Margin="0,0,8,0" />
+
+                                            <Button Content="Restore from where they are"
+                                                    Command="{Binding DataContext.RestoreFromWhereTheyAreCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Style="{StaticResource SecondaryButton}"
+                                                    Padding="10,4" Margin="0,0,8,0"
+                                                    ToolTip="Adds these to the timeline and reads them from this path instead of copying them into the container. The target has to be able to reach it - checked before the restore runs." />
+
+                                            <Button Content="Copy to clipboard"
+                                                    Command="{Binding DataContext.CopyCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Style="{StaticResource SecondaryButton}"
+                                                    Padding="10,4"
+                                                    Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}" />
+                                        </WrapPanel>
+
+                                        <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                                                BorderThickness="1" CornerRadius="4"
+                                                Margin="0,8,0,0"
+                                                Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
+                                            <ScrollViewer MaxHeight="200"
+                                                          VerticalScrollBarVisibility="Auto"
+                                                          HorizontalScrollBarVisibility="Auto"
+                                                          Padding="10,8">
+                                                <TextBlock Text="{Binding Script}"
+                                                           FontFamily="{StaticResource ConsoleFont}"
+                                                           FontSize="11"
+                                                           Foreground="{DynamicResource ConsoleTextBrush}" />
+                                            </ScrollViewer>
+                                        </Border>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <TextBlock Text="{Binding Gap.ComparedWhat}"
+                               Style="{StaticResource SecondaryText}"
+                               FontSize="10" TextWrapping="Wrap" Margin="0,4,0,0"
+                               Visibility="{Binding Gap.ComparedWhat, Converter={StaticResource NullToVis}}" />
+                </StackPanel>
+            </Border>
+
                     <!-- Reported, not corrected. A database full of these almost always means the
                          PATH PATTERN is wrong, and fixing each symptom quietly would hide it. -->
                     <ItemsControl ItemsSource="{Binding Inventory.AuditFindings}" Margin="0,10,0,0">
@@ -1581,172 +1753,6 @@
                                        Margin="0,0,0,12"
                                        Visibility="{Binding Options.ContinueAfterError, Converter={StaticResource BoolToVis}}"
                                        Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
-
-                            <!-- What the source instance recorded, against what this container
-                                 holds (#451). Behind the advanced options because it means
-                                 connecting to a SECOND server - the one that took the backups,
-                                 which is routinely not the one being restored to. -->
-                            <Border Style="{StaticResource CardBorder}"
-                                    Margin="0,4,0,16"
-                                    Visibility="{Binding ShowAdvancedOptions, Converter={StaticResource BoolToVis}}">
-                                <StackPanel>
-                                    <TextBlock Text="BACKUPS THIS CONTAINER IS MISSING"
-                                               Style="{StaticResource LabelText}" Margin="0,0,0,6" />
-
-                                    <TextBlock Style="{StaticResource SecondaryText}"
-                                               TextWrapping="Wrap" Margin="0,0,0,10"
-                                               Text="Logs often go somewhere else - a local or cluster disk for throughput, or a share because log shipping already owns them. The container cannot tell you that; the instance that took them can. Ask it, and anything written elsewhere shows up here with the path it went to." />
-
-                                    <Grid Margin="0,0,0,10">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-
-                                        <ComboBox Grid.Column="0"
-                                                  ItemsSource="{Binding Gap.Servers}"
-                                                  SelectedItem="{Binding Gap.SourceServer}"
-                                                  Style="{StaticResource DarkComboBox}"
-                                                  ToolTip="The instance that TOOK these backups - not necessarily the one being restored to.">
-                                            <ComboBox.ItemTemplate>
-                                                <DataTemplate>
-                                                    <TextBlock Text="{Binding DisplayText}" />
-                                                </DataTemplate>
-                                            </ComboBox.ItemTemplate>
-                                        </ComboBox>
-
-                                        <Button Grid.Column="1"
-                                                Content="Check its history"
-                                                Command="{Binding CheckForMissingBackupsCommand}"
-                                                Style="{StaticResource SecondaryButton}"
-                                                Padding="12,6" Margin="8,0,0,0"
-                                                IsEnabled="{Binding Gap.CanCheck}" />
-                                    </Grid>
-
-                                    <TextBlock Text="Reading the instance's own record..."
-                                               Style="{StaticResource SecondaryText}"
-                                               Margin="0,0,0,8"
-                                               Visibility="{Binding Gap.IsChecking, Converter={StaticResource BoolToVis}}" />
-
-                                    <ContentControl Style="{StaticResource ErrorBanner}"
-                                                    DataContext="{Binding Gap}" />
-
-                                    <!-- The all-clear, said out loud. An empty panel is
-                                         indistinguishable from never having pressed the button. -->
-                                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
-                                            Background="{DynamicResource SuccessPanelBackgroundBrush}"
-                                            BorderBrush="{DynamicResource SuccessPanelBorderBrush}"
-                                            BorderThickness="1"
-                                            Visibility="{Binding Gap.FoundNothingMissing, Converter={StaticResource BoolToVis}}">
-                                        <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
-                                                   Text="Everything the instance recorded is in this container. The chain on offer is the whole chain." />
-                                    </Border>
-
-                                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
-                                            Background="{DynamicResource WarningPanelBackgroundBrush}"
-                                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
-                                            BorderThickness="1"
-                                            Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}">
-                                        <StackPanel>
-                                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
-                                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}}">
-                                                <Run Text="This container is" />
-                                                <Run Text="{Binding Gap.BehindBy, Mode=OneWay}" FontWeight="SemiBold" />
-                                                <Run Text="behind what the instance recorded. Restoring from it alone throws that away." />
-                                            </TextBlock>
-
-                                            <!-- A gap and a MEASURED gap are not the same thing: a
-                                                 container holding nothing for this database has
-                                                 everything missing and no interval to quote. -->
-                                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
-                                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
-                                                       Text="The instance recorded backups this container does not hold. Restoring from it alone leaves them out." />
-                                        </StackPanel>
-                                    </Border>
-
-                                    <ItemsControl ItemsSource="{Binding Gap.Locations}">
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <Border Background="{DynamicResource InputBackgroundBrush}"
-                                                        CornerRadius="4" Padding="10,8" Margin="0,0,0,8">
-                                                    <StackPanel>
-                                                        <TextBlock Text="{Binding Folder}"
-                                                                   Style="{StaticResource BodyText}"
-                                                                   FontFamily="{StaticResource ConsoleFont}"
-                                                                   TextWrapping="Wrap" />
-
-                                                        <TextBlock Style="{StaticResource SecondaryText}"
-                                                                   Margin="0,4,0,0" TextWrapping="Wrap">
-                                                            <Run Text="{Binding Summary, Mode=OneWay}" />
-                                                            <Run Text="-" />
-                                                            <Run Text="{Binding FileCount, Mode=OneWay}" />
-                                                            <Run Text="file(s)," />
-                                                            <Run Text="{Binding SizeDisplay, Mode=OneWay}" />
-                                                        </TextBlock>
-
-                                                        <TextBlock Text="{Binding Window}"
-                                                                   Style="{StaticResource SecondaryText}"
-                                                                   Margin="0,2,0,0" />
-
-                                                        <!-- A backup recorded to a URL is not a file on
-                                                             that machine, so there is nothing for a copy
-                                                             script to pick up. -->
-                                                        <TextBlock Style="{StaticResource SecondaryText}"
-                                                                   Margin="0,6,0,0" TextWrapping="Wrap"
-                                                                   Foreground="{DynamicResource WarningBrush}"
-                                                                   Text="Recorded as written to storage rather than to disk, so there is no file here to copy - the listing did not see something that should be in the container. Check its base path."
-                                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
-
-                                                        <WrapPanel Margin="0,8,0,0"
-                                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}}">
-                                                            <Button Content="Write a copy script"
-                                                                    Command="{Binding DataContext.BuildCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                                    CommandParameter="{Binding}"
-                                                                    Style="{StaticResource SecondaryButton}"
-                                                                    Padding="10,4" Margin="0,0,8,0" />
-
-                                                            <Button Content="Restore from where they are"
-                                                                    Command="{Binding DataContext.RestoreFromWhereTheyAreCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                                    CommandParameter="{Binding}"
-                                                                    Style="{StaticResource SecondaryButton}"
-                                                                    Padding="10,4" Margin="0,0,8,0"
-                                                                    ToolTip="Adds these to the timeline and reads them from this path instead of copying them into the container. The target has to be able to reach it - checked before the restore runs." />
-
-                                                            <Button Content="Copy to clipboard"
-                                                                    Command="{Binding DataContext.CopyCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                                    CommandParameter="{Binding}"
-                                                                    Style="{StaticResource SecondaryButton}"
-                                                                    Padding="10,4"
-                                                                    Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}" />
-                                                        </WrapPanel>
-
-                                                        <Border Background="{DynamicResource ConsoleBackgroundBrush}"
-                                                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                                                                BorderThickness="1" CornerRadius="4"
-                                                                Margin="0,8,0,0"
-                                                                Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
-                                                            <ScrollViewer MaxHeight="200"
-                                                                          VerticalScrollBarVisibility="Auto"
-                                                                          HorizontalScrollBarVisibility="Auto"
-                                                                          Padding="10,8">
-                                                                <TextBlock Text="{Binding Script}"
-                                                                           FontFamily="{StaticResource ConsoleFont}"
-                                                                           FontSize="11"
-                                                                           Foreground="{DynamicResource ConsoleTextBrush}" />
-                                                            </ScrollViewer>
-                                                        </Border>
-                                                    </StackPanel>
-                                                </Border>
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-
-                                    <TextBlock Text="{Binding Gap.ComparedWhat}"
-                                               Style="{StaticResource SecondaryText}"
-                                               FontSize="10" TextWrapping="Wrap" Margin="0,4,0,0"
-                                               Visibility="{Binding Gap.ComparedWhat, Converter={StaticResource NullToVis}}" />
-                                </StackPanel>
-                            </Border>
 
                             <CheckBox Content="WITH MOVE (relocate files)"
                                       Visibility="{Binding ShowFileRelocation, Converter={StaticResource BoolToVis}}"


### PR DESCRIPTION
Closes #466 — reported from a demo restore.

## Where it was

**Step 4, Restore options**, below the eight option checkboxes. Step 4 is not offered until a restore point has been **confirmed**, and it starts collapsed.

So a feature whose entire purpose is telling somebody the chain is shorter than they think sat behind a step reached only by confirming a restore point *computed from that same short chain*. They had to already suspect something was wrong to go looking — which is precisely the knowledge the feature exists to supply. Same fault as the bug it fixes.

I flagged this placement in the PR that shipped it and should have acted then rather than noting it and moving on.

## Where it is now

**Step 1, Select source, beside the audit panel.** Reachable the moment a database is picked — no target, no confirmed restore point — and next to the other tool that asks an instance about these same backups, which is the same kind of question.

Step 3 was the intermediate attempt and is also wrong: it shows the chain, but is not offered until a *target* has been chosen, and this question is about the source. **Rendering it there is what showed that** — the panel was present and `Visible` while the step containing it was not, so a naive "is it in the tree" check would have passed.

Also dropped the `ShowAdvancedOptions` gate. It returns `true` for every mode, so it did nothing except imply to anyone reading the markup that this was a Pro-only tool.

## The guard

Two placements have now compiled and hidden it, so this is pinned rather than left to care:

- on screen with only a container chosen — no target, no confirmed point
- on screen in Basic, Standard and Pro
- sharing a container with the audit panel, checked by walking the visual tree rather than trusting a line number

## Still to do

The **Copy Database** surface, which does not have this at all. Tracked on #451.

## Effect

`-c Release -warnaserror` clean, **2,209 passed** (up 5).