### PR TITLE
The Restore screen survives being navigated away from (#478, #479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The Execute confirmation banner names the instance the restore will actually run against**
+  (#479). The red panel above Execute is the last thing read before an irreversible write, and its
+  own comment explains that two hostnames can differ by a single character. It reads
+  ConnectedServerName; the restore, like every server call on that screen, uses ConnectedServer -
+  and the two could diverge, because the name was only written after a connection probe, and
+  picking a different target skips the probe when something is already connected. Connect to SRV01
+  on the SQL Servers screen, change the target to SRV02 on the Restore screen, arm: the banner said
+  SRV01 and the restore ran against SRV02. The name now follows the server wherever it is set, and
+  disconnecting clears it rather than leaving the last one named.
+
+- **The Restore screen stops throwing your work away every time you visit it** (#478). The third
+  screen with the fault behind #457 and #476, and the one where it costs most. Navigation re-reads
+  containers and servers on every visit and re-points four selections at fresh objects, which the
+  screen read as four separate changes of mind: the loaded backups and the timeline were emptied,
+  Execute was disarmed, the missing-backup answer and its arrival comparison were discarded, and
+  the target instance was connected to again. Reading a container of 98 headers takes minutes, and
+  glancing at Browse Backups to check a file name emptied it silently. Worst on the gap panel,
+  where going away to run the copy script and coming back to press rescan is the whole workflow.
+  A genuine change of container, source or target still clears everything.
+
 - **The Back Up screen stops clearing your database ticks every time you visit it** (#476). The
   same fault as #457 on the Copy screen, on the screen where it costs more. Navigation re-reads the
   server list on every visit and re-assigns the chosen server to a fresh object, which the screen

--- a/src/NineLives.Tests/ArmBannerNamesTheRealTargetTests.cs
+++ b/src/NineLives.Tests/ArmBannerNamesTheRealTargetTests.cs
@@ -1,0 +1,96 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The confirmation banner names the instance the restore will actually run against (#479).
+///
+/// The red panel above Execute is the last thing anybody reads before an irreversible write, and
+/// its own comment in RestoreView.xaml says why it is worded the way it is: "blackcatsvr01 and
+/// blackcatsvr02 differ by one character".
+///
+/// It binds ConnectedServerName. Every server call on this screen - including the restore itself -
+/// uses ConnectedServer. Those are two different things, and they diverged:
+///
+///   ConnectedServerName was only ever written after a successful connection probe, or by the
+///   shell when the SQL Servers screen connects. Picking a different target on THIS screen sets
+///   ConnectedServer, and the probe is skipped when IsConnectedToServer is already true - which it
+///   is, because connecting on the Servers screen is how most people get here.
+///
+/// So: connect to SRV01 on the Servers screen, come to Restore, change the target to SRV02, arm.
+/// The banner said SRV01. The restore ran against SRV02.
+///
+/// The step that changes the target is the one this screen invites you to use - its own subtitle
+/// offers it as the equivalent of connecting elsewhere - so this is not an exotic path.
+/// </summary>
+public class ArmBannerNamesTheRealTargetTests
+{
+    private static RestoreViewModel Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+
+        return new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp(), TestAuditStores.Temp());
+    }
+
+    /// <summary>How the shell announces a connection made on the SQL Servers screen.</summary>
+    private static void ConnectedElsewhereTo(RestoreViewModel vm, string id)
+    {
+        var server = vm.TargetServers.First(s => s.Id == id);
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServerName = server.ServerName;
+        vm.ConnectedServer = server;
+    }
+
+    /// <summary>The reported divergence, in the order somebody does it.</summary>
+    [Fact]
+    public void ChangingTheTargetChangesWhatTheBannerNames()
+    {
+        var vm = Screen();
+        ConnectedElsewhereTo(vm, "s1");
+
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.Id == "s2");
+
+        // Where the restore will actually run - this was already right.
+        Assert.Equal("SRV02", vm.ConnectedServer?.ServerName);
+
+        // What the banner tells the user it will run against.
+        Assert.Equal("SRV02", vm.ConnectedServerName);
+    }
+
+    /// <summary>
+    /// The same through the property the rest of the screen sets, since every server call reads
+    /// ConnectedServer and the name has to follow it however it was set.
+    /// </summary>
+    [Fact]
+    public void SettingTheConnectedServerDirectlyRenamesTheBannerToo()
+    {
+        var vm = Screen();
+        ConnectedElsewhereTo(vm, "s1");
+
+        vm.ConnectedServer = vm.TargetServers.First(s => s.Id == "s2");
+
+        Assert.Equal("SRV02", vm.ConnectedServerName);
+    }
+
+    /// <summary>Disconnecting leaves nothing named, rather than the last server that was.</summary>
+    [Fact]
+    public void DisconnectingClearsTheName()
+    {
+        var vm = Screen();
+        ConnectedElsewhereTo(vm, "s1");
+
+        vm.ConnectedServer = null;
+
+        Assert.Equal(string.Empty, vm.ConnectedServerName);
+    }
+}

--- a/src/NineLives.Tests/RestoreScreenSurvivesNavigationTests.cs
+++ b/src/NineLives.Tests/RestoreScreenSurvivesNavigationTests.cs
@@ -1,0 +1,253 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Leaving the Restore screen and coming back does not throw the work away (#478).
+///
+/// The third screen with the fault behind #457 and #476, and the one where it costs most.
+/// RefreshContainers runs on every visit - deliberately, so a container or server added elsewhere
+/// is selectable here - and it re-points four selections at entries from a freshly loaded config.
+/// Every one of those is a different OBJECT, because the store deserializes on each read, so all
+/// four assignments counted as changes and the handlers did what they should do when somebody
+/// genuinely picks something else:
+///
+///   SelectedContainer  -> ClearLoadedBackups: the listing, the timeline, and Execute disarmed
+///   SourceServer       -> the same
+///   Gap.SourceServer   -> the gap answer and the arrival comparison thrown away (#451)
+///   SelectedTargetServer -> a fresh connection to the target instance, per visit
+///
+/// This is the screen somebody is on at 2am with production down. Reading a container of 98 headers
+/// takes minutes; glancing at Browse Backups to check a file name emptied it, silently, and the
+/// only thing on screen said "Load Backups". The gap panel is worse: the whole point of the second
+/// check is comparing against what was missing before, and returning to the screen is exactly what
+/// somebody does after going away to run the copy script.
+/// </summary>
+public class RestoreScreenSurvivesNavigationTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 18, 22, 0, 0);
+
+    private static (RestoreViewModel vm, FakeSqlServerService sql, FakeCredentialStore store) Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c2",
+            Name = "archive",
+            ContainerUrl = "https://acct.blob.core.windows.net/archive"
+        });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = "FULL/SRV01/MyDb/MyDb_FULL_20260818_220000.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/MyDb_FULL_20260818_220000.bak",
+                    Type = BackupType.Full,
+                    InferredDatabaseName = "MyDb",
+                    InferredServerName = "SRV01",
+                    LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+                }
+            ]
+        };
+
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreViewModel(
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(),
+            store, new FakeOperationHistoryStore(), TestLogs.Temp(), TestAuditStores.Temp());
+
+        return (vm, sql, store);
+    }
+
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> LoadedAsync()
+    {
+        var (vm, sql, _) = Screen();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        Assert.NotEmpty(vm.Inventory.AllSets);
+        return (vm, sql);
+    }
+
+    // ── the listing ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The reported shape: load a container, glance at another screen, come back to an empty one.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenKeepsTheLoadedBackups()
+    {
+        var (vm, _) = await LoadedAsync();
+
+        // What navigating away and back does.
+        vm.RefreshContainers();
+
+        Assert.NotEmpty(vm.Inventory.AllSets);
+    }
+
+    /// <summary>
+    /// Arming is a five-second window somebody opens deliberately after reading a banner naming
+    /// the server and the database. Disarming it because navigation re-read the config is not the
+    /// safety this was written for - it is the button going dead under the cursor.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenDoesNotDisarmExecute()
+    {
+        var (vm, _) = await LoadedAsync();
+        vm.Execution.Arm();
+
+        vm.RefreshContainers();
+
+        Assert.True(vm.Execution.IsArmed);
+    }
+
+    /// <summary>
+    /// The guard. A container genuinely changed still clears everything, and the comment on the
+    /// handler explains why in full: the credential panel targeted the new container while the
+    /// script still restored from the old one's URLs, so Execute stayed armed and failed with
+    /// Msg 3201 after WITH REPLACE had already dropped the target.
+    /// </summary>
+    [Fact]
+    public async Task ChoosingADifferentContainerStillClearsTheListing()
+    {
+        var (vm, _) = await LoadedAsync();
+
+        vm.SelectedContainer = vm.Containers.First(c => c.Name == "archive");
+
+        Assert.Empty(vm.Inventory.AllSets);
+    }
+
+    /// <summary>And the same for the shared-path source, which clears for the same reason.</summary>
+    [Fact]
+    public async Task ChoosingADifferentSourceServerStillClearsTheListing()
+    {
+        var (vm, _) = await LoadedAsync();
+        vm.SourceServer = vm.SourceServers.First(s => s.Id == "s1");
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.SourceServer = vm.SourceServers.First(s => s.Id == "s2");
+
+        Assert.Empty(vm.Inventory.AllSets);
+    }
+
+    // ── the gap answer (#451) ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Worse here than anywhere: going away is the workflow. The panel names the logs that never
+    /// reached the container and hands over a script to copy them, somebody runs it on the source
+    /// machine, and comes back to press "rescan and check again". Coming back is what cleared the
+    /// answer it was about to be compared with, so the second check reported everything as still
+    /// missing.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenKeepsTheGapAnswer()
+    {
+        var (vm, sql, _) = Screen();
+        sql.BackupHistory =
+        [
+            new BackupHistoryEntry
+            {
+                DatabaseName = "MyDb",
+                Type = BackupType.TransactionLog,
+                StartedAt = T0,
+                Files = [@"E:\SQLLogs\MyDb_20260818_220000.trn"]
+            }
+        ];
+
+        vm.RefreshContainers();
+        vm.Gap.SourceServer = vm.Gap.Servers.First(s => s.Id == "s1");
+        await vm.Gap.CheckCommand.ExecuteAsync(
+            new GapCheckRequest("MyDb", vm.Containers[0], []));
+        Assert.True(vm.Gap.HasGap);
+
+        vm.RefreshContainers();
+
+        Assert.True(vm.Gap.HasGap);
+        Assert.NotEmpty(vm.Gap.Locations);
+    }
+
+    /// <summary>
+    /// The guard again. Measuring one instance's backups against another's would report every
+    /// file as arrived, so a real change of source still throws the comparison away.
+    /// </summary>
+    [Fact]
+    public async Task ChoosingADifferentGapSourceStillClearsTheAnswer()
+    {
+        var (vm, sql, _) = Screen();
+        sql.BackupHistory =
+        [
+            new BackupHistoryEntry
+            {
+                DatabaseName = "MyDb",
+                Type = BackupType.TransactionLog,
+                StartedAt = T0,
+                Files = [@"E:\SQLLogs\MyDb_20260818_220000.trn"]
+            }
+        ];
+
+        vm.RefreshContainers();
+        vm.Gap.SourceServer = vm.Gap.Servers.First(s => s.Id == "s1");
+        await vm.Gap.CheckCommand.ExecuteAsync(
+            new GapCheckRequest("MyDb", vm.Containers[0], []));
+
+        vm.Gap.SourceServer = vm.Gap.Servers.First(s => s.Id == "s2");
+
+        Assert.False(vm.Gap.HasGap);
+        Assert.Empty(vm.Gap.Locations);
+    }
+
+    // ── the target connection ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// A connection per visit to a production instance, for a target that was already connected.
+    /// Nothing on screen changes, so nothing says it is happening.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenDoesNotReconnectToTheTarget()
+    {
+        var (vm, sql, _) = Screen();
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.Id == "s1");
+        await vm.WaitForTargetConnectionForTests();
+        Assert.Single(sql.Connected);
+
+        vm.RefreshContainers();
+        await vm.WaitForTargetConnectionForTests();
+
+        Assert.Single(sql.Connected);
+    }
+
+    /// <summary>
+    /// A target the user actually changes to still takes effect everywhere it matters.
+    ///
+    /// Not by connecting a second time - the probe has always been skipped once something is
+    /// connected (#420), and that is deliberate. What has to follow the change is the server every
+    /// call on this screen runs against, and the name the confirmation banner reads (#479).
+    /// </summary>
+    [Fact]
+    public async Task ChoosingADifferentTargetStillTakesEffect()
+    {
+        var (vm, sql, _) = Screen();
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.Id == "s1");
+        await vm.WaitForTargetConnectionForTests();
+        Assert.Single(sql.Connected);
+
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.Id == "s2");
+        await vm.WaitForTargetConnectionForTests();
+
+        Assert.Equal("SRV02", vm.ConnectedServer?.ServerName);
+        Assert.Equal("SRV02", vm.ConnectedServerName);
+    }
+}

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -56,9 +56,17 @@ public partial class BackupGapViewModel : ViewModelBase
     [ObservableProperty]
     private ServerConnection? _sourceServer;
 
-    partial void OnSourceServerChanged(ServerConnection? value)
+    partial void OnSourceServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
     {
         CheckCommand.NotifyCanExecuteChanged();
+
+        // The SAME server arriving again is navigation re-reading the config, not a new selection
+        // (#478) - and going away is this panel's own workflow. It names the logs that never
+        // reached the container and hands over a script to copy them; somebody runs that on the
+        // source machine and comes back to press "rescan and check again". Coming back was what
+        // threw away the answer the second check compares against, so it reported everything as
+        // still missing however much had arrived.
+        if (oldValue?.Id == newValue?.Id) return;
 
         // A previous answer described a different server. Leaving it on screen under a new
         // selection is the stale-result problem, and this panel's whole job is to be believed -

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -275,11 +275,20 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnTargetServersChanged(ObservableCollection<ServerConnection> value) =>
         OnPropertyChanged(nameof(HasNoTargetServers));
 
-    partial void OnSelectedTargetServerChanged(ServerConnection? value)
+    partial void OnSelectedTargetServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
     {
+        var value = newValue;
+
         Steps.Target.Report(value != null, value?.Name ?? string.Empty);
         if (value != null && !ReferenceEquals(_connectedServer, value))
             ConnectedServer = value;
+
+        // The SAME target arriving again is navigation, not a choice (#478). RefreshContainers
+        // runs on every visit to this screen and re-points this at an entry from a freshly loaded
+        // config - a different object each time, so the assignment always counts as a change - and
+        // reconnecting opened a connection to a production instance on every visit, with nothing
+        // on screen to say it was happening.
+        if (oldValue != null && oldValue.Id == newValue?.Id) return;
 
         // Picking a target here PROVES it, rather than only naming it (#420).
         //
@@ -290,8 +299,16 @@ public partial class RestoreViewModel : ViewModelBase
         // got every step ticked, a generated script, and "Connect to a SQL Server instance (SQL
         // Servers tab)" telling them to go elsewhere and do it again.
         if (value != null && !IsConnectedToServer)
-            _ = ConnectToTargetAsync(value);
+            _targetConnectTask = ConnectToTargetAsync(value);
     }
+
+    /// <summary>
+    /// The connection this handler started, so a test waits for it rather than guessing a delay.
+    /// A fixed delay is how a test passes here and fails on a loaded runner.
+    /// </summary>
+    private Task _targetConnectTask = Task.CompletedTask;
+
+    internal Task WaitForTargetConnectionForTests() => _targetConnectTask;
 
     /// <summary>
     /// What the target connection is doing, or why it did not happen (#420).
@@ -378,6 +395,19 @@ public partial class RestoreViewModel : ViewModelBase
         set
         {
             _connectedServer = value;
+
+            // The confirmation banner follows the server, not the last successful connection
+            // (#479). It binds ConnectedServerName, every server call on this screen - the restore
+            // included - uses ConnectedServer, and the two diverged: the name was written only
+            // after a connection probe, and picking a different target here skips the probe when
+            // the Servers screen has already connected, which is how most people arrive.
+            //
+            // Connect to SRV01 elsewhere, change the target here to SRV02, arm: the banner said
+            // SRV01 and the restore ran against SRV02. That is precisely the confusion the panel
+            // exists to prevent - its own comment gives blackcatsvr01 and blackcatsvr02 as the
+            // example - so naming the wrong instance there is worse than not naming one at all.
+            ConnectedServerName = value?.ServerName ?? string.Empty;
+
             Credential.Server = value;
             _ = Credential.RefreshAsync();
 
@@ -536,15 +566,27 @@ public partial class RestoreViewModel : ViewModelBase
         OnPropertyChanged(nameof(ShowMultipleContainers));
     }
 
-    partial void OnSelectedContainerChanged(BlobContainerConfig? value)
+    partial void OnSelectedContainerChanged(BlobContainerConfig? oldValue, BlobContainerConfig? newValue)
     {
+        var value = newValue;
+
         RefreshAdditionalContainers();
 
         // Everything on screen below this point came from the PREVIOUS container. Leaving it there
         // meant the credential panel and Create credential targeted the new container while the
         // script still restored from the old one's URLs - so Execute stayed armed and enabled, and
         // failed with Msg 3201 after WITH REPLACE had already dropped the target.
-        ClearLoadedBackups();
+        //
+        // But the SAME container arriving again is not that (#478). RefreshContainers runs on
+        // every visit to this screen and re-points this at an entry from a freshly loaded config,
+        // which is a different object each time, so the assignment always counted as a change.
+        // Reading a container of 98 headers takes minutes; glancing at Browse Backups to check a
+        // file name emptied the listing and the timeline and disarmed Execute, silently, leaving
+        // "Load Backups" as the only thing on screen.
+        //
+        // By id, not by name: the id is what survives the config's JSON round-trip, and two
+        // entries that differ by id are two containers however they are labelled.
+        if (oldValue?.Id != newValue?.Id) ClearLoadedBackups();
 
         _ = Credential.PointAtAsync(value);
     }
@@ -752,7 +794,15 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private ServerConnection? _sourceServer;
 
-    partial void OnSourceServerChanged(ServerConnection? value) => ClearLoadedBackups();
+    /// <summary>
+    /// Same as the container above, and for the same reason (#478): navigation re-points this at
+    /// a fresh object from the config on every visit, and clearing on that emptied a shared-path
+    /// listing somebody had just waited for.
+    /// </summary>
+    partial void OnSourceServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
+    {
+        if (oldValue?.Id != newValue?.Id) ClearLoadedBackups();
+    }
 
     /// <summary>The path as the source wrote it, when the target reaches it by another name.</summary>
     [ObservableProperty]


### PR DESCRIPTION
Closes #478. Closes #479.

Found by asking whether #457 (Copy) and #476 (Back Up) had a third sibling. They did — on the screen where it costs most — and looking at it turned up a worse bug next to it.

## #478 — navigation throws the work away

`RefreshContainers()` runs on every visit, deliberately, so a container or server added elsewhere is selectable here. It re-points **four** selections at entries from a freshly loaded config, and each is a different object because the store deserializes on every read — so all four assignments counted as changes and the handlers ran.

| Selection | What was lost |
|---|---|
| `SelectedContainer` | the listing, the timeline, Execute disarmed |
| `SourceServer` | the same |
| `Gap.SourceServer` | the missing-backup answer and its arrival comparison (#451) |
| `SelectedTargetServer` | a fresh connection to the target instance, per visit |

Reading a container of 98 headers takes minutes. Glancing at Browse Backups to check a file name emptied it, silently, leaving "Load Backups" as the only thing on screen.

Worst on the gap panel, because going away **is** its workflow: it names the logs that never reached the container, hands over a script to copy them, and waits for "I have copied them — rescan and check again". Coming back is what cleared the answer the second check compares against, so it reported everything as still missing however much had arrived.

Guarded on id — what survives the config's JSON round-trip. A genuine change still clears everything, and the existing regression tests for that (`ChangingContainerDropsWhatTheLastOneLoaded`, `ChangingContainerDisarmsExecute`) keep their meaning under an id guard because they assign a container with a new id. Both stayed green; the first pass guarded on **name** and turned them red, which is what pointed at the right identity.

## #479 — the confirmation banner could name the wrong instance

Found while testing the target handler above, and worse than #478.

The red panel above Execute is the last thing read before an irreversible write, and its own comment in `RestoreView.xaml` explains the wording: two hostnames can differ by a single character.

It binds `ConnectedServerName`. The restore — like every server call on that screen — uses `ConnectedServer`. The name was only ever written after a successful connection probe, and picking a different target **skips** the probe when something is already connected, which it is, because connecting on the SQL Servers screen is how most people arrive.

1. Connect to `SRV01` on the SQL Servers screen
2. Change the target to `SRV02` on the Restore screen — the step this screen invites you to use
3. Arm

Banner: **"Click again to execute restore against SRV01."** Restore runs against **SRV02**.

Exactly the confusion the panel exists to prevent, and naming the wrong instance is worse than naming none — it reassures. Fixed in the `ConnectedServer` setter so every path is covered rather than the two that happened to remember, and disconnecting now clears the name instead of leaving the last one standing.

## Tests

Eleven, every one confirmed red against the unfixed code before the fix went in — four for the navigation losses, three for the banner, four guarding the behaviour that should still clear.

The target-connection test waits on the connection the handler started rather than guessing a delay.

One correction along the way: a test I wrote asserted that switching target while connected probes the new one. It does not, and never has (#420) — so the test was asserting an invention. Rewritten to assert what actually matters: that the switch reaches `ConnectedServer` and the banner.

## Effect

`-c Release -warnaserror` clean, **2,257 passed** (up 11).