### PR TITLE
Release 1.7.2 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The Execute confirmation banner names the instance the restore will actually run against**
+  (#479). The red panel above Execute is the last thing read before an irreversible write, and its
+  own comment explains that two hostnames can differ by a single character. It reads
+  ConnectedServerName; the restore, like every server call on that screen, uses ConnectedServer -
+  and the two could diverge, because the name was only written after a connection probe, and
+  picking a different target skips the probe when something is already connected. Connect to SRV01
+  on the SQL Servers screen, change the target to SRV02 on the Restore screen, arm: the banner said
+  SRV01 and the restore ran against SRV02. The name now follows the server wherever it is set, and
+  disconnecting clears it rather than leaving the last one named.
+
+- **The Restore screen stops throwing your work away every time you visit it** (#478). The third
+  screen with the fault behind #457 and #476, and the one where it costs most. Navigation re-reads
+  containers and servers on every visit and re-points four selections at fresh objects, which the
+  screen read as four separate changes of mind: the loaded backups and the timeline were emptied,
+  Execute was disarmed, the missing-backup answer and its arrival comparison were discarded, and
+  the target instance was connected to again. Reading a container of 98 headers takes minutes, and
+  glancing at Browse Backups to check a file name emptied it silently. Worst on the gap panel,
+  where going away to run the copy script and coming back to press rescan is the whole workflow.
+  A genuine change of container, source or target still clears everything.
+
 - **The Back Up screen stops clearing your database ticks every time you visit it** (#476). The
   same fault as #457 on the Copy screen, on the screen where it costs more. Navigation re-reads the
   server list on every visit and re-assigns the chosen server to a fresh object, which the screen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Release notes on the [Releases page](https://github.com/jakemorgangit/NineLives/releases) go into
 more detail on the user-facing changes; this file is the short history.
 
+## [Unreleased]
+
+### Added
+
+- **After copying the missing backups in, one press confirms it worked** (#451). The copy script
+  is taken away and run on the machine that holds the files, and whoever ran it comes back with
+  one question: did it work. Re-running the check answered a different one - what is missing now -
+  and a still-red panel listing five files looks identical whether eighteen arrived or none did.
+  There is now a single button that re-reads the container and asks the source again, both in one
+  press because doing them separately is how somebody concludes the copy failed when it was the
+  listing that was stale. It reports what changed: all of them arrived, or three of five with two
+  still to come, or none. Backups the instance has taken *since* are counted separately, because
+  more work appearing is not the same as the copy having failed.
+
 ## [1.7.1] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Back Up screen stops clearing your database ticks every time you visit it** (#476). The
+  same fault as #457 on the Copy screen, on the screen where it costs more. Navigation re-reads the
+  server list on every visit and re-assigns the chosen server to a fresh object, which the screen
+  read as somebody picking a different one - so it emptied the multi-select ticks, the database
+  list and the certificate list, and opened a connection to the instance to re-read them. Ticking
+  twelve of forty databases before a patch window and glancing at another screen silently emptied
+  the lot. The list is still re-read, because a database created since the last visit should
+  appear; only the ticks survive, and only for databases the instance still has. Switching to a
+  genuinely different server still clears everything, which is correct and is why the clearing was
+  there.
+
 ### Added
 
 - **After copying the missing backups in, one press confirms it worked** (#451). The copy script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-08-18
+
 ### Fixed
 
 - **The Execute confirmation banner names the instance the restore will actually run against**

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.7.1</Version>
+    <Version>1.7.2</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.1</Version>
+    <Version>1.7.2</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Tests/ArmBannerNamesTheRealTargetTests.cs
+++ b/src/NineLives.Tests/ArmBannerNamesTheRealTargetTests.cs
@@ -1,0 +1,96 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The confirmation banner names the instance the restore will actually run against (#479).
+///
+/// The red panel above Execute is the last thing anybody reads before an irreversible write, and
+/// its own comment in RestoreView.xaml says why it is worded the way it is: "blackcatsvr01 and
+/// blackcatsvr02 differ by one character".
+///
+/// It binds ConnectedServerName. Every server call on this screen - including the restore itself -
+/// uses ConnectedServer. Those are two different things, and they diverged:
+///
+///   ConnectedServerName was only ever written after a successful connection probe, or by the
+///   shell when the SQL Servers screen connects. Picking a different target on THIS screen sets
+///   ConnectedServer, and the probe is skipped when IsConnectedToServer is already true - which it
+///   is, because connecting on the Servers screen is how most people get here.
+///
+/// So: connect to SRV01 on the Servers screen, come to Restore, change the target to SRV02, arm.
+/// The banner said SRV01. The restore ran against SRV02.
+///
+/// The step that changes the target is the one this screen invites you to use - its own subtitle
+/// offers it as the equivalent of connecting elsewhere - so this is not an exotic path.
+/// </summary>
+public class ArmBannerNamesTheRealTargetTests
+{
+    private static RestoreViewModel Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+
+        return new RestoreViewModel(
+            new FakeBlobStorageService(), new FakeSqlServerService(), new BackupChainBuilder(),
+            new RestoreScriptGenerator(), store, new FakeOperationHistoryStore(),
+            TestLogs.Temp(), TestAuditStores.Temp());
+    }
+
+    /// <summary>How the shell announces a connection made on the SQL Servers screen.</summary>
+    private static void ConnectedElsewhereTo(RestoreViewModel vm, string id)
+    {
+        var server = vm.TargetServers.First(s => s.Id == id);
+        vm.IsConnectedToServer = true;
+        vm.ConnectedServerName = server.ServerName;
+        vm.ConnectedServer = server;
+    }
+
+    /// <summary>The reported divergence, in the order somebody does it.</summary>
+    [Fact]
+    public void ChangingTheTargetChangesWhatTheBannerNames()
+    {
+        var vm = Screen();
+        ConnectedElsewhereTo(vm, "s1");
+
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.Id == "s2");
+
+        // Where the restore will actually run - this was already right.
+        Assert.Equal("SRV02", vm.ConnectedServer?.ServerName);
+
+        // What the banner tells the user it will run against.
+        Assert.Equal("SRV02", vm.ConnectedServerName);
+    }
+
+    /// <summary>
+    /// The same through the property the rest of the screen sets, since every server call reads
+    /// ConnectedServer and the name has to follow it however it was set.
+    /// </summary>
+    [Fact]
+    public void SettingTheConnectedServerDirectlyRenamesTheBannerToo()
+    {
+        var vm = Screen();
+        ConnectedElsewhereTo(vm, "s1");
+
+        vm.ConnectedServer = vm.TargetServers.First(s => s.Id == "s2");
+
+        Assert.Equal("SRV02", vm.ConnectedServerName);
+    }
+
+    /// <summary>Disconnecting leaves nothing named, rather than the last server that was.</summary>
+    [Fact]
+    public void DisconnectingClearsTheName()
+    {
+        var vm = Screen();
+        ConnectedElsewhereTo(vm, "s1");
+
+        vm.ConnectedServer = null;
+
+        Assert.Equal(string.Empty, vm.ConnectedServerName);
+    }
+}

--- a/src/NineLives.Tests/BackupScreenKeepsYourTicksTests.cs
+++ b/src/NineLives.Tests/BackupScreenKeepsYourTicksTests.cs
@@ -1,0 +1,139 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Revisiting the Back Up screen keeps what was ticked (#476).
+///
+/// The same defect as #457 on the Copy screen, on the screen where it costs more. Navigation calls
+/// Refresh on every visit - deliberately, so a server added elsewhere appears - and Refresh
+/// re-assigns Server to whichever config entry matches by id. That is a different OBJECT each
+/// time, because the real store deserializes on every read, so the change handler fired on arrival
+/// and did what it should do when somebody genuinely picks a different server: emptied the list,
+/// the ticks and the certificates, and opened a connection to re-read them.
+///
+/// This is the screen for backing up forty databases before a patch window. Ticking twelve of them
+/// and glancing at another screen emptied the list, silently, because from the screen's point of
+/// view nothing had gone wrong.
+/// </summary>
+public class BackupScreenKeepsYourTicksTests
+{
+    private static (BackupViewModel vm, FakeSqlServerService sql, FakeCredentialStore store) Screen(
+        params string[] databases)
+    {
+        var store = new FakeCredentialStore();
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+
+        var sql = new FakeSqlServerService
+        {
+            DatabaseList = databases.Length > 0
+                ? databases.ToList()
+                : ["Sales", "Payroll", "Warehouse"]
+        };
+
+        var vm = new BackupViewModel(store, sql, TestLogs.Temp(), history: new FakeOperationHistoryStore());
+        return (vm, sql, store);
+    }
+
+    private static async Task<BackupViewModel> TickedAsync(params string[] toTick)
+    {
+        var (vm, _, _) = Screen();
+        vm.Refresh();
+        vm.Server = vm.Servers.First(s => s.Id == "s1");
+        vm.Container = vm.Containers[0];
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+
+        foreach (var name in toTick)
+            vm.DatabasePicks.First(p => p.Name == name).IsPicked = true;
+
+        return vm;
+    }
+
+    /// <summary>The reported behaviour: tick two, come back, both gone.</summary>
+    [Fact]
+    public async Task RevisitingTheScreenKeepsWhatWasTicked()
+    {
+        var vm = await TickedAsync("Sales", "Payroll");
+        Assert.Equal(2, vm.DatabasePicks.Count(p => p.IsPicked));
+
+        // What navigating away and back does.
+        vm.Refresh();
+        await vm.WaitForDatabaseListForTests();
+
+        Assert.Equal(2, vm.DatabasePicks.Count(p => p.IsPicked));
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Sales" && p.IsPicked);
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Payroll" && p.IsPicked);
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Warehouse" && !p.IsPicked);
+    }
+
+    /// <summary>
+    /// The list is still re-read, because a database created since the last visit should appear.
+    /// Only the ticks survive, not the list.
+    /// </summary>
+    [Fact]
+    public async Task TheListIsStillRefreshedSoANewDatabaseAppears()
+    {
+        var (vm, sql, _) = Screen();
+        vm.Refresh();
+        vm.Server = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.DatabasePicks.First(p => p.Name == "Sales").IsPicked = true;
+
+        sql.DatabaseList = ["Sales", "Payroll", "Warehouse", "Reporting"];
+
+        vm.Refresh();
+        await vm.WaitForDatabaseListForTests();
+
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Reporting");
+        Assert.Contains(vm.DatabasePicks, p => p.Name == "Sales" && p.IsPicked);
+    }
+
+    /// <summary>
+    /// A tick restored against a database that has gone would arm the run for something the
+    /// instance cannot back up.
+    /// </summary>
+    [Fact]
+    public async Task ATickForADatabaseThatHasGoneIsNotRestored()
+    {
+        var (vm, sql, _) = Screen();
+        vm.Refresh();
+        vm.Server = vm.Servers.First(s => s.Id == "s1");
+        await vm.LoadDatabasesCommand.ExecuteAsync(null);
+        vm.DatabasePicks.First(p => p.Name == "Payroll").IsPicked = true;
+
+        sql.DatabaseList = ["Sales", "Warehouse"];
+
+        vm.Refresh();
+        await vm.WaitForDatabaseListForTests();
+
+        Assert.DoesNotContain(vm.DatabasePicks, p => p.Name == "Payroll");
+        Assert.DoesNotContain(vm.DatabasePicks, p => p.IsPicked);
+    }
+
+    /// <summary>
+    /// And a genuine switch still clears everything. The existing comment explains why in full:
+    /// stale ticks satisfied CanGenerate, so the regenerated statements named the OLD server's
+    /// databases with destinations claiming the new one.
+    /// </summary>
+    [Fact]
+    public async Task SwitchingToADifferentServerStillClearsTheTicks()
+    {
+        var vm = await TickedAsync("Sales", "Payroll");
+
+        vm.Server = vm.Servers.First(s => s.Id == "s2");
+        await vm.WaitForDatabaseListForTests();
+
+        Assert.DoesNotContain(vm.DatabasePicks, p => p.IsPicked);
+    }
+}

--- a/src/NineLives.Tests/RescanAndConfirmTests.cs
+++ b/src/NineLives.Tests/RescanAndConfirmTests.cs
@@ -1,0 +1,184 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The other end of the copy script (#451).
+///
+/// The script is taken away and run on the source machine, and whoever ran it comes back wanting
+/// one thing: did it work. Re-running the check answers "what is missing now", which is a
+/// different question - a still-red panel listing five files looks identical whether eighteen
+/// arrived or none did.
+/// </summary>
+public class RescanAndConfirmTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 17, 22, 0, 0);
+
+    private static ServerConnection Server() => new()
+    { Id = "s1", Name = "SRV01", ServerName = "SRV01" };
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+    };
+
+    private static BackupHistoryEntry Log(DateTime at, string folder = @"E:\SQLLogs") => new()
+    {
+        DatabaseName = "Sales",
+        Type = BackupType.TransactionLog,
+        StartedAt = at,
+        Files = [$@"{folder}\Sales_{at:yyyyMMdd_HHmmss}.trn"],
+        BackupSizeBytes = 10 * 1024 * 1024
+    };
+
+    private static BackupSet Held(DateTime at) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        Type = BackupType.TransactionLog,
+        Timestamp = at,
+        DatabaseName = "Sales",
+        Files = [new BackupFileInfo { BlobName = "x.trn", Type = BackupType.TransactionLog }]
+    };
+
+    private static BackupGapViewModel Panel(params BackupHistoryEntry[] history)
+    {
+        var vm = new BackupGapViewModel(new FakeSqlServerService { BackupHistory = history.ToList() });
+        vm.Servers.Add(Server());
+        vm.SourceServer = vm.Servers[0];
+        return vm;
+    }
+
+    private static GapCheckRequest Ask(params BackupSet[] held)
+        => new("Sales", Container(), held);
+
+    // ── what the second check says ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task TheFirstCheckComparesWithNothingAndSaysNothing()
+    {
+        var vm = Panel(Log(T0), Log(T0.AddHours(1)));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.True(vm.HasGap);
+        Assert.False(vm.HasArrivalReport);
+    }
+
+    /// <summary>The press somebody is hoping for.</summary>
+    [Fact]
+    public async Task WhenEverythingArrivedItSaysSo()
+    {
+        var vm = Panel(Log(T0), Log(T0.AddHours(1)));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+        Assert.Equal(2, vm.Locations.Sum(l => l.FileCount));
+
+        // The copy ran: both are in the container now.
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(T0), Held(T0.AddHours(1))));
+
+        Assert.False(vm.HasGap);
+        Assert.True(vm.HasArrivalReport);
+        Assert.Contains("All 2 arrived", vm.ArrivalReport);
+    }
+
+    /// <summary>
+    /// The one the panel alone cannot tell you. Five still missing looks the same whether the
+    /// copy moved eighteen or nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task WhenSomeArrivedItSaysHowManyOfHowMany()
+    {
+        var logs = Enumerable.Range(0, 5).Select(i => Log(T0.AddHours(i))).ToArray();
+        var vm = Panel(logs);
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        // Three of the five made it across.
+        await vm.CheckCommand.ExecuteAsync(
+            Ask(Held(T0), Held(T0.AddHours(1)), Held(T0.AddHours(2))));
+
+        Assert.True(vm.HasGap);
+        Assert.Contains("3 of 5 arrived", vm.ArrivalReport);
+        Assert.Contains("2 still to come", vm.ArrivalReport);
+    }
+
+    [Fact]
+    public async Task WhenNothingArrivedItSaysThatRatherThanRepeatingTheList()
+    {
+        var vm = Panel(Log(T0), Log(T0.AddHours(1)));
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.Contains("None of the 2 arrived", vm.ArrivalReport);
+    }
+
+    /// <summary>
+    /// A backup taken between the two checks is not a failed copy, and saying so separately
+    /// matters because the answer is different - nothing went wrong, there is simply more now.
+    /// </summary>
+    [Fact]
+    public async Task BackupsTakenSinceTheLastCheckAreCalledOutSeparately()
+    {
+        var sql = new FakeSqlServerService { BackupHistory = [Log(T0), Log(T0.AddHours(1))] };
+        var vm = new BackupGapViewModel(sql);
+        vm.Servers.Add(Server());
+        vm.SourceServer = vm.Servers[0];
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        // Both copied across - and the instance has taken two more in the meantime.
+        sql.BackupHistory.Add(Log(T0.AddHours(2)));
+        sql.BackupHistory.Add(Log(T0.AddHours(3)));
+
+        await vm.CheckCommand.ExecuteAsync(Ask(Held(T0), Held(T0.AddHours(1))));
+
+        Assert.Contains("All 2 arrived", vm.ArrivalReport);
+        Assert.Contains("2 more have been taken since", vm.ArrivalReport);
+    }
+
+    /// <summary>
+    /// Counted by file, not by number. A retention job trimming an old log between the checks
+    /// would otherwise be indistinguishable from a file that arrived.
+    /// </summary>
+    [Fact]
+    public void ArrivalsAreJudgedByWhichFilesNotHowMany()
+    {
+        var before = new HashSet<string> { @"E:\a.trn", @"E:\b.trn" };
+        var after = new HashSet<string> { @"E:\c.trn", @"E:\d.trn" };
+
+        var said = BackupGapViewModel.DescribeArrivals(before, after);
+
+        // Both originals gone AND two unfamiliar ones present: two arrived, two are new.
+        Assert.Contains("All 2 arrived", said);
+        Assert.Contains("2 more have been taken since", said);
+    }
+
+    [Fact]
+    public void WithNoPreviousCheckThereIsNothingToCompare()
+        => Assert.Empty(BackupGapViewModel.DescribeArrivals(
+            new HashSet<string>(), new HashSet<string> { @"E:\a.trn" }));
+
+    /// <summary>
+    /// Changing the source instance throws the comparison away with the answer. Measuring one
+    /// instance's backups against another's would report every file as arrived.
+    /// </summary>
+    [Fact]
+    public async Task ChangingTheSourceForgetsWhatWasMissing()
+    {
+        var vm = Panel(Log(T0), Log(T0.AddHours(1)));
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        vm.Servers.Add(new ServerConnection { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+        vm.SourceServer = vm.Servers[1];
+
+        await vm.CheckCommand.ExecuteAsync(Ask());
+
+        Assert.False(vm.HasArrivalReport);
+    }
+}

--- a/src/NineLives.Tests/RestoreScreenSurvivesNavigationTests.cs
+++ b/src/NineLives.Tests/RestoreScreenSurvivesNavigationTests.cs
@@ -1,0 +1,253 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// Leaving the Restore screen and coming back does not throw the work away (#478).
+///
+/// The third screen with the fault behind #457 and #476, and the one where it costs most.
+/// RefreshContainers runs on every visit - deliberately, so a container or server added elsewhere
+/// is selectable here - and it re-points four selections at entries from a freshly loaded config.
+/// Every one of those is a different OBJECT, because the store deserializes on each read, so all
+/// four assignments counted as changes and the handlers did what they should do when somebody
+/// genuinely picks something else:
+///
+///   SelectedContainer  -> ClearLoadedBackups: the listing, the timeline, and Execute disarmed
+///   SourceServer       -> the same
+///   Gap.SourceServer   -> the gap answer and the arrival comparison thrown away (#451)
+///   SelectedTargetServer -> a fresh connection to the target instance, per visit
+///
+/// This is the screen somebody is on at 2am with production down. Reading a container of 98 headers
+/// takes minutes; glancing at Browse Backups to check a file name emptied it, silently, and the
+/// only thing on screen said "Load Backups". The gap panel is worse: the whole point of the second
+/// check is comparing against what was missing before, and returning to the screen is exactly what
+/// somebody does after going away to run the copy script.
+/// </summary>
+public class RestoreScreenSurvivesNavigationTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 18, 22, 0, 0);
+
+    private static (RestoreViewModel vm, FakeSqlServerService sql, FakeCredentialStore store) Screen()
+    {
+        var store = new FakeCredentialStore();
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c1",
+            Name = "backups",
+            ContainerUrl = "https://acct.blob.core.windows.net/backups"
+        });
+        store.Config.BlobContainers.Add(new BlobContainerConfig
+        {
+            Id = "c2",
+            Name = "archive",
+            ContainerUrl = "https://acct.blob.core.windows.net/archive"
+        });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        store.Config.Servers.Add(new ServerConnection
+        { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+
+        var blob = new FakeBlobStorageService
+        {
+            Files =
+            [
+                new BackupFileInfo
+                {
+                    BlobName = "FULL/SRV01/MyDb/MyDb_FULL_20260818_220000.bak",
+                    BlobUrl = "https://acct.blob.core.windows.net/backups/FULL/SRV01/MyDb/MyDb_FULL_20260818_220000.bak",
+                    Type = BackupType.Full,
+                    InferredDatabaseName = "MyDb",
+                    InferredServerName = "SRV01",
+                    LastModified = new DateTimeOffset(T0, TimeSpan.Zero)
+                }
+            ]
+        };
+
+        var sql = new FakeSqlServerService();
+        var vm = new RestoreViewModel(
+            blob, sql, new BackupChainBuilder(), new RestoreScriptGenerator(),
+            store, new FakeOperationHistoryStore(), TestLogs.Temp(), TestAuditStores.Temp());
+
+        return (vm, sql, store);
+    }
+
+    private static async Task<(RestoreViewModel vm, FakeSqlServerService sql)> LoadedAsync()
+    {
+        var (vm, sql, _) = Screen();
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+        Assert.NotEmpty(vm.Inventory.AllSets);
+        return (vm, sql);
+    }
+
+    // ── the listing ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The reported shape: load a container, glance at another screen, come back to an empty one.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenKeepsTheLoadedBackups()
+    {
+        var (vm, _) = await LoadedAsync();
+
+        // What navigating away and back does.
+        vm.RefreshContainers();
+
+        Assert.NotEmpty(vm.Inventory.AllSets);
+    }
+
+    /// <summary>
+    /// Arming is a five-second window somebody opens deliberately after reading a banner naming
+    /// the server and the database. Disarming it because navigation re-read the config is not the
+    /// safety this was written for - it is the button going dead under the cursor.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenDoesNotDisarmExecute()
+    {
+        var (vm, _) = await LoadedAsync();
+        vm.Execution.Arm();
+
+        vm.RefreshContainers();
+
+        Assert.True(vm.Execution.IsArmed);
+    }
+
+    /// <summary>
+    /// The guard. A container genuinely changed still clears everything, and the comment on the
+    /// handler explains why in full: the credential panel targeted the new container while the
+    /// script still restored from the old one's URLs, so Execute stayed armed and failed with
+    /// Msg 3201 after WITH REPLACE had already dropped the target.
+    /// </summary>
+    [Fact]
+    public async Task ChoosingADifferentContainerStillClearsTheListing()
+    {
+        var (vm, _) = await LoadedAsync();
+
+        vm.SelectedContainer = vm.Containers.First(c => c.Name == "archive");
+
+        Assert.Empty(vm.Inventory.AllSets);
+    }
+
+    /// <summary>And the same for the shared-path source, which clears for the same reason.</summary>
+    [Fact]
+    public async Task ChoosingADifferentSourceServerStillClearsTheListing()
+    {
+        var (vm, _) = await LoadedAsync();
+        vm.SourceServer = vm.SourceServers.First(s => s.Id == "s1");
+        await vm.LoadBackupsCommand.ExecuteAsync(null);
+
+        vm.SourceServer = vm.SourceServers.First(s => s.Id == "s2");
+
+        Assert.Empty(vm.Inventory.AllSets);
+    }
+
+    // ── the gap answer (#451) ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Worse here than anywhere: going away is the workflow. The panel names the logs that never
+    /// reached the container and hands over a script to copy them, somebody runs it on the source
+    /// machine, and comes back to press "rescan and check again". Coming back is what cleared the
+    /// answer it was about to be compared with, so the second check reported everything as still
+    /// missing.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenKeepsTheGapAnswer()
+    {
+        var (vm, sql, _) = Screen();
+        sql.BackupHistory =
+        [
+            new BackupHistoryEntry
+            {
+                DatabaseName = "MyDb",
+                Type = BackupType.TransactionLog,
+                StartedAt = T0,
+                Files = [@"E:\SQLLogs\MyDb_20260818_220000.trn"]
+            }
+        ];
+
+        vm.RefreshContainers();
+        vm.Gap.SourceServer = vm.Gap.Servers.First(s => s.Id == "s1");
+        await vm.Gap.CheckCommand.ExecuteAsync(
+            new GapCheckRequest("MyDb", vm.Containers[0], []));
+        Assert.True(vm.Gap.HasGap);
+
+        vm.RefreshContainers();
+
+        Assert.True(vm.Gap.HasGap);
+        Assert.NotEmpty(vm.Gap.Locations);
+    }
+
+    /// <summary>
+    /// The guard again. Measuring one instance's backups against another's would report every
+    /// file as arrived, so a real change of source still throws the comparison away.
+    /// </summary>
+    [Fact]
+    public async Task ChoosingADifferentGapSourceStillClearsTheAnswer()
+    {
+        var (vm, sql, _) = Screen();
+        sql.BackupHistory =
+        [
+            new BackupHistoryEntry
+            {
+                DatabaseName = "MyDb",
+                Type = BackupType.TransactionLog,
+                StartedAt = T0,
+                Files = [@"E:\SQLLogs\MyDb_20260818_220000.trn"]
+            }
+        ];
+
+        vm.RefreshContainers();
+        vm.Gap.SourceServer = vm.Gap.Servers.First(s => s.Id == "s1");
+        await vm.Gap.CheckCommand.ExecuteAsync(
+            new GapCheckRequest("MyDb", vm.Containers[0], []));
+
+        vm.Gap.SourceServer = vm.Gap.Servers.First(s => s.Id == "s2");
+
+        Assert.False(vm.Gap.HasGap);
+        Assert.Empty(vm.Gap.Locations);
+    }
+
+    // ── the target connection ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// A connection per visit to a production instance, for a target that was already connected.
+    /// Nothing on screen changes, so nothing says it is happening.
+    /// </summary>
+    [Fact]
+    public async Task RevisitingTheScreenDoesNotReconnectToTheTarget()
+    {
+        var (vm, sql, _) = Screen();
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.Id == "s1");
+        await vm.WaitForTargetConnectionForTests();
+        Assert.Single(sql.Connected);
+
+        vm.RefreshContainers();
+        await vm.WaitForTargetConnectionForTests();
+
+        Assert.Single(sql.Connected);
+    }
+
+    /// <summary>
+    /// A target the user actually changes to still takes effect everywhere it matters.
+    ///
+    /// Not by connecting a second time - the probe has always been skipped once something is
+    /// connected (#420), and that is deliberate. What has to follow the change is the server every
+    /// call on this screen runs against, and the name the confirmation banner reads (#479).
+    /// </summary>
+    [Fact]
+    public async Task ChoosingADifferentTargetStillTakesEffect()
+    {
+        var (vm, sql, _) = Screen();
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.Id == "s1");
+        await vm.WaitForTargetConnectionForTests();
+        Assert.Single(sql.Connected);
+
+        vm.SelectedTargetServer = vm.TargetServers.First(s => s.Id == "s2");
+        await vm.WaitForTargetConnectionForTests();
+
+        Assert.Equal("SRV02", vm.ConnectedServer?.ServerName);
+        Assert.Equal("SRV02", vm.ConnectedServerName);
+    }
+}

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.1</Version>
+    <Version>1.7.2</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -56,9 +56,17 @@ public partial class BackupGapViewModel : ViewModelBase
     [ObservableProperty]
     private ServerConnection? _sourceServer;
 
-    partial void OnSourceServerChanged(ServerConnection? value)
+    partial void OnSourceServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
     {
         CheckCommand.NotifyCanExecuteChanged();
+
+        // The SAME server arriving again is navigation re-reading the config, not a new selection
+        // (#478) - and going away is this panel's own workflow. It names the logs that never
+        // reached the container and hands over a script to copy them; somebody runs that on the
+        // source machine and comes back to press "rescan and check again". Coming back was what
+        // threw away the answer the second check compares against, so it reported everything as
+        // still missing however much had arrived.
+        if (oldValue?.Id == newValue?.Id) return;
 
         // A previous answer described a different server. Leaving it on screen under a new
         // selection is the stale-result problem, and this panel's whole job is to be believed -

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -61,7 +61,9 @@ public partial class BackupGapViewModel : ViewModelBase
         CheckCommand.NotifyCanExecuteChanged();
 
         // A previous answer described a different server. Leaving it on screen under a new
-        // selection is the stale-result problem, and this panel's whole job is to be believed.
+        // selection is the stale-result problem, and this panel's whole job is to be believed -
+        // including the comparison, which would otherwise measure one instance against another.
+        _previouslyMissing = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         Clear();
     }
 
@@ -103,6 +105,26 @@ public partial class BackupGapViewModel : ViewModelBase
     public bool CanCheck => SourceServer != null && !IsChecking;
 
     /// <summary>
+    /// Every file the previous check reported missing, so this one can say what ARRIVED (#451).
+    ///
+    /// Re-running the check and drawing a new panel answers "what is missing now", which is not
+    /// the question somebody has after running a copy script. Theirs is "did it work" - and a
+    /// still-red panel listing five files looks identical whether eighteen arrived or none did.
+    ///
+    /// By file rather than by count, because a retention job trimming an old log while a copy runs
+    /// would otherwise look like a file that arrived.
+    /// </summary>
+    private HashSet<string> _previouslyMissing = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>What changed since the last check, or empty when there is nothing to compare.</summary>
+    [ObservableProperty]
+    private string _arrivalReport = string.Empty;
+
+    public bool HasArrivalReport => ArrivalReport.Length > 0;
+
+    partial void OnArrivalReportChanged(string value) => OnPropertyChanged(nameof(HasArrivalReport));
+
+    /// <summary>
     /// Reads the source instance's own record and sets it against the container's contents.
     ///
     /// The container and the database name come from the screen at the moment of the press rather
@@ -138,6 +160,15 @@ public partial class BackupGapViewModel : ViewModelBase
 
             var locations = BackupGapAnalyser.Compare(history, held, database);
             foreach (var location in locations) Locations.Add(new MissingLocationRow(location));
+
+            // What arrived since last time, before this check's own answer replaces it.
+            var stillMissing = locations
+                .SelectMany(l => l.Backups)
+                .SelectMany(b => b.Files)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            ArrivalReport = DescribeArrivals(_previouslyMissing, stillMissing);
+            _previouslyMissing = stillMissing;
 
             var behind = BackupGapAnalyser.RecoveryTimeNotInContainer(history, held, database);
             BehindBy = behind is { } gap ? Humanise(gap) : string.Empty;
@@ -224,6 +255,41 @@ public partial class BackupGapViewModel : ViewModelBase
     private void Cancel() => _cancellation.Cancel();
 
     /// <summary>
+    /// What happened between two checks, in the terms somebody who has just run a copy script
+    /// cares about (#451).
+    ///
+    /// Nothing at all on the first check: there is no previous answer, and inventing a comparison
+    /// against zero would report every missing file as a fresh loss.
+    ///
+    /// Files that were missing and are missing still are not mentioned as a number on their own -
+    /// the panel below already lists them, and repeating the count in two places invites the two
+    /// to disagree.
+    /// </summary>
+    internal static string DescribeArrivals(
+        IReadOnlySet<string> before, IReadOnlySet<string> after)
+    {
+        if (before.Count == 0) return string.Empty;
+
+        var arrived = before.Count(f => !after.Contains(f));
+        var stillGone = before.Count - arrived;
+
+        // Something the copy did not account for: files missing now that were not missing before.
+        // A backup taken since the last check is the ordinary cause, and it is worth separating
+        // from "the copy failed" because the answer is different.
+        var newlyMissing = after.Count(f => !before.Contains(f));
+
+        var report =
+            arrived == 0 ? $"None of the {before.Count} arrived."
+            : stillGone == 0 ? $"All {arrived} arrived - the container now holds them."
+            : $"{arrived} of {before.Count} arrived. {stillGone} still to come.";
+
+        if (newlyMissing > 0)
+            report += $" {newlyMissing} more have been taken since, and are not in the container either.";
+
+        return report;
+    }
+
+    /// <summary>
     /// Builds the copy script for one location, on demand rather than for every location up front.
     /// Most checks find one location and nobody reads the others.
     /// </summary>
@@ -233,6 +299,7 @@ public partial class BackupGapViewModel : ViewModelBase
     private void Clear()
     {
         Locations.Clear();
+        ArrivalReport = string.Empty;
         BehindBy = string.Empty;
         ComparedWhat = string.Empty;
         HasChecked = false;

--- a/src/NineLives/ViewModels/BackupViewModel.cs
+++ b/src/NineLives/ViewModels/BackupViewModel.cs
@@ -236,9 +236,18 @@ public partial class BackupViewModel : ViewModelBase
     /// </summary>
     private int _listGeneration;
 
+    /// <summary>
+    /// The in-flight listing, so a test can wait for the one the change handler started rather
+    /// than sleeping and hoping. A timing guess is how a test passes here and fails on a loaded
+    /// runner.
+    /// </summary>
+    private Task _listTask = Task.CompletedTask;
+
+    internal Task WaitForDatabaseListForTests() => _listTask;
+
     /// <summary>Asks the chosen instance what it has, rather than making somebody type a name.</summary>
     [RelayCommand(CanExecute = nameof(CanLoadDatabases))]
-    private async Task LoadDatabasesAsync()
+    private async Task LoadDatabasesAsync(IReadOnlySet<string>? carryTicks = null)
     {
         if (Server == null)
         {
@@ -265,7 +274,12 @@ public partial class BackupViewModel : ViewModelBase
 
             Databases = new ObservableCollection<string>(names);
             DatabasePicks = new ObservableCollection<DatabasePick>(
-                names.Select(n => new DatabasePick(n, Invalidate)));
+                names.Select(n => new DatabasePick(n, Invalidate)
+                {
+                    // Only for databases the instance STILL has (#476). A tick restored against a
+                    // name that has gone would arm the run for something it cannot back up.
+                    IsPicked = carryTicks?.Contains(n) == true
+                }));
 
             // The certificates ride along with the database list - same instance, same moment.
             // Best effort: an instance that will not list them still backs up unencrypted.
@@ -314,8 +328,23 @@ public partial class BackupViewModel : ViewModelBase
         }
     }
 
-    partial void OnServerChanged(ServerConnection? value)
+    partial void OnServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
     {
+        // The SAME server arriving again is not somebody choosing a different one (#476). Refresh
+        // runs on every visit to this screen and re-assigns Server to whichever config entry
+        // matches by id - a different OBJECT every time, because the real store deserializes on
+        // each read - so this fired on arrival and silently emptied the ticks. On the screen for
+        // backing up forty databases before a patch window, where twelve of them are ticked.
+        //
+        // Carried across rather than skipped wholesale: the list still gets re-read, because a
+        // database created since the last visit should appear. Only the ticks survive, and only
+        // for databases that are still there.
+        var carryTicks = oldValue?.Id == newValue?.Id
+            ? DatabasePicks.Where(p => p.IsPicked).Select(p => p.Name).ToHashSet(StringComparer.OrdinalIgnoreCase)
+            : null;
+
+        var value = newValue;
+
         // The database list belonged to the previous instance. Leaving it up invites somebody to
         // back up a name that exists on both and mean the other one - and the multi-select
         // ticks and certificate list are the same hazard with the same fix (#278): stale ticks
@@ -336,7 +365,7 @@ public partial class BackupViewModel : ViewModelBase
         // new selection has just made irrelevant. It stays out of the way mid-run, where the list
         // is deliberately unfetchable (#281) and the backup must not be disturbed.
         if (value != null && CanLoadDatabases)
-            _ = LoadDatabasesAsync();
+            _listTask = LoadDatabasesAsync(carryTicks);
     }
 
     partial void OnSelectedDatabaseChanged(string? value) => Invalidate();

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -2126,6 +2126,25 @@ public partial class RestoreViewModel : ViewModelBase
             Inventory.AllSets));
 
     /// <summary>
+    /// Re-reads the container, then asks the same question again (#451).
+    ///
+    /// The other end of the copy script. It is run over on the source machine, and the person who
+    /// ran it comes back here wanting one thing: did it work. Answering that needs the container
+    /// listing to be re-read first - the check compares msdb against what THIS app last saw, so
+    /// re-checking without re-listing compares against a stale picture and reports everything as
+    /// still missing.
+    ///
+    /// Both steps in one press, because doing them separately is how somebody concludes the copy
+    /// failed when it was the listing that was out of date.
+    /// </summary>
+    [RelayCommand]
+    private async Task RescanAndCheckAsync()
+    {
+        await LoadBackupsAsync();
+        await CheckForMissingBackupsAsync();
+    }
+
+    /// <summary>
     /// Writes the copy script for one location. On demand: most checks find one location, and
     /// building every script up front is work nobody reads.
     /// </summary>

--- a/src/NineLives/ViewModels/RestoreViewModel.cs
+++ b/src/NineLives/ViewModels/RestoreViewModel.cs
@@ -275,11 +275,20 @@ public partial class RestoreViewModel : ViewModelBase
     partial void OnTargetServersChanged(ObservableCollection<ServerConnection> value) =>
         OnPropertyChanged(nameof(HasNoTargetServers));
 
-    partial void OnSelectedTargetServerChanged(ServerConnection? value)
+    partial void OnSelectedTargetServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
     {
+        var value = newValue;
+
         Steps.Target.Report(value != null, value?.Name ?? string.Empty);
         if (value != null && !ReferenceEquals(_connectedServer, value))
             ConnectedServer = value;
+
+        // The SAME target arriving again is navigation, not a choice (#478). RefreshContainers
+        // runs on every visit to this screen and re-points this at an entry from a freshly loaded
+        // config - a different object each time, so the assignment always counts as a change - and
+        // reconnecting opened a connection to a production instance on every visit, with nothing
+        // on screen to say it was happening.
+        if (oldValue != null && oldValue.Id == newValue?.Id) return;
 
         // Picking a target here PROVES it, rather than only naming it (#420).
         //
@@ -290,8 +299,16 @@ public partial class RestoreViewModel : ViewModelBase
         // got every step ticked, a generated script, and "Connect to a SQL Server instance (SQL
         // Servers tab)" telling them to go elsewhere and do it again.
         if (value != null && !IsConnectedToServer)
-            _ = ConnectToTargetAsync(value);
+            _targetConnectTask = ConnectToTargetAsync(value);
     }
+
+    /// <summary>
+    /// The connection this handler started, so a test waits for it rather than guessing a delay.
+    /// A fixed delay is how a test passes here and fails on a loaded runner.
+    /// </summary>
+    private Task _targetConnectTask = Task.CompletedTask;
+
+    internal Task WaitForTargetConnectionForTests() => _targetConnectTask;
 
     /// <summary>
     /// What the target connection is doing, or why it did not happen (#420).
@@ -378,6 +395,19 @@ public partial class RestoreViewModel : ViewModelBase
         set
         {
             _connectedServer = value;
+
+            // The confirmation banner follows the server, not the last successful connection
+            // (#479). It binds ConnectedServerName, every server call on this screen - the restore
+            // included - uses ConnectedServer, and the two diverged: the name was written only
+            // after a connection probe, and picking a different target here skips the probe when
+            // the Servers screen has already connected, which is how most people arrive.
+            //
+            // Connect to SRV01 elsewhere, change the target here to SRV02, arm: the banner said
+            // SRV01 and the restore ran against SRV02. That is precisely the confusion the panel
+            // exists to prevent - its own comment gives blackcatsvr01 and blackcatsvr02 as the
+            // example - so naming the wrong instance there is worse than not naming one at all.
+            ConnectedServerName = value?.ServerName ?? string.Empty;
+
             Credential.Server = value;
             _ = Credential.RefreshAsync();
 
@@ -536,15 +566,27 @@ public partial class RestoreViewModel : ViewModelBase
         OnPropertyChanged(nameof(ShowMultipleContainers));
     }
 
-    partial void OnSelectedContainerChanged(BlobContainerConfig? value)
+    partial void OnSelectedContainerChanged(BlobContainerConfig? oldValue, BlobContainerConfig? newValue)
     {
+        var value = newValue;
+
         RefreshAdditionalContainers();
 
         // Everything on screen below this point came from the PREVIOUS container. Leaving it there
         // meant the credential panel and Create credential targeted the new container while the
         // script still restored from the old one's URLs - so Execute stayed armed and enabled, and
         // failed with Msg 3201 after WITH REPLACE had already dropped the target.
-        ClearLoadedBackups();
+        //
+        // But the SAME container arriving again is not that (#478). RefreshContainers runs on
+        // every visit to this screen and re-points this at an entry from a freshly loaded config,
+        // which is a different object each time, so the assignment always counted as a change.
+        // Reading a container of 98 headers takes minutes; glancing at Browse Backups to check a
+        // file name emptied the listing and the timeline and disarmed Execute, silently, leaving
+        // "Load Backups" as the only thing on screen.
+        //
+        // By id, not by name: the id is what survives the config's JSON round-trip, and two
+        // entries that differ by id are two containers however they are labelled.
+        if (oldValue?.Id != newValue?.Id) ClearLoadedBackups();
 
         _ = Credential.PointAtAsync(value);
     }
@@ -752,7 +794,15 @@ public partial class RestoreViewModel : ViewModelBase
     [ObservableProperty]
     private ServerConnection? _sourceServer;
 
-    partial void OnSourceServerChanged(ServerConnection? value) => ClearLoadedBackups();
+    /// <summary>
+    /// Same as the container above, and for the same reason (#478): navigation re-points this at
+    /// a fresh object from the config on every visit, and clearing on that emptied a shared-path
+    /// listing somebody had just waited for.
+    /// </summary>
+    partial void OnSourceServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
+    {
+        if (oldValue?.Id != newValue?.Id) ClearLoadedBackups();
+    }
 
     /// <summary>The path as the source wrote it, when the target reaches it by another name.</summary>
     [ObservableProperty]

--- a/src/NineLives/Views/RestoreView.xaml
+++ b/src/NineLives/Views/RestoreView.xaml
@@ -662,6 +662,18 @@
                         </StackPanel>
                     </Border>
 
+                    <!-- What changed since the last check (#451). The answer somebody has after
+                         running a copy script is "did it work", and a still-red panel listing five
+                         files looks the same whether eighteen arrived or none did. -->
+                    <Border CornerRadius="4" Padding="10,8" Margin="0,0,0,8"
+                            Background="{DynamicResource SuccessPanelBackgroundBrush}"
+                            BorderBrush="{DynamicResource SuccessPanelBorderBrush}"
+                            BorderThickness="1"
+                            Visibility="{Binding Gap.HasArrivalReport, Converter={StaticResource BoolToVis}}">
+                        <TextBlock Text="{Binding Gap.ArrivalReport}"
+                                   Style="{StaticResource BodyText}" TextWrapping="Wrap" />
+                    </Border>
+
                     <ItemsControl ItemsSource="{Binding Gap.Locations}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
@@ -738,6 +750,14 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
+
+                    <Button Content="I have copied them - rescan and check again"
+                            Command="{Binding RescanAndCheckCommand}"
+                            Style="{StaticResource SecondaryButton}"
+                            HorizontalAlignment="Left"
+                            Padding="12,6" Margin="0,4,0,8"
+                            Visibility="{Binding Gap.HasGap, Converter={StaticResource BoolToVis}}"
+                            ToolTip="Re-reads the container, then asks the source the same question again. Both, because re-checking without re-reading compares against what this app last saw and reports everything as still missing." />
 
                     <TextBlock Text="{Binding Gap.ComparedWhat}"
                                Style="{StaticResource SecondaryText}"


### PR DESCRIPTION
Promotes `dev` to `main` for the **1.7.2** release.

Four defects, all found by asking whether an already-fixed bug had siblings:

- **#476** the Back Up screen cleared your database ticks on every visit
- **#478** the Restore screen threw away the loaded backups, the timeline, the armed Execute and the missing-backup answer on every visit, and reconnected to the target each time
- **#479** the Execute confirmation banner could name a different instance from the one the restore would run against
- **#451** the rescan loop that finishes the missing-transaction-log feature

`-c Release -warnaserror` clean, 2,257 passed.