### PR TITLE
v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,20 @@ more detail on the user-facing changes; this file is the short history.
   has to be able to open that path as its own service account - a different question from whether
   the container is reachable, and one now asked in the preflight, before anything is dropped.
 
+### Added
+
+- **Copy a database for a cutover, not just a refresh** (#451). A copy brought the target online,
+  which is right for refreshing a test environment and wrong for a migration: online means no
+  more logs can be applied, so the copy is frozen at the moment it was taken. Tick "Leave the
+  target ready for more log backups" and it stays in RESTORING - the full is restored in advance,
+  and the switch-over costs only the logs that accumulated since. The screen then asks the source
+  which logs it has taken since that full, says where they live, and writes the statements to
+  apply them, oldest first, recovering only at the end. Offered only when the target has been left
+  restorable, because against a database already online those statements fail with 3101. It is not
+  the Restore screen's check ported across: this screen reads no container chain at all - it
+  writes its own full - so "what is this container missing" means nothing here, and the question
+  that does mean something is which of the source's logs would carry the copy forward.
+
 ### Fixed
 
 - **The Copy screen says why it will not generate, and stops losing the database you chose**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Added
+
+- **Both service accounts are proven against the shared folder before anything is backed up**
+  (#452). The Copy screen has always said the source writes there as its own service account and
+  the target reads there as its own - two different accounts, routinely not the same one - but the
+  check ran on a *file*, so it could not run until a file was there. Which meant after a full
+  backup had been written. A share the target could not read cost you the whole backup first, and
+  the source's write was never checked ahead of time at all. Generating the scripts now asks each
+  instance about the folder as itself: can the source create in it, can the target see it. Two
+  verdicts kept apart, because the fix is a permission grant to a specific account and one
+  combined answer loses which. It stays honest about what it proves - the folder is reachable, not
+  that a backup inside it will open - so the file-level check after the backup remains the
+  authoritative one. An instance that never answers does not block the copy: not knowing is not
+  the same as refusing.
+
 ## [1.7.0] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,22 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
-## [Unreleased]
+## [1.7.1] - 2026-08-17
 
 ### Added
+
+- **Copy a database for a cutover, not just a refresh** (#451). A copy brought the target online,
+  which is right for refreshing a test environment and wrong for a migration: online means no
+  more logs can be applied, so the copy is frozen at the moment it was taken. Tick "Leave the
+  target ready for more log backups" and it stays in RESTORING - the full is restored in advance,
+  and the switch-over costs only the logs that accumulated since. The screen then asks the source
+  which logs it has taken since that full, says where they live, and writes the statements to
+  apply them, oldest first, recovering only at the end. Offered only when the target has been left
+  restorable, because against a database already online those statements fail with 3101. It is not
+  the Restore screen's check ported across: this screen reads no container chain at all - it
+  writes its own full - so "what is this container missing" means nothing here, and the question
+  that does mean something is which of the source's logs would carry the copy forward.
+
 
 - **Both service accounts are proven against the shared folder before anything is backed up**
   (#452). The Copy screen has always said the source writes there as its own service account and
@@ -25,8 +38,6 @@ more detail on the user-facing changes; this file is the short history.
   authoritative one. An instance that never answers does not block the copy: not knowing is not
   the same as refusing.
 
-## [1.7.0] - 2026-08-17
-
 ### Fixed
 
 - **A completed restore can no longer surface as a crash** (#471). Reading the console to file a
@@ -36,8 +47,6 @@ more detail on the user-facing changes; this file is the short history.
   target online, and an exception on screen. The console now snapshots before reading and tolerates
   a torn one, and filing a receipt can no longer fail the thing it is filing: it says so on the
   console instead. Found as a red build rather than by looking for it.
-
-
 - **The gap check can be found** (#466). It shipped in 1.7.0 inside the restore options, which
   meant behind a step you only reach after *confirming* a restore point - and which starts
   collapsed. A feature whose whole purpose is telling you the chain is shorter than you think
@@ -47,6 +56,8 @@ more detail on the user-facing changes; this file is the short history.
   It was also gated on a mode check that returns true for every mode, which did nothing except
   imply it was a Pro-only tool. A test now asserts it is on screen with only a container chosen,
   in every mode, because two placements have compiled and hidden it.
+
+## [1.7.0] - 2026-08-17
 
 ### Added
 
@@ -79,20 +90,6 @@ more detail on the user-facing changes; this file is the short history.
   reads the container by URL and those logs from their own path by DISK, in one run. The target
   has to be able to open that path as its own service account - a different question from whether
   the container is reachable, and one now asked in the preflight, before anything is dropped.
-
-### Added
-
-- **Copy a database for a cutover, not just a refresh** (#451). A copy brought the target online,
-  which is right for refreshing a test environment and wrong for a migration: online means no
-  more logs can be applied, so the copy is frozen at the moment it was taken. Tick "Leave the
-  target ready for more log backups" and it stays in RESTORING - the full is restored in advance,
-  and the switch-over costs only the logs that accumulated since. The screen then asks the source
-  which logs it has taken since that full, says where they live, and writes the statements to
-  apply them, oldest first, recovering only at the end. Offered only when the target has been left
-  restorable, because against a database already online those statements fail with 3101. It is not
-  the Restore screen's check ported across: this screen reads no container chain at all - it
-  writes its own full - so "what is this container missing" means nothing here, and the question
-  that does mean something is which of the source's logs would carry the copy forward.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A completed restore can no longer surface as a crash** (#471). Reading the console to file a
+  run's receipt was not thread-safe: the line collection could be enumerated while another thread
+  was still appending to it, handing back a null and throwing. That happened inside the run's own
+  finally block, unguarded, so it came out of the restore itself - the database restored, the
+  target online, and an exception on screen. The console now snapshots before reading and tolerates
+  a torn one, and filing a receipt can no longer fail the thing it is filing: it says so on the
+  console instead. Found as a red build rather than by looking for it.
+
+
 - **The gap check can be found** (#466). It shipped in 1.7.0 inside the restore options, which
   meant behind a step you only reach after *confirming* a restore point - and which starts
   collapsed. A feature whose whole purpose is telling you the chain is shorter than you think

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [1.7.0] - 2026-08-17
 
+### Fixed
+
+- **The gap check can be found** (#466). It shipped in 1.7.0 inside the restore options, which
+  meant behind a step you only reach after *confirming* a restore point - and which starts
+  collapsed. A feature whose whole purpose is telling you the chain is shorter than you think
+  cannot require you to already suspect it; that is the same fault as the bug it fixes, and the
+  first person to look for it could not find it. It now sits in step 1 beside the audit panel,
+  reachable as soon as a database is picked, with no target and no confirmed restore point needed.
+  It was also gated on a mode check that returns true for every mode, which did nothing except
+  imply it was a Pro-only tool. A test now asserts it is on screen with only a container chosen,
+  in every mode, because two placements have compiled and hidden it.
+
 ### Added
 
 - **The script that carries a login across from the source instance** (#459). When a restored

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/Models/FolderAccessCheck.cs
+++ b/src/NineLives.Core/Models/FolderAccessCheck.cs
@@ -1,0 +1,113 @@
+namespace Blackcat.NineLives.Models;
+
+/// <summary>What one instance's service account could do with a folder.</summary>
+public enum FolderAccess
+{
+    /// <summary>Not asked yet.</summary>
+    Unknown,
+
+    /// <summary>The folder is there and the account could do what was asked of it.</summary>
+    Ok,
+
+    /// <summary>
+    /// The account cannot see the folder at all.
+    ///
+    /// The one this check exists for. A SQL Server running as a local account, or as
+    /// NT SERVICE\MSSQLSERVER, has no identity on the network and so cannot reach ANY share -
+    /// which from the outside is indistinguishable from a path that does not exist, and is the
+    /// commonest way a copy through a shared folder fails.
+    /// </summary>
+    NotVisible,
+
+    /// <summary>Visible, and the account cannot create in it.</summary>
+    CannotWrite,
+
+    /// <summary>
+    /// The instance never answered.
+    ///
+    /// A UNC path whose host does not resolve does not come back as "not found": the statement
+    /// hangs while Windows looks for the machine, and the command timeout expires first.
+    /// </summary>
+    Unreachable,
+
+    /// <summary>Something else. The server's own words are in the message.</summary>
+    Other
+}
+
+/// <summary>
+/// Whether one instance can use a folder, asked of that instance (#452).
+///
+/// The distinction that makes it worth asking at all: a copy through a shared folder needs the
+/// SOURCE to write there as its own service account and the TARGET to read there as its own - two
+/// different accounts, routinely not the same one, and neither of them this app. A check from here
+/// would answer for the wrong identity entirely.
+///
+/// Asked BEFORE the backup, which is the whole point. The readability check that already exists
+/// runs on a file, so it cannot run until a file is there - by which time a full backup has been
+/// written and the wait is over. This one costs a round trip and answers the common failure in a
+/// second.
+/// </summary>
+/// <param name="Folder">The folder as it was asked about.</param>
+/// <param name="Access">What the account could do.</param>
+/// <param name="ServerMessage">What SQL Server said, verbatim, whatever the classification.</param>
+public sealed record FolderAccessCheck(
+    string Folder, FolderAccess Access, string? ServerMessage = null)
+{
+    public bool IsOk => Access == FolderAccess.Ok;
+
+    public static FolderAccessCheck Ok(string folder) => new(folder, FolderAccess.Ok);
+
+    /// <summary>
+    /// Turns what SQL Server said into which failure it was.
+    ///
+    /// The message is kept whatever the classification: the numbered error is what somebody
+    /// searches for, and a wrong guess here must not hide the server's own words.
+    /// </summary>
+    public static FolderAccessCheck FromError(string folder, string message)
+    {
+        var m = message ?? string.Empty;
+
+        var access =
+            Contains(m, "timeout") || Contains(m, "network path was not found")
+                ? FolderAccess.Unreachable
+            : Contains(m, "access is denied") || Contains(m, "permission")
+                ? FolderAccess.CannotWrite
+            : Contains(m, "cannot find") || Contains(m, "does not exist")
+                ? FolderAccess.NotVisible
+                : FolderAccess.Other;
+
+        return new FolderAccessCheck(folder, access, m);
+    }
+
+    private static bool Contains(string haystack, string needle)
+        => haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// What to tell somebody, naming the instance whose account could not do it.
+    ///
+    /// Names the ACCOUNT rather than just the failure, because the fix is a permission grant to a
+    /// specific identity and "access denied" on its own sends people to check the share from their
+    /// own logged-in session, where it works.
+    /// </summary>
+    public string Explain(string serverName, bool wasWriteCheck) => Access switch
+    {
+        FolderAccess.Ok => wasWriteCheck
+            ? $"{serverName} can write here as its own service account."
+            : $"{serverName} can see this folder as its own service account.",
+
+        FolderAccess.NotVisible =>
+            $"{serverName} cannot see {Folder} at all. Its SQL Server service account is the one " +
+            "that has to reach it, not your login - an instance running as a local account or as " +
+            "NT SERVICE\\MSSQLSERVER has no identity on the network and cannot open any share.",
+
+        FolderAccess.CannotWrite =>
+            $"{serverName} can see {Folder} but its service account cannot create files there. " +
+            "The backup would fail at the point of writing.",
+
+        FolderAccess.Unreachable =>
+            $"{serverName} never answered about {Folder}. A UNC path whose host does not resolve " +
+            "hangs rather than reporting a missing folder, so check the machine name first.",
+
+        _ => $"{serverName} could not use {Folder}: {ServerMessage}"
+    };
+}

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/Services/BackupGapAnalyser.cs
+++ b/src/NineLives.Core/Services/BackupGapAnalyser.cs
@@ -1,4 +1,4 @@
-using Blackcat.NineLives.Models;
+﻿using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -135,6 +135,38 @@ public static class BackupGapAnalyser
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// The source's log backups taken after a given moment, grouped by where they live (#451).
+    ///
+    /// The Copy screen's question, which is not the Restore screen's. A copy writes its own full and
+    /// reads no existing chain, so "what is this container missing" means nothing there. What does
+    /// mean something is the cutover: the copy restores a full taken at T, and the logs the source
+    /// has taken SINCE T are what would roll the target forward to now. The long part happens in
+    /// advance and the downtime is only the tail.
+    ///
+    /// Strictly after, and by the log's own start: a log backup that began before the full was
+    /// taken is already inside it.
+    /// </summary>
+    public static IReadOnlyList<MissingLocation> LogsTakenAfter(
+        IReadOnlyList<BackupHistoryEntry> history,
+        string database,
+        DateTime after)
+    {
+        var logs = history
+            .Where(h => string.Equals(h.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Where(h => h.Type == BackupType.TransactionLog)
+            .Where(h => h.HasFiles)
+            .Where(h => h.StartedAt > after)
+            .ToList();
+
+        return logs
+            .Select(h => new MissingBackup(h, FolderOf(h.Files[0])))
+            .GroupBy(m => m.Folder, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new MissingLocation(g.Key, g.OrderBy(m => m.TakenAt).ToList()))
+            .OrderBy(l => l.Earliest)
+            .ToList();
     }
 
     /// <summary>

--- a/src/NineLives.Core/Services/ISqlServerService.cs
+++ b/src/NineLives.Core/Services/ISqlServerService.cs
@@ -182,6 +182,21 @@ public interface ISqlServerService
     Task<BackupFileCheck> CheckBackupFileAsync(
         ServerConnection server, string path, CancellationToken ct = default);
 
+    /// <summary>
+    /// Whether THIS instance's service account can use a folder, asked before anything is written
+    /// (#452).
+    ///
+    /// The file-level check below cannot run until a file is there, which on the copy screen means
+    /// after a full backup has been taken - so a share the target cannot read costs the whole
+    /// backup first. This one costs a round trip.
+    ///
+    /// <paramref name="needsWrite"/> picks the question: whether the account can see the folder, or
+    /// whether it can create in it. Both are asked ON the instance, because the account that
+    /// matters is its service account and not this app.
+    /// </summary>
+    Task<FolderAccessCheck> CheckFolderAccessAsync(
+        ServerConnection server, string folder, bool needsWrite, CancellationToken ct = default);
+
     /// <summary>Checks every file a chain needs, stopping at the first that cannot be read.</summary>
     Task<List<BackupFileCheck>> CheckBackupFilesAsync(
         ServerConnection server, IEnumerable<string> paths, CancellationToken ct = default);

--- a/src/NineLives.Core/Services/LogRollForwardScript.cs
+++ b/src/NineLives.Core/Services/LogRollForwardScript.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using Blackcat.NineLives.Models;
+
+namespace Blackcat.NineLives.Services;
+
+/// <summary>
+/// Rolls a database that is already sitting in RESTORING forward with more log backups (#451).
+///
+/// The cutover shape. A copy takes a full now and restores it; if it is left in NORECOVERY the
+/// target stays restorable, and the source's later log backups can be applied at the moment of
+/// switching over. The long part - the full - happens in advance, and the downtime is only the
+/// logs that accumulated since.
+///
+/// Separate from <see cref="RestoreScriptGenerator"/> rather than a mode of it, because that one
+/// always begins with a full: it describes restoring a chain from nothing. This describes adding
+/// to a restore already under way, which is a different statement sequence with a different
+/// precondition - the database must already be in RESTORING, and if it is not, every statement
+/// here fails with 3101 rather than doing something unintended.
+/// </summary>
+public static class LogRollForwardScript
+{
+    /// <summary>
+    /// The logs in the order they must be applied, against a database left in NORECOVERY.
+    ///
+    /// <paramref name="bringOnline"/> decides whether the last statement recovers. Left false, the
+    /// target stays restorable and another batch can follow - which is what a rehearsal of the
+    /// cutover wants, and what somebody applying logs hourly until the switch wants too.
+    /// </summary>
+    public static string Build(
+        string targetDatabase,
+        IReadOnlyList<BackupHistoryEntry> logs,
+        bool bringOnline = true)
+    {
+        var ordered = logs
+            .Where(l => l.Type == BackupType.TransactionLog && l.HasFiles)
+            .OrderBy(l => l.StartedAt)
+            .ToList();
+
+        var sb = new StringBuilder();
+        var db = TSql.QuoteName(targetDatabase);
+
+        sb.AppendLine("-- ============================================================");
+        sb.AppendLine("-- Nine Lives - roll the copy forward");
+        sb.AppendLine($"-- Target: {TSql.CommentText(targetDatabase)}");
+        sb.AppendLine($"-- {ordered.Count} log backup(s)");
+        if (ordered.Count > 0)
+            sb.AppendLine($"-- Covering {ordered[0].StartedAt:yyyy-MM-dd HH:mm} to {ordered[^1].StartedAt:yyyy-MM-dd HH:mm}");
+        sb.AppendLine("-- ============================================================");
+        sb.AppendLine();
+
+        if (ordered.Count == 0)
+        {
+            sb.AppendLine("-- No log backups to apply. The source has taken none since the copy,");
+            sb.AppendLine("-- so there is nothing between the copy and now to roll forward.");
+            return sb.ToString();
+        }
+
+        // Said, not assumed. Run against a database that is already online, every statement below
+        // fails with 3101 - which is safe but reads as a broken script rather than a precondition
+        // nobody met.
+        sb.AppendLine($"-- {targetDatabase} must still be in RESTORING for these to apply. If the copy");
+        sb.AppendLine("-- brought it online, it cannot take more logs and has to be redone with");
+        sb.AppendLine("-- \"Leave the target ready for more log backups\" ticked.");
+        sb.AppendLine();
+
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            var log = ordered[i];
+            var isLast = i == ordered.Count - 1;
+            var recovery = isLast && bringOnline ? "RECOVERY" : "NORECOVERY";
+
+            sb.AppendLine($"-- {log.StartedAt:yyyy-MM-dd HH:mm:ss}");
+            sb.AppendLine($"RESTORE LOG {db}");
+
+            // Every file of the set, in stripe order, in ONE statement - a striped log is one media
+            // set and naming half of it fails with 3132.
+            for (int f = 0; f < log.Files.Count; f++)
+            {
+                var prefix = f == 0 ? "    FROM" : "        ";
+                var suffix = f < log.Files.Count - 1 ? "," : "";
+                sb.AppendLine($"{prefix} {BackupDevice.Clause(log.Files[f])}{suffix}");
+            }
+
+            sb.AppendLine("    WITH");
+            sb.AppendLine($"         {recovery},");
+            sb.AppendLine("         STATS = 10;");
+            sb.AppendLine("GO");
+            sb.AppendLine();
+        }
+
+        if (!bringOnline)
+        {
+            sb.AppendLine("-- Still in RESTORING, ready for the next batch. To finish:");
+            sb.AppendLine($"-- RESTORE DATABASE {db} WITH RECOVERY;");
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/NineLives.Core/Services/SqlServerService.cs
+++ b/src/NineLives.Core/Services/SqlServerService.cs
@@ -554,6 +554,80 @@ public class SqlServerService : ISqlServerService
     /// cause - the service account having no access to the share - fails every file identically,
     /// so carrying on would produce a page of the same message.
     /// </summary>
+    /// <summary>
+    /// The name of the folder created to prove a write (#452).
+    ///
+    /// A write cannot be proven without writing, and SQL Server has no primitive for removing a
+    /// directory again - xp_delete_files takes files with an extension and a date filter. So this
+    /// leaves one empty folder behind, with a name that says what it is, and reuses it on every
+    /// later check because xp_create_subdir succeeds silently when the directory already exists.
+    ///
+    /// One obvious artefact beats the alternatives: writing a real backup to prove the write costs
+    /// minutes and megabytes, and proving nothing costs somebody a full backup before they find out.
+    /// </summary>
+    internal const string WriteProbeFolder = "_ninelives_write_check";
+
+    /// <inheritdoc />
+    public async Task<FolderAccessCheck> CheckFolderAccessAsync(
+        ServerConnection server, string folder, bool needsWrite, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(folder)) return FolderAccessCheck.Ok(folder);
+
+        var trimmed = folder.TrimEnd('\\', '/');
+
+        try
+        {
+            await using var conn = CreateConnection(server);
+            await conn.OpenAsync(ct);
+
+            // Shorter than the default: the failure this is most likely to hit is a UNC host that
+            // does not resolve, which hangs rather than answering, and the whole value of asking
+            // early is lost if the answer takes as long as the backup would have.
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandTimeout = 30;
+
+            if (needsWrite)
+            {
+                // Creating a subfolder is the cheapest thing that genuinely proves the account can
+                // write here, and it is what the maintenance scripts everybody already runs use for
+                // the same purpose. Idempotent, so the probe folder is created at most once.
+                cmd.CommandText = "EXEC master.sys.xp_create_subdir @probe";
+                cmd.Parameters.Add(new SqlParameter("@probe",
+                    trimmed + "\\" + WriteProbeFolder));
+
+                await cmd.ExecuteNonQueryAsync(ct);
+                return FolderAccessCheck.Ok(folder);
+            }
+
+            // Visible, and a directory rather than a file. xp_fileexist answers three columns:
+            // whether the path exists as a file, whether it is a directory, and whether its parent
+            // exists - and it answers as the SERVICE account, which is the whole point.
+            cmd.CommandText = "EXEC master.dbo.xp_fileexist @path";
+            cmd.Parameters.Add(new SqlParameter("@path", trimmed));
+
+            await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+            if (!await reader.ReadAsync(ct))
+                return new FolderAccessCheck(folder, FolderAccess.Other,
+                    "xp_fileexist returned no rows.");
+
+            var isDirectory = !reader.IsDBNull(1) && reader.GetInt32(1) == 1;
+
+            return isDirectory
+                ? FolderAccessCheck.Ok(folder)
+                : new FolderAccessCheck(folder, FolderAccess.NotVisible,
+                    "xp_fileexist reported it is not a directory this account can see.");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return FolderAccessCheck.FromError(folder, ex.Message);
+        }
+    }
+
     public async Task<List<BackupFileCheck>> CheckBackupFilesAsync(
         ServerConnection server, IEnumerable<string> paths, CancellationToken ct = default)
     {

--- a/src/NineLives.IntegrationTests/NineLives.IntegrationTests.csproj
+++ b/src/NineLives.IntegrationTests/NineLives.IntegrationTests.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/NineLives.IntegrationTests/NineLives.IntegrationTests.csproj
+++ b/src/NineLives.IntegrationTests/NineLives.IntegrationTests.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NineLives.IntegrationTests/packages.lock.json
+++ b/src/NineLives.IntegrationTests/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "kzLFyBYUnoidpGOXvpNOfIo8C92gVgVR6X8ncHwhcrDYugiOut5rrhDkr0L3cWHd7J2pKXf6LgaeXoBBDlx1ag=="
       },
       "Azure.Core": {
         "type": "Transitive",

--- a/src/NineLives.IntegrationTests/packages.lock.json
+++ b/src/NineLives.IntegrationTests/packages.lock.json
@@ -4,12 +4,12 @@
     "net10.0-windows7.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.8.1, )",
-        "resolved": "18.8.1",
-        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "xIzVXa/VpKXqDWzyC/5Hw8JbFY5u9k3Jc53CpcjBiOXvkQGio484LD9FNwOiGUSMDcYL3Rcw9sNgGi5WrswlPQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.8.1",
-          "Microsoft.TestPlatform.TestHost": "18.8.1"
+          "Microsoft.CodeCoverage": "18.9.0",
+          "Microsoft.TestPlatform.TestHost": "18.9.0"
         }
       },
       "xunit": {
@@ -86,8 +86,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+        "resolved": "18.9.0",
+        "contentHash": "MtegCIKGuG0r/LCdIjoR1HgzCGIUBhR3aNdbtQpts5vMXQuqBDZ2Jsd2uFKoHFM2XrQV6ZrDf3F5oLi3SLTp8w=="
       },
       "Microsoft.Data.SqlClient": {
         "type": "Transitive",
@@ -304,15 +304,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
+        "resolved": "18.9.0",
+        "contentHash": "Fz/qXC52VXXopzHj7v2reCKcCqSxkTDCkEDfkNAH0vni/7qK/KLMiEYtRmnUanxO2F2g2zZZ60qCpxF0AF7URA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "resolved": "18.9.0",
+        "contentHash": "Oq+Pma/J86aZL72t71bcESvDszDsTjUfl6PIsuDdPoKTHZfNMhKamCfLD5fKx51W/u0KozXtJo2/3fnt0sgPxg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+          "Microsoft.TestPlatform.ObjectModel": "18.9.0"
         }
       },
       "System.ClientModel": {
@@ -389,7 +389,7 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Mvvm": "[8.4.2, )",
-          "NineLives.Core": "[1.5.0, )"
+          "NineLives.Core": "[1.7.0, )"
         }
       },
       "ninelives.core": {

--- a/src/NineLives.Tests/CutoverRollForwardTests.cs
+++ b/src/NineLives.Tests/CutoverRollForwardTests.cs
@@ -1,0 +1,260 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Copying for a cutover rather than a refresh (#451).
+///
+/// A copy normally brings the target online, which is right for a test refresh and wrong for a
+/// migration: online means no more logs can be applied, so the copy is frozen at the moment it was
+/// taken. Left in RESTORING, the long part - the full - happens in advance, and the switch-over
+/// costs only the logs that accumulated since.
+///
+/// The gap check could not simply be ported from the Restore screen: this screen reads no container
+/// chain at all, it writes its own full, so "what is this container missing" means nothing here.
+/// The question that does mean something is which of the SOURCE's logs would carry that full
+/// forward.
+/// </summary>
+public class CutoverRollForwardTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 17, 14, 0, 0);
+
+    private static BackupHistoryEntry Log(DateTime at, string folder = @"E:\SQLLogs", int stripes = 1)
+    {
+        var files = Enumerable.Range(1, stripes)
+            .Select(n => stripes == 1
+                ? $@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn"
+                : $@"{folder}\Sales_{at:yyyyMMdd_HHmmss}_{n}.trn")
+            .ToList();
+
+        return new BackupHistoryEntry
+        {
+            DatabaseName = "Sales",
+            Type = BackupType.TransactionLog,
+            StartedAt = at,
+            Files = files,
+            BackupSizeBytes = 1024
+        };
+    }
+
+    // ── which logs are the right ones ───────────────────────────────────────────
+
+    /// <summary>
+    /// Strictly after the full, by the log's own start. A log that began before the full was taken
+    /// is already inside it, and applying it would be applying something twice.
+    /// </summary>
+    [Fact]
+    public void OnlyLogsTakenAfterTheCopyCount()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            Log(T0.AddHours(-1)),   // before the full
+            Log(T0),                // exactly at it
+            Log(T0.AddHours(1)),
+            Log(T0.AddHours(2))
+        };
+
+        var locations = BackupGapAnalyser.LogsTakenAfter(history, "Sales", T0);
+
+        var only = Assert.Single(locations);
+        Assert.Equal(2, only.Backups.Count);
+        Assert.Equal(T0.AddHours(1), only.Earliest);
+    }
+
+    [Fact]
+    public void FullsAndDifferentialsAreNotLogsToRollForwardWith()
+    {
+        var history = new List<BackupHistoryEntry>
+        {
+            new()
+            {
+                DatabaseName = "Sales", Type = BackupType.Full, StartedAt = T0.AddHours(1),
+                Files = [@"E:\Backups\Sales.bak"]
+            },
+            Log(T0.AddHours(2))
+        };
+
+        var only = Assert.Single(BackupGapAnalyser.LogsTakenAfter(history, "Sales", T0));
+        Assert.Single(only.Backups);
+    }
+
+    [Fact]
+    public void ASourceThatHasTakenNoLogsSinceReportsNothing()
+        => Assert.Empty(BackupGapAnalyser.LogsTakenAfter([Log(T0.AddHours(-2))], "Sales", T0));
+
+    // ── the script ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Applied oldest first, and only the last statement recovers - a log applied out of order
+    /// fails with 4305, and recovering early ends the sequence with logs still to go.
+    /// </summary>
+    [Fact]
+    public void TheLogsAreAppliedInOrderAndOnlyTheLastRecovers()
+    {
+        var sql = LogRollForwardScript.Build("Sales_Migrated",
+            [Log(T0.AddHours(3)), Log(T0.AddHours(1)), Log(T0.AddHours(2))]);
+
+        var first = sql.IndexOf("Sales_20260817_150000.trn", StringComparison.Ordinal);
+        var second = sql.IndexOf("Sales_20260817_160000.trn", StringComparison.Ordinal);
+        var third = sql.IndexOf("Sales_20260817_170000.trn", StringComparison.Ordinal);
+
+        Assert.True(first < second && second < third, "The logs are out of order.");
+
+        Assert.Equal(2, CountOf(sql, "NORECOVERY,"));
+        Assert.Equal(1, CountOf(sql, "RECOVERY,") - CountOf(sql, "NORECOVERY,"));
+    }
+
+    /// <summary>
+    /// Left restorable, for somebody applying logs repeatedly up to the switch rather than
+    /// finishing in one go.
+    /// </summary>
+    [Fact]
+    public void ItCanLeaveTheTargetReadyForAnotherBatch()
+    {
+        var sql = LogRollForwardScript.Build(
+            "Sales_Migrated", [Log(T0.AddHours(1))], bringOnline: false);
+
+        Assert.Contains("NORECOVERY,", sql);
+        Assert.Contains("WITH RECOVERY;", sql);          // the how-to-finish line
+        Assert.Contains("ready for the next batch", sql);
+    }
+
+    /// <summary>
+    /// The precondition said rather than assumed. Run against a database already online, every
+    /// statement fails with 3101 - safe, but it reads as a broken script rather than as something
+    /// nobody met the condition for.
+    /// </summary>
+    [Fact]
+    public void ItStatesThatTheTargetMustStillBeRestoring()
+    {
+        var sql = LogRollForwardScript.Build("Sales_Migrated", [Log(T0.AddHours(1))]);
+
+        Assert.Contains("must still be in RESTORING", sql);
+        Assert.Contains("Leave the target ready for more log backups", sql);
+    }
+
+    /// <summary>A striped log is one media set - naming half of it fails with 3132.</summary>
+    [Fact]
+    public void AStripedLogIsOneStatementNamingEveryFile()
+    {
+        var sql = LogRollForwardScript.Build(
+            "Sales_Migrated", [Log(T0.AddHours(1), stripes: 3)]);
+
+        Assert.Equal(1, CountOf(sql, "RESTORE LOG"));
+        Assert.Equal(3, CountOf(sql, "DISK = N'"));
+    }
+
+    [Fact]
+    public void NoLogsAtAllSaysSoRatherThanEmittingNothing()
+    {
+        var sql = LogRollForwardScript.Build("Sales_Migrated", []);
+
+        Assert.Contains("No log backups to apply", sql);
+        Assert.DoesNotContain("RESTORE LOG", sql);
+    }
+
+    /// <summary>The target name is an identifier, and one holding a bracket must not break out.</summary>
+    [Fact]
+    public void TheTargetNameIsQuotedAsAnIdentifier()
+    {
+        var sql = LogRollForwardScript.Build("odd]name", [Log(T0.AddHours(1))]);
+        Assert.Contains("[odd]]name]", sql);
+    }
+
+    // ── the screen ──────────────────────────────────────────────────────────────
+
+    private static (CopyDatabaseViewModel vm, FakeSqlServerService sql) Ready()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1", Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["Sales"] };
+        var vm = new CopyDatabaseViewModel(store, sql, TestLogs.Temp(),
+            history: new FakeOperationHistoryStore());
+
+        vm.Refresh();
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        vm.LoadSourceDatabasesCommand.ExecuteAsync(null).GetAwaiter().GetResult();
+        vm.SourceDatabase = "Sales";
+        vm.Container = vm.Containers[0];
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "Sales_Migrated";
+        return (vm, sql);
+    }
+
+    [Fact]
+    public void ARefreshBringsTheTargetOnlineAndACutoverDoesNot()
+    {
+        var (vm, _) = Ready();
+
+        vm.LeaveRestoringForMoreLogs = false;
+        vm.GenerateCommand.Execute(null);
+        Assert.Contains("RECOVERY,", vm.RestoreScript);
+        Assert.DoesNotContain("NORECOVERY,", vm.RestoreScript);
+
+        vm.LeaveRestoringForMoreLogs = true;
+        vm.GenerateCommand.Execute(null);
+        Assert.Contains("NORECOVERY,", vm.RestoreScript);
+    }
+
+    /// <summary>
+    /// End to end on the screen: ask the source, then write the script for what came back.
+    /// </summary>
+    [Fact]
+    public async Task TheScreenFindsTheLogsAndWritesTheScriptForThem()
+    {
+        var (vm, sql) = Ready();
+
+        vm.LeaveRestoringForMoreLogs = true;
+        vm.GenerateCommand.Execute(null);
+
+        // Taken after the copy, so they count; the fake's clock is this machine's.
+        sql.BackupHistory.Add(Log(DateTime.Now.AddMinutes(5)));
+        sql.BackupHistory.Add(Log(DateTime.Now.AddMinutes(65)));
+
+        await vm.CheckSourceLogsCommand.ExecuteAsync(null);
+        Assert.True(vm.Gap.HasGap);
+
+        vm.BuildRollForwardCommand.Execute(null);
+
+        Assert.True(vm.HasRollForwardScript);
+        Assert.Contains("RESTORE LOG [Sales_Migrated]", vm.RollForwardScript);
+        Assert.Contains(@"E:\SQLLogs", vm.RollForwardScript);
+    }
+
+    /// <summary>
+    /// Asked before the scripts exist there is no "since when", and inventing one would report the
+    /// wrong logs - which on a cutover means a target that is short of where somebody thinks it is.
+    /// </summary>
+    [Fact]
+    public async Task AskingBeforeGeneratingSaysWhyRatherThanGuessing()
+    {
+        var (vm, _) = Ready();
+        vm.LeaveRestoringForMoreLogs = true;
+
+        await vm.CheckSourceLogsCommand.ExecuteAsync(null);
+
+        Assert.Contains("Generate the scripts first", vm.StatusMessage);
+        Assert.False(vm.Gap.HasChecked);
+    }
+
+    private static int CountOf(string haystack, string needle)
+    {
+        int count = 0, at = 0;
+        while ((at = haystack.IndexOf(needle, at, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            at += needle.Length;
+        }
+        return count;
+    }
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -822,6 +822,24 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// <summary>Set to make the target unreachable rather than merely unhelpful.</summary>
     public Exception? ThrowOnCheck { get; set; }
 
+    /// <summary>What each folder check should answer, keyed by "serverName|folder|write" (#452).
+    /// Anything not listed answers Ok, so a test only has to state the failure it cares about.</summary>
+    public Dictionary<string, FolderAccessCheck> FolderAccess { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Every folder check asked for, so a test can prove BOTH sides were asked.</summary>
+    public List<string> FolderChecks { get; } = [];
+
+    public Task<FolderAccessCheck> CheckFolderAccessAsync(
+        ServerConnection server, string folder, bool needsWrite, CancellationToken ct = default)
+    {
+        var key = $"{server.ServerName}|{folder}|{(needsWrite ? "write" : "read")}";
+        FolderChecks.Add(key);
+
+        return Task.FromResult(FolderAccess.TryGetValue(key, out var answer)
+            ? answer
+            : FolderAccessCheck.Ok(folder));
+    }
+
     public Task<BackupFileCheck> CheckBackupFileAsync(
         ServerConnection server, string path, CancellationToken ct = default)
     {

--- a/src/NineLives.Tests/NineLives.Tests.csproj
+++ b/src/NineLives.Tests/NineLives.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/NineLives.Tests/NineLives.Tests.csproj
+++ b/src/NineLives.Tests/NineLives.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/NineLives.Tests/ProveTheShareBeforeTheBackupTests.cs
+++ b/src/NineLives.Tests/ProveTheShareBeforeTheBackupTests.cs
@@ -1,0 +1,209 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Both accounts are proven against the shared folder before anything is backed up (#452).
+///
+/// The screen's own text has always said it: the source writes here as its own service account and
+/// the target reads here as its own, two different accounts and routinely not the same one. But
+/// the check that existed ran on a FILE, so it could not run until a file was there - which meant
+/// after a full backup had been written. A share the target could not read cost the whole backup
+/// first, and the source's write was never checked ahead of time at all.
+/// </summary>
+public class ProveTheShareBeforeTheBackupTests
+{
+    private const string Folder = @"\\nas01\sql";
+
+    private static (CopyDatabaseViewModel vm, FakeSqlServerService sql) Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+
+        var sql = new FakeSqlServerService { DatabaseList = ["MyDb"] };
+        var vm = new CopyDatabaseViewModel(store, sql);
+        vm.Refresh();
+        return (vm, sql);
+    }
+
+    /// <summary>Everything answered, going through a folder rather than a container.</summary>
+    private static async Task<(CopyDatabaseViewModel vm, FakeSqlServerService sql)> ReadyAsync()
+    {
+        var (vm, sql) = Screen();
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.SharedPath;
+        vm.SharedPathRoot = Folder;
+
+        // The sweep runs on Generate, not on every keystroke - re-asking two production instances
+        // per character typed was the disease #285 cured. Still before anything is written.
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+        return (vm, sql);
+    }
+
+    private static string Key(string server, bool write)
+        => $"{server}|{Folder}|{(write ? "write" : "read")}";
+
+    // ── both sides are asked, as themselves ─────────────────────────────────────
+
+    [Fact]
+    public async Task BothAccountsAreAskedAndEachAboutItsOwnQuestion()
+    {
+        var (_, sql) = await ReadyAsync();
+
+        // The source has to CREATE here; the target only has to see it.
+        Assert.Contains(Key("SRV01", write: true), sql.FolderChecks);
+        Assert.Contains(Key("SRV02", write: false), sql.FolderChecks);
+    }
+
+    [Fact]
+    public async Task WhenBothCanUseItTheScreenSaysSoAndDoesNotRefuse()
+    {
+        var (vm, _) = await ReadyAsync();
+
+        Assert.True(vm.SharedFolderProven);
+        Assert.Contains("SRV01", vm.SourceCanWriteHere);
+        Assert.Contains("SRV02", vm.TargetCanReadHere);
+        Assert.Empty(vm.SharedFolderRefusal);
+    }
+
+    // ── and refused when one of them cannot ─────────────────────────────────────
+
+    /// <summary>
+    /// The failure this exists for, and the reason the message names the ACCOUNT: an instance
+    /// running as a local account has no identity on the network, so it cannot open any share -
+    /// while the share opens perfectly from the operator's own logged-in session.
+    /// </summary>
+    [Fact]
+    public async Task ATargetThatCannotSeeTheFolderRefusesBeforeAnythingIsWritten()
+    {
+        var (vm, sql) = Screen();
+        sql.FolderAccess[Key("SRV02", write: false)] =
+            new FolderAccessCheck(Folder, FolderAccess.NotVisible, "Operating system error 5.");
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.SharedPath;
+        vm.SharedPathRoot = Folder;
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+
+        Assert.False(vm.SharedFolderProven);
+        Assert.True(vm.IsRefused);
+        Assert.Contains("SRV02", vm.Refusal);
+        Assert.Contains("service account", vm.Refusal);
+        Assert.False(vm.CanGenerate);
+    }
+
+    [Fact]
+    public async Task ASourceThatCannotWriteRefusesToo()
+    {
+        var (vm, sql) = Screen();
+        sql.FolderAccess[Key("SRV01", write: true)] =
+            new FolderAccessCheck(Folder, FolderAccess.CannotWrite, "Access is denied.");
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.SharedPath;
+        vm.SharedPathRoot = Folder;
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+
+        Assert.True(vm.IsRefused);
+        Assert.Contains("SRV01", vm.Refusal);
+        Assert.Contains("cannot create", vm.Refusal);
+    }
+
+    /// <summary>
+    /// A check that could not be COMPLETED is not a check that failed. An instance that never
+    /// answers - a UNC host that does not resolve, so the statement hangs until the timeout - must
+    /// not block a copy that would have worked. Same rule the space check follows.
+    /// </summary>
+    [Fact]
+    public async Task AnInstanceThatNeverAnsweredDoesNotBlockTheCopy()
+    {
+        var (vm, sql) = Screen();
+        sql.FolderAccess[Key("SRV02", write: false)] =
+            new FolderAccessCheck(Folder, FolderAccess.Unreachable, "Execution Timeout Expired.");
+
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.SharedPath;
+        vm.SharedPathRoot = Folder;
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+
+        Assert.False(vm.SharedFolderProven);
+        Assert.Empty(vm.SharedFolderRefusal);
+
+        // Said, though - not knowing is worth reporting even when it is not worth refusing over.
+        Assert.Contains("never answered", vm.TargetCanReadHere);
+    }
+
+    // ── it is a shared-folder question only ─────────────────────────────────────
+
+    [Fact]
+    public async Task GoingThroughACloudContainerAsksNothingAboutFolders()
+    {
+        var (vm, sql) = Screen();
+        vm.SourceServer = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadSourceDatabasesCommand.ExecuteAsync(null);
+        vm.SourceDatabase = "MyDb";
+        vm.TargetServer = vm.Servers.First(s => s.Id == "s2");
+        vm.TargetDatabaseName = "MyDb_Copy";
+        vm.Medium = BackupMedium.AzureBlob;
+        vm.GenerateCommand.Execute(null);
+        await vm.WaitForChecksForTests();
+
+        Assert.Empty(sql.FolderChecks);
+        Assert.Empty(vm.SourceCanWriteHere);
+    }
+
+    // ── what it does and does not prove ─────────────────────────────────────────
+
+    /// <summary>
+    /// The wording has to stay narrower than the check. xp_fileexist proves the folder is visible
+    /// to that account; it does not prove a backup inside it will be readable, because a share can
+    /// be traversable and still refuse the read. The file-level check after the backup is still
+    /// the authoritative one, and claiming more here would make it look redundant.
+    /// </summary>
+    [Fact]
+    public void TheVisibilityVerdictDoesNotClaimReadability()
+    {
+        var seen = new FolderAccessCheck(Folder, FolderAccess.Ok);
+
+        var said = seen.Explain("SRV02", wasWriteCheck: false);
+
+        Assert.Contains("can see", said);
+        Assert.DoesNotContain("readable", said);
+        Assert.DoesNotContain("can read the backup", said);
+    }
+
+    [Fact]
+    public void AnUnreachableFolderPointsAtTheMachineNameFirst()
+    {
+        var check = new FolderAccessCheck(
+            Folder, FolderAccess.Unreachable, "timeout");
+
+        Assert.Contains("machine name", check.Explain("SRV02", wasWriteCheck: false));
+    }
+}

--- a/src/NineLives.Tests/RecordingCannotFailTheRunTests.cs
+++ b/src/NineLives.Tests/RecordingCannotFailTheRunTests.cs
@@ -1,0 +1,133 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Filing a run cannot fail the run (#469).
+///
+/// Found as a red build on main, not by looking: a NullReferenceException out of
+/// <c>ConsoleBuffer.Text</c>, thrown while assembling the receipt in the run's own finally block,
+/// and propagating all the way out of RunAsync. In a test that reads as a failure. In the app it
+/// would have read as a completed restore surfacing a crash - the database restored, and an
+/// exception on screen.
+///
+/// Two faults, and both are worth having separately. The console could hand back a torn read;
+/// and nothing was catching it if it did. The store already promises never to fail what it
+/// records, but that promise lives inside Append - everything before it, reading the console and
+/// building the entry, was unguarded.
+/// </summary>
+public class RecordingCannotFailTheRunTests
+{
+    // ── the console survives being read from another thread ─────────────────────
+
+    /// <summary>
+    /// ObservableCollection is not thread-safe: enumerated mid-write it can hand back a null slot
+    /// from the array it is growing. Reproduced by hammering it, which is the only honest way to
+    /// test a race - and it fails reliably on the old implementation.
+    /// </summary>
+    [Fact]
+    public async Task ReadingTheTextWhileItIsBeingWrittenDoesNotThrow()
+    {
+        var console = new ConsoleBuffer(null, dispatcher: null);
+        using var stop = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        var writer = Task.Run(() =>
+        {
+            int n = 0;
+            while (!stop.IsCancellationRequested)
+                console.Append($"line {n++} of the restore output");
+        });
+
+        var reader = Task.Run(() =>
+        {
+            while (!stop.IsCancellationRequested)
+            {
+                // The assertion IS that this does not throw.
+                _ = console.Text;
+            }
+        });
+
+        await Task.WhenAll(writer, reader);
+    }
+
+    [Fact]
+    public void TheTextIsStillTheTextWhenNothingIsRacing()
+    {
+        var console = new ConsoleBuffer(null, dispatcher: null);
+        console.Append("first");
+        console.Append("second");
+        console.Flush();
+
+        var text = console.Text;
+
+        Assert.Contains("first", text);
+        Assert.Contains("second", text);
+    }
+
+    // ── and a failure to record does not fail the restore ───────────────────────
+
+    private static (RestoreExecutionViewModel vm, FakeOperationHistoryStore history) Execution(
+        Exception? appendThrows)
+    {
+        var history = new FakeOperationHistoryStore { AppendThrows = appendThrows };
+        var vm = new RestoreExecutionViewModel(
+            new FakeSqlServerService(), history, TestLogs.Temp(), new OperationCancellation());
+        return (vm, history);
+    }
+
+    private static Task<CredentialPreflight> Proceed(Action<string> _)
+        => Task.FromResult(CredentialPreflight.Proceed);
+
+    private static RestoreRun Run() => new(
+        new ServerConnection { Id = "s1", Name = "SRV01", ServerName = "SRV01" },
+        "RESTORE DATABASE [MyDb_Restored] FROM URL = 'https://acct/backups/full.bak'",
+        "MyDb_Restored",
+        "MyDb",
+        "backups",
+        "Full",
+        new DateTime(2026, 8, 17, 22, 0, 0),
+        "WITH REPLACE=True, recovery=Recovery, stopAt=none");
+
+    /// <summary>
+    /// The restore has already happened by the time the receipt is written. Nothing that goes
+    /// wrong while filing it may change that - and before this, an exception here came out of
+    /// RunAsync and turned a completed restore into a crash.
+    /// </summary>
+    [Fact]
+    public async Task AStoreThatThrowsDoesNotFailTheRestore()
+    {
+        var (vm, _) = Execution(new InvalidOperationException("history file is read-only"));
+
+        await vm.RunAsync(Run(), Proceed);
+
+        Assert.True(vm.ExecutionComplete);
+        Assert.True(vm.ExecutionSuccess);
+    }
+
+    /// <summary>Said out loud, though. A receipt that silently did not happen is worse.</summary>
+    [Fact]
+    public async Task AndItSaysTheRecordingFailed()
+    {
+        var (vm, _) = Execution(new InvalidOperationException("history file is read-only"));
+
+        await vm.RunAsync(Run(), Proceed);
+        vm.Console.Flush();
+
+        Assert.Contains("Recording it in History failed", vm.Console.Text);
+        Assert.Contains("read-only", vm.Console.Text);
+    }
+
+    [Fact]
+    public async Task AndAWorkingStoreStillGetsItsReceipt()
+    {
+        var (vm, history) = Execution(null);
+
+        await vm.RunAsync(Run(), Proceed);
+
+        var entry = Assert.Single(history.Entries);
+        Assert.Equal(OperationOutcome.Succeeded, entry.Outcome);
+    }
+}

--- a/src/NineLives.Tests/RestoreExecutionSeamTests.cs
+++ b/src/NineLives.Tests/RestoreExecutionSeamTests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using Blackcat.NineLives.Models;
 using Blackcat.NineLives.Services;
 using Blackcat.NineLives.ViewModels;
@@ -119,19 +119,36 @@ public class RestoreExecutionSeamTests
     }
 
     /// <summary>
-    /// The recorded log is the WHOLE console, not whatever had made it out of the batching buffer
-    /// when the run ended - which is why the flush happens before the history entry is written.
+    /// The recorded log is the console as it stood when the run ended, from its first line - not
+    /// whatever had made it out of the batching buffer, which is why the flush happens before the
+    /// history entry is written.
+    ///
+    /// A PREFIX rather than equality, and the distinction is a real one rather than a way of making
+    /// a test pass (#461). Progress&lt;T&gt; POSTS its callbacks, so a report issued just before the
+    /// execution returned can still be queued when the run's finally block flushes and records -
+    /// and it then reaches the console after the receipt was taken. The receipt is one line short
+    /// of the console, on CI, perhaps one run in twenty.
+    ///
+    /// Prefix keeps everything worth keeping: nothing in the receipt that is not in the console, in
+    /// the same order, starting at the same place. A receipt truncated early, out of order, or
+    /// holding text the console never had all still fail. Only a trailing progress line arriving
+    /// late is tolerated, which is the one thing that is genuinely not guaranteed.
     /// </summary>
     [Fact]
-    public async Task TheRecordedLogIsTheWholeConsole()
+    public async Task TheRecordedLogIsTheConsoleAsItStoodWhenTheRunEnded()
     {
         var (vm, _, history) = New();
 
         await vm.RunAsync(Run(), Proceed);
 
         var entry = Assert.Single(history.Entries);
+
         Assert.Contains("Beginning restore execution", entry.Log);
-        Assert.Equal(vm.Console.Text, entry.Log);
+        Assert.StartsWith(entry.Log, vm.Console.Text);
+
+        // And it is the run, not a fragment of it: the outcome has to be in there, because that is
+        // what somebody opens a receipt to find.
+        Assert.Contains("Restore completed", entry.Log);
     }
 
     [Fact]

--- a/src/NineLives.Tests/TheGapCheckIsReachableTests.cs
+++ b/src/NineLives.Tests/TheGapCheckIsReachableTests.cs
@@ -1,0 +1,164 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Views;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The gap check can be found (#466).
+///
+/// It shipped in v1.7.0 inside the restore options - which is to say behind a step that only
+/// appears once a restore point has been confirmed, and which starts collapsed. A feature whose
+/// entire purpose is telling somebody the chain is shorter than they think cannot require them to
+/// already suspect it: that is the same fault as the bug it exists to fix. It was reported as
+/// missing by the first person to look for it, which is about as clear as evidence gets.
+///
+/// Pinned in the view rather than the view model, because the view model was never the problem.
+/// Every assertion here is about what is on screen and when.
+/// </summary>
+[Collection(WpfCollection.Name)]
+public class TheGapCheckIsReachableTests(WpfFixture wpf)
+{
+    private const string Header = "BACKUPS THIS CONTAINER IS MISSING";
+
+    private static RestoreViewModel Screen(AppMode mode)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Mode = mode;
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "sqlbackups",
+            ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+        });
+
+        var vm = new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp());
+
+        vm.Mode = mode;
+        vm.SelectedContainer = store.Config.BlobContainers[0];
+        return vm;
+    }
+
+    private static TextBlock? FindHeader(DependencyObject view) =>
+        FindAll<TextBlock>(view).FirstOrDefault(t => t.Text == Header);
+
+    /// <summary>
+    /// The one that would have caught the report: nothing chosen but a container, no target, no
+    /// confirmed restore point - and it is on screen.
+    /// </summary>
+    [Fact]
+    public void ItIsOnScreenBeforeATargetOrARestorePointIsChosen()
+    {
+        wpf.Invoke(() =>
+        {
+            var vm = Screen(AppMode.Pro);
+            var view = new RestoreView { DataContext = vm };
+            Layout(view);
+
+            Assert.Null(vm.SelectedTargetServer);
+            Assert.False(vm.Steps.Options.IsVisible);
+
+            var header = FindHeader(view);
+            Assert.NotNull(header);
+            Assert.Equal(Visibility.Visible, header!.Visibility);
+        });
+    }
+
+    /// <summary>
+    /// In every mode. It was gated on ShowAdvancedOptions, which happens to return true for all of
+    /// them - so the gate did nothing except imply this was a Pro-only tool to anybody reading it.
+    /// </summary>
+    [Theory]
+    [InlineData(AppMode.Basic)]
+    [InlineData(AppMode.Standard)]
+    [InlineData(AppMode.Pro)]
+    public void ItIsOnScreenInEveryMode(AppMode mode)
+    {
+        wpf.Invoke(() =>
+        {
+            var view = new RestoreView { DataContext = Screen(mode) };
+            Layout(view);
+
+            var header = FindHeader(view);
+            Assert.NotNull(header);
+            Assert.Equal(Visibility.Visible, header!.Visibility);
+        });
+    }
+
+    /// <summary>
+    /// And it sits in the SOURCE step, beside the other tool that asks an instance about these same
+    /// backups. Proven by walking up from the header to the step that contains it, rather than by
+    /// trusting a line number - the previous two placements both compiled and both hid it.
+    /// </summary>
+    [Fact]
+    public void ItSitsInTheSourceStepBesideTheAuditPanel()
+    {
+        wpf.Invoke(() =>
+        {
+            var view = new RestoreView { DataContext = Screen(AppMode.Pro) };
+            Layout(view);
+
+            var header = FindHeader(view);
+            Assert.NotNull(header);
+
+            var audit = FindAll<TextBlock>(view)
+                .FirstOrDefault(t => t.Text == "AUDIT THESE BACKUPS");
+            Assert.NotNull(audit);
+
+            // Both inside one container, which is the source step's own panel.
+            Assert.True(SharesAnAncestorWithin(header!, audit!, generations: 4),
+                "The gap check is no longer beside the audit panel - check which step it landed in.");
+        });
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static bool SharesAnAncestorWithin(
+        DependencyObject a, DependencyObject b, int generations)
+    {
+        var ancestors = new List<DependencyObject>();
+        var walk = a;
+        for (int i = 0; i < generations && walk != null; i++)
+        {
+            walk = VisualTreeHelper.GetParent(walk);
+            if (walk != null) ancestors.Add(walk);
+        }
+
+        walk = b;
+        for (int i = 0; i < generations && walk != null; i++)
+        {
+            walk = VisualTreeHelper.GetParent(walk);
+            if (walk != null && ancestors.Contains(walk)) return true;
+        }
+
+        return false;
+    }
+
+    private static void Layout(FrameworkElement element)
+    {
+        element.Measure(new Size(1400, 2400));
+        element.Arrange(new Rect(0, 0, 1400, 2400));
+        element.UpdateLayout();
+    }
+
+    private static IEnumerable<T> FindAll<T>(DependencyObject root) where T : DependencyObject
+    {
+        int count = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < count; i++)
+        {
+            var node = VisualTreeHelper.GetChild(root, i);
+            if (node is T match) yield return match;
+            foreach (var d in FindAll<T>(node)) yield return d;
+        }
+    }
+}

--- a/src/NineLives.Tests/packages.lock.json
+++ b/src/NineLives.Tests/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "kzLFyBYUnoidpGOXvpNOfIo8C92gVgVR6X8ncHwhcrDYugiOut5rrhDkr0L3cWHd7J2pKXf6LgaeXoBBDlx1ag=="
       },
       "Azure.Core": {
         "type": "Transitive",

--- a/src/NineLives.Tests/packages.lock.json
+++ b/src/NineLives.Tests/packages.lock.json
@@ -4,12 +4,12 @@
     "net10.0-windows7.0": {
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.8.1, )",
-        "resolved": "18.8.1",
-        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "xIzVXa/VpKXqDWzyC/5Hw8JbFY5u9k3Jc53CpcjBiOXvkQGio484LD9FNwOiGUSMDcYL3Rcw9sNgGi5WrswlPQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.8.1",
-          "Microsoft.TestPlatform.TestHost": "18.8.1"
+          "Microsoft.CodeCoverage": "18.9.0",
+          "Microsoft.TestPlatform.TestHost": "18.9.0"
         }
       },
       "xunit": {
@@ -86,8 +86,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+        "resolved": "18.9.0",
+        "contentHash": "MtegCIKGuG0r/LCdIjoR1HgzCGIUBhR3aNdbtQpts5vMXQuqBDZ2Jsd2uFKoHFM2XrQV6ZrDf3F5oLi3SLTp8w=="
       },
       "Microsoft.Data.SqlClient": {
         "type": "Transitive",
@@ -304,15 +304,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
+        "resolved": "18.9.0",
+        "contentHash": "Fz/qXC52VXXopzHj7v2reCKcCqSxkTDCkEDfkNAH0vni/7qK/KLMiEYtRmnUanxO2F2g2zZZ60qCpxF0AF7URA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "resolved": "18.9.0",
+        "contentHash": "Oq+Pma/J86aZL72t71bcESvDszDsTjUfl6PIsuDdPoKTHZfNMhKamCfLD5fKx51W/u0KozXtJo2/3fnt0sgPxg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+          "Microsoft.TestPlatform.ObjectModel": "18.9.0"
         }
       },
       "System.ClientModel": {
@@ -388,14 +388,14 @@
       "9lives": {
         "type": "Project",
         "dependencies": {
-          "NineLives.Core": "[1.5.0, )"
+          "NineLives.Core": "[1.7.0, )"
         }
       },
       "ninelives": {
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Mvvm": "[8.4.2, )",
-          "NineLives.Core": "[1.5.0, )"
+          "NineLives.Core": "[1.7.0, )"
         }
       },
       "ninelives.core": {

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -170,6 +170,56 @@ public partial class BackupGapViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// The source's logs taken after a moment, rather than what a container is missing (#451).
+    ///
+    /// The Copy screen's question. It reads no container chain - it writes its own full - so the
+    /// useful thing is which of the source's logs would carry that full forward to now.
+    /// </summary>
+    public async Task CheckLogsAfterAsync(string database, DateTime after)
+    {
+        if (SourceServer is not { } server) return;
+
+        IsChecking = true;
+        ClearStatus();
+        Clear();
+
+        var ct = _cancellation.Begin();
+
+        try
+        {
+            var history = await _sql.ReadBackupHistoryAsync(server, database, ct);
+            var locations = BackupGapAnalyser.LogsTakenAfter(history, database, after);
+
+            foreach (var location in locations) Locations.Add(new MissingLocationRow(location));
+
+            ComparedWhat =
+                $"{database} on {server.ServerName}: log backups taken after " +
+                $"{after:yyyy-MM-dd HH:mm}.";
+
+            HasChecked = true;
+
+            var files = Locations.Sum(l => l.FileCount);
+            SetStatus(Locations.Count == 0
+                ? "The source has taken no log backups since the copy - there is nothing to roll forward."
+                : $"{files} log backup file(s) could roll this copy forward.");
+        }
+        catch (OperationCanceledException)
+        {
+            SetStatus("Check cancelled.");
+        }
+        catch (Exception ex)
+        {
+            SetError($"Could not read {server.ServerName}'s backup history: {ex.Message}");
+        }
+        finally
+        {
+            IsChecking = false;
+            _cancellation.End();
+            RaiseDerived();
+        }
+    }
+
     [RelayCommand]
     private void Cancel() => _cancellation.Cancel();
 

--- a/src/NineLives/ViewModels/ConsoleBuffer.cs
+++ b/src/NineLives/ViewModels/ConsoleBuffer.cs
@@ -75,8 +75,43 @@ public partial class ConsoleBuffer : ObservableObject
     [ObservableProperty]
     private bool _hasOutput;
 
-    /// <summary>The console as plain text, for copying into a bug report.</summary>
-    public string Text => string.Join(Environment.NewLine, Lines.Select(l => l.Text));
+    /// <summary>
+    /// The console as plain text, for copying into a bug report or filing in a receipt.
+    ///
+    /// Defensive about what it enumerates, because it is read from a thread that does not own this
+    /// collection. Writes are marshalled to the dispatcher - which makes the app itself safe, since
+    /// the receipt is written there too - but the run's finally is not guaranteed to be on it once
+    /// anything in the chain has awaited, and a test has no dispatcher at all. ObservableCollection
+    /// is not thread-safe: enumerating one mid-write can hand back a null slot from the array it is
+    /// growing, and this threw a NullReferenceException on CI doing exactly that.
+    ///
+    /// Snapshotted first so the join cannot fail halfway with the collection changing underneath
+    /// it, and null-tolerant because a torn read is the thing being defended against - dropping a
+    /// line that has not landed yet is the right answer, and throwing is not.
+    /// </summary>
+    public string Text
+    {
+        get
+        {
+            ConsoleLine[] snapshot;
+            try
+            {
+                snapshot = Lines.ToArray();
+            }
+            catch (ArgumentException)
+            {
+                // "Destination array was not long enough" - the collection grew during the copy.
+                // One retry, then give back what is stable rather than failing a caller whose real
+                // job is finishing a restore.
+                try { snapshot = Lines.ToArray(); }
+                catch (ArgumentException) { return string.Empty; }
+            }
+
+            return string.Join(
+                Environment.NewLine,
+                snapshot.Where(l => l != null).Select(l => l.Text));
+        }
+    }
 
     /// <summary>
     /// Adds a message, splitting it into lines and collapsing runs of blanks.

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -48,6 +48,7 @@ public partial class CopyDatabaseViewModel : ViewModelBase
         _sql = sql;
         _log = log ?? App.Log;
         _history = history ?? new OperationHistoryStore();
+        Gap = new BackupGapViewModel(sql);
 
         Refresh();
     }
@@ -144,12 +145,62 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             if (previousSource != null) SourceServer = Servers.FirstOrDefault(s => s.Id == previousSource);
             if (previousTarget != null) TargetServer = Servers.FirstOrDefault(s => s.Id == previousTarget);
             if (previousContainer != null) Container = Containers.FirstOrDefault(c => c.Id == previousContainer);
+
+            // The log check offers the same saved list.
+            Gap.Servers.Clear();
+            foreach (var server in config.Servers) Gap.Servers.Add(server);
         }
         catch
         {
             Servers = [];
             Containers = [];
         }
+    }
+
+    /// <summary>
+    /// Asks the source what logs it has taken since this copy's full, and where they went (#451).
+    ///
+    /// Not the Restore screen's question. That one asks what a container is MISSING; this screen
+    /// reads no container chain at all - it writes its own full - so the useful question is which
+    /// of the source's logs would carry that full forward to now.
+    ///
+    /// Only worth asking once the scripts exist, because "since when" is the copy's own timestamp.
+    /// </summary>
+    [RelayCommand]
+    private async Task CheckSourceLogsAsync()
+    {
+        if (SourceServer == null || string.IsNullOrWhiteSpace(SourceDatabase)) return;
+        if (_copyTakenAt is not { } takenAt)
+        {
+            SetStatus("Generate the scripts first - the logs to apply are the ones taken since.");
+            return;
+        }
+
+        Gap.SourceServer = SourceServer;
+        await Gap.CheckLogsAfterAsync(SourceDatabase!, takenAt);
+    }
+
+    /// <summary>
+    /// Writes the statements that apply those logs to the copy.
+    ///
+    /// Brought online at the end, because somebody pressing this is doing the cutover. Applying
+    /// logs repeatedly up to the switch is the other shape, and the script says how.
+    /// </summary>
+    [RelayCommand]
+    private void BuildRollForward()
+    {
+        var logs = Gap.Locations
+            .SelectMany(l => l.Location.Backups.Select(b => b.Entry))
+            .ToList();
+
+        RollForwardScript = LogRollForwardScript.Build(TargetDatabaseName, logs);
+    }
+
+    [RelayCommand]
+    private void CopyRollForward()
+    {
+        if (!HasRollForwardScript) return;
+        TryCopyToClipboard(RollForwardScript, "Roll-forward script copied to clipboard.");
     }
 
     /// <summary>The list is not fetchable mid-run: it can wait; the copy cannot re-run (#281).</summary>
@@ -484,10 +535,17 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             {
                 TargetDatabaseName = TargetDatabaseName,
                 WithReplace = WithReplace,
-                RecoveryMode = RecoveryMode.Recovery
+                // Left restoring for a cutover, online for a refresh (#451).
+                RecoveryMode = LeaveRestoringForMoreLogs
+                    ? RecoveryMode.NoRecovery
+                    : RecoveryMode.Recovery
             });
 
-        SetStatus("Scripts generated.");
+        _copyTakenAt = takenAt;
+
+        SetStatus(LeaveRestoringForMoreLogs
+            ? "Scripts generated. The target will be left in RESTORING, ready for more logs."
+            : "Scripts generated.");
 
         // The checks depend on the SERVERS and the SOURCE database - not on the target
         // name or any other keystroke-speed field. Re-asking two production instances six
@@ -550,6 +608,45 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     private string _sharedFolderRefusal = string.Empty;
 
     partial void OnSharedFolderRefusalChanged(string value) => Invalidate();
+
+    /// <summary>
+    /// Leave the target in RESTORING so more log backups can be applied to it (#451).
+    ///
+    /// The cutover. A copy normally brings the target online, which is right for a test refresh and
+    /// wrong for a migration: online means no more logs can be applied, so the copy is frozen at
+    /// the moment it was taken. Left restoring, the long part - the full - happens in advance, and
+    /// the switch-over costs only the logs that accumulated since.
+    ///
+    /// Off by default, because a database left in RESTORING is not usable and somebody refreshing a
+    /// test environment wants the opposite. The screen says which it will be.
+    /// </summary>
+    [ObservableProperty]
+    private bool _leaveRestoringForMoreLogs;
+
+    partial void OnLeaveRestoringForMoreLogsChanged(bool value)
+    {
+        Invalidate();
+        RollForwardScript = string.Empty;
+        if (HasScripts) Generate();
+    }
+
+    /// <summary>The logs on the source that would roll this copy forward, and where they live.</summary>
+    public BackupGapViewModel Gap { get; }
+
+    /// <summary>
+    /// The statements that apply those logs, or empty. Built on demand: most copies are refreshes
+    /// and nobody wants this.
+    /// </summary>
+    [ObservableProperty]
+    private string _rollForwardScript = string.Empty;
+
+    public bool HasRollForwardScript => RollForwardScript.Length > 0;
+
+    partial void OnRollForwardScriptChanged(string value)
+        => OnPropertyChanged(nameof(HasRollForwardScript));
+
+    /// <summary>When the copy's own full was taken - what the logs have to come after.</summary>
+    private DateTime? _copyTakenAt;
 
     /// <summary>
     /// The three generation-time checks as one serialised sweep (#285): warnings cleared once

--- a/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
+++ b/src/NineLives/ViewModels/CopyDatabaseViewModel.cs
@@ -278,6 +278,11 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             if (string.IsNullOrWhiteSpace(SourceDatabase)) return string.Empty;
             if (string.IsNullOrWhiteSpace(TargetDatabaseName)) return string.Empty;
 
+            // A folder one side cannot use (#452). Before the version and encryption verdicts,
+            // because there is no point discussing what the target can restore when the backup
+            // cannot be written in the first place.
+            if (SharedFolderRefusal.Length > 0) return SharedFolderRefusal;
+
             // Onto itself, under its own name. That is not a copy - it is a backup of a database
             // immediately restored over the top of the database it was taken from, which at best
             // is an expensive no-op and at worst destroys it when the restore fails halfway.
@@ -506,7 +511,45 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// <summary>The in-flight sweep, so the run can refuse to start before the verdicts are in.</summary>
     private Task _checksTask = Task.CompletedTask;
 
+    /// <summary>
+    /// Awaits the in-flight check sweep. For tests, so they turn on the sweep having finished
+    /// rather than on a sleep long enough to hope it has - a timing guess is how a test passes
+    /// locally and fails on a loaded runner.
+    /// </summary>
+    internal Task WaitForChecksForTests() => _checksTask;
+
     private readonly OperationCancellation _checksCancellation = new();
+
+    /// <summary>
+    /// What the SOURCE said about writing to the shared folder, and the TARGET about reading it
+    /// (#452).
+    ///
+    /// Two accounts, two answers, kept apart. The screen's own text has always said the source
+    /// writes as its service account and the target reads as its own - routinely not the same one -
+    /// and reporting them as one verdict loses the only thing that makes the message actionable,
+    /// which is WHICH permission grant is needed and to whom.
+    /// </summary>
+    [ObservableProperty]
+    private string _sourceCanWriteHere = string.Empty;
+
+    [ObservableProperty]
+    private string _targetCanReadHere = string.Empty;
+
+    [ObservableProperty]
+    private bool _sharedFolderProven;
+
+    /// <summary>
+    /// The folder problem, or empty. Feeds the refusal, because a copy through a folder one side
+    /// cannot use will not work and generating a script for it wastes the wait.
+    ///
+    /// A check that could not be COMPLETED is not a check that failed - an instance that refuses to
+    /// answer must not block a copy that would have worked, the same rule the space check follows.
+    /// So only a definite no counts.
+    /// </summary>
+    [ObservableProperty]
+    private string _sharedFolderRefusal = string.Empty;
+
+    partial void OnSharedFolderRefusalChanged(string value) => Invalidate();
 
     /// <summary>
     /// The three generation-time checks as one serialised sweep (#285): warnings cleared once
@@ -523,6 +566,12 @@ public partial class CopyDatabaseViewModel : ViewModelBase
             SpaceWarning = string.Empty;
             VolumeSpace = [];
 
+            SourceCanWriteHere = string.Empty;
+            TargetCanReadHere = string.Empty;
+            SharedFolderRefusal = string.Empty;
+            SharedFolderProven = false;
+
+            await CheckSharedFolderAsync(ct);
             await CheckVersionAsync(ct);
             await CheckEncryptionAsync(ct);
             await CheckSpaceAsync(ct);
@@ -558,6 +607,51 @@ public partial class CopyDatabaseViewModel : ViewModelBase
     /// STRONGEST terms, because unlike disk space nothing can change between generating and
     /// running that makes this legal.
     /// </summary>
+    /// <summary>
+    /// Asks both instances about the shared folder before anything is backed up (#452).
+    ///
+    /// The readability check that already exists runs on a FILE, so it cannot run until a file is
+    /// there - which on this screen is after a full backup has been written. A share the target
+    /// cannot read therefore cost the whole backup first. This costs two round trips.
+    ///
+    /// What it proves is narrower than what the file check proves, and the wording says so: that
+    /// the folder is visible to the target's account, not that a backup inside it will be
+    /// readable - a share can be traversable and still refuse the read. It catches the common
+    /// failure, which is an account with no access to the share at all, in a second.
+    /// </summary>
+    private async Task CheckSharedFolderAsync(CancellationToken ct)
+    {
+        if (MediumIsBlob) return;
+        if (string.IsNullOrWhiteSpace(SharedPathRoot)) return;
+        if (SourceServer == null || TargetServer == null) return;
+
+        try
+        {
+            // The source has to CREATE here; the target only has to see it.
+            var write = await _sql.CheckFolderAccessAsync(SourceServer, SharedPathRoot, true, ct);
+            SourceCanWriteHere = write.Explain(SourceServer.ServerName, wasWriteCheck: true);
+
+            var read = await _sql.CheckFolderAccessAsync(TargetServer, SharedPathRoot, false, ct);
+            TargetCanReadHere = read.Explain(TargetServer.ServerName, wasWriteCheck: false);
+
+            SharedFolderProven = write.IsOk && read.IsOk;
+
+            SharedFolderRefusal =
+                !write.IsOk && write.Access != FolderAccess.Unreachable ? SourceCanWriteHere
+                : !read.IsOk && read.Access != FolderAccess.Unreachable ? TargetCanReadHere
+                : string.Empty;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Never the reason a copy cannot be set up. Not knowing is not the same as refusing.
+            _log.Info($"[share] could not check {SharedPathRoot}: {ex.Message}");
+        }
+    }
+
     private async Task CheckVersionAsync(CancellationToken ct)
     {
         if (SourceServer == null || TargetServer == null) return;

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -395,7 +395,24 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             // mid-finally, which is a worse trade than a receipt missing "100 percent processed" -
             // every line that carries meaning is already in it, because those are appended
             // directly rather than through the progress channel.
-            if (attempted) await RecordHistory(run, startedAt, outcome, failure);
+            if (attempted)
+            {
+                try
+                {
+                    await RecordHistory(run, startedAt, outcome, failure);
+                }
+                catch (Exception ex)
+                {
+                    // The store already promises never to fail the thing it records - but that
+                    // promise lives inside Append, and everything BEFORE it was unguarded: reading
+                    // the console, assembling the entry. A NullReferenceException from a torn read
+                    // of the console came out of here on CI, and in the app it would have surfaced
+                    // a completed restore as a crash. The restore has already happened by this
+                    // point; nothing that goes wrong while filing it may change that.
+                    _log.Error($"Could not record this run in the history: {ex.Message}");
+                    AppendLog($"The restore finished. Recording it in History failed: {ex.Message}");
+                }
+            }
         }
     }
 

--- a/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreExecutionViewModel.cs
@@ -383,9 +383,18 @@ public partial class RestoreExecutionViewModel : ViewModelBase
             Console.Flush();   // nothing buffered may outlive the run
             RaiseCancelStateChanged();
 
-            // After the flush, so the recorded log is the whole console rather than whatever had
-            // made it out of the batching buffer. Recorded for every outcome including cancelled -
-            // "I stopped it" is exactly the kind of thing a change ticket needs to say.
+            // After the flush, so the recorded log is the console as it stands rather than
+            // whatever had made it out of the batching buffer. Recorded for every outcome
+            // including cancelled - "I stopped it" is exactly the kind of thing a change ticket
+            // needs to say.
+            //
+            // Not quite the WHOLE console, and the gap is worth knowing about (#461): Progress<T>
+            // posts its callbacks, so a report issued just before the execution returned can still
+            // be queued here and reach the console after this receipt is taken. The receipt can be
+            // one trailing progress line short. Draining that would mean pumping the dispatcher
+            // mid-finally, which is a worse trade than a receipt missing "100 percent processed" -
+            // every line that carries meaning is already in it, because those are appended
+            // directly rather than through the progress channel.
             if (attempted) await RecordHistory(run, startedAt, outcome, failure);
         }
     }

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -164,7 +164,52 @@
                                  Margin="0,4,0,0"
                                  ToolTip="For example \\nas01\sql" />
                         <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap" Margin="0,6,0,0"
-                                   Text="The source has to WRITE here as its own service account, and the target has to READ here as its own - two different accounts, and routinely not the same one. Whether the target can read it is checked after the backup, before the restore." />
+                                   Text="The source has to WRITE here as its own service account, and the target has to READ here as its own - two different accounts, and routinely not the same one. Both are checked when you generate the scripts - before anything is written, rather than after the backup as it used to be." />
+
+                        <!-- The two verdicts, kept apart (#452). One combined answer loses the only
+                             thing that makes the message actionable: which permission grant is
+                             needed, and to which account. Coloured on the outcome, so a refusal
+                             does not read as reassurance. -->
+                        <StackPanel Margin="0,8,0,0"
+                                    Visibility="{Binding SourceCanWriteHere, Converter={StaticResource NullToVis}}">
+                            <TextBlock Text="{Binding SourceCanWriteHere}"
+                                       TextWrapping="Wrap" Margin="0,0,0,4">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                        <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding SharedFolderProven}" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
+                            <TextBlock Text="{Binding TargetCanReadHere}"
+                                       TextWrapping="Wrap"
+                                       Visibility="{Binding TargetCanReadHere, Converter={StaticResource NullToVis}}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock" BasedOn="{StaticResource SecondaryText}">
+                                        <Setter Property="Foreground" Value="{DynamicResource WarningBrush}" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding SharedFolderProven}" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource SuccessBrush}" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
+                            <!-- What xp_fileexist actually proves, said rather than implied: the
+                                 folder is visible to that account, not that a backup inside it will
+                                 be readable. The file-level check after the backup is still the
+                                 authoritative one. -->
+                            <TextBlock Style="{StaticResource SecondaryText}"
+                                       FontSize="10" TextWrapping="Wrap" Margin="0,6,0,0"
+                                       Visibility="{Binding SharedFolderProven, Converter={StaticResource BoolToVis}}"
+                                       Text="That proves the folder is reachable by both accounts. Whether a backup inside it can be opened is checked again once it is written - a share can be visible and still refuse the read." />
+                        </StackPanel>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal" Margin="0,14,0,0">

--- a/src/NineLives/Views/CopyDatabaseView.xaml
+++ b/src/NineLives/Views/CopyDatabaseView.xaml
@@ -264,6 +264,21 @@
                         </StackPanel>
                     </Grid>
 
+                    <!-- The cutover (#451). Online is right for a test refresh and wrong for a
+                         migration: online means no more logs can be applied, so the copy is
+                         frozen at the moment it was taken. -->
+                    <CheckBox Content="Leave the target ready for more log backups (NORECOVERY)"
+                              IsChecked="{Binding LeaveRestoringForMoreLogs}"
+                              Style="{StaticResource DarkCheckBox}"
+                              Margin="0,0,0,4"
+                              ToolTip="For a migration: the full is restored now and the target stays in RESTORING, so the source's later logs can be applied at the moment you switch over. The database is NOT usable until they are." />
+
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               FontSize="11" TextWrapping="Wrap" Margin="0,0,0,12"
+                               Foreground="{DynamicResource WarningBrush}"
+                               Visibility="{Binding LeaveRestoringForMoreLogs, Converter={StaticResource BoolToVis}}"
+                               Text="The target will be left in RESTORING and will not be usable until logs are applied and it is brought online. For a test refresh, leave this unticked." />
+
                     <CheckBox Content="Overwrite it if it already exists (WITH REPLACE)"
                               IsChecked="{Binding WithReplace}"
                               Style="{StaticResource DarkCheckBox}"
@@ -415,6 +430,86 @@
                                                     Foreground="{DynamicResource ConsoleTextBrush}" />
                             </StackPanel>
                         </ScrollViewer>
+                    </Border>
+
+                    <!-- Rolling the copy forward (#451). Only when the target has been left
+                         restorable - on a copy brought online these logs cannot be applied at all,
+                         and offering them would be offering something that fails with 3101. -->
+                    <Border Style="{StaticResource CardBorder}" Margin="0,12,0,0"
+                            Visibility="{Binding LeaveRestoringForMoreLogs, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <TextBlock Text="ROLL THIS COPY FORWARD" Style="{StaticResource LabelText}"
+                                       Margin="0,0,0,6" />
+
+                            <TextBlock Style="{StaticResource SecondaryText}" TextWrapping="Wrap"
+                                       Margin="0,0,0,10"
+                                       Text="The copy restores a full taken now. The log backups the source takes after it are what carry the target up to the moment you switch over - so the long part happens in advance and the downtime is only the tail. Ask the source what it has taken since." />
+
+                            <WrapPanel>
+                                <Button Content="What has the source taken since?"
+                                        Command="{Binding CheckSourceLogsCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="12,6" Margin="0,0,8,8" />
+
+                                <Button Content="Write the roll-forward script"
+                                        Command="{Binding BuildRollForwardCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="12,6" Margin="0,0,8,8"
+                                        Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}" />
+
+                                <Button Content="Copy to clipboard"
+                                        Command="{Binding CopyRollForwardCommand}"
+                                        Style="{StaticResource SecondaryButton}"
+                                        Padding="12,6" Margin="0,0,8,8"
+                                        Visibility="{Binding HasRollForwardScript, Converter={StaticResource BoolToVis}}" />
+                            </WrapPanel>
+
+                            <ContentControl Style="{StaticResource ErrorBanner}" DataContext="{Binding Gap}" />
+
+                            <TextBlock Text="{Binding Gap.StatusMessage}"
+                                       Style="{StaticResource SecondaryText}"
+                                       TextWrapping="Wrap" Margin="0,0,0,8"
+                                       Visibility="{Binding Gap.StatusMessage, Converter={StaticResource NullToVis}}" />
+
+                            <ItemsControl ItemsSource="{Binding Gap.Locations}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="{DynamicResource InputBackgroundBrush}"
+                                                CornerRadius="4" Padding="10,8" Margin="0,0,0,8">
+                                            <StackPanel>
+                                                <TextBlock Text="{Binding Folder}"
+                                                           Style="{StaticResource BodyText}"
+                                                           FontFamily="{StaticResource ConsoleFont}"
+                                                           TextWrapping="Wrap" />
+                                                <TextBlock Style="{StaticResource SecondaryText}"
+                                                           Margin="0,4,0,0" TextWrapping="Wrap">
+                                                    <Run Text="{Binding Summary, Mode=OneWay}" />
+                                                    <Run Text="-" />
+                                                    <Run Text="{Binding SizeDisplay, Mode=OneWay}" />
+                                                </TextBlock>
+                                                <TextBlock Text="{Binding Window}"
+                                                           Style="{StaticResource SecondaryText}"
+                                                           Margin="0,2,0,0" />
+                                            </StackPanel>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                                    BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                                    BorderThickness="1" CornerRadius="4" Margin="0,8,0,0"
+                                    Visibility="{Binding HasRollForwardScript, Converter={StaticResource BoolToVis}}">
+                                <ScrollViewer MaxHeight="240" VerticalScrollBarVisibility="Auto"
+                                              HorizontalScrollBarVisibility="Auto" Padding="10,8">
+                                    <views:SqlTextBlock Sql="{Binding RollForwardScript}"
+                                                        FontFamily="{StaticResource ConsoleFont}"
+                                                        FontSize="12"
+                                                        TextWrapping="NoWrap"
+                                                        Foreground="{DynamicResource ConsoleTextBrush}" />
+                                </ScrollViewer>
+                            </Border>
+                        </StackPanel>
                     </Border>
 
                     <!-- What state the two servers were left in, in terms of what to do next. -->

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -574,6 +574,178 @@
                 </StackPanel>
             </Border>
 
+            <!-- Beside the audit panel, in SELECT SOURCE, and the placement took two goes to get
+                 right (#466). It began in the restore options: a feature whose entire point is
+                 telling somebody the chain is shorter than they think, behind a step reached only
+                 after confirming a restore point computed from that same short chain. Then step 3,
+                 which shows the chain but is not offered until a TARGET has been chosen - and this
+                 question is about the SOURCE. Here it is reachable the moment a database is picked,
+                 next to the other tool that asks an instance about these same backups. -->
+            <!-- What the source instance recorded, against what this container
+                 holds (#451). Behind the advanced options because it means
+                 connecting to a SECOND server - the one that took the backups,
+                 which is routinely not the one being restored to. -->
+            <Border Style="{StaticResource CardBorder}"
+                    Margin="0,4,0,16">
+                <StackPanel>
+                    <TextBlock Text="BACKUPS THIS CONTAINER IS MISSING"
+                               Style="{StaticResource LabelText}" Margin="0,0,0,6" />
+
+                    <TextBlock Style="{StaticResource SecondaryText}"
+                               TextWrapping="Wrap" Margin="0,0,0,10"
+                               Text="Logs often go somewhere else - a local or cluster disk for throughput, or a share because log shipping already owns them. The container cannot tell you that; the instance that took them can. Ask it, and anything written elsewhere shows up here with the path it went to." />
+
+                    <Grid Margin="0,0,0,10">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <ComboBox Grid.Column="0"
+                                  ItemsSource="{Binding Gap.Servers}"
+                                  SelectedItem="{Binding Gap.SourceServer}"
+                                  Style="{StaticResource DarkComboBox}"
+                                  ToolTip="The instance that TOOK these backups - not necessarily the one being restored to.">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding DisplayText}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+
+                        <Button Grid.Column="1"
+                                Content="Check its history"
+                                Command="{Binding CheckForMissingBackupsCommand}"
+                                Style="{StaticResource SecondaryButton}"
+                                Padding="12,6" Margin="8,0,0,0"
+                                IsEnabled="{Binding Gap.CanCheck}" />
+                    </Grid>
+
+                    <TextBlock Text="Reading the instance's own record..."
+                               Style="{StaticResource SecondaryText}"
+                               Margin="0,0,0,8"
+                               Visibility="{Binding Gap.IsChecking, Converter={StaticResource BoolToVis}}" />
+
+                    <ContentControl Style="{StaticResource ErrorBanner}"
+                                    DataContext="{Binding Gap}" />
+
+                    <!-- The all-clear, said out loud. An empty panel is
+                         indistinguishable from never having pressed the button. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                            Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource SuccessPanelBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding Gap.FoundNothingMissing, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                   Text="Everything the instance recorded is in this container. The chain on offer is the whole chain." />
+                    </Border>
+
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                            Background="{DynamicResource WarningPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}">
+                        <StackPanel>
+                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}}">
+                                <Run Text="This container is" />
+                                <Run Text="{Binding Gap.BehindBy, Mode=OneWay}" FontWeight="SemiBold" />
+                                <Run Text="behind what the instance recorded. Restoring from it alone throws that away." />
+                            </TextBlock>
+
+                            <!-- A gap and a MEASURED gap are not the same thing: a
+                                 container holding nothing for this database has
+                                 everything missing and no interval to quote. -->
+                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
+                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
+                                       Text="The instance recorded backups this container does not hold. Restoring from it alone leaves them out." />
+                        </StackPanel>
+                    </Border>
+
+                    <ItemsControl ItemsSource="{Binding Gap.Locations}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{DynamicResource InputBackgroundBrush}"
+                                        CornerRadius="4" Padding="10,8" Margin="0,0,0,8">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Folder}"
+                                                   Style="{StaticResource BodyText}"
+                                                   FontFamily="{StaticResource ConsoleFont}"
+                                                   TextWrapping="Wrap" />
+
+                                        <TextBlock Style="{StaticResource SecondaryText}"
+                                                   Margin="0,4,0,0" TextWrapping="Wrap">
+                                            <Run Text="{Binding Summary, Mode=OneWay}" />
+                                            <Run Text="-" />
+                                            <Run Text="{Binding FileCount, Mode=OneWay}" />
+                                            <Run Text="file(s)," />
+                                            <Run Text="{Binding SizeDisplay, Mode=OneWay}" />
+                                        </TextBlock>
+
+                                        <TextBlock Text="{Binding Window}"
+                                                   Style="{StaticResource SecondaryText}"
+                                                   Margin="0,2,0,0" />
+
+                                        <!-- A backup recorded to a URL is not a file on
+                                             that machine, so there is nothing for a copy
+                                             script to pick up. -->
+                                        <TextBlock Style="{StaticResource SecondaryText}"
+                                                   Margin="0,6,0,0" TextWrapping="Wrap"
+                                                   Foreground="{DynamicResource WarningBrush}"
+                                                   Text="Recorded as written to storage rather than to disk, so there is no file here to copy - the listing did not see something that should be in the container. Check its base path."
+                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
+
+                                        <WrapPanel Margin="0,8,0,0"
+                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}}">
+                                            <Button Content="Write a copy script"
+                                                    Command="{Binding DataContext.BuildCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Style="{StaticResource SecondaryButton}"
+                                                    Padding="10,4" Margin="0,0,8,0" />
+
+                                            <Button Content="Restore from where they are"
+                                                    Command="{Binding DataContext.RestoreFromWhereTheyAreCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Style="{StaticResource SecondaryButton}"
+                                                    Padding="10,4" Margin="0,0,8,0"
+                                                    ToolTip="Adds these to the timeline and reads them from this path instead of copying them into the container. The target has to be able to reach it - checked before the restore runs." />
+
+                                            <Button Content="Copy to clipboard"
+                                                    Command="{Binding DataContext.CopyCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                    CommandParameter="{Binding}"
+                                                    Style="{StaticResource SecondaryButton}"
+                                                    Padding="10,4"
+                                                    Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}" />
+                                        </WrapPanel>
+
+                                        <Border Background="{DynamicResource ConsoleBackgroundBrush}"
+                                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                                                BorderThickness="1" CornerRadius="4"
+                                                Margin="0,8,0,0"
+                                                Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
+                                            <ScrollViewer MaxHeight="200"
+                                                          VerticalScrollBarVisibility="Auto"
+                                                          HorizontalScrollBarVisibility="Auto"
+                                                          Padding="10,8">
+                                                <TextBlock Text="{Binding Script}"
+                                                           FontFamily="{StaticResource ConsoleFont}"
+                                                           FontSize="11"
+                                                           Foreground="{DynamicResource ConsoleTextBrush}" />
+                                            </ScrollViewer>
+                                        </Border>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <TextBlock Text="{Binding Gap.ComparedWhat}"
+                               Style="{StaticResource SecondaryText}"
+                               FontSize="10" TextWrapping="Wrap" Margin="0,4,0,0"
+                               Visibility="{Binding Gap.ComparedWhat, Converter={StaticResource NullToVis}}" />
+                </StackPanel>
+            </Border>
+
                     <!-- Reported, not corrected. A database full of these almost always means the
                          PATH PATTERN is wrong, and fixing each symptom quietly would hide it. -->
                     <ItemsControl ItemsSource="{Binding Inventory.AuditFindings}" Margin="0,10,0,0">
@@ -1581,172 +1753,6 @@
                                        Margin="0,0,0,12"
                                        Visibility="{Binding Options.ContinueAfterError, Converter={StaticResource BoolToVis}}"
                                        Text="A restore that finishes despite errors can leave a corrupt database. Run DBCC CHECKDB on the result before trusting it." />
-
-                            <!-- What the source instance recorded, against what this container
-                                 holds (#451). Behind the advanced options because it means
-                                 connecting to a SECOND server - the one that took the backups,
-                                 which is routinely not the one being restored to. -->
-                            <Border Style="{StaticResource CardBorder}"
-                                    Margin="0,4,0,16"
-                                    Visibility="{Binding ShowAdvancedOptions, Converter={StaticResource BoolToVis}}">
-                                <StackPanel>
-                                    <TextBlock Text="BACKUPS THIS CONTAINER IS MISSING"
-                                               Style="{StaticResource LabelText}" Margin="0,0,0,6" />
-
-                                    <TextBlock Style="{StaticResource SecondaryText}"
-                                               TextWrapping="Wrap" Margin="0,0,0,10"
-                                               Text="Logs often go somewhere else - a local or cluster disk for throughput, or a share because log shipping already owns them. The container cannot tell you that; the instance that took them can. Ask it, and anything written elsewhere shows up here with the path it went to." />
-
-                                    <Grid Margin="0,0,0,10">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="Auto" />
-                                        </Grid.ColumnDefinitions>
-
-                                        <ComboBox Grid.Column="0"
-                                                  ItemsSource="{Binding Gap.Servers}"
-                                                  SelectedItem="{Binding Gap.SourceServer}"
-                                                  Style="{StaticResource DarkComboBox}"
-                                                  ToolTip="The instance that TOOK these backups - not necessarily the one being restored to.">
-                                            <ComboBox.ItemTemplate>
-                                                <DataTemplate>
-                                                    <TextBlock Text="{Binding DisplayText}" />
-                                                </DataTemplate>
-                                            </ComboBox.ItemTemplate>
-                                        </ComboBox>
-
-                                        <Button Grid.Column="1"
-                                                Content="Check its history"
-                                                Command="{Binding CheckForMissingBackupsCommand}"
-                                                Style="{StaticResource SecondaryButton}"
-                                                Padding="12,6" Margin="8,0,0,0"
-                                                IsEnabled="{Binding Gap.CanCheck}" />
-                                    </Grid>
-
-                                    <TextBlock Text="Reading the instance's own record..."
-                                               Style="{StaticResource SecondaryText}"
-                                               Margin="0,0,0,8"
-                                               Visibility="{Binding Gap.IsChecking, Converter={StaticResource BoolToVis}}" />
-
-                                    <ContentControl Style="{StaticResource ErrorBanner}"
-                                                    DataContext="{Binding Gap}" />
-
-                                    <!-- The all-clear, said out loud. An empty panel is
-                                         indistinguishable from never having pressed the button. -->
-                                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
-                                            Background="{DynamicResource SuccessPanelBackgroundBrush}"
-                                            BorderBrush="{DynamicResource SuccessPanelBorderBrush}"
-                                            BorderThickness="1"
-                                            Visibility="{Binding Gap.FoundNothingMissing, Converter={StaticResource BoolToVis}}">
-                                        <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
-                                                   Text="Everything the instance recorded is in this container. The chain on offer is the whole chain." />
-                                    </Border>
-
-                                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
-                                            Background="{DynamicResource WarningPanelBackgroundBrush}"
-                                            BorderBrush="{DynamicResource WarningPanelBorderBrush}"
-                                            BorderThickness="1"
-                                            Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}">
-                                        <StackPanel>
-                                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
-                                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}}">
-                                                <Run Text="This container is" />
-                                                <Run Text="{Binding Gap.BehindBy, Mode=OneWay}" FontWeight="SemiBold" />
-                                                <Run Text="behind what the instance recorded. Restoring from it alone throws that away." />
-                                            </TextBlock>
-
-                                            <!-- A gap and a MEASURED gap are not the same thing: a
-                                                 container holding nothing for this database has
-                                                 everything missing and no interval to quote. -->
-                                            <TextBlock Style="{StaticResource BodyText}" TextWrapping="Wrap"
-                                                       Visibility="{Binding Gap.HasMeasuredGap, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}"
-                                                       Text="The instance recorded backups this container does not hold. Restoring from it alone leaves them out." />
-                                        </StackPanel>
-                                    </Border>
-
-                                    <ItemsControl ItemsSource="{Binding Gap.Locations}">
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <Border Background="{DynamicResource InputBackgroundBrush}"
-                                                        CornerRadius="4" Padding="10,8" Margin="0,0,0,8">
-                                                    <StackPanel>
-                                                        <TextBlock Text="{Binding Folder}"
-                                                                   Style="{StaticResource BodyText}"
-                                                                   FontFamily="{StaticResource ConsoleFont}"
-                                                                   TextWrapping="Wrap" />
-
-                                                        <TextBlock Style="{StaticResource SecondaryText}"
-                                                                   Margin="0,4,0,0" TextWrapping="Wrap">
-                                                            <Run Text="{Binding Summary, Mode=OneWay}" />
-                                                            <Run Text="-" />
-                                                            <Run Text="{Binding FileCount, Mode=OneWay}" />
-                                                            <Run Text="file(s)," />
-                                                            <Run Text="{Binding SizeDisplay, Mode=OneWay}" />
-                                                        </TextBlock>
-
-                                                        <TextBlock Text="{Binding Window}"
-                                                                   Style="{StaticResource SecondaryText}"
-                                                                   Margin="0,2,0,0" />
-
-                                                        <!-- A backup recorded to a URL is not a file on
-                                                             that machine, so there is nothing for a copy
-                                                             script to pick up. -->
-                                                        <TextBlock Style="{StaticResource SecondaryText}"
-                                                                   Margin="0,6,0,0" TextWrapping="Wrap"
-                                                                   Foreground="{DynamicResource WarningBrush}"
-                                                                   Text="Recorded as written to storage rather than to disk, so there is no file here to copy - the listing did not see something that should be in the container. Check its base path."
-                                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}, ConverterParameter=Invert}" />
-
-                                                        <WrapPanel Margin="0,8,0,0"
-                                                                   Visibility="{Binding IsOnDisk, Converter={StaticResource BoolToVis}}">
-                                                            <Button Content="Write a copy script"
-                                                                    Command="{Binding DataContext.BuildCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                                    CommandParameter="{Binding}"
-                                                                    Style="{StaticResource SecondaryButton}"
-                                                                    Padding="10,4" Margin="0,0,8,0" />
-
-                                                            <Button Content="Restore from where they are"
-                                                                    Command="{Binding DataContext.RestoreFromWhereTheyAreCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                                    CommandParameter="{Binding}"
-                                                                    Style="{StaticResource SecondaryButton}"
-                                                                    Padding="10,4" Margin="0,0,8,0"
-                                                                    ToolTip="Adds these to the timeline and reads them from this path instead of copying them into the container. The target has to be able to reach it - checked before the restore runs." />
-
-                                                            <Button Content="Copy to clipboard"
-                                                                    Command="{Binding DataContext.CopyCopyScriptCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                                    CommandParameter="{Binding}"
-                                                                    Style="{StaticResource SecondaryButton}"
-                                                                    Padding="10,4"
-                                                                    Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}" />
-                                                        </WrapPanel>
-
-                                                        <Border Background="{DynamicResource ConsoleBackgroundBrush}"
-                                                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                                                                BorderThickness="1" CornerRadius="4"
-                                                                Margin="0,8,0,0"
-                                                                Visibility="{Binding HasScript, Converter={StaticResource BoolToVis}}">
-                                                            <ScrollViewer MaxHeight="200"
-                                                                          VerticalScrollBarVisibility="Auto"
-                                                                          HorizontalScrollBarVisibility="Auto"
-                                                                          Padding="10,8">
-                                                                <TextBlock Text="{Binding Script}"
-                                                                           FontFamily="{StaticResource ConsoleFont}"
-                                                                           FontSize="11"
-                                                                           Foreground="{DynamicResource ConsoleTextBrush}" />
-                                                            </ScrollViewer>
-                                                        </Border>
-                                                    </StackPanel>
-                                                </Border>
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-
-                                    <TextBlock Text="{Binding Gap.ComparedWhat}"
-                                               Style="{StaticResource SecondaryText}"
-                                               FontSize="10" TextWrapping="Wrap" Margin="0,4,0,0"
-                                               Visibility="{Binding Gap.ComparedWhat, Converter={StaticResource NullToVis}}" />
-                                </StackPanel>
-                            </Border>
 
                             <CheckBox Content="WITH MOVE (relocate files)"
                                       Visibility="{Binding ShowFileRelocation, Converter={StaticResource BoolToVis}}"


### PR DESCRIPTION
Two new capabilities and two fixes since v1.7.0. No breaking changes, no config or schema changes.

## The one that matters most

**A completed restore could surface as a crash** (#471). Reading the console to file a run's receipt was not thread-safe — the line collection could be enumerated while another thread was still appending, handing back a null and throwing. That happened inside the run's own `finally`, unguarded, so it came out of the restore itself: the database restored, the target online, and an exception on screen.

Found as a red build on `main` after the v1.7.0 merge rather than by looking for it. The console now snapshots before reading and tolerates a torn one, and filing a receipt can no longer fail the thing it is filing.

## Copy a database for a cutover, not just a refresh (#451)

A copy brought the target online, which is right for refreshing a test environment and wrong for a migration — online means no more logs can be applied, so the copy is frozen at the moment it was taken. There is now an option to leave it in RESTORING, and the source can be asked which logs it has taken since, with the statements to apply them. The long part happens in advance and the switch-over costs only the tail.

## Both service accounts are proven against the shared folder (#452)

The Copy screen has always said the source writes there as its own service account and the target reads there as its own — two different accounts, routinely not the same one. But the check ran on a *file*, so it could not run until after a full backup had been written. A share the target could not read cost you the whole backup first, and the source's write was never checked ahead of time at all.

Both are now asked as themselves, before anything is written, with the two verdicts kept apart — the fix is a permission grant to a specific account and one combined answer loses which.

## The gap check can be found (#466)

It shipped in 1.7.0 inside the restore options, behind a step only reachable after confirming a restore point computed from the very chain it was meant to question. A feature whose whole point is telling you the chain is shorter than you think cannot require you to already suspect. It now sits in Select source, beside the audit panel.

## Also

The changelog itself is repaired: three entries belonging to this release had been written into the published `[1.7.0]` section, which was claiming fixes its binary does not contain.

Full detail in [CHANGELOG.md](CHANGELOG.md).

**Gate:** `dotnet build NineLives.sln -c Release -warnaserror` clean, `dotnet test` → **2,234 passed, 0 failed**.