### PR TITLE
Filing a run cannot fail the run (#471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A completed restore can no longer surface as a crash** (#471). Reading the console to file a
+  run's receipt was not thread-safe: the line collection could be enumerated while another thread
+  was still appending to it, handing back a null and throwing. That happened inside the run's own
+  finally block, unguarded, so it came out of the restore itself - the database restored, the
+  target online, and an exception on screen. The console now snapshots before reading and tolerates
+  a torn one, and filing a receipt can no longer fail the thing it is filing: it says so on the
+  console instead. Found as a red build rather than by looking for it.
+
+
 - **The gap check can be found** (#466). It shipped in 1.7.0 inside the restore options, which
   meant behind a step you only reach after *confirming* a restore point - and which starts
   collapsed. A feature whose whole purpose is telling you the chain is shorter than you think

--- a/src/NineLives.Tests/RecordingCannotFailTheRunTests.cs
+++ b/src/NineLives.Tests/RecordingCannotFailTheRunTests.cs
@@ -1,0 +1,133 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Filing a run cannot fail the run (#469).
+///
+/// Found as a red build on main, not by looking: a NullReferenceException out of
+/// <c>ConsoleBuffer.Text</c>, thrown while assembling the receipt in the run's own finally block,
+/// and propagating all the way out of RunAsync. In a test that reads as a failure. In the app it
+/// would have read as a completed restore surfacing a crash - the database restored, and an
+/// exception on screen.
+///
+/// Two faults, and both are worth having separately. The console could hand back a torn read;
+/// and nothing was catching it if it did. The store already promises never to fail what it
+/// records, but that promise lives inside Append - everything before it, reading the console and
+/// building the entry, was unguarded.
+/// </summary>
+public class RecordingCannotFailTheRunTests
+{
+    // ── the console survives being read from another thread ─────────────────────
+
+    /// <summary>
+    /// ObservableCollection is not thread-safe: enumerated mid-write it can hand back a null slot
+    /// from the array it is growing. Reproduced by hammering it, which is the only honest way to
+    /// test a race - and it fails reliably on the old implementation.
+    /// </summary>
+    [Fact]
+    public async Task ReadingTheTextWhileItIsBeingWrittenDoesNotThrow()
+    {
+        var console = new ConsoleBuffer(null, dispatcher: null);
+        using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        var writer = Task.Run(() =>
+        {
+            int n = 0;
+            while (!stop.IsCancellationRequested)
+                console.Append($"line {n++} of the restore output");
+        });
+
+        var reader = Task.Run(() =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                // The assertion IS that this does not throw.
+                _ = console.Text;
+            }
+        });
+
+        await Task.WhenAll(writer, reader);
+    }
+
+    [Fact]
+    public void TheTextIsStillTheTextWhenNothingIsRacing()
+    {
+        var console = new ConsoleBuffer(null, dispatcher: null);
+        console.Append("first");
+        console.Append("second");
+        console.Flush();
+
+        var text = console.Text;
+
+        Assert.Contains("first", text);
+        Assert.Contains("second", text);
+    }
+
+    // ── and a failure to record does not fail the restore ───────────────────────
+
+    private static (RestoreExecutionViewModel vm, FakeOperationHistoryStore history) Execution(
+        Exception? appendThrows)
+    {
+        var history = new FakeOperationHistoryStore { AppendThrows = appendThrows };
+        var vm = new RestoreExecutionViewModel(
+            new FakeSqlServerService(), history, TestLogs.Temp(), new OperationCancellation());
+        return (vm, history);
+    }
+
+    private static Task<CredentialPreflight> Proceed(Action<string> _)
+        => Task.FromResult(CredentialPreflight.Proceed);
+
+    private static RestoreRun Run() => new(
+        new ServerConnection { Id = "s1", Name = "SRV01", ServerName = "SRV01" },
+        "RESTORE DATABASE [MyDb_Restored] FROM URL = 'https://acct/backups/full.bak'",
+        "MyDb_Restored",
+        "MyDb",
+        "backups",
+        "Full",
+        new DateTime(2026, 8, 17, 22, 0, 0),
+        "WITH REPLACE=True, recovery=Recovery, stopAt=none");
+
+    /// <summary>
+    /// The restore has already happened by the time the receipt is written. Nothing that goes
+    /// wrong while filing it may change that - and before this, an exception here came out of
+    /// RunAsync and turned a completed restore into a crash.
+    /// </summary>
+    [Fact]
+    public async Task AStoreThatThrowsDoesNotFailTheRestore()
+    {
+        var (vm, _) = Execution(new InvalidOperationException("history file is read-only"));
+
+        await vm.RunAsync(Run(), Proceed);
+
+        Assert.True(vm.ExecutionComplete);
+        Assert.True(vm.ExecutionSuccess);
+    }
+
+    /// <summary>Said out loud, though. A receipt that silently did not happen is worse.</summary>
+    [Fact]
+    public async Task AndItSaysTheRecordingFailed()
+    {
+        var (vm, _) = Execution(new InvalidOperationException("history file is read-only"));
+
+        await vm.RunAsync(Run(), Proceed);
+        vm.Console.Flush();
+
+        Assert.Contains("Recording it in History failed", vm.Console.Text);
+        Assert.Contains("read-only", vm.Console.Text);
+    }
+
+    [Fact]
+    public async Task AndAWorkingStoreStillGetsItsReceipt()
+    {
+        var (vm, history) = Execution(null);
+
+        await vm.RunAsync(Run(), Proceed);
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(OperationOutcome.Succeeded, entry.Outcome);
+    }
+}

--- a/src/NineLives/ViewModels/ConsoleBuffer.cs
+++ b/src/NineLives/ViewModels/ConsoleBuffer.cs
@@ -75,8 +75,43 @@ public partial class ConsoleBuffer : ObservableObject
     [ObservableProperty]
     private bool _hasOutput;
 
-    /// <summary>The console as plain text, for copying into a bug report.</summary>
-    public string Text => string.Join(Environment.NewLine, Lines.Select(l => l.Text));
+    /// <summary>
+    /// The console as plain text, for copying into a bug report or filing in a receipt.
+    ///
+    /// Defensive about what it enumerates, because it is read from a thread that does not own this
+    /// collection. Writes are marshalled to the dispatcher - which makes the app itself safe, since
+    /// the receipt is written there too - but the run's finally is not guaranteed to be on it once
+    /// anything in the chain has awaited, and a test has no dispatcher at all. ObservableCollection
+    /// is not thread-safe: enumerating one mid-write can hand back a null slot from the array it is
+    /// growing, and this threw a NullReferenceException on CI doing exactly that.
+    ///
+    /// Snapshotted first so the join cannot fail halfway with the collection changing underneath
+    /// it, and null-tolerant because a torn read is the thing being defended against - dropping a
+    /// line that has not landed yet is the right answer, and throwing is not.
+    /// </summary>
+    public string Text
+    {
+        get
+        {
+            ConsoleLine[] snapshot;
+            try
+            {
+                snapshot = Lines.ToArray();
+            }
+            catch (ArgumentException)
+            {
+                // "Destination array was not long enough" - the collection grew during the copy.
+                // One retry, then give back what is stable rather than failing a caller whose real
+                // job is finishing a restore.
+                try { snapshot = Lines.ToArray(); }
+                catch (ArgumentException) { return string.Empty; }
+            }
+
+            return string.Join(
+                Environment.NewLine,
+                snapshot.Where(l => l != null).Select(l => l.Text));
+        }
+    }
 
     /// <summary>
     /// Adds a message, splitting it into lines and collapsing runs of blanks.

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -395,7 +395,24 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             // mid-finally, which is a worse trade than a receipt missing "100 percent processed" -
             // every line that carries meaning is already in it, because those are appended
             // directly rather than through the progress channel.
-            if (attempted) await RecordHistory(run, startedAt, outcome, failure);
+            if (attempted)
+            {
+                try
+                {
+                    await RecordHistory(run, startedAt, outcome, failure);
+                }
+                catch (Exception ex)
+                {
+                    // The store already promises never to fail the thing it records - but that
+                    // promise lives inside Append, and everything BEFORE it was unguarded: reading
+                    // the console, assembling the entry. A NullReferenceException from a torn read
+                    // of the console came out of here on CI, and in the app it would have surfaced
+                    // a completed restore as a crash. The restore has already happened by this
+                    // point; nothing that goes wrong while filing it may change that.
+                    _log.Error($"Could not record this run in the history: {ex.Message}");
+                    AppendLog($"The restore finished. Recording it in History failed: {ex.Message}");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #471. Found as a **red build on main** after the v1.7.0 merge — not by looking for it.

```
System.NullReferenceException
  at ConsoleBuffer.get_Text()                    ConsoleBuffer.cs:79
  at RestoreExecutionViewModel.RecordHistory(…)  :431
  at RestoreExecutionViewModel.RunAsync(…)       :389
```

## Two faults

**The console could hand back a torn read.** `Text` joined over an `ObservableCollection`, which is not thread-safe: enumerated while another thread appends, it can return a **null slot** from the array it is growing. Writes are marshalled to the dispatcher — which makes the app mostly safe, since the receipt is written there too — but the run's `finally` is not guaranteed to be on the dispatcher once anything in the chain has awaited, and a test has no dispatcher at all.

**Nothing caught it.** The store already promises never to fail the thing it records, but that promise lives inside `Append`. Everything before it — reading the console, assembling the entry — was outside it.

## Why this is more than a red build

In a test it reads as a failure. **In the app it reads as a completed restore surfacing a crash** — the database restored, the target online, and an exception on screen. The restore has already happened by the time the receipt is written; nothing that goes wrong while filing it may change that.

## The fix

- `Text` snapshots before joining, retries once on a torn copy, and skips nulls. Dropping a line that has not landed yet is the right answer; throwing is not.
- The `RecordHistory` call is guarded, logged, and reported on the console — rather than failing the run, or being swallowed so a missing receipt looks like it never happened.

## The test was verified, not assumed

It hammers append-and-read concurrently. Reverted to the old one-liner it **fails**; against the fix it passes. I checked both directions rather than trusting that a race test races.

## Effect

`-c Release -warnaserror` clean, **2,234 passed** (up 5).