### PR TITLE
Confirm the copy worked, in one press (#451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Added
+
+- **After copying the missing backups in, one press confirms it worked** (#451). The copy script
+  is taken away and run on the machine that holds the files, and whoever ran it comes back with
+  one question: did it work. Re-running the check answered a different one - what is missing now -
+  and a still-red panel listing five files looks identical whether eighteen arrived or none did.
+  There is now a single button that re-reads the container and asks the source again, both in one
+  press because doing them separately is how somebody concludes the copy failed when it was the
+  listing that was stale. It reports what changed: all of them arrived, or three of five with two
+  still to come, or none. Backups the instance has taken *since* are counted separately, because
+  more work appearing is not the same as the copy having failed.
+
 ## [1.7.1] - 2026-08-17
 
 ### Added

--- a/src/NineLives.Tests/RescanAndConfirmTests.cs
+++ b/src/NineLives.Tests/RescanAndConfirmTests.cs
@@ -1,0 +1,184 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The other end of the copy script (#451).
+///
+/// The script is taken away and run on the source machine, and whoever ran it comes back wanting
+/// one thing: did it work. Re-running the check answers "what is missing now", which is a
+/// different question - a still-red panel listing five files looks identical whether eighteen
+/// arrived or none did.
+/// </summary>
+public class RescanAndConfirmTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 17, 22, 0, 0);
+
+    private static ServerConnection Server() => new()
+    { Id = "s1", Name = "SRV01", ServerName = "SRV01" };
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+    };
+
+    private static BackupHistoryEntry Log(DateTime at, string folder = @"E:\SQLLogs") => new()
+    {
+        DatabaseName = "Sales",
+        Type = BackupType.TransactionLog,
+        StartedAt = at,
+        Files = [$@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn"],
+        BackupSizeBytes = 10 * 1024 * 1024
+    };
+
+    private static BackupSet Held(DateTime at) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        Type = BackupType.TransactionLog,
+        Timestamp = at,
+        DatabaseName = "Sales",
+        Files = [new BackupFileInfo { BlobName = "x.trn", Type = BackupType.TransactionLog }]
+    };
+
+    private static BackupGapViewModel Panel(params BackupHistoryEntry[] history)
+    {
+        var vm = new BackupGapViewModel(new FakeSqlServerService { BackupHistory = history.ToList() });
+        vm.Servers.Add(Server());
+        vm.SourceServer = vm.Servers[0];
+        return vm;
+    }
+
+    private static GapCheckRequest Ask(params BackupSet[] held)
+        => new("Sales", Container(), held);
+
+    // ── what the second check says ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task TheFirstCheckComparesWithNothingAndSaysNothing()
+    {
+        var vm = Panel(Log(T0), Log(T0.AddHours(1)));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.True(vm.HasGap);
+        Assert.False(vm.HasArrivalReport);
+    }
+
+    /// <summary>The press somebody is hoping for.</summary>
+    [Fact]
+    public async Task WhenEverythingArrivedItSaysSo()
+    {
+        var vm = Panel(Log(T0), Log(T0.AddHours(1)));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+        Assert.Equal(2, vm.Locations.Sum(l => l.FileCount));
+
+        // The copy ran: both are in the container now.
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(T0), Held(T0.AddHours(1))));
+
+        Assert.False(vm.HasGap);
+        Assert.True(vm.HasArrivalReport);
+        Assert.Contains("All 2 arrived", vm.ArrivalReport);
+    }
+
+    /// <summary>
+    /// The one the panel alone cannot tell you. Five still missing looks the same whether the
+    /// copy moved eighteen or nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task WhenSomeArrivedItSaysHowManyOfHowMany()
+    {
+        var logs = Enumerable.Range(0, 5).Select(i => Log(T0.AddHours(i))).ToArray();
+        var vm = Panel(logs);
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        // Three of the five made it across.
+        await vm.CheckCommand.ExecuteAsync(
+            Ask(Held(T0), Held(T0.AddHours(1)), Held(T0.AddHours(2))));
+
+        Assert.True(vm.HasGap);
+        Assert.Contains("3 of 5 arrived", vm.ArrivalReport);
+        Assert.Contains("2 still to come", vm.ArrivalReport);
+    }
+
+    [Fact]
+    public async Task WhenNothingArrivedItSaysThatRatherThanRepeatingTheList()
+    {
+        var vm = Panel(Log(T0), Log(T0.AddHours(1)));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.Contains("None of the 2 arrived", vm.ArrivalReport);
+    }
+
+    /// <summary>
+    /// A backup taken between the two checks is not a failed copy, and saying so separately
+    /// matters because the answer is different - nothing went wrong, there is simply more now.
+    /// </summary>
+    [Fact]
+    public async Task BackupsTakenSinceTheLastCheckAreCalledOutSeparately()
+    {
+        var sql = new FakeSqlServerService { BackupHistory = [Log(T0), Log(T0.AddHours(1))] };
+        var vm = new BackupGapViewModel(sql);
+        vm.Servers.Add(Server());
+        vm.SourceServer = vm.Servers[0];
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        // Both copied across - and the instance has taken two more in the meantime.
+        sql.BackupHistory.Add(Log(T0.AddHours(2)));
+        sql.BackupHistory.Add(Log(T0.AddHours(3)));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(T0), Held(T0.AddHours(1))));
+
+        Assert.Contains("All 2 arrived", vm.ArrivalReport);
+        Assert.Contains("2 more have been taken since", vm.ArrivalReport);
+    }
+
+    /// <summary>
+    /// Counted by file, not by number. A retention job trimming an old log between the checks
+    /// would otherwise be indistinguishable from a file that arrived.
+    /// </summary>
+    [Fact]
+    public void ArrivalsAreJudgedByWhichFilesNotHowMany()
+    {
+        var before = new HashSet<string> { @"E:\a.trn", @"E:\b.trn" };
+        var after = new HashSet<string> { @"E:\c.trn", @"E:\d.trn" };
+
+        var said = BackupGapViewModel.DescribeArrivals(before, after);
+
+        // Both originals gone AND two unfamiliar ones present: two arrived, two are new.
+        Assert.Contains("All 2 arrived", said);
+        Assert.Contains("2 more have been taken since", said);
+    }
+
+    [Fact]
+    public void WithNoPreviousCheckThereIsNothingToCompare()
+        => Assert.Empty(BackupGapViewModel.DescribeArrivals(
+            new HashSet<string>(), new HashSet<string> { @"E:\a.trn" }));
+
+    /// <summary>
+    /// Changing the source instance throws the comparison away with the answer. Measuring one
+    /// instance's backups against another's would report every file as arrived.
+    /// </summary>
+    [Fact]
+    public async Task ChangingTheSourceForgetsWhatWasMissing()
+    {
+        var vm = Panel(Log(T0), Log(T0.AddHours(1)));
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        vm.Servers.Add(new ServerConnection { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+        vm.SourceServer = vm.Servers[1];
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.False(vm.HasArrivalReport);
+    }
+}

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -61,7 +61,9 @@ public partial class BackupGapViewModel : ViewModelBase
         CheckCommand.NotifyCanExecuteChanged();
 
         // A previous answer described a different server. Leaving it on screen under a new
-        // selection is the stale-result problem, and this panel's whole job is to be believed.
+        // selection is the stale-result problem, and this panel's whole job is to be believed -
+        // including the comparison, which would otherwise measure one instance against another.
+        _previouslyMissing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         Clear();
     }
 
@@ -103,6 +105,26 @@ public partial class BackupGapViewModel : ViewModelBase
     public bool CanCheck => SourceServer != null && !IsChecking;
 
     /// <summary>
+    /// Every file the previous check reported missing, so this one can say what ARRIVED (#451).
+    ///
+    /// Re-running the check and drawing a new panel answers "what is missing now", which is not
+    /// the question somebody has after running a copy script. Theirs is "did it work" - and a
+    /// still-red panel listing five files looks identical whether eighteen arrived or none did.
+    ///
+    /// By file rather than by count, because a retention job trimming an old log while a copy runs
+    /// would otherwise look like a file that arrived.
+    /// </summary>
+    private HashSet<string> _previouslyMissing = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>What changed since the last check, or empty when there is nothing to compare.</summary>
+    [ObservableProperty]
+    private string _arrivalReport = string.Empty;
+
+    public bool HasArrivalReport => ArrivalReport.Length > 0;
+
+    partial void OnArrivalReportChanged(string value) => OnPropertyChanged(nameof(HasArrivalReport));
+
+    /// <summary>
     /// Reads the source instance's own record and sets it against the container's contents.
     ///
     /// The container and the database name come from the screen at the moment of the press rather
@@ -138,6 +160,15 @@ public partial class BackupGapViewModel : ViewModelBase
 
             var locations = BackupGapAnalyser.Compare(history, held, database);
             foreach (var location in locations) Locations.Add(new MissingLocationRow(location));
+
+            // What arrived since last time, before this check's own answer replaces it.
+            var stillMissing = locations
+                .SelectMany(l => l.Backups)
+                .SelectMany(b => b.Files)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            ArrivalReport = DescribeArrivals(_previouslyMissing, stillMissing);
+            _previouslyMissing = stillMissing;
 
             var behind = BackupGapAnalyser.RecoveryTimeNotInContainer(history, held, database);
             BehindBy = behind is { } gap ? Humanise(gap) : string.Empty;
@@ -224,6 +255,41 @@ public partial class BackupGapViewModel : ViewModelBase
     private void Cancel() => _cancellation.Cancel();
 
     /// <summary>
+    /// What happened between two checks, in the terms somebody who has just run a copy script
+    /// cares about (#451).
+    ///
+    /// Nothing at all on the first check: there is no previous answer, and inventing a comparison
+    /// against zero would report every missing file as a fresh loss.
+    ///
+    /// Files that were missing and are missing still are not mentioned as a number on their own -
+    /// the panel below already lists them, and repeating the count in two places invites the two
+    /// to disagree.
+    /// </summary>
+    internal static string DescribeArrivals(
+        IReadOnlySet<string> before, IReadOnlySet<string> after)
+    {
+        if (before.Count == 0) return string.Empty;
+
+        var arrived = before.Count(f => !after.Contains(f));
+        var stillGone = before.Count - arrived;
+
+        // Something the copy did not account for: files missing now that were not missing before.
+        // A backup taken since the last check is the ordinary cause, and it is worth separating
+        // from "the copy failed" because the answer is different.
+        var newlyMissing = after.Count(f => !before.Contains(f));
+
+        var report =
+            arrived == 0 ? $"None of the {before.Count} arrived."
+            : stillGone == 0 ? $"All {arrived} arrived - the container now holds them."
+            : $"{arrived} of {before.Count} arrived. {stillGone} still to come.";
+
+        if (newlyMissing > 0)
+            report += $" {newlyMissing} more have been taken since, and are not in the container either.";
+
+        return report;
+    }
+
+    /// <summary>
     /// Builds the copy script for one location, on demand rather than for every location up front.
     /// Most checks find one location and nobody reads the others.
     /// </summary>
@@ -233,6 +299,7 @@ public partial class BackupGapViewModel : ViewModelBase
     private void Clear()
     {
         Locations.Clear();
+        ArrivalReport = string.Empty;
         BehindBy = string.Empty;
         ComparedWhat = string.Empty;
         HasChecked = false;

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2126,6 +2126,25 @@ public partial class RestoreViewModel : ViewModelBase
             Inventory.AllSets));
 
     /// <summary>
+    /// Re-reads the container, then asks the same question again (#451).
+    ///
+    /// The other end of the copy script. It is run over on the source machine, and the person who
+    /// ran it comes back here wanting one thing: did it work. Answering that needs the container
+    /// listing to be re-read first - the check compares msdb against what THIS app last saw, so
+    /// re-checking without re-listing compares against a stale picture and reports everything as
+    /// still missing.
+    ///
+    /// Both steps in one press, because doing them separately is how somebody concludes the copy
+    /// failed when it was the listing that was out of date.
+    /// </summary>
+    [RelayCommand]
+    private async Task RescanAndCheckAsync()
+    {
+        await LoadBackupsAsync();
+        await CheckForMissingBackupsAsync();
+    }
+
+    /// <summary>
     /// Writes the copy script for one location. On demand: most checks find one location, and
     /// building every script up front is work nobody reads.
     /// </summary>

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -662,6 +662,18 @@
                         </StackPanel>
                     </Border>
 
+                    <!-- What changed since the last check (#451). The answer somebody has after
+                         running a copy script is "did it work", and a still-red panel listing five
+                         files looks the same whether eighteen arrived or none did. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                            Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource SuccessPanelBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding Gap.HasArrivalReport, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding Gap.ArrivalReport}"
+                                   Style="{StaticResource BodyText}" TextWrapping="Wrap" />
+                    </Border>
+
                     <ItemsControl ItemsSource="{Binding Gap.Locations}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
@@ -738,6 +750,14 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+
+                    <Button Content="I have copied them - rescan and check again"
+                            Command="{Binding RescanAndCheckCommand}"
+                            Style="{StaticResource SecondaryButton}"
+                            HorizontalAlignment="Left"
+                            Padding="12,6" Margin="0,4,0,8"
+                            Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}"
+                            ToolTip="Re-reads the container, then asks the source the same question again. Both, because re-checking without re-reading compares against what this app last saw and reports everything as still missing." />
 
                     <TextBlock Text="{Binding Gap.ComparedWhat}"
                                Style="{StaticResource SecondaryText}"


### PR DESCRIPTION
Closes #451 — the last piece.

## The question somebody actually has

The copy script is taken away and run on the machine that holds the files. Whoever ran it comes back wanting one thing: **did it work.**

Re-running the check answers a different question — *what is missing now* — and a still-red panel listing five files looks identical whether eighteen arrived or none did.

## What it does

The check now compares against what it found last time and says what changed:

- `All 8 arrived - the container now holds them.`
- `5 of 8 arrived. 3 still to come.`
- `None of the 8 arrived.`

Counted **by file** rather than by number, because a retention job trimming an old log between the two checks would otherwise be indistinguishable from a file that arrived. Backups the instance has taken *since* are reported separately — more work appearing is not the same as the copy having failed, and the answer to each is different.

Nothing is claimed on the first check: there is no previous answer, and measuring against zero would report every missing file as a fresh loss. Changing the source instance throws the comparison away along with the answer, for the same reason it already throws away the answer.

## One button, both halves

`I have copied them - rescan and check again` re-reads the container *and* re-asks the source.

Both, deliberately. The check compares msdb against what this app last saw of the container, so re-checking without re-reading compares against a stale picture and reports everything as still missing — which is precisely the wrong answer to give somebody who has just spent ten minutes copying files across.

## Rendered before shipping

Both endings: five of eight, and all eight. That habit has caught two of my own defects this week.

## Effect

`-c Release -warnaserror` clean, **2,242 passed** (up 8).