### PR TITLE
Measure how far behind from times that are backup times (#489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **"This container is N behind" no longer disappears when a set carries only a blob upload time**
+  (#489). The same fault as #487, in the figure above the list rather than in the list, and with a
+  worse outcome: that one could name the wrong backup, this hid the warning altogether. The gap was
+  measured from the newest held set's timestamp without asking where it came from - and a blob
+  reading is the wrong event (an upload finishes after its backup started, so it flatters the
+  container) and possibly the wrong clock (UTC against msdb's local dates, which west of UTC runs
+  hours AHEAD of local time). Both shrink the gap, and a non-positive result meant no banner at
+  all, so a container genuinely hours behind could report nothing. Only filename and backup-header
+  times measure it now; with neither available it quotes no figure rather than a wrong one, which
+  is the shape the panel already had.
+
 - **A backup is no longer reported as present because an unrelated blob finished uploading near
   it** (#487). The missing-backups comparison matches by LSN where both sides have one and falls
   back to type plus timestamp within five seconds - and that fallback is the ordinary path,

--- a/src/NineLives.Core/Services/BackupGapAnalyser.cs
+++ b/src/NineLives.Core/Services/BackupGapAnalyser.cs
@@ -219,8 +219,21 @@ public static class BackupGapAnalyser
             .DefaultIfEmpty(null)
             .Max();
 
+        // Only sets whose timestamp is a real backup time can measure this (#489), for the same
+        // reason they cannot vouch for a backup in IsHeld - and here the consequence is worse.
+        //
+        // A blob reading is the wrong EVENT: an upload finishes after its backup started, so it
+        // always makes the container look more current than it is. A raw one is also on the wrong
+        // CLOCK - UTC, against msdb's local dates - and west of UTC that reading runs AHEAD of
+        // local time by hours.
+        //
+        // Both shrink the gap, and this returns null when the difference is not positive. So one
+        // blob-stamped set landing after the newest recorded backup took the maximum, made the
+        // subtraction negative, and the banner did not appear at all - on a container genuinely
+        // hours behind. Nothing else on the panel says how far behind it is.
         var newestHeld = inContainer
             .Where(s => string.Equals(s.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Where(s => !s.IsTimestampApproximate)
             .Select(s => (DateTime?)s.Timestamp)
             .DefaultIfEmpty(null)
             .Max();

--- a/src/NineLives.Tests/BehindByIsMeasuredFromRealBackupTimesTests.cs
+++ b/src/NineLives.Tests/BehindByIsMeasuredFromRealBackupTimesTests.cs
@@ -1,0 +1,114 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// "This container is N behind" is measured from times that are actually backup times (#489).
+///
+/// The same fault as #487, in the number printed above the list rather than in the list itself, and
+/// with a worse failure mode: #487 could name the wrong backup, this can suppress the warning
+/// altogether.
+///
+/// RecoveryTimeNotInContainer takes the newest held set's Timestamp and subtracts it from the
+/// newest backup msdb recorded. It never asked where that timestamp came from. When it came from
+/// the blob rather than the filename it is two things it should not be:
+///
+///   The wrong EVENT - when the upload finished, not when the backup started. Always later, so it
+///   always makes the container look more current than it is.
+///
+///   Possibly the wrong CLOCK - a raw BlobLastModified reading is UTC, while msdb's dates are the
+///   instance's local time. BackupSet's own comment says this "can sort it hours out of position".
+///
+/// Both shrink the measured gap, and the method returns null when the difference is not positive.
+/// So a single blob-stamped set whose reading lands after the newest recorded backup takes the
+/// maximum, makes the subtraction negative, and the banner does not appear at all - on a container
+/// that is genuinely hours behind.
+///
+/// Which way the clock error runs depends on where the server is. West of UTC the blob reading is
+/// AHEAD of local time, which is the direction that suppresses the warning, and by four or five
+/// hours rather than by minutes.
+/// </summary>
+public class BehindByIsMeasuredFromRealBackupTimesTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 18, 22, 0, 0);
+
+    private static BackupHistoryEntry Recorded(DateTime at) => new()
+    {
+        DatabaseName = "MyDb",
+        Type = BackupType.TransactionLog,
+        StartedAt = at,
+        Files = [$@"E:\SQLLogs\MyDb_{at:yyyyMMdd_HHmmss}.trn"]
+    };
+
+    private static BackupSet Held(DateTime at, BackupTimestampSource source) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        DatabaseName = "MyDb",
+        Type = BackupType.TransactionLog,
+        Timestamp = at,
+        TimestampSource = source,
+        Files = [new BackupFileInfo { BlobName = "x.trn", Type = BackupType.TransactionLog }]
+    };
+
+    private static TimeSpan? Behind(params BackupSet[] held)
+        => BackupGapAnalyser.RecoveryTimeNotInContainer([Recorded(T0)], held, "MyDb");
+
+    /// <summary>
+    /// The suppression. The container's real newest backup is sixteen hours old; one set carries
+    /// only an upload time, read on a clock that puts it after the newest recorded backup. That
+    /// reading took the maximum and the gap came out negative, so nothing was said.
+    /// </summary>
+    [Fact]
+    public void AnUploadTimeCannotHideTheGap()
+    {
+        var behind = Behind(
+            Held(T0.AddHours(-16), BackupTimestampSource.FileName),
+            Held(T0.AddHours(1), BackupTimestampSource.BlobLastModified));
+
+        Assert.Equal(TimeSpan.FromHours(16), behind);
+    }
+
+    /// <summary>
+    /// And cannot shrink it either. Converting the reading into the server's zone fixes the clock
+    /// and leaves the event wrong - an upload finishes after its backup started, so it always
+    /// flatters the container.
+    /// </summary>
+    [Fact]
+    public void AConvertedUploadTimeCannotShrinkTheGap()
+    {
+        var behind = Behind(
+            Held(T0.AddHours(-16), BackupTimestampSource.FileName),
+            Held(T0.AddHours(-2), BackupTimestampSource.BlobLastModifiedConverted));
+
+        Assert.Equal(TimeSpan.FromHours(16), behind);
+    }
+
+    /// <summary>
+    /// With nothing but upload times there is no interval anybody can stand behind, and the panel
+    /// already has a shape for that: it says the container is missing backups without quoting a
+    /// figure. A wrong number is worse than no number.
+    /// </summary>
+    [Fact]
+    public void WithNoRealBackupTimesThereIsNothingToQuote()
+        => Assert.Null(Behind(Held(T0.AddHours(-16), BackupTimestampSource.BlobLastModified)));
+
+    // ── what must keep working ──────────────────────────────────────────────────
+
+    [Fact]
+    public void AFilenameTimestampStillMeasures()
+        => Assert.Equal(TimeSpan.FromHours(16),
+            Behind(Held(T0.AddHours(-16), BackupTimestampSource.FileName)));
+
+    /// <summary>A header time is SQL Server's own account of the backup, on the right clock.</summary>
+    [Fact]
+    public void AHeaderTimestampStillMeasures()
+        => Assert.Equal(TimeSpan.FromHours(16),
+            Behind(Held(T0.AddHours(-16), BackupTimestampSource.BackupHeader)));
+
+    /// <summary>A container that is up to date still reports no gap.</summary>
+    [Fact]
+    public void AContainerThatIsCurrentStillSaysNothing()
+        => Assert.Null(Behind(Held(T0, BackupTimestampSource.FileName)));
+}


### PR DESCRIPTION
Closes #489. Found by asking whether #487's fault had a sibling in the figure printed *above* the list. It did, and this one fails worse.

## The chain

`RecoveryTimeNotInContainer` takes the newest held set's `Timestamp`, subtracts it from the newest backup msdb recorded, and returns `null` when the difference is not positive. It never asked where that timestamp came from.

A blob reading is:

- **the wrong event** — an upload finishes *after* its backup started, so it always makes the container look more current than it is;
- **possibly the wrong clock** — raw `BlobLastModified` is UTC against msdb's local dates, and `BackupSet` says it "can sort it hours out of position".

Both shrink the gap. Because a non-positive difference returns `null`, **one** such set landing after the newest recorded backup takes the maximum and the banner does not render at all.

## Where it bites hardest

West of UTC, where the blob reading runs four or five hours *ahead* of the server's local clock. A container several hours behind can measure as not behind — and nothing else on the panel quotes that figure. The list still names the missing backups; the line saying how much recoverable time is being discarded goes quiet.

East of UTC the error runs the other way and the number is simply overstated by the offset.

## Fix

Only filename and backup-header timestamps measure it — both the backup server's own clock, both the backup's own start. Consistent with #487, where the same readings were barred from vouching for presence.

With neither available it quotes no figure rather than a wrong one, using the shape the panel already had: `HasMeasuredGap` exists precisely because a gap and a *measured* gap are different things.

## Tests

Six. Three fail on the old code — suppression, shrinking, and nothing-to-quote. Three pin what must keep working.

`-c Release -warnaserror --no-incremental` clean, **2,284 passed**.