### PR TITLE
Release 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+## [1.7.3] - 2026-08-18
+
 ### Fixed
 
 - **The copy script puts backups where this app can find them again** (#491). The missing-backups

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.7.2</Version>
+    <Version>1.7.3</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.2</Version>
+    <Version>1.7.3</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.2</Version>
+    <Version>1.7.3</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>


### PR DESCRIPTION
Version bump and changelog section for **1.7.3**. All fixes, no new capability — patch under semver.

Everything here is in the missing-backups check, and four of the six made it under-report: a backup declared present when it was not, or a container declared current when it was hours behind. That is the direction that reads as an all-clear.

- **#486** the backup history is read whole, with no cap on any path that feeds a restore chain or a missing-backups answer
- **#484** the cap, when a caller asks for one, counts backup sets rather than `backupmediafamily` rows — it used to count files, so a striped setup got a quarter of what the number promised, and the cut could land inside a set
- **#491** the copy script writes into the container's own path layout, so the app can see the files it just copied — it used to upload to the root, where a blob belongs to no database and the rescan reported "None arrived" after a copy in which every byte transferred
- **#487** an approximate timestamp no longer vouches for a backup's presence
- **#489** "this container is N behind" is measured only from real backup times, and can no longer be suppressed entirely by one blob upload time
- **#483** "Check its history" is live as soon as an instance is chosen, instead of needing a trip off the screen and back

## Gate

`-c Release -warnaserror --no-incremental` clean, **2,291 passed**, 35 skipped. Version bumped in all three project files.

## Caveat carried forward

None of the missing-backups work has been run against a real msdb or a real container. The round-trip test for #491 exercises this app's own listing parser, not Azure or S3.