### PR TITLE
Release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-08-18
+
 ### Fixed
 
 - **The Execute confirmation banner names the instance the restore will actually run against**

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.7.1</Version>
+    <Version>1.7.2</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.1</Version>
+    <Version>1.7.2</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.1</Version>
+    <Version>1.7.2</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>


### PR DESCRIPTION
Version bump and changelog section for **1.7.2**.

Everything in it is a defect found by asking whether a fixed bug had siblings. It did — three times.

## What is in it

**#476** — the Back Up screen cleared your database ticks on every visit. The screen for ticking twelve of forty databases before a patch window; glancing elsewhere emptied it silently.

**#478** — the Restore screen threw away the loaded backups, the timeline, the armed Execute, the missing-backup answer and its arrival comparison, and reconnected to the target instance. Once per visit. Reading a container of 98 headers takes minutes.

**#479** — the red confirmation banner above Execute could name a different instance from the one the restore would run against. Connect to `SRV01` elsewhere, change the target to `SRV02` here, arm: banner said `SRV01`, restore ran against `SRV02`. That is the exact confusion the banner exists to prevent.

**#451** — the rescan loop that closes the missing-transaction-log feature: after running the copy script, one press answers "did it work" instead of re-listing what is still missing.

## Gate

`-c Release -warnaserror --no-incremental` clean, **2,257 passed**, 35 skipped.

Version bumped in all three project files.