### PR TITLE
Copied backups land where this app looks for them (#491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The copy script puts backups where this app can find them again** (#491). The missing-backups
+  feature is a loop - name what the container has not got, hand over a script to copy it in, rescan
+  and say whether it worked - and the script broke the loop. It uploaded each file under its bare
+  name, which puts it at the root of the container. Nothing about the upload fails, but the listing
+  reads a blob's database and server back out of its PATH, so a file at the root belongs to no
+  database, every per-database question steps over it, and the rescan reported "None of the N
+  arrived" after a copy in which every byte transferred. The destination is now worked out from the
+  container's own pattern and what msdb recorded about the backup, and written into the script per
+  file rather than left to Split-Path on the source machine. The file keeps its name; only where it
+  lands changes.
+
 - **"This container is N behind" no longer disappears when a set carries only a blob upload time**
   (#489). The same fault as #487, in the figure above the list rather than in the list, and with a
   worse outcome: that one could name the wrong backup, this hid the warning altogether. The gap was

--- a/src/NineLives.Core/Services/BackupDestinationBuilder.cs
+++ b/src/NineLives.Core/Services/BackupDestinationBuilder.cs
@@ -65,6 +65,39 @@ public static class BackupDestinationBuilder
     }
 
     /// <summary>
+    /// Where a file belongs INSIDE the container, by the container's own pattern (#491).
+    ///
+    /// Split out of <see cref="ForContainer"/> because writing a new backup is not the only thing
+    /// that has to land in the right place. A backup that was taken to a local disk and is being
+    /// copied in afterwards keeps the name it already has - but it still has to arrive where the
+    /// listing looks, or the app cannot see it at all.
+    ///
+    /// The listing reads the database and server back OUT of this path: the pattern's tokens are
+    /// how a blob is attributed. A file dropped at the container root has no path to read, so it
+    /// belongs to no database, and every question asked per database steps straight over it.
+    /// </summary>
+    public static string PathFor(
+        BlobContainerConfig container,
+        string serverName,
+        string databaseName,
+        BackupType type,
+        string fileName)
+    {
+        var (host, instance) = ServerIdentity.Split(serverName);
+
+        var path = container.PathPattern
+            .Replace("{BackupType}", FolderFor(type), StringComparison.OrdinalIgnoreCase)
+            .Replace("{ServerName}", Sanitise(host), StringComparison.OrdinalIgnoreCase)
+            .Replace("{InstanceName}", Sanitise(instance), StringComparison.OrdinalIgnoreCase)
+            .Replace("{DatabaseName}", Sanitise(databaseName), StringComparison.OrdinalIgnoreCase)
+            .Replace("{FileName}", fileName, StringComparison.OrdinalIgnoreCase);
+
+        // A pattern with a token this app cannot fill leaves an empty segment behind, which would
+        // put the backup one folder shallower than the listing expects to find it.
+        return string.Join("/", path.Split('/', StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    /// <summary>
     /// The blob URLs to write, in stripe order, laid out by the container's own pattern.
     /// </summary>
     public static List<string> ForContainer(
@@ -84,18 +117,7 @@ public static class BackupDestinationBuilder
             {
                 var name = FileName(databaseName, type, takenAt, stripes > 1 ? i : null, copyOnly);
 
-                var path = container.PathPattern
-                    .Replace("{BackupType}", FolderFor(type), StringComparison.OrdinalIgnoreCase)
-                    .Replace("{ServerName}", Sanitise(host), StringComparison.OrdinalIgnoreCase)
-                    .Replace("{InstanceName}", Sanitise(instance), StringComparison.OrdinalIgnoreCase)
-                    .Replace("{DatabaseName}", Sanitise(databaseName), StringComparison.OrdinalIgnoreCase)
-                    .Replace("{FileName}", name, StringComparison.OrdinalIgnoreCase);
-
-                // A pattern with a token this app cannot fill leaves an empty segment behind, which
-                // would put the backup one folder shallower than the listing expects to find it.
-                path = string.Join("/", path.Split('/', StringSplitOptions.RemoveEmptyEntries));
-
-                return $"{root}/{path}";
+                return $"{root}/{PathFor(container, serverName, databaseName, type, name)}";
             })
             .ToList();
     }

--- a/src/NineLives.Core/Services/MissingBackupCopyScript.cs
+++ b/src/NineLives.Core/Services/MissingBackupCopyScript.cs
@@ -66,34 +66,34 @@ public static class MissingBackupCopyScript
         sb.AppendLine("$azcopy = Get-Command azcopy -ErrorAction SilentlyContinue");
         sb.AppendLine();
 
-        AppendFileList(sb, location);
+        AppendFileList(sb, location, container);
 
         sb.AppendLine("$failed = @()");
         sb.AppendLine();
         sb.AppendLine("foreach ($file in $files) {");
-        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file)) {");
-        sb.AppendLine("        Write-Warning \"Not on disk any more: $file\"");
-        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file.Source)) {");
+        sb.AppendLine("        Write-Warning \"Not on disk any more: $($file.Source)\"");
+        sb.AppendLine("        $failed += $file.Source");
         sb.AppendLine("        continue");
         sb.AppendLine("    }");
         sb.AppendLine();
-        sb.AppendLine("    $name = Split-Path -Leaf $file");
+        sb.AppendLine("    $name = $file.Destination");
         sb.AppendLine("    Write-Host \"Copying $name...\"");
         sb.AppendLine();
         sb.AppendLine("    try {");
         sb.AppendLine("        if ($azcopy) {");
-        sb.AppendLine("            & azcopy copy $file \"$container/$name$Sas\" --overwrite=ifSourceNewer | Out-Null");
+        sb.AppendLine("            & azcopy copy $file.Source \"$container/$name$Sas\" --overwrite=ifSourceNewer | Out-Null");
         sb.AppendLine("            if ($LASTEXITCODE -ne 0) { throw \"azcopy exited $LASTEXITCODE\" }");
         sb.AppendLine("        }");
         sb.AppendLine("        else {");
         sb.AppendLine("            $ctx = New-AzStorageContext -BlobEndpoint ($container -replace '/[^/]+$', '') -SasToken $Sas");
         sb.AppendLine("            $containerName = Split-Path -Leaf $container");
-        sb.AppendLine("            Set-AzStorageBlobContent -File $file -Container $containerName -Blob $name -Context $ctx -Force | Out-Null");
+        sb.AppendLine("            Set-AzStorageBlobContent -File $file.Source -Container $containerName -Blob $name -Context $ctx -Force | Out-Null");
         sb.AppendLine("        }");
         sb.AppendLine("    }");
         sb.AppendLine("    catch {");
         sb.AppendLine("        Write-Warning \"Failed: $name - $_\"");
-        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("        $failed += $file.Source");
         sb.AppendLine("    }");
         sb.AppendLine("}");
         sb.AppendLine();
@@ -129,24 +129,24 @@ public static class MissingBackupCopyScript
         sb.AppendLine($"$endpoint = 'https://{endpoint}'");
         sb.AppendLine();
 
-        AppendFileList(sb, location);
+        AppendFileList(sb, location, container);
 
         sb.AppendLine("$failed = @()");
         sb.AppendLine();
         sb.AppendLine("foreach ($file in $files) {");
-        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file)) {");
-        sb.AppendLine("        Write-Warning \"Not on disk any more: $file\"");
-        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file.Source)) {");
+        sb.AppendLine("        Write-Warning \"Not on disk any more: $($file.Source)\"");
+        sb.AppendLine("        $failed += $file.Source");
         sb.AppendLine("        continue");
         sb.AppendLine("    }");
         sb.AppendLine();
-        sb.AppendLine("    $name = Split-Path -Leaf $file");
+        sb.AppendLine("    $name = $file.Destination");
         sb.AppendLine("    Write-Host \"Copying $name...\"");
         sb.AppendLine();
-        sb.AppendLine("    & aws s3 cp $file \"s3://$bucket/$prefix$name\" --endpoint-url $endpoint");
+        sb.AppendLine("    & aws s3 cp $file.Source \"s3://$bucket/$prefix$name\" --endpoint-url $endpoint");
         sb.AppendLine("    if ($LASTEXITCODE -ne 0) {");
         sb.AppendLine("        Write-Warning \"Failed: $name\"");
-        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("        $failed += $file.Source");
         sb.AppendLine("    }");
         sb.AppendLine("}");
         sb.AppendLine();
@@ -162,21 +162,54 @@ public static class MissingBackupCopyScript
     /// specific question (what is this chain missing), and copying anything else is both a
     /// surprise and, on a metered egress link, a bill.
     /// </summary>
-    private static void AppendFileList(StringBuilder sb, MissingLocation location)
+    private static void AppendFileList(
+        StringBuilder sb, MissingLocation location, BlobContainerConfig container)
     {
         sb.AppendLine("# Named individually, not a wildcard: only what this chain is actually missing.");
+        sb.AppendLine("#");
+        sb.AppendLine("# Each carries where it goes INSIDE the container, laid out by this container's");
+        sb.AppendLine("# own pattern. The listing reads the database and the server back out of that");
+        sb.AppendLine("# path, so a file dropped at the root belongs to no database and this app");
+        sb.AppendLine("# cannot see it - however successfully it uploaded.");
         sb.AppendLine("$files = @(");
 
-        var paths = location.Backups.SelectMany(b => b.Files).ToList();
-        for (int i = 0; i < paths.Count; i++)
+        var pairs = location.Backups
+            .SelectMany(b => b.Files.Select(f => (Source: f, Backup: b)))
+            .ToList();
+
+        for (int i = 0; i < pairs.Count; i++)
         {
-            var comma = i < paths.Count - 1 ? "," : "";
-            sb.AppendLine($"    '{paths[i].Replace("'", "''")}'{comma}");
+            var (source, backup) = pairs[i];
+            var entry = backup.Entry;
+
+            var destination = BackupDestinationBuilder.PathFor(
+                container,
+                entry.ServerName ?? string.Empty,
+                entry.DatabaseName,
+                entry.Type,
+                LeafOf(source));
+
+            var comma = i < pairs.Count - 1 ? "," : "";
+            sb.AppendLine(
+                $"    @{{ Source = '{Escape(source)}'; Destination = '{Escape(destination)}' }}{comma}");
         }
 
         sb.AppendLine(")");
         sb.AppendLine();
     }
+
+    /// <summary>
+    /// The file's own name, from a path the SOURCE machine wrote - so both separators, and never
+    /// Path.GetFileName, which answers for the filesystem this app happens to be running on.
+    /// </summary>
+    private static string LeafOf(string path)
+    {
+        var cut = path.LastIndexOfAny(['\\', '/']);
+        return cut < 0 ? path : path[(cut + 1)..];
+    }
+
+    /// <summary>A PowerShell single-quoted literal doubles its own quote and escapes nothing else.</summary>
+    private static string Escape(string value) => value.Replace("'", "''");
 
     private static void AppendEnding(StringBuilder sb)
     {

--- a/src/NineLives.Tests/CopiedBackupsLandWhereTheAppLooksTests.cs
+++ b/src/NineLives.Tests/CopiedBackupsLandWhereTheAppLooksTests.cs
@@ -1,0 +1,155 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The copy script puts files where this app can find them again (#491).
+///
+/// The whole feature is a loop: name the backups the container has not got, hand over a script to
+/// copy them in, then rescan and say whether it worked. The script uploaded each file under its
+/// bare name - Split-Path -Leaf - which puts it at the ROOT of the container.
+///
+/// Nothing about the upload fails. But the listing reads a blob's database and server back OUT of
+/// its path, by the container's own pattern, and the default pattern is
+/// {BackupType}/{ServerName}/{DatabaseName}/{FileName}. A blob at the root has no path to read:
+/// the pattern cannot match it, and the structural fallback needs at least three segments to guess
+/// a database from. So it is attributed to no database at all.
+///
+/// Every question this app asks is asked per database, so the copied files are stepped straight
+/// over. The rescan compares what is held FOR THIS DATABASE, finds them absent, and reports "None
+/// of the N arrived" - after a copy in which every byte transferred successfully. The listing is
+/// also prefix-scoped once a database is chosen, so they may not even be enumerated.
+///
+/// The destination is worked out here now, from the container's pattern and what msdb recorded
+/// about the backup, rather than left to Split-Path at run time on the source machine.
+/// </summary>
+public class CopiedBackupsLandWhereTheAppLooksTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 18, 22, 0, 0);
+
+    private static BlobContainerConfig Container(string? pattern = null) => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups",
+        PathPattern = pattern ?? BlobContainerConfig.DefaultPathPattern
+    };
+
+    private static MissingLocation OneMissingLog(string file = @"E:\SQLLogs\MyDb_20260818_220000.trn")
+    {
+        var entry = new BackupHistoryEntry
+        {
+            DatabaseName = "MyDb",
+            ServerName = "SRV01",
+            Type = BackupType.TransactionLog,
+            StartedAt = T0,
+            Files = [file],
+            BackupSizeBytes = 10 * 1024 * 1024
+        };
+
+        return new MissingLocation(@"E:\SQLLogs", [new MissingBackup(entry, @"E:\SQLLogs")]);
+    }
+
+    /// <summary>
+    /// The destination carries the container's layout, so the file lands beside the backups
+    /// already there rather than in the root.
+    /// </summary>
+    [Fact]
+    public void TheDestinationFollowsTheContainersOwnPattern()
+    {
+        var script = MissingBackupCopyScript.Build(OneMissingLog(), Container());
+
+        Assert.Contains("Destination = 'LOG/SRV01/MyDb/MyDb_20260818_220000.trn'", script);
+    }
+
+    /// <summary>
+    /// The proof that matters: the destination, put back through the REAL listing parser, is
+    /// attributed to the database it belongs to. Without that the rescan cannot count it.
+    /// </summary>
+    [Fact]
+    public void TheDestinationListsBackAsThisDatabase()
+    {
+        var container = Container();
+        var script = MissingBackupCopyScript.Build(OneMissingLog(), container);
+
+        var listed = ListBack(container, Destination(script));
+
+        Assert.Equal("MyDb", listed.InferredDatabaseName);
+        Assert.Equal("SRV01", listed.InferredServerName);
+        Assert.Equal(BackupType.TransactionLog, listed.Type);
+    }
+
+    /// <summary>
+    /// And what the old script produced does NOT, which is why the rescan reported nothing had
+    /// arrived. Pinned so the bare-leaf destination cannot come back unnoticed.
+    /// </summary>
+    [Fact]
+    public void ABareFilenameAtTheRootIsAttributedToNoDatabase()
+    {
+        var listed = ListBack(Container(), "MyDb_20260818_220000.trn");
+
+        Assert.True(string.IsNullOrEmpty(listed.InferredDatabaseName));
+    }
+
+    /// <summary>A container laid out differently is followed, not overridden.</summary>
+    [Fact]
+    public void ADifferentPatternIsHonoured()
+    {
+        var script = MissingBackupCopyScript.Build(
+            OneMissingLog(), Container("{DatabaseName}/{BackupType}/{FileName}"));
+
+        Assert.Contains("Destination = 'MyDb/LOG/MyDb_20260818_220000.trn'", script);
+    }
+
+    /// <summary>
+    /// The name is taken off a path the SOURCE machine wrote. A UNC share uses the same separator
+    /// this app runs on, but the reverse is not guaranteed, so both are cut.
+    /// </summary>
+    [Fact]
+    public void AUncSourcePathStillYieldsItsFileName()
+    {
+        var script = MissingBackupCopyScript.Build(
+            OneMissingLog(@"\fileserver\logship\MyDb_20260818_220000.trn"), Container());
+
+        Assert.Contains("Destination = 'LOG/SRV01/MyDb/MyDb_20260818_220000.trn'", script);
+    }
+
+    /// <summary>The source is still named in full - that is the file being picked up.</summary>
+    [Fact]
+    public void TheSourcePathIsStillTheFullPath()
+    {
+        var script = MissingBackupCopyScript.Build(OneMissingLog(), Container());
+
+        Assert.Contains(@"Source = 'E:\SQLLogs\MyDb_20260818_220000.trn'", script);
+    }
+
+    /// <summary>Still no credential in the file, which every generator has to keep true.</summary>
+    [Fact]
+    public void TheScriptStillCarriesNoCredential()
+    {
+        var script = MissingBackupCopyScript.Build(OneMissingLog(), Container());
+
+        Assert.Contains("Mandatory = $true", script);
+        Assert.DoesNotContain("sig=", script);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static string Destination(string script)
+    {
+        var marker = "Destination = '";
+        var start = script.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+        var end = script.IndexOf('\'', start);
+        return script[start..end];
+    }
+
+    /// <summary>
+    /// Runs a destination back through the REAL listing parser, so this breaks if either side of
+    /// the round trip changes without the other.
+    /// </summary>
+    private static BackupFileInfo ListBack(BlobContainerConfig container, string blobName)
+        => Assert.Single(new BlobStorageService(new FakeCredentialStore())
+            .ParseListedBlobsForTests(container, [(blobName, 5_000_000L, new DateTimeOffset(T0, TimeSpan.Zero))]));
+}


### PR DESCRIPTION
Closes #491.

Found by reviewing the one artefact here that runs on somebody else's production server.

## The loop, broken by its own script

Name what the container has not got → hand over a script to copy it in → rescan and say whether it worked.

The script uploaded each file under its bare name:

```powershell
$name = Split-Path -Leaf $file
& azcopy copy $file "$container/$name$Sas"
```

That is the **root** of the container. Nothing about the upload fails — but the listing reads a blob's database and server back **out of its path**, by the container's own pattern (`{BackupType}/{ServerName}/{DatabaseName}/{FileName}` by default). A root blob has no path to read: the pattern cannot match one segment, and the structural fallback needs three before it will guess a database from `pathParts[^2]`.

So the file is attributed to **no database**.

## What it costs

Every question this app asks is asked per database. `IsHeld` filters the container to the database being checked, so the copied files are stepped over: still listed as missing, and the arrival report says **"None of the N arrived"** after a copy in which every byte transferred successfully.

Exactly the failure the rescan was built to prevent, caused by the script the same feature generates. The listing is also prefix-scoped once a database is chosen, so they may not even be enumerated.

## Fix

The destination is worked out in C# — from the container's `PathPattern` and what msdb recorded (type, server, database) — and written per file:

```powershell
$files = @(
    @{ Source = 'E:\SQLLogs\MyDb_20260818_220000.trn'; Destination = 'LOG/SRV01/MyDb/MyDb_20260818_220000.trn' }
)
```

`BackupDestinationBuilder`'s path-building half is now shared rather than copied, so what the copy script writes and what a backup writes cannot drift apart — and neither can drift from what the listing reads.

The file keeps its name. Only where it lands changes.

## Tests

Seven; **five fail on the old code**. The one that matters puts the generated destination back through the *real* listing parser and asserts the app attributes it to the right database and server, so the round trip breaks if either side changes without the other. One pins the old behaviour explicitly — a bare filename at the root is attributed to no database.

## Not verified against a live container

Same caveat as the rest of #451: this has not been run against a real container. The round-trip test exercises the app's own parser, not Azure or S3.

`-c Release -warnaserror --no-incremental` clean, **2,291 passed**.