### PR TITLE
The Back Up screen keeps your ticks (#476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Back Up screen stops clearing your database ticks every time you visit it** (#476). The
+  same fault as #457 on the Copy screen, on the screen where it costs more. Navigation re-reads the
+  server list on every visit and re-assigns the chosen server to a fresh object, which the screen
+  read as somebody picking a different one - so it emptied the multi-select ticks, the database
+  list and the certificate list, and opened a connection to the instance to re-read them. Ticking
+  twelve of forty databases before a patch window and glancing at another screen silently emptied
+  the lot. The list is still re-read, because a database created since the last visit should
+  appear; only the ticks survive, and only for databases the instance still has. Switching to a
+  genuinely different server still clears everything, which is correct and is why the clearing was
+  there.
+
 ### Added
 
 - **After copying the missing backups in, one press confirms it worked** (#451). The copy script

--- a/src/NineLives.Tests/BackupScreenKeepsYourTicksTests.cs
+++ b/src/NineLives.Tests/BackupScreenKeepsYourTicksTests.cs
@@ -1,0 +1,139 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Revisiting the Back Up screen keeps what was ticked (#476).
+///
+/// The same defect as #457 on the Copy screen, on the screen where it costs more. Navigation calls
+/// Refresh on every visit - deliberately, so a server added elsewhere appears - and Refresh
+/// re-assigns Server to whichever config entry matches by id. That is a different OBJECT each
+/// time, because the real store deserializes on every read, so the change handler fired on arrival
+/// and did what it should do when somebody genuinely picks a different server: emptied the list,
+/// the ticks and the certificates, and opened a connection to re-read them.
+///
+/// This is the screen for backing up forty databases before a patch window. Ticking twelve of them
+/// and glancing at another screen emptied the list, silently, because from the screen's point of
+/// view nothing had gone wrong.
+/// </summary>
+public class BackupScreenKeepsYourTicksTests
+{
+    private static (BackupViewModel vm, FakeSqlServerService sql, FakeCredentialStore store) Screen(
+        params string[] databases)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService
+        {
+            DatabaseList = databases.Length > 0
+                ? databases.ToList()
+                : ["Sales", "Payroll", "Warehouse"]
+        };
+
+        var vm = new BackupViewModel(store, sql, TestLogs.Temp(), history: new FakeOperationHistoryStore());
+        return (vm, sql, store);
+    }
+
+    private static async Task<BackupViewModel> TickedAsync(params string[] toTick)
+    {
+        var (vm, _, _) = Screen();
+        vm.Refresh();
+        vm.Server = vm.Servers.First(s => s.Id == "s1");
+        vm.Container = vm.Containers[0];
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+
+        foreach (var name in toTick)
+            vm.DatabasePicks.First(p => p.Name == name).IsPicked = true;
+
+        return vm;
+    }
+
+    /// <summary>The reported behaviour: tick two, come back, both gone.</summary>
+    [Fact]
+    public async Task RevisitingTheScreenKeepsWhatWasTicked()
+    {
+        var vm = await TickedAsync("Sales", "Payroll");
+        Assert.Equal(2, vm.DatabasePicks.Count(p => p.IsPicked));
+
+        // What navigating away and back does.
+        vm.Refresh();
+        await vm.WaitForDatabaseListForTests();
+
+        Assert.Equal(2, vm.DatabasePicks.Count(p => p.IsPicked));
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Sales" && p.IsPicked);
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Payroll" && p.IsPicked);
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Warehouse" && !p.IsPicked);
+    }
+
+    /// <summary>
+    /// The list is still re-read, because a database created since the last visit should appear.
+    /// Only the ticks survive, not the list.
+    /// </summary>
+    [Fact]
+    public async Task TheListIsStillRefreshedSoANewDatabaseAppears()
+    {
+        var (vm, sql, _) = Screen();
+        vm.Refresh();
+        vm.Server = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.DatabasePicks.First(p => p.Name == "Sales").IsPicked = true;
+
+        sql.DatabaseList = ["Sales", "Payroll", "Warehouse", "Reporting"];
+
+        vm.Refresh();
+        await vm.WaitForDatabaseListForTests();
+
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Reporting");
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Sales" && p.IsPicked);
+    }
+
+    /// <summary>
+    /// A tick restored against a database that has gone would arm the run for something the
+    /// instance cannot back up.
+    /// </summary>
+    [Fact]
+    public async Task ATickForADatabaseThatHasGoneIsNotRestored()
+    {
+        var (vm, sql, _) = Screen();
+        vm.Refresh();
+        vm.Server = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.DatabasePicks.First(p => p.Name == "Payroll").IsPicked = true;
+
+        sql.DatabaseList = ["Sales", "Warehouse"];
+
+        vm.Refresh();
+        await vm.WaitForDatabaseListForTests();
+
+        Assert.DoesNotContain(vm.DatabasePicks, p => p.Name == "Payroll");
+        Assert.DoesNotContain(vm.DatabasePicks, p => p.IsPicked);
+    }
+
+    /// <summary>
+    /// And a genuine switch still clears everything. The existing comment explains why in full:
+    /// stale ticks satisfied CanGenerate, so the regenerated statements named the OLD server's
+    /// databases with destinations claiming the new one.
+    /// </summary>
+    [Fact]
+    public async Task SwitchingToADifferentServerStillClearsTheTicks()
+    {
+        var vm = await TickedAsync("Sales", "Payroll");
+
+        vm.Server = vm.Servers.First(s => s.Id == "s2");
+        await vm.WaitForDatabaseListForTests();
+
+        Assert.DoesNotContain(vm.DatabasePicks, p => p.IsPicked);
+    }
+}

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -236,9 +236,18 @@ public partial class BackupViewModel : ViewModelBase
     /// </summary>
     private int _listGeneration;
 
+    /// <summary>
+    /// The in-flight listing, so a test can wait for the one the change handler started rather
+    /// than sleeping and hoping. A timing guess is how a test passes here and fails on a loaded
+    /// runner.
+    /// </summary>
+    private Task _listTask = Task.CompletedTask;
+
+    internal Task WaitForDatabaseListForTests() => _listTask;
+
     /// <summary>Asks the chosen instance what it has, rather than making somebody type a name.</summary>
     [RelayCommand(CanExecute = nameof(CanLoadDatabases))]
-    private async Task LoadDatabasesAsync()
+    private async Task LoadDatabasesAsync(IReadOnlySet<string>? carryTicks = null)
     {
         if (Server == null)
         {
@@ -265,7 +274,12 @@ public partial class BackupViewModel : ViewModelBase
 
             Databases = new ObservableCollection<string>(names);
             DatabasePicks = new ObservableCollection<DatabasePick>(
-                names.Select(n => new DatabasePick(n, Invalidate)));
+                names.Select(n => new DatabasePick(n, Invalidate)
+                {
+                    // Only for databases the instance STILL has (#476). A tick restored against a
+                    // name that has gone would arm the run for something it cannot back up.
+                    IsPicked = carryTicks?.Contains(n) == true
+                }));
 
             // The certificates ride along with the database list - same instance, same moment.
             // Best effort: an instance that will not list them still backs up unencrypted.
@@ -314,8 +328,23 @@ public partial class BackupViewModel : ViewModelBase
         }
     }
 
-    partial void OnServerChanged(ServerConnection? value)
+    partial void OnServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
     {
+        // The SAME server arriving again is not somebody choosing a different one (#476). Refresh
+        // runs on every visit to this screen and re-assigns Server to whichever config entry
+        // matches by id - a different OBJECT every time, because the real store deserializes on
+        // each read - so this fired on arrival and silently emptied the ticks. On the screen for
+        // backing up forty databases before a patch window, where twelve of them are ticked.
+        //
+        // Carried across rather than skipped wholesale: the list still gets re-read, because a
+        // database created since the last visit should appear. Only the ticks survive, and only
+        // for databases that are still there.
+        var carryTicks = oldValue?.Id == newValue?.Id
+            ? DatabasePicks.Where(p => p.IsPicked).Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase)
+            : null;
+
+        var value = newValue;
+
         // The database list belonged to the previous instance. Leaving it up invites somebody to
         // back up a name that exists on both and mean the other one - and the multi-select
         // ticks and certificate list are the same hazard with the same fix (#278): stale ticks
@@ -336,7 +365,7 @@ public partial class BackupViewModel : ViewModelBase
         // new selection has just made irrelevant. It stays out of the way mid-run, where the list
         // is deliberately unfetchable (#281) and the backup must not be disturbed.
         if (value != null && CanLoadDatabases)
-            _ = LoadDatabasesAsync();
+            _listTask = LoadDatabasesAsync(carryTicks);
     }
 
     partial void OnSelectedDatabaseChanged(string? value) => Invalidate();


### PR DESCRIPTION
Closes #476. Found by asking whether #457 on the Copy screen had siblings — it did, on the screen where it costs more.

## The chain

Navigation calls `Backup.Refresh()` on every visit, deliberately, so a server added elsewhere appears.

`Refresh()` re-assigns `Server` to whichever config entry matches by id — **a different object every time**, because the real store deserializes on each read. `[ObservableProperty]` compares with `EqualityComparer<T>.Default`, which for a reference type without an `Equals` override is reference equality, so the assignment always counts as a change.

`OnServerChanged` then did exactly what it should when somebody genuinely picks a different server: emptied the database list, the multi-select ticks and the certificates, and opened a connection to re-read them.

## Why it bites here

This is the screen for backing up forty databases before a patch window. Ticking twelve of them and glancing at another screen emptied the lot — silently, because from the screen's point of view nothing had gone wrong.

Confirmed with a test before fixing: tick two, `Refresh()`, expected 2 and got **0**.

## The fix

The same server arriving again carries the ticks across. Three things kept deliberate:

- **The list is still re-read.** A database created since the last visit should appear — only the ticks survive, not the list.
- **Only for databases the instance still has.** A tick restored against a name that has gone would arm the run for something it cannot back up.
- **A genuine switch still clears everything.** That is correct, and the comment above it explains why: stale ticks satisfied `CanGenerate`, so the regenerated statements named the *old* server's databases with destinations claiming the new one.

## Two notes

The test waits on the listing the handler started rather than sleeping — a timing guess is how a test passes locally and fails on a loaded runner, which this repo has paid for already.

And `-warnaserror` caught two `Assert.Empty(collection.Where(...))` calls that should have been `Assert.DoesNotContain`, before they reached CI. Worth mentioning because the full-solution build is the only place that shows up.

## Effect

`-c Release -warnaserror` clean, **2,246 passed** (up 4).