### PR TITLE
Copy for a cutover, not just a refresh (#451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,20 @@ more detail on the user-facing changes; this file is the short history.
   has to be able to open that path as its own service account - a different question from whether
   the container is reachable, and one now asked in the preflight, before anything is dropped.
 
+### Added
+
+- **Copy a database for a cutover, not just a refresh** (#451). A copy brought the target online,
+  which is right for refreshing a test environment and wrong for a migration: online means no
+  more logs can be applied, so the copy is frozen at the moment it was taken. Tick "Leave the
+  target ready for more log backups" and it stays in RESTORING - the full is restored in advance,
+  and the switch-over costs only the logs that accumulated since. The screen then asks the source
+  which logs it has taken since that full, says where they live, and writes the statements to
+  apply them, oldest first, recovering only at the end. Offered only when the target has been left
+  restorable, because against a database already online those statements fail with 3101. It is not
+  the Restore screen's check ported across: this screen reads no container chain at all - it
+  writes its own full - so "what is this container missing" means nothing here, and the question
+  that does mean something is which of the source's logs would carry the copy forward.
+
 ### Fixed
 
 - **The Copy screen says why it will not generate, and stops losing the database you chose**

--- a/src/NineLives.Core/Services/BackupGapAnalyser.cs
+++ b/src/NineLives.Core/Services/BackupGapAnalyser.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -135,6 +135,38 @@ public static class BackupGapAnalyser
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// The source's log backups taken after a given moment, grouped by where they live (#451).
+    ///
+    /// The Copy screen's question, which is not the Restore screen's. A copy writes its own full and
+    /// reads no existing chain, so "what is this container missing" means nothing there. What does
+    /// mean something is the cutover: the copy restores a full taken at T, and the logs the source
+    /// has taken SINCE T are what would roll the target forward to now. The long part happens in
+    /// advance and the downtime is only the tail.
+    ///
+    /// Strictly after, and by the log's own start: a log backup that began before the full was
+    /// taken is already inside it.
+    /// </summary>
+    public static IReadOnlyList<MissingLocation> LogsTakenAfter(
+        IReadOnlyList<BackupHistoryEntry> history,
+        string database,
+        DateTime after)
+    {
+        var logs = history
+            .Where(h => string.Equals(h.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Where(h => h.Type == BackupType.TransactionLog)
+            .Where(h => h.HasFiles)
+            .Where(h => h.StartedAt > after)
+            .ToList();
+
+        return logs
+            .Select(h => new MissingBackup(h, FolderOf(h.Files[0])))
+            .GroupBy(m => m.Folder, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new MissingLocation(g.Key, g.OrderBy(m => m.TakenAt).ToList()))
+            .OrderBy(l => l.Earliest)
+            .ToList();
     }
 
     /// <summary>

--- a/src/NineLives.Core/Services/LogRollForwardScript.cs
+++ b/src/NineLives.Core/Services/LogRollForwardScript.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Rolls a database that is already sitting in RESTORING forward with more log backups (#451).
+///
+/// The cutover shape. A copy takes a full now and restores it; if it is left in NORECOVERY the
+/// target stays restorable, and the source's later log backups can be applied at the moment of
+/// switching over. The long part - the full - happens in advance, and the downtime is only the
+/// logs that accumulated since.
+///
+/// Separate from <see cref="RestoreScriptGenerator"/> rather than a mode of it, because that one
+/// always begins with a full: it describes restoring a chain from nothing. This describes adding
+/// to a restore already under way, which is a different statement sequence with a different
+/// precondition - the database must already be in RESTORING, and if it is not, every statement
+/// here fails with 3101 rather than doing something unintended.
+/// </summary>
+public static class LogRollForwardScript
+{
+    /// <summary>
+    /// The logs in the order they must be applied, against a database left in NORECOVERY.
+    ///
+    /// <paramref name="bringOnline"/> decides whether the last statement recovers. Left false, the
+    /// target stays restorable and another batch can follow - which is what a rehearsal of the
+    /// cutover wants, and what somebody applying logs hourly until the switch wants too.
+    /// </summary>
+    public static string Build(
+        string targetDatabase,
+        IReadOnlyList<BackupHistoryEntry> logs,
+        bool bringOnline = true)
+    {
+        var ordered = logs
+            .Where(l => l.Type == BackupType.TransactionLog && l.HasFiles)
+            .OrderBy(l => l.StartedAt)
+            .ToList();
+
+        var sb = new StringBuilder();
+        var db = TSql.QuoteName(targetDatabase);
+
+        sb.AppendLine("-- ============================================================");
+        sb.AppendLine("-- Nine Lives - roll the copy forward");
+        sb.AppendLine($"-- Target: {TSql.CommentText(targetDatabase)}");
+        sb.AppendLine($"-- {ordered.Count} log backup(s)");
+        if (ordered.Count > 0)
+            sb.AppendLine($"-- Covering {ordered[0].StartedAt:yyyy-MM-dd HH:mm} to {ordered[^1].StartedAt:yyyy-MM-dd HH:mm}");
+        sb.AppendLine("-- ============================================================");
+        sb.AppendLine();
+
+        if (ordered.Count == 0)
+        {
+            sb.AppendLine("-- No log backups to apply. The source has taken none since the copy,");
+            sb.AppendLine("-- so there is nothing between the copy and now to roll forward.");
+            return sb.ToString();
+        }
+
+        // Said, not assumed. Run against a database that is already online, every statement below
+        // fails with 3101 - which is safe but reads as a broken script rather than a precondition
+        // nobody met.
+        sb.AppendLine($"-- {targetDatabase} must still be in RESTORING for these to apply. If the copy");
+        sb.AppendLine("-- brought it online, it cannot take more logs and has to be redone with");
+        sb.AppendLine("-- \"Leave the target ready for more log backups\" ticked.");
+        sb.AppendLine();
+
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            var log = ordered[i];
+            var isLast = i == ordered.Count - 1;
+            var recovery = isLast && bringOnline ? "RECOVERY" : "NORECOVERY";
+
+            sb.AppendLine($"-- {log.StartedAt:yyyy-MM-dd HH:mm:ss}");
+            sb.AppendLine($"RESTORE LOG {db}");
+
+            // Every file of the set, in stripe order, in ONE statement - a striped log is one media
+            // set and naming half of it fails with 3132.
+            for (int f = 0; f < log.Files.Count; f++)
+            {
+                var prefix = f == 0 ? "    FROM" : "        ";
+                var suffix = f < log.Files.Count - 1 ? "," : "";
+                sb.AppendLine($"{prefix} {BackupDevice.Clause(log.Files[f])}{suffix}");
+            }
+
+            sb.AppendLine("    WITH");
+            sb.AppendLine($"         {recovery},");
+            sb.AppendLine("         STATS = 10;");
+            sb.AppendLine("GO");
+            sb.AppendLine();
+        }
+
+        if (!bringOnline)
+        {
+            sb.AppendLine("-- Still in RESTORING, ready for the next batch. To finish:");
+            sb.AppendLine($"-- RESTORE DATABASE {db} WITH RECOVERY;");
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/NineLives.Tests/CutoverRollForwardTests.cs
+++ b/src/NineLives.Tests/CutoverRollForwardTests.cs
@@ -1,0 +1,260 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Copying for a cutover rather than a refresh (#451).
+///
+/// A copy normally brings the target online, which is right for a test refresh and wrong for a
+/// migration: online means no more logs can be applied, so the copy is frozen at the moment it was
+/// taken. Left in RESTORING, the long part - the full - happens in advance, and the switch-over
+/// costs only the logs that accumulated since.
+///
+/// The gap check could not simply be ported from the Restore screen: this screen reads no container
+/// chain at all, it writes its own full, so "what is this container missing" means nothing here.
+/// The question that does mean something is which of the SOURCE's logs would carry that full
+/// forward.
+/// </summary>
+public class CutoverRollForwardTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 17, 14, 0, 0);
+
+    private static BackupHistoryEntry Log(DateTime at, string folder = @"E:\SQLLogs", int stripes = 1)
+    {
+        var files = Enumerable.Range(1, stripes)
+            .Select(n => stripes == 1
+                ? $@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn"
+                : $@"{folder}\Sales_{at:yyyyMMdd_HHmmss}_{n}.trn")
+            .ToList();
+
+        return new BackupHistoryEntry
+        {
+            DatabaseName = "Sales",
+            Type = BackupType.TransactionLog,
+            StartedAt = at,
+            Files = files,
+            BackupSizeBytes = 1024
+        };
+    }
+
+    // ── which logs are the right ones ───────────────────────────────────────────
+
+    /// <summary>
+    /// Strictly after the full, by the log's own start. A log that began before the full was taken
+    /// is already inside it, and applying it would be applying something twice.
+    /// </summary>
+    [Fact]
+    public void OnlyLogsTakenAfterTheCopyCount()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Log(T0.AddHours(-1)),   // before the full
+            Log(T0),                // exactly at it
+            Log(T0.AddHours(1)),
+            Log(T0.AddHours(2))
+        };
+
+        var locations = BackupGapAnalyser.LogsTakenAfter(history, "Sales", T0);
+
+        var only = Assert.Single(locations);
+        Assert.Equal(2, only.Backups.Count);
+        Assert.Equal(T0.AddHours(1), only.Earliest);
+    }
+
+    [Fact]
+    public void FullsAndDifferentialsAreNotLogsToRollForwardWith()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            new()
+            {
+                DatabaseName = "Sales", Type = BackupType.Full, StartedAt = T0.AddHours(1),
+                Files = [@"E:\Backups\Sales.bak"]
+            },
+            Log(T0.AddHours(2))
+        };
+
+        var only = Assert.Single(BackupGapAnalyser.LogsTakenAfter(history, "Sales", T0));
+        Assert.Single(only.Backups);
+    }
+
+    [Fact]
+    public void ASourceThatHasTakenNoLogsSinceReportsNothing()
+        => Assert.Empty(BackupGapAnalyser.LogsTakenAfter([Log(T0.AddHours(-2))], "Sales", T0));
+
+    // ── the script ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Applied oldest first, and only the last statement recovers - a log applied out of order
+    /// fails with 4305, and recovering early ends the sequence with logs still to go.
+    /// </summary>
+    [Fact]
+    public void TheLogsAreAppliedInOrderAndOnlyTheLastRecovers()
+    {
+        var sql = LogRollForwardScript.Build("Sales_Migrated",
+            [Log(T0.AddHours(3)), Log(T0.AddHours(1)), Log(T0.AddHours(2))]);
+
+        var first = sql.IndexOf("Sales_20260817_150000.trn", StringComparison.Ordinal);
+        var second = sql.IndexOf("Sales_20260817_160000.trn", StringComparison.Ordinal);
+        var third = sql.IndexOf("Sales_20260817_170000.trn", StringComparison.Ordinal);
+
+        Assert.True(first < second && second < third, "The logs are out of order.");
+
+        Assert.Equal(2, CountOf(sql, "NORECOVERY,"));
+        Assert.Equal(1, CountOf(sql, "RECOVERY,") - CountOf(sql, "NORECOVERY,"));
+    }
+
+    /// <summary>
+    /// Left restorable, for somebody applying logs repeatedly up to the switch rather than
+    /// finishing in one go.
+    /// </summary>
+    [Fact]
+    public void ItCanLeaveTheTargetReadyForAnotherBatch()
+    {
+        var sql = LogRollForwardScript.Build(
+            "Sales_Migrated", [Log(T0.AddHours(1))], bringOnline: false);
+
+        Assert.Contains("NORECOVERY,", sql);
+        Assert.Contains("WITH RECOVERY;", sql);          // the how-to-finish line
+        Assert.Contains("ready for the next batch", sql);
+    }
+
+    /// <summary>
+    /// The precondition said rather than assumed. Run against a database already online, every
+    /// statement fails with 3101 - safe, but it reads as a broken script rather than as something
+    /// nobody met the condition for.
+    /// </summary>
+    [Fact]
+    public void ItStatesThatTheTargetMustStillBeRestoring()
+    {
+        var sql = LogRollForwardScript.Build("Sales_Migrated", [Log(T0.AddHours(1))]);
+
+        Assert.Contains("must still be in RESTORING", sql);
+        Assert.Contains("Leave the target ready for more log backups", sql);
+    }
+
+    /// <summary>A striped log is one media set - naming half of it fails with 3132.</summary>
+    [Fact]
+    public void AStripedLogIsOneStatementNamingEveryFile()
+    {
+        var sql = LogRollForwardScript.Build(
+            "Sales_Migrated", [Log(T0.AddHours(1), stripes: 3)]);
+
+        Assert.Equal(1, CountOf(sql, "RESTORE LOG"));
+        Assert.Equal(3, CountOf(sql, "DISK = N'"));
+    }
+
+    [Fact]
+    public void NoLogsAtAllSaysSoRatherThanEmittingNothing()
+    {
+        var sql = LogRollForwardScript.Build("Sales_Migrated", []);
+
+        Assert.Contains("No log backups to apply", sql);
+        Assert.DoesNotContain("RESTORE LOG", sql);
+    }
+
+    /// <summary>The target name is an identifier, and one holding a bracket must not break out.</summary>
+    [Fact]
+    public void TheTargetNameIsQuotedAsAnIdentifier()
+    {
+        var sql = LogRollForwardScript.Build("odd]name", [Log(T0.AddHours(1))]);
+        Assert.Contains("[odd]]name]", sql);
+    }
+
+    // ── the screen ──────────────────────────────────────────────────────────────
+
+    private static (CopyDatabaseViewModel vm, FakeSqlServerService sql) Ready()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1", Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["Sales"] };
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp(),
+            history: new FakeOperationHistoryStore());
+
+        vm.Refresh();
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        vm.LoadSourceDatabasesCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        vm.SourceDatabase = "Sales";
+        vm.Container = vm.Containers[0];
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "Sales_Migrated";
+        return (vm, sql);
+    }
+
+    [Fact]
+    public void ARefreshBringsTheTargetOnlineAndACutoverDoesNot()
+    {
+        var (vm, _) = Ready();
+
+        vm.LeaveRestoringForMoreLogs = false;
+        vm.GenerateCommand.Execute(null);
+        Assert.Contains("RECOVERY,", vm.RestoreScript);
+        Assert.DoesNotContain("NORECOVERY,", vm.RestoreScript);
+
+        vm.LeaveRestoringForMoreLogs = true;
+        vm.GenerateCommand.Execute(null);
+        Assert.Contains("NORECOVERY,", vm.RestoreScript);
+    }
+
+    /// <summary>
+    /// End to end on the screen: ask the source, then write the script for what came back.
+    /// </summary>
+    [Fact]
+    public async Task TheScreenFindsTheLogsAndWritesTheScriptForThem()
+    {
+        var (vm, sql) = Ready();
+
+        vm.LeaveRestoringForMoreLogs = true;
+        vm.GenerateCommand.Execute(null);
+
+        // Taken after the copy, so they count; the fake's clock is this machine's.
+        sql.BackupHistory.Add(Log(DateTime.Now.AddMinutes(5)));
+        sql.BackupHistory.Add(Log(DateTime.Now.AddMinutes(65)));
+
+        await vm.CheckSourceLogsCommand.ExecuteAsync(null);
+        Assert.True(vm.Gap.HasGap);
+
+        vm.BuildRollForwardCommand.Execute(null);
+
+        Assert.True(vm.HasRollForwardScript);
+        Assert.Contains("RESTORE LOG [Sales_Migrated]", vm.RollForwardScript);
+        Assert.Contains(@"E:\SQLLogs", vm.RollForwardScript);
+    }
+
+    /// <summary>
+    /// Asked before the scripts exist there is no "since when", and inventing one would report the
+    /// wrong logs - which on a cutover means a target that is short of where somebody thinks it is.
+    /// </summary>
+    [Fact]
+    public async Task AskingBeforeGeneratingSaysWhyRatherThanGuessing()
+    {
+        var (vm, _) = Ready();
+        vm.LeaveRestoringForMoreLogs = true;
+
+        await vm.CheckSourceLogsCommand.ExecuteAsync(null);
+
+        Assert.Contains("Generate the scripts first", vm.StatusMessage);
+        Assert.False(vm.Gap.HasChecked);
+    }
+
+    private static int CountOf(string haystack, string needle)
+    {
+        int count = 0, at = 0;
+        while ((at = haystack.IndexOf(needle, at, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            at += needle.Length;
+        }
+        return count;
+    }
+}

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -170,6 +170,56 @@ public partial class BackupGapViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// The source's logs taken after a moment, rather than what a container is missing (#451).
+    ///
+    /// The Copy screen's question. It reads no container chain - it writes its own full - so the
+    /// useful thing is which of the source's logs would carry that full forward to now.
+    /// </summary>
+    public async Task CheckLogsAfterAsync(string database, DateTime after)
+    {
+        if (SourceServer is not { } server) return;
+
+        IsChecking = true;
+        ClearStatus();
+        Clear();
+
+        var ct = _cancellation.Begin();
+
+        try
+        {
+            var history = await _sql.ReadBackupHistoryAsync(server, database, ct);
+            var locations = BackupGapAnalyser.LogsTakenAfter(history, database, after);
+
+            foreach (var location in locations) Locations.Add(new MissingLocationRow(location));
+
+            ComparedWhat =
+                $"{database} on {server.ServerName}: log backups taken after " +
+                $"{after:yyyy-MM-dd HH:mm}.";
+
+            HasChecked = true;
+
+            var files = Locations.Sum(l => l.FileCount);
+            SetStatus(Locations.Count == 0
+                ? "The source has taken no log backups since the copy - there is nothing to roll forward."
+                : $"{files} log backup file(s) could roll this copy forward.");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Check cancelled.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not read {server.ServerName}'s backup history: {ex.Message}");
+        }
+        finally
+        {
+            IsChecking = false;
+            _cancellation.End();
+            RaiseDerived();
+        }
+    }
+
     [RelayCommand]
     private void Cancel() => _cancellation.Cancel();
 

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -48,6 +48,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         _sql = sql;
         _log = log ?? App.Log;
         _history = history ?? new OperationHistoryStore();
+        Gap = new BackupGapViewModel(sql);
 
         Refresh();
     }
@@ -144,12 +145,62 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             if (previousSource != null) SourceServer = Servers.FirstOrDefault(s => s.Id == previousSource);
             if (previousTarget != null) TargetServer = Servers.FirstOrDefault(s => s.Id == previousTarget);
             if (previousContainer != null) Container = Containers.FirstOrDefault(c => c.Id == previousContainer);
+
+            // The log check offers the same saved list.
+            Gap.Servers.Clear();
+            foreach (var server in config.Servers) Gap.Servers.Add(server);
         }
         catch
         {
             Servers = [];
             Containers = [];
         }
+    }
+
+    /// <summary>
+    /// Asks the source what logs it has taken since this copy's full, and where they went (#451).
+    ///
+    /// Not the Restore screen's question. That one asks what a container is MISSING; this screen
+    /// reads no container chain at all - it writes its own full - so the useful question is which
+    /// of the source's logs would carry that full forward to now.
+    ///
+    /// Only worth asking once the scripts exist, because "since when" is the copy's own timestamp.
+    /// </summary>
+    [RelayCommand]
+    private async Task CheckSourceLogsAsync()
+    {
+        if (SourceServer == null || string.IsNullOrWhiteSpace(SourceDatabase)) return;
+        if (_copyTakenAt is not { } takenAt)
+        {
+            SetStatus("Generate the scripts first - the logs to apply are the ones taken since.");
+            return;
+        }
+
+        Gap.SourceServer = SourceServer;
+        await Gap.CheckLogsAfterAsync(SourceDatabase!, takenAt);
+    }
+
+    /// <summary>
+    /// Writes the statements that apply those logs to the copy.
+    ///
+    /// Brought online at the end, because somebody pressing this is doing the cutover. Applying
+    /// logs repeatedly up to the switch is the other shape, and the script says how.
+    /// </summary>
+    [RelayCommand]
+    private void BuildRollForward()
+    {
+        var logs = Gap.Locations
+            .SelectMany(l => l.Location.Backups.Select(b => b.Entry))
+            .ToList();
+
+        RollForwardScript = LogRollForwardScript.Build(TargetDatabaseName, logs);
+    }
+
+    [RelayCommand]
+    private void CopyRollForward()
+    {
+        if (!HasRollForwardScript) return;
+        TryCopyToClipboard(RollForwardScript, "Roll-forward script copied to clipboard.");
     }
 
     /// <summary>The list is not fetchable mid-run: it can wait; the copy cannot re-run (#281).</summary>
@@ -484,10 +535,17 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             {
                 TargetDatabaseName = TargetDatabaseName,
                 WithReplace = WithReplace,
-                RecoveryMode = RecoveryMode.Recovery
+                // Left restoring for a cutover, online for a refresh (#451).
+                RecoveryMode = LeaveRestoringForMoreLogs
+                    ? RecoveryMode.NoRecovery
+                    : RecoveryMode.Recovery
             });
 
-        SetStatus("Scripts generated.");
+        _copyTakenAt = takenAt;
+
+        SetStatus(LeaveRestoringForMoreLogs
+            ? "Scripts generated. The target will be left in RESTORING, ready for more logs."
+            : "Scripts generated.");
 
         // The checks depend on the SERVERS and the SOURCE database - not on the target
         // name or any other keystroke-speed field. Re-asking two production instances six
@@ -550,6 +608,45 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     private string _sharedFolderRefusal = string.Empty;
 
     partial void OnSharedFolderRefusalChanged(string value) => Invalidate();
+
+    /// <summary>
+    /// Leave the target in RESTORING so more log backups can be applied to it (#451).
+    ///
+    /// The cutover. A copy normally brings the target online, which is right for a test refresh and
+    /// wrong for a migration: online means no more logs can be applied, so the copy is frozen at
+    /// the moment it was taken. Left restoring, the long part - the full - happens in advance, and
+    /// the switch-over costs only the logs that accumulated since.
+    ///
+    /// Off by default, because a database left in RESTORING is not usable and somebody refreshing a
+    /// test environment wants the opposite. The screen says which it will be.
+    /// </summary>
+    [ObservableProperty]
+    private bool _leaveRestoringForMoreLogs;
+
+    partial void OnLeaveRestoringForMoreLogsChanged(bool value)
+    {
+        Invalidate();
+        RollForwardScript = string.Empty;
+        if (HasScripts) Generate();
+    }
+
+    /// <summary>The logs on the source that would roll this copy forward, and where they live.</summary>
+    public BackupGapViewModel Gap { get; }
+
+    /// <summary>
+    /// The statements that apply those logs, or empty. Built on demand: most copies are refreshes
+    /// and nobody wants this.
+    /// </summary>
+    [ObservableProperty]
+    private string _rollForwardScript = string.Empty;
+
+    public bool HasRollForwardScript => RollForwardScript.Length > 0;
+
+    partial void OnRollForwardScriptChanged(string value)
+        => OnPropertyChanged(nameof(HasRollForwardScript));
+
+    /// <summary>When the copy's own full was taken - what the logs have to come after.</summary>
+    private DateTime? _copyTakenAt;
 
     /// <summary>
     /// The three generation-time checks as one serialised sweep (#285): warnings cleared once

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -264,6 +264,21 @@
                         </StackPanel>
                     </Grid>
 
+                    <!-- The cutover (#451). Online is right for a test refresh and wrong for a
+                         migration: online means no more logs can be applied, so the copy is
+                         frozen at the moment it was taken. -->
+                    <CheckBox Content="Leave the target ready for more log backups (NORECOVERY)"
+                              IsChecked="{Binding LeaveRestoringForMoreLogs}"
+                              Style="{StaticResource DarkCheckBox}"
+                              Margin="0,0,0,4"
+                              ToolTip="For a migration: the full is restored now and the target stays in RESTORING, so the source's later logs can be applied at the moment you switch over. The database is NOT usable until they are." />
+
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               FontSize="11" TextWrapping="Wrap" Margin="0,0,0,12"
+                               Foreground="{DynamicResource WarningBrush}"
+                               Visibility="{Binding LeaveRestoringForMoreLogs, Converter={StaticResource BoolToVis}}"
+                               Text="The target will be left in RESTORING and will not be usable until logs are applied and it is brought online. For a test refresh, leave this unticked." />
+
                     <CheckBox Content="Overwrite it if it already exists (WITH REPLACE)"
                               IsChecked="{Binding WithReplace}"
                               Style="{StaticResource DarkCheckBox}"
@@ -415,6 +430,86 @@
                                                     Foreground="{DynamicResource ConsoleTextBrush}" />
                             </StackPanel>
                         </ScrollViewer>
+                    </Border>
+
+                    <!-- Rolling the copy forward (#451). Only when the target has been left
+                         restorable - on a copy brought online these logs cannot be applied at all,
+                         and offering them would be offering something that fails with 3101. -->
+                    <Border Style="{StaticResource CardBorder}" Margin="0,12,0,0"
+                            Visibility="{Binding LeaveRestoringForMoreLogs, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <TextBlock Text="ROLL THIS COPY FORWARD" Style="{StaticResource LabelText}"
+                                       Margin="0,0,0,6" />
+
+                            <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
+                                       Margin="0,0,0,10"
+                                       Text="The copy restores a full taken now. The log backups the source takes after it are what carry the target up to the moment you switch over - so the long part happens in advance and the downtime is only the tail. Ask the source what it has taken since." />
+
+                            <WrapPanel>
+                                <Button Content="What has the source taken since?"
+                                        Command="{Binding CheckSourceLogsCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="12,6" Margin="0,0,8,8" />
+
+                                <Button Content="Write the roll-forward script"
+                                        Command="{Binding BuildRollForwardCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="12,6" Margin="0,0,8,8"
+                                        Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}" />
+
+                                <Button Content="Copy to clipboard"
+                                        Command="{Binding CopyRollForwardCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="12,6" Margin="0,0,8,8"
+                                        Visibility="{Binding HasRollForwardScript, Converter={StaticResource BoolToVis}}" />
+                            </WrapPanel>
+
+                            <ContentControl Style="{StaticResource ErrorBanner}" DataContext="{Binding Gap}" />
+
+                            <TextBlock Text="{Binding Gap.StatusMessage}"
+                                       Style="{StaticResource SecondaryText}"
+                                       TextWrapping="Wrap" Margin="0,0,0,8"
+                                       Visibility="{Binding Gap.StatusMessage, Converter={StaticResource NullToVis}}" />
+
+                            <ItemsControl ItemsSource="{Binding Gap.Locations}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="{DynamicResource InputBackgroundBrush}"
+                                                CornerRadius="4" Padding="10,8" Margin="0,0,0,8">
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Folder}"
+                                                           Style="{StaticResource BodyText}"
+                                                           FontFamily="{StaticResource ConsoleFont}"
+                                                           TextWrapping="Wrap" />
+                                                <TextBlock Style="{StaticResource SecondaryText}"
+                                                           Margin="0,4,0,0" TextWrapping="Wrap">
+                                                    <Run Text="{Binding Summary, Mode=OneWay}" />
+                                                    <Run Text="-" />
+                                                    <Run Text="{Binding SizeDisplay, Mode=OneWay}" />
+                                                </TextBlock>
+                                                <TextBlock Text="{Binding Window}"
+                                                           Style="{StaticResource SecondaryText}"
+                                                           Margin="0,2,0,0" />
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                                    BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                                    BorderThickness="1" CornerRadius="4" Margin="0,8,0,0"
+                                    Visibility="{Binding HasRollForwardScript, Converter={StaticResource BoolToVis}}">
+                                <ScrollViewer MaxHeight="240" VerticalScrollBarVisibility="Auto"
+                                              HorizontalScrollBarVisibility="Auto" Padding="10,8">
+                                    <views:SqlTextBlock Sql="{Binding RollForwardScript}"
+                                                        FontFamily="{StaticResource ConsoleFont}"
+                                                        FontSize="12"
+                                                        TextWrapping="NoWrap"
+                                                        Foreground="{DynamicResource ConsoleTextBrush}" />
+                                </ScrollViewer>
+                            </Border>
+                        </StackPanel>
                     </Border>
 
                     <!-- What state the two servers were left in, in terms of what to do next. -->


### PR DESCRIPTION
The Copy screen's half of #451 — and deliberately **not** the Restore screen's check ported across, because that would have been meaningless here.

## Why a straight port was wrong

This screen reads no container chain at all. It writes its own full and restores that, so *"what is this container missing"* has no referent.

Worse, it restored with `RecoveryMode.Recovery` unconditionally — the target comes **online**, which means no log can ever be applied to it. A panel offering logs to apply would have been offering statements that fail with 3101.

## The question that does mean something

A copy restores a full taken *now*. The logs the source takes **after** it are what carry the target up to the moment of switching over. That is a migration cutover: the long part happens in advance and the downtime is only the tail.

It needed three things this screen did not have.

**An option to leave the target restorable.** Off by default — a database in RESTORING is not usable, and somebody refreshing a test environment wants the opposite. The screen says which it will be, in amber, because that is a surprise worth having in advance.

**A way to ask the source what it has taken since.** `BackupGapAnalyser.LogsTakenAfter` — strictly after, by the log's own start, because a log that began before the full is already inside it and applying it would apply something twice.

**The statements themselves.** `LogRollForwardScript` is separate from `RestoreScriptGenerator` rather than a mode of it: that one always begins with a full, because it describes restoring a chain from nothing. This describes *adding to a restore already under way*, which has a precondition — the database must still be in RESTORING — and the script states it rather than letting somebody discover it as a broken-looking script.

Oldest first, `NORECOVERY` on all but the last, and an option to leave it restorable for another batch — which is what applying logs hourly up to the switch actually looks like.

## Rendered

Confirmed the whole path on screen, and it confirmed the boundary condition while it was at it: **six logs staged, five offered**, because one was taken a minute before the copy's own full.

## Effect

`-c Release -warnaserror` clean, **2,216 passed** (up 12).