### PR TITLE
Release 1.7.3 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+## [1.7.3] - 2026-08-18
+
 ### Fixed
 
 - **The copy script puts backups where this app can find them again** (#491). The missing-backups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **A backup is no longer reported as present because an unrelated blob finished uploading near
+  it** (#487). The missing-backups comparison matches by LSN where both sides have one and falls
+  back to type plus timestamp within five seconds - and that fallback is the ordinary path,
+  because a container set only carries an LSN once it has been audited. The tolerance assumed the
+  timestamp came from the file name, where it is the backup's own start time. When it could not be
+  parsed the set falls back to the blob's upload time, which is a different event on a clock that
+  can be hours out of position, and the comparison never checked which it had. Failing to match
+  costs an unnecessary copy; matching the WRONG backup reported a log as present, left it out of
+  the copy script, and had the rescan confirm it arrived while the chain stayed broken - and at a
+  one-minute log cadence an arbitrary upload time lands within five seconds of some log's start
+  about one time in six. An approximate timestamp now vouches for nothing. Auditing a container
+  still settles it exactly, and the panel says how many sets could not be identified rather than
+  leaving a container that appears to have lost everything.
+
 - **The instance's backup history is read whole - no cap, anywhere** (#484, #486). Reported
   against a container more than sixteen hours behind, where the panel listed exactly 500 log
   backups covering about eight: a cap, presented as an answer. It reached further than that one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **"This container is N behind" no longer disappears when a set carries only a blob upload time**
+  (#489). The same fault as #487, in the figure above the list rather than in the list, and with a
+  worse outcome: that one could name the wrong backup, this hid the warning altogether. The gap was
+  measured from the newest held set's timestamp without asking where it came from - and a blob
+  reading is the wrong event (an upload finishes after its backup started, so it flatters the
+  container) and possibly the wrong clock (UTC against msdb's local dates, which west of UTC runs
+  hours AHEAD of local time). Both shrink the gap, and a non-positive result meant no banner at
+  all, so a container genuinely hours behind could report nothing. Only filename and backup-header
+  times measure it now; with neither available it quotes no figure rather than a wrong one, which
+  is the shape the panel already had.
+
 - **A backup is no longer reported as present because an unrelated blob finished uploading near
   it** (#487). The missing-backups comparison matches by LSN where both sides have one and falls
   back to type plus timestamp within five seconds - and that fallback is the ordinary path,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The instance's backup history is read whole - no cap, anywhere** (#484, #486). Reported
+  against a container more than sixteen hours behind, where the panel listed exactly 500 log
+  backups covering about eight: a cap, presented as an answer. It reached further than that one
+  screen. Every caller was on the same default, including the restore inventory and the CLI's,
+  where 500 backup sets is about eight hours of a one-minute log schedule and a chain rolling
+  forward from yesterday's full would silently stop short. Two faults in how it capped, as well as
+  that it did: the limit sat on the joined result, where it counted backup FILES rather than
+  backups, so a striped setup got a quarter of what the number promised - and the cut could land
+  inside a backup set, leaving an entry holding only some of its stripes, which a RESTORE cannot
+  use and which the missing-backups check reported as files the container lacked. The read is now
+  uncapped; a caller can still ask for a limit, and none does. When one is asked for it selects
+  backup sets in their own pass with the files joined afterwards, so a striped backup always
+  arrives whole.
+
+- **"Check its history" is live as soon as an instance is chosen** (#483). The button read a
+  computed property that was never raised, so it kept the answer it was given while the dropdown
+  was still empty and stayed disabled beside a chosen instance - the only way to wake it was to
+  leave the Restore screen and come back, which rebuilds every binding from scratch. It also now
+  greys out while a check is running, so a second press cannot land on one already in flight.
+
 ## [1.7.2] - 2026-08-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ### Fixed
 
+- **The copy script puts backups where this app can find them again** (#491). The missing-backups
+  feature is a loop - name what the container has not got, hand over a script to copy it in, rescan
+  and say whether it worked - and the script broke the loop. It uploaded each file under its bare
+  name, which puts it at the root of the container. Nothing about the upload fails, but the listing
+  reads a blob's database and server back out of its PATH, so a file at the root belongs to no
+  database, every per-database question steps over it, and the rescan reported "None of the N
+  arrived" after a copy in which every byte transferred. The destination is now worked out from the
+  container's own pattern and what msdb recorded about the backup, and written into the script per
+  file rather than left to Split-Path on the source machine. The file keeps its name; only where it
+  lands changes.
+
 - **"This container is N behind" no longer disappears when a set carries only a blob upload time**
   (#489). The same fault as #487, in the figure above the list rather than in the list, and with a
   worse outcome: that one could name the wrong backup, this hid the warning altogether. The gap was

--- a/src/NineLives.Cli/NineLives.Cli.csproj
+++ b/src/NineLives.Cli/NineLives.Cli.csproj
@@ -13,7 +13,7 @@
          Windows filenames are case-insensitive, so it would collide with the GUI beside it. -->
     <AssemblyName>9lives</AssemblyName>
     <RootNamespace>Blackcat.NineLives.Cli</RootNamespace>
-    <Version>1.7.2</Version>
+    <Version>1.7.3</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/NineLives.Core.csproj
+++ b/src/NineLives.Core/NineLives.Core.csproj
@@ -11,7 +11,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>NineLives.Core</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.2</Version>
+    <Version>1.7.3</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives.Core/Services/BackupDestinationBuilder.cs
+++ b/src/NineLives.Core/Services/BackupDestinationBuilder.cs
@@ -65,6 +65,39 @@ public static class BackupDestinationBuilder
     }
 
     /// <summary>
+    /// Where a file belongs INSIDE the container, by the container's own pattern (#491).
+    ///
+    /// Split out of <see cref="ForContainer"/> because writing a new backup is not the only thing
+    /// that has to land in the right place. A backup that was taken to a local disk and is being
+    /// copied in afterwards keeps the name it already has - but it still has to arrive where the
+    /// listing looks, or the app cannot see it at all.
+    ///
+    /// The listing reads the database and server back OUT of this path: the pattern's tokens are
+    /// how a blob is attributed. A file dropped at the container root has no path to read, so it
+    /// belongs to no database, and every question asked per database steps straight over it.
+    /// </summary>
+    public static string PathFor(
+        BlobContainerConfig container,
+        string serverName,
+        string databaseName,
+        BackupType type,
+        string fileName)
+    {
+        var (host, instance) = ServerIdentity.Split(serverName);
+
+        var path = container.PathPattern
+            .Replace("{BackupType}", FolderFor(type), StringComparison.OrdinalIgnoreCase)
+            .Replace("{ServerName}", Sanitise(host), StringComparison.OrdinalIgnoreCase)
+            .Replace("{InstanceName}", Sanitise(instance), StringComparison.OrdinalIgnoreCase)
+            .Replace("{DatabaseName}", Sanitise(databaseName), StringComparison.OrdinalIgnoreCase)
+            .Replace("{FileName}", fileName, StringComparison.OrdinalIgnoreCase);
+
+        // A pattern with a token this app cannot fill leaves an empty segment behind, which would
+        // put the backup one folder shallower than the listing expects to find it.
+        return string.Join("/", path.Split('/', StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    /// <summary>
     /// The blob URLs to write, in stripe order, laid out by the container's own pattern.
     /// </summary>
     public static List<string> ForContainer(
@@ -84,18 +117,7 @@ public static class BackupDestinationBuilder
             {
                 var name = FileName(databaseName, type, takenAt, stripes > 1 ? i : null, copyOnly);
 
-                var path = container.PathPattern
-                    .Replace("{BackupType}", FolderFor(type), StringComparison.OrdinalIgnoreCase)
-                    .Replace("{ServerName}", Sanitise(host), StringComparison.OrdinalIgnoreCase)
-                    .Replace("{InstanceName}", Sanitise(instance), StringComparison.OrdinalIgnoreCase)
-                    .Replace("{DatabaseName}", Sanitise(databaseName), StringComparison.OrdinalIgnoreCase)
-                    .Replace("{FileName}", name, StringComparison.OrdinalIgnoreCase);
-
-                // A pattern with a token this app cannot fill leaves an empty segment behind, which
-                // would put the backup one folder shallower than the listing expects to find it.
-                path = string.Join("/", path.Split('/', StringSplitOptions.RemoveEmptyEntries));
-
-                return $"{root}/{path}";
+                return $"{root}/{PathFor(container, serverName, databaseName, type, name)}";
             })
             .ToList();
     }

--- a/src/NineLives.Core/Services/BackupGapAnalyser.cs
+++ b/src/NineLives.Core/Services/BackupGapAnalyser.cs
@@ -219,8 +219,21 @@ public static class BackupGapAnalyser
             .DefaultIfEmpty(null)
             .Max();
 
+        // Only sets whose timestamp is a real backup time can measure this (#489), for the same
+        // reason they cannot vouch for a backup in IsHeld - and here the consequence is worse.
+        //
+        // A blob reading is the wrong EVENT: an upload finishes after its backup started, so it
+        // always makes the container look more current than it is. A raw one is also on the wrong
+        // CLOCK - UTC, against msdb's local dates - and west of UTC that reading runs AHEAD of
+        // local time by hours.
+        //
+        // Both shrink the gap, and this returns null when the difference is not positive. So one
+        // blob-stamped set landing after the newest recorded backup took the maximum, made the
+        // subtraction negative, and the banner did not appear at all - on a container genuinely
+        // hours behind. Nothing else on the panel says how far behind it is.
         var newestHeld = inContainer
             .Where(s => string.Equals(s.DatabaseName, database, StringComparison.OrdinalIgnoreCase))
+            .Where(s => !s.IsTimestampApproximate)
             .Select(s => (DateTime?)s.Timestamp)
             .DefaultIfEmpty(null)
             .Max();

--- a/src/NineLives.Core/Services/BackupGapAnalyser.cs
+++ b/src/NineLives.Core/Services/BackupGapAnalyser.cs
@@ -129,6 +129,24 @@ public static class BackupGapAnalyser
                 continue;
             }
 
+            // An approximate timestamp is not a backup time (#487). It is when the BLOB finished
+            // uploading, read off a clock that may not even be this server's - BackupSet's own
+            // comment says it "can sort it hours out of position" - so comparing it to msdb's
+            // start time with a five-second tolerance is comparing two different kinds of thing.
+            //
+            // Worse than merely failing to match: at a one-minute log cadence an upload time
+            // lands within five seconds of SOME log's start about one time in six, and a
+            // container holds hundreds. Whichever log it happened to land near was then reported
+            // as present, left out of the copy script, and confirmed as arrived by the rescan,
+            // while the chain stayed broken.
+            //
+            // So it does not vouch for anything. The backup is reported missing instead, which
+            // costs an unnecessary copy of a file that may already be there - and that is the
+            // bias this file states outright, because the other direction leaves somebody
+            // restoring to an hour earlier than they could have. Auditing the container settles
+            // it properly by giving the set an LSN.
+            if (set.IsTimestampApproximate) continue;
+
             if (Math.Abs((set.Timestamp - entry.StartedAt).TotalSeconds)
                 <= SameBackupWindow.TotalSeconds)
                 return true;

--- a/src/NineLives.Core/Services/ISqlServerService.cs
+++ b/src/NineLives.Core/Services/ISqlServerService.cs
@@ -1,4 +1,4 @@
-﻿using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Models;
 
 namespace Blackcat.NineLives.Services;
 
@@ -175,8 +175,17 @@ public interface ISqlServerService
     Task<List<ExposureRow>> GetBackupExposureAsync(
         ServerConnection server, CancellationToken ct = default);
 
+    /// <summary>
+    /// What msdb recorded for a database, newest first, and by default ALL of it (#486).
+    ///
+    /// A cap is applied only when <paramref name="limit"/> is given, and then it counts backup
+    /// SETS - not rows, and not files, which are one per stripe. Nothing in the app passes one:
+    /// every caller feeds something a short answer quietly breaks, and a caller that did cap
+    /// should say so rather than presenting the newest N as the whole history.
+    /// </summary>
     Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
-        ServerConnection server, string? databaseName = null, CancellationToken ct = default);
+        ServerConnection server, string? databaseName = null,
+        int? limit = null, CancellationToken ct = default);
 
     /// <summary>Whether THIS instance can read a backup file, and why not (#149).</summary>
     Task<BackupFileCheck> CheckBackupFileAsync(

--- a/src/NineLives.Core/Services/MissingBackupCopyScript.cs
+++ b/src/NineLives.Core/Services/MissingBackupCopyScript.cs
@@ -66,34 +66,34 @@ public static class MissingBackupCopyScript
         sb.AppendLine("$azcopy = Get-Command azcopy -ErrorAction SilentlyContinue");
         sb.AppendLine();
 
-        AppendFileList(sb, location);
+        AppendFileList(sb, location, container);
 
         sb.AppendLine("$failed = @()");
         sb.AppendLine();
         sb.AppendLine("foreach ($file in $files) {");
-        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file)) {");
-        sb.AppendLine("        Write-Warning \"Not on disk any more: $file\"");
-        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file.Source)) {");
+        sb.AppendLine("        Write-Warning \"Not on disk any more: $($file.Source)\"");
+        sb.AppendLine("        $failed += $file.Source");
         sb.AppendLine("        continue");
         sb.AppendLine("    }");
         sb.AppendLine();
-        sb.AppendLine("    $name = Split-Path -Leaf $file");
+        sb.AppendLine("    $name = $file.Destination");
         sb.AppendLine("    Write-Host \"Copying $name...\"");
         sb.AppendLine();
         sb.AppendLine("    try {");
         sb.AppendLine("        if ($azcopy) {");
-        sb.AppendLine("            & azcopy copy $file \"$container/$name$Sas\" --overwrite=ifSourceNewer | Out-Null");
+        sb.AppendLine("            & azcopy copy $file.Source \"$container/$name$Sas\" --overwrite=ifSourceNewer | Out-Null");
         sb.AppendLine("            if ($LASTEXITCODE -ne 0) { throw \"azcopy exited $LASTEXITCODE\" }");
         sb.AppendLine("        }");
         sb.AppendLine("        else {");
         sb.AppendLine("            $ctx = New-AzStorageContext -BlobEndpoint ($container -replace '/[^/]+$', '') -SasToken $Sas");
         sb.AppendLine("            $containerName = Split-Path -Leaf $container");
-        sb.AppendLine("            Set-AzStorageBlobContent -File $file -Container $containerName -Blob $name -Context $ctx -Force | Out-Null");
+        sb.AppendLine("            Set-AzStorageBlobContent -File $file.Source -Container $containerName -Blob $name -Context $ctx -Force | Out-Null");
         sb.AppendLine("        }");
         sb.AppendLine("    }");
         sb.AppendLine("    catch {");
         sb.AppendLine("        Write-Warning \"Failed: $name - $_\"");
-        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("        $failed += $file.Source");
         sb.AppendLine("    }");
         sb.AppendLine("}");
         sb.AppendLine();
@@ -129,24 +129,24 @@ public static class MissingBackupCopyScript
         sb.AppendLine($"$endpoint = 'https://{endpoint}'");
         sb.AppendLine();
 
-        AppendFileList(sb, location);
+        AppendFileList(sb, location, container);
 
         sb.AppendLine("$failed = @()");
         sb.AppendLine();
         sb.AppendLine("foreach ($file in $files) {");
-        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file)) {");
-        sb.AppendLine("        Write-Warning \"Not on disk any more: $file\"");
-        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("    if (-not (Test-Path -LiteralPath $file.Source)) {");
+        sb.AppendLine("        Write-Warning \"Not on disk any more: $($file.Source)\"");
+        sb.AppendLine("        $failed += $file.Source");
         sb.AppendLine("        continue");
         sb.AppendLine("    }");
         sb.AppendLine();
-        sb.AppendLine("    $name = Split-Path -Leaf $file");
+        sb.AppendLine("    $name = $file.Destination");
         sb.AppendLine("    Write-Host \"Copying $name...\"");
         sb.AppendLine();
-        sb.AppendLine("    & aws s3 cp $file \"s3://$bucket/$prefix$name\" --endpoint-url $endpoint");
+        sb.AppendLine("    & aws s3 cp $file.Source \"s3://$bucket/$prefix$name\" --endpoint-url $endpoint");
         sb.AppendLine("    if ($LASTEXITCODE -ne 0) {");
         sb.AppendLine("        Write-Warning \"Failed: $name\"");
-        sb.AppendLine("        $failed += $file");
+        sb.AppendLine("        $failed += $file.Source");
         sb.AppendLine("    }");
         sb.AppendLine("}");
         sb.AppendLine();
@@ -162,21 +162,54 @@ public static class MissingBackupCopyScript
     /// specific question (what is this chain missing), and copying anything else is both a
     /// surprise and, on a metered egress link, a bill.
     /// </summary>
-    private static void AppendFileList(StringBuilder sb, MissingLocation location)
+    private static void AppendFileList(
+        StringBuilder sb, MissingLocation location, BlobContainerConfig container)
     {
         sb.AppendLine("# Named individually, not a wildcard: only what this chain is actually missing.");
+        sb.AppendLine("#");
+        sb.AppendLine("# Each carries where it goes INSIDE the container, laid out by this container's");
+        sb.AppendLine("# own pattern. The listing reads the database and the server back out of that");
+        sb.AppendLine("# path, so a file dropped at the root belongs to no database and this app");
+        sb.AppendLine("# cannot see it - however successfully it uploaded.");
         sb.AppendLine("$files = @(");
 
-        var paths = location.Backups.SelectMany(b => b.Files).ToList();
-        for (int i = 0; i < paths.Count; i++)
+        var pairs = location.Backups
+            .SelectMany(b => b.Files.Select(f => (Source: f, Backup: b)))
+            .ToList();
+
+        for (int i = 0; i < pairs.Count; i++)
         {
-            var comma = i < paths.Count - 1 ? "," : "";
-            sb.AppendLine($"    '{paths[i].Replace("'", "''")}'{comma}");
+            var (source, backup) = pairs[i];
+            var entry = backup.Entry;
+
+            var destination = BackupDestinationBuilder.PathFor(
+                container,
+                entry.ServerName ?? string.Empty,
+                entry.DatabaseName,
+                entry.Type,
+                LeafOf(source));
+
+            var comma = i < pairs.Count - 1 ? "," : "";
+            sb.AppendLine(
+                $"    @{{ Source = '{Escape(source)}'; Destination = '{Escape(destination)}' }}{comma}");
         }
 
         sb.AppendLine(")");
         sb.AppendLine();
     }
+
+    /// <summary>
+    /// The file's own name, from a path the SOURCE machine wrote - so both separators, and never
+    /// Path.GetFileName, which answers for the filesystem this app happens to be running on.
+    /// </summary>
+    private static string LeafOf(string path)
+    {
+        var cut = path.LastIndexOfAny(['\\', '/']);
+        return cut < 0 ? path : path[(cut + 1)..];
+    }
+
+    /// <summary>A PowerShell single-quoted literal doubles its own quote and escapes nothing else.</summary>
+    private static string Escape(string value) => value.Replace("'", "''");
 
     private static void AppendEnding(StringBuilder sb)
     {

--- a/src/NineLives.Core/Services/SqlServerService.cs
+++ b/src/NineLives.Core/Services/SqlServerService.cs
@@ -254,9 +254,9 @@ public class SqlServerService : ISqlServerService
     /// but the instance that took the backups knows exactly what it took, when, to which files and
     /// at which LSNs.
     ///
-    /// Ordered newest first, and capped, because msdb on a busy instance holds years of history and
-    /// a restore is almost always from the recent end of it. A cap is honest about what it returns -
-    /// see BackupHistoryLimit.
+    /// Ordered newest first, and no longer capped (#486). "The newest N" is indistinguishable on
+    /// screen from "all there is", and every caller turns this into something a short answer
+    /// quietly breaks - a restore chain, or the check that names what a container is missing.
     ///
     /// It reports what msdb SAYS. Whether those files still exist is a different question, asked
     /// separately and on the target, because msdb keeps history for backups whose files were
@@ -315,20 +315,34 @@ public class SqlServerService : ISqlServerService
         return rows;
     }
 
-    public async Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
-        ServerConnection server, string? databaseName = null, CancellationToken ct = default)
-    {
-        await using var conn = CreateConnection(server);
-        await conn.OpenAsync(ct);
-
-        await using var cmd = conn.CreateCommand();
-
-        // backupset holds one row per backup; backupmediafamily one per FILE it was written to, so
-        // a striped backup is several rows and family_sequence_number is the stripe order. Grouping
-        // in the app rather than with STRING_AGG keeps this readable on every supported version.
-        cmd.CommandText = $@"
-            SELECT TOP ({BackupHistoryLimit})
-                   bs.backup_set_id,
+    /// <summary>
+    /// The history read. Uncapped unless a caller asks for a cap (#486).
+    ///
+    /// It used to take the newest N always, and every caller here feeds something that a short
+    /// answer quietly breaks - the restore chain, the CLI's inventory, and the check whose whole
+    /// job is naming backups that are missing. "The newest N" is not a safe default for any of
+    /// them: it is indistinguishable from "all there is", and the direction it is wrong in is the
+    /// one that reads as an all-clear.
+    ///
+    /// Two things about the shape are worth a test rather than a comment, because both are easy
+    /// to undo by accident. The cap - when there is one - belongs to the CTE, which selects backup
+    /// SETS. Moved down into the join it would count backupmediafamily rows, which are one per
+    /// FILE, so a four-way striped backup is four of them; that is where this started, with a
+    /// limit documented as 500 backups returning 125 of them and a cut that could land inside a
+    /// set, leaving an entry holding some of its stripes.
+    /// </summary>
+    internal static string BuildBackupHistoryQuery(bool capped) => $@"
+            WITH candidates AS (
+                SELECT {(capped ? "TOP (@limit)" : string.Empty)} bs.backup_set_id
+                FROM msdb.dbo.backupset AS bs
+                WHERE (@database IS NULL OR bs.database_name = @database)
+                  AND EXISTS (SELECT 1
+                              FROM msdb.dbo.backupmediafamily AS f
+                              WHERE f.media_set_id = bs.media_set_id
+                                AND f.device_type IN (2, 102))
+                {(capped ? "ORDER BY bs.backup_start_date DESC, bs.backup_set_id DESC" : string.Empty)}
+            )
+            SELECT bs.backup_set_id,
                    bs.database_name,
                    bs.type,
                    bs.backup_start_date,
@@ -343,13 +357,42 @@ public class SqlServerService : ISqlServerService
                    bmf.physical_device_name,
                    bmf.family_sequence_number
             FROM msdb.dbo.backupset AS bs
+            JOIN candidates AS c
+              ON c.backup_set_id = bs.backup_set_id
             JOIN msdb.dbo.backupmediafamily AS bmf
               ON bmf.media_set_id = bs.media_set_id
-            WHERE (@database IS NULL OR bs.database_name = @database)
-              AND bmf.device_type IN (2, 102)   -- disk, including logical disk devices
+            WHERE bmf.device_type IN (2, 102)   -- disk, including logical disk devices
             ORDER BY bs.backup_start_date DESC, bs.backup_set_id DESC, bmf.family_sequence_number";
 
+    public async Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
+        ServerConnection server, string? databaseName = null,
+        int? limit = null, CancellationToken ct = default)
+    {
+        await using var conn = CreateConnection(server);
+        await conn.OpenAsync(ct);
+
+        await using var cmd = conn.CreateCommand();
+
+        // backupset holds one row per backup; backupmediafamily one per FILE it was written to, so
+        // a striped backup is several rows and family_sequence_number is the stripe order. Grouping
+        // in the app rather than with STRING_AGG keeps this readable on every supported version.
+        //
+        // The cap picks the SETS first, in its own pass, and the families are joined afterwards
+        // (#484). It used to sit on the joined result, where it counted FILES - two things wrong
+        // with that, and the striping above is exactly what made both of them possible:
+        //
+        //   The unit was not the documented one. A four-way striped backup is four rows, so a cap
+        //   described and reasoned about as 500 backups returned 125 of them.
+        //
+        //   Worse, the cut could land INSIDE a set, and the oldest entry then came back holding
+        //   some of its stripes. That entry is indistinguishable from a genuine one-file backup:
+        //   a RESTORE built from it names two of four devices and fails, and the gap check reports
+        //   the stripes beyond the cut as files the container is missing when they are neither
+        //   missing nor beyond it.
+        cmd.CommandText = BuildBackupHistoryQuery(limit.HasValue);
+
         cmd.Parameters.AddWithValue("@database", (object?)databaseName ?? DBNull.Value);
+        if (limit.HasValue) cmd.Parameters.AddWithValue("@limit", limit.Value);
 
         // One row per FILE, gathered back into one entry per backup set.
         var files = new Dictionary<int, List<(int Sequence, string Path)>>();
@@ -394,14 +437,6 @@ public class SqlServerService : ISqlServerService
                 files[id].OrderBy(f => f.Sequence).Select(f => f.Path).ToList()))
             .ToList();
     }
-
-    /// <summary>
-    /// How far back to read. msdb on a busy instance holds years of history, and a restore is
-    /// almost always from the recent end of it - but the number is stated here rather than left
-    /// implicit, because silently returning "the newest 500" while looking like "everything" is
-    /// how somebody concludes a backup is missing when it is simply older than the cap.
-    /// </summary>
-    public const int BackupHistoryLimit = 500;
 
     private static BackupHistoryEntry CloneWithFiles(BackupHistoryEntry entry, List<string> files) => new()
     {

--- a/src/NineLives.Tests/BackupHistoryIsNotCappedTests.cs
+++ b/src/NineLives.Tests/BackupHistoryIsNotCappedTests.cs
@@ -1,0 +1,187 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The instance's backup history is read WHOLE (#486).
+///
+/// It used to come back capped, and the cap was never asked for by anybody - it was the default.
+/// Every caller feeds something that a short answer quietly breaks:
+///
+///   the missing-backups check, whose entire job is naming backups a container has not got
+///   the restore inventory, which turns the answer into the chain that gets restored
+///   the CLI's inventory, the same
+///   the Browse Backups listing
+///
+/// "The newest N" is indistinguishable on screen from "all there is", and the direction it is
+/// wrong in is the one that reads as an all-clear: copy the files it named, press rescan, be told
+/// they all arrived, and the chain is still broken by the logs nobody was told about.
+///
+/// A cap can still be asked for. Nothing asks.
+/// </summary>
+public class BackupHistoryIsNotCappedTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 18, 9, 0, 0);
+
+    private static ServerConnection Server() => new()
+    { Id = "s1", Name = "SRV01", ServerName = "SRV01" };
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+    };
+
+    /// <summary>One log backup, at the minute-by-minute cadence that made 500 laughable.</summary>
+    private static BackupHistoryEntry Log(int minutesBeforeT0) => new()
+    {
+        DatabaseName = "MyDb",
+        Type = BackupType.TransactionLog,
+        StartedAt = T0.AddMinutes(-minutesBeforeT0),
+        Files = [$@"E:\SQLLogs\MyDb_{minutesBeforeT0}.trn"],
+        BackupSizeBytes = 10 * 1024 * 1024
+    };
+
+    private static (BackupGapViewModel vm, FakeSqlServerService sql) Panel(int logCount)
+    {
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory = Enumerable.Range(0, logCount).Select(Log).ToList()
+        };
+
+        var vm = new BackupGapViewModel(sql);
+        vm.Servers.Add(Server());
+        vm.SourceServer = vm.Servers[0];
+        return (vm, sql);
+    }
+
+    // ── the check asks for everything ───────────────────────────────────────────
+
+    [Fact]
+    public async Task TheMissingBackupsCheckAsksForTheWholeHistory()
+    {
+        var (vm, sql) = Panel(10);
+
+        await vm.CheckCommand.ExecuteAsync(new GapCheckRequest("MyDb", Container(), []));
+
+        Assert.False(sql.LastHistoryReadWasCapped);
+        Assert.Null(sql.LastHistoryLimit);
+    }
+
+    /// <summary>The Copy screen's version of the question reads the same history, the same way.</summary>
+    [Fact]
+    public async Task TheCopyScreensCheckAsksForTheWholeHistoryToo()
+    {
+        var (vm, sql) = Panel(10);
+
+        await vm.CheckLogsAfterAsync("MyDb", T0.AddDays(-30));
+
+        Assert.False(sql.LastHistoryReadWasCapped);
+    }
+
+    /// <summary>
+    /// The number that started this. A container sixteen hours behind, against a database taking a
+    /// log a minute: nearly twice the old cap, and every one of them has to be named or the copy
+    /// script that follows is incomplete.
+    /// </summary>
+    [Fact]
+    public async Task EveryLogIsReportedNotJustTheNewestFiveHundred()
+    {
+        const int SixteenHoursOfMinuteByMinuteLogs = 16 * 60;
+        var (vm, _) = Panel(SixteenHoursOfMinuteByMinuteLogs);
+
+        await vm.CheckCommand.ExecuteAsync(new GapCheckRequest("MyDb", Container(), []));
+
+        Assert.True(vm.HasGap);
+        Assert.Equal(SixteenHoursOfMinuteByMinuteLogs, vm.Locations.Sum(l => l.FileCount));
+
+        // And the OLDEST is named, not just the recent end - that is the one a cap loses.
+        var oldest = $@"E:\SQLLogs\MyDb_{SixteenHoursOfMinuteByMinuteLogs - 1}.trn";
+        Assert.Contains(
+            vm.Locations.SelectMany(l => l.Location.Backups).SelectMany(b => b.Files),
+            f => f == oldest);
+    }
+
+    /// <summary>
+    /// Well past any round number, so a plausible-looking total cannot be read as the real one.
+    /// </summary>
+    [Fact]
+    public async Task AHistoryOfTensOfThousandsComesBackWhole()
+    {
+        var (vm, _) = Panel(25_000);
+
+        await vm.CheckCommand.ExecuteAsync(new GapCheckRequest("MyDb", Container(), []));
+
+        Assert.Equal(25_000, vm.Locations.Sum(l => l.FileCount));
+        Assert.Contains("25000 backup(s) in its history", vm.ComparedWhat);
+    }
+}
+
+/// <summary>
+/// The shape of the history read itself (#484, #486).
+///
+/// Not a substitute for running it - that needs a real msdb - but these pin what a careless edit
+/// would undo, and the second of them is exactly what was wrong before.
+///
+/// backupmediafamily holds one row per file a backup was written to, so a four-way striped backup
+/// is four rows. The cap used to sit on the joined result, where it counted those: a limit
+/// described and reasoned about as 500 backups returned 125 of them, and the cut could land INSIDE
+/// a set, leaving an entry holding only some of its stripes. That entry is indistinguishable from
+/// a genuine single-file backup - a RESTORE built from it names two of four devices and fails, and
+/// the missing-backups check reports the stripes beyond the cut as files the container lacks.
+/// </summary>
+public class BackupHistoryQueryShapeTests
+{
+    private static readonly string Uncapped = SqlServerService.BuildBackupHistoryQuery(capped: false);
+    private static readonly string Capped = SqlServerService.BuildBackupHistoryQuery(capped: true);
+
+    /// <summary>What every caller in the app gets: no row limit anywhere in the statement.</summary>
+    [Fact]
+    public void TheDefaultStatementHasNoLimitAtAll()
+    {
+        Assert.DoesNotContain("TOP", Uncapped);
+        Assert.DoesNotContain("@limit", Uncapped);
+    }
+
+    /// <summary>And when one IS asked for, it counts backup sets rather than file rows.</summary>
+    [Fact]
+    public void ACapIsTakenOverBackupSetsNotOverFileRows()
+    {
+        Assert.Contains("SELECT TOP (@limit) bs.backup_set_id", Capped);
+
+        // The moment the inner query joins the media families, the cap is counting files again.
+        var inner = Capped[Capped.IndexOf("WITH candidates AS", StringComparison.Ordinal)..
+                           Capped.IndexOf("SELECT bs.backup_set_id", StringComparison.Ordinal)];
+        Assert.DoesNotContain("JOIN msdb.dbo.backupmediafamily", inner);
+    }
+
+    /// <summary>One cap, so there is no second one further down doing the old job.</summary>
+    [Fact]
+    public void ACappedStatementCapsExactlyOnce()
+        => Assert.Equal(1, Capped.Split("TOP (").Length - 1);
+
+    /// <summary>
+    /// Every family of the sets that survived, so a striped backup arrives whole either way.
+    /// </summary>
+    [Fact]
+    public void TheFamiliesAreJoinedAfterwardsAndAreNeverLimited()
+    {
+        foreach (var sql in new[] { Uncapped, Capped })
+        {
+            var outer = sql[sql.IndexOf("SELECT bs.backup_set_id", StringComparison.Ordinal)..];
+
+            Assert.Contains("JOIN candidates AS c", outer);
+            Assert.Contains("JOIN msdb.dbo.backupmediafamily", outer);
+            Assert.Contains("family_sequence_number", outer);
+            Assert.DoesNotContain("TOP", outer);
+        }
+    }
+
+    /// <summary>The cap is a parameter, never pasted into the statement.</summary>
+    [Fact]
+    public void ACapIsParameterised() => Assert.DoesNotContain("TOP (500)", Capped);
+}

--- a/src/NineLives.Tests/BackupHistoryTests.cs
+++ b/src/NineLives.Tests/BackupHistoryTests.cs
@@ -90,15 +90,6 @@ public class BackupHistoryTests
         Assert.NotEqual(full.CheckpointLsn, strayDiff.DatabaseBackupLsn);
     }
 
-    /// <summary>
-    /// The cap is a number somebody can read, not a silent truncation. Returning "the newest 500"
-    /// while looking like "everything" is how a backup gets concluded missing when it is simply
-    /// older than the limit.
-    /// </summary>
-    [Fact]
-    public void TheHistoryLimitIsStatedRatherThanImplied()
-        => Assert.True(SqlServerService.BackupHistoryLimit > 0);
-
     // ── against a real instance ─────────────────────────────────────────────────
 
     /// <summary>

--- a/src/NineLives.Tests/BehindByIsMeasuredFromRealBackupTimesTests.cs
+++ b/src/NineLives.Tests/BehindByIsMeasuredFromRealBackupTimesTests.cs
@@ -1,0 +1,114 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// "This container is N behind" is measured from times that are actually backup times (#489).
+///
+/// The same fault as #487, in the number printed above the list rather than in the list itself, and
+/// with a worse failure mode: #487 could name the wrong backup, this can suppress the warning
+/// altogether.
+///
+/// RecoveryTimeNotInContainer takes the newest held set's Timestamp and subtracts it from the
+/// newest backup msdb recorded. It never asked where that timestamp came from. When it came from
+/// the blob rather than the filename it is two things it should not be:
+///
+///   The wrong EVENT - when the upload finished, not when the backup started. Always later, so it
+///   always makes the container look more current than it is.
+///
+///   Possibly the wrong CLOCK - a raw BlobLastModified reading is UTC, while msdb's dates are the
+///   instance's local time. BackupSet's own comment says this "can sort it hours out of position".
+///
+/// Both shrink the measured gap, and the method returns null when the difference is not positive.
+/// So a single blob-stamped set whose reading lands after the newest recorded backup takes the
+/// maximum, makes the subtraction negative, and the banner does not appear at all - on a container
+/// that is genuinely hours behind.
+///
+/// Which way the clock error runs depends on where the server is. West of UTC the blob reading is
+/// AHEAD of local time, which is the direction that suppresses the warning, and by four or five
+/// hours rather than by minutes.
+/// </summary>
+public class BehindByIsMeasuredFromRealBackupTimesTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 18, 22, 0, 0);
+
+    private static BackupHistoryEntry Recorded(DateTime at) => new()
+    {
+        DatabaseName = "MyDb",
+        Type = BackupType.TransactionLog,
+        StartedAt = at,
+        Files = [$@"E:\SQLLogs\MyDb_{at:yyyyMMdd_HHmmss}.trn"]
+    };
+
+    private static BackupSet Held(DateTime at, BackupTimestampSource source) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        DatabaseName = "MyDb",
+        Type = BackupType.TransactionLog,
+        Timestamp = at,
+        TimestampSource = source,
+        Files = [new BackupFileInfo { BlobName = "x.trn", Type = BackupType.TransactionLog }]
+    };
+
+    private static TimeSpan? Behind(params BackupSet[] held)
+        => BackupGapAnalyser.RecoveryTimeNotInContainer([Recorded(T0)], held, "MyDb");
+
+    /// <summary>
+    /// The suppression. The container's real newest backup is sixteen hours old; one set carries
+    /// only an upload time, read on a clock that puts it after the newest recorded backup. That
+    /// reading took the maximum and the gap came out negative, so nothing was said.
+    /// </summary>
+    [Fact]
+    public void AnUploadTimeCannotHideTheGap()
+    {
+        var behind = Behind(
+            Held(T0.AddHours(-16), BackupTimestampSource.FileName),
+            Held(T0.AddHours(1), BackupTimestampSource.BlobLastModified));
+
+        Assert.Equal(TimeSpan.FromHours(16), behind);
+    }
+
+    /// <summary>
+    /// And cannot shrink it either. Converting the reading into the server's zone fixes the clock
+    /// and leaves the event wrong - an upload finishes after its backup started, so it always
+    /// flatters the container.
+    /// </summary>
+    [Fact]
+    public void AConvertedUploadTimeCannotShrinkTheGap()
+    {
+        var behind = Behind(
+            Held(T0.AddHours(-16), BackupTimestampSource.FileName),
+            Held(T0.AddHours(-2), BackupTimestampSource.BlobLastModifiedConverted));
+
+        Assert.Equal(TimeSpan.FromHours(16), behind);
+    }
+
+    /// <summary>
+    /// With nothing but upload times there is no interval anybody can stand behind, and the panel
+    /// already has a shape for that: it says the container is missing backups without quoting a
+    /// figure. A wrong number is worse than no number.
+    /// </summary>
+    [Fact]
+    public void WithNoRealBackupTimesThereIsNothingToQuote()
+        => Assert.Null(Behind(Held(T0.AddHours(-16), BackupTimestampSource.BlobLastModified)));
+
+    // ── what must keep working ──────────────────────────────────────────────────
+
+    [Fact]
+    public void AFilenameTimestampStillMeasures()
+        => Assert.Equal(TimeSpan.FromHours(16),
+            Behind(Held(T0.AddHours(-16), BackupTimestampSource.FileName)));
+
+    /// <summary>A header time is SQL Server's own account of the backup, on the right clock.</summary>
+    [Fact]
+    public void AHeaderTimestampStillMeasures()
+        => Assert.Equal(TimeSpan.FromHours(16),
+            Behind(Held(T0.AddHours(-16), BackupTimestampSource.BackupHeader)));
+
+    /// <summary>A container that is up to date still reports no gap.</summary>
+    [Fact]
+    public void AContainerThatIsCurrentStillSaysNothing()
+        => Assert.Null(Behind(Held(T0, BackupTimestampSource.FileName)));
+}

--- a/src/NineLives.Tests/CopiedBackupsLandWhereTheAppLooksTests.cs
+++ b/src/NineLives.Tests/CopiedBackupsLandWhereTheAppLooksTests.cs
@@ -1,0 +1,155 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The copy script puts files where this app can find them again (#491).
+///
+/// The whole feature is a loop: name the backups the container has not got, hand over a script to
+/// copy them in, then rescan and say whether it worked. The script uploaded each file under its
+/// bare name - Split-Path -Leaf - which puts it at the ROOT of the container.
+///
+/// Nothing about the upload fails. But the listing reads a blob's database and server back OUT of
+/// its path, by the container's own pattern, and the default pattern is
+/// {BackupType}/{ServerName}/{DatabaseName}/{FileName}. A blob at the root has no path to read:
+/// the pattern cannot match it, and the structural fallback needs at least three segments to guess
+/// a database from. So it is attributed to no database at all.
+///
+/// Every question this app asks is asked per database, so the copied files are stepped straight
+/// over. The rescan compares what is held FOR THIS DATABASE, finds them absent, and reports "None
+/// of the N arrived" - after a copy in which every byte transferred successfully. The listing is
+/// also prefix-scoped once a database is chosen, so they may not even be enumerated.
+///
+/// The destination is worked out here now, from the container's pattern and what msdb recorded
+/// about the backup, rather than left to Split-Path at run time on the source machine.
+/// </summary>
+public class CopiedBackupsLandWhereTheAppLooksTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 18, 22, 0, 0);
+
+    private static BlobContainerConfig Container(string? pattern = null) => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups",
+        PathPattern = pattern ?? BlobContainerConfig.DefaultPathPattern
+    };
+
+    private static MissingLocation OneMissingLog(string file = @"E:\SQLLogs\MyDb_20260818_220000.trn")
+    {
+        var entry = new BackupHistoryEntry
+        {
+            DatabaseName = "MyDb",
+            ServerName = "SRV01",
+            Type = BackupType.TransactionLog,
+            StartedAt = T0,
+            Files = [file],
+            BackupSizeBytes = 10 * 1024 * 1024
+        };
+
+        return new MissingLocation(@"E:\SQLLogs", [new MissingBackup(entry, @"E:\SQLLogs")]);
+    }
+
+    /// <summary>
+    /// The destination carries the container's layout, so the file lands beside the backups
+    /// already there rather than in the root.
+    /// </summary>
+    [Fact]
+    public void TheDestinationFollowsTheContainersOwnPattern()
+    {
+        var script = MissingBackupCopyScript.Build(OneMissingLog(), Container());
+
+        Assert.Contains("Destination = 'LOG/SRV01/MyDb/MyDb_20260818_220000.trn'", script);
+    }
+
+    /// <summary>
+    /// The proof that matters: the destination, put back through the REAL listing parser, is
+    /// attributed to the database it belongs to. Without that the rescan cannot count it.
+    /// </summary>
+    [Fact]
+    public void TheDestinationListsBackAsThisDatabase()
+    {
+        var container = Container();
+        var script = MissingBackupCopyScript.Build(OneMissingLog(), container);
+
+        var listed = ListBack(container, Destination(script));
+
+        Assert.Equal("MyDb", listed.InferredDatabaseName);
+        Assert.Equal("SRV01", listed.InferredServerName);
+        Assert.Equal(BackupType.TransactionLog, listed.Type);
+    }
+
+    /// <summary>
+    /// And what the old script produced does NOT, which is why the rescan reported nothing had
+    /// arrived. Pinned so the bare-leaf destination cannot come back unnoticed.
+    /// </summary>
+    [Fact]
+    public void ABareFilenameAtTheRootIsAttributedToNoDatabase()
+    {
+        var listed = ListBack(Container(), "MyDb_20260818_220000.trn");
+
+        Assert.True(string.IsNullOrEmpty(listed.InferredDatabaseName));
+    }
+
+    /// <summary>A container laid out differently is followed, not overridden.</summary>
+    [Fact]
+    public void ADifferentPatternIsHonoured()
+    {
+        var script = MissingBackupCopyScript.Build(
+            OneMissingLog(), Container("{DatabaseName}/{BackupType}/{FileName}"));
+
+        Assert.Contains("Destination = 'MyDb/LOG/MyDb_20260818_220000.trn'", script);
+    }
+
+    /// <summary>
+    /// The name is taken off a path the SOURCE machine wrote. A UNC share uses the same separator
+    /// this app runs on, but the reverse is not guaranteed, so both are cut.
+    /// </summary>
+    [Fact]
+    public void AUncSourcePathStillYieldsItsFileName()
+    {
+        var script = MissingBackupCopyScript.Build(
+            OneMissingLog(@"\fileserver\logship\MyDb_20260818_220000.trn"), Container());
+
+        Assert.Contains("Destination = 'LOG/SRV01/MyDb/MyDb_20260818_220000.trn'", script);
+    }
+
+    /// <summary>The source is still named in full - that is the file being picked up.</summary>
+    [Fact]
+    public void TheSourcePathIsStillTheFullPath()
+    {
+        var script = MissingBackupCopyScript.Build(OneMissingLog(), Container());
+
+        Assert.Contains(@"Source = 'E:\SQLLogs\MyDb_20260818_220000.trn'", script);
+    }
+
+    /// <summary>Still no credential in the file, which every generator has to keep true.</summary>
+    [Fact]
+    public void TheScriptStillCarriesNoCredential()
+    {
+        var script = MissingBackupCopyScript.Build(OneMissingLog(), Container());
+
+        Assert.Contains("Mandatory = $true", script);
+        Assert.DoesNotContain("sig=", script);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────
+
+    private static string Destination(string script)
+    {
+        var marker = "Destination = '";
+        var start = script.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+        var end = script.IndexOf('\'', start);
+        return script[start..end];
+    }
+
+    /// <summary>
+    /// Runs a destination back through the REAL listing parser, so this breaks if either side of
+    /// the round trip changes without the other.
+    /// </summary>
+    private static BackupFileInfo ListBack(BlobContainerConfig container, string blobName)
+        => Assert.Single(new BlobStorageService(new FakeCredentialStore())
+            .ParseListedBlobsForTests(container, [(blobName, 5_000_000L, new DateTimeOffset(T0, TimeSpan.Zero))]));
+}

--- a/src/NineLives.Tests/Fakes.cs
+++ b/src/NineLives.Tests/Fakes.cs
@@ -811,13 +811,36 @@ public sealed class FakeSqlServerService : ISqlServerService
     /// rights on msdb, which is the ordinary reason a source refuses this (#451).</summary>
     public Exception? BackupHistoryThrows { get; set; }
 
+    /// <summary>
+    /// The limit the last caller asked for - null when it asked for everything, which is what
+    /// every caller in the app does (#486). A test can prove it rather than assuming.
+    /// </summary>
+    public int? LastHistoryLimit { get; private set; }
+
+    public bool LastHistoryReadWasCapped { get; private set; }
+
     public Task<List<BackupHistoryEntry>> ReadBackupHistoryAsync(
-        ServerConnection server, string? databaseName = null, CancellationToken ct = default)
-        => BackupHistoryThrows != null
-            ? Task.FromException<List<BackupHistoryEntry>>(BackupHistoryThrows)
-            : Task.FromResult(databaseName == null
-                ? BackupHistory
-                : BackupHistory.Where(h => h.DatabaseName == databaseName).ToList());
+        ServerConnection server, string? databaseName = null,
+        int? limit = null, CancellationToken ct = default)
+    {
+        LastHistoryLimit = limit;
+        LastHistoryReadWasCapped = limit.HasValue;
+
+        if (BackupHistoryThrows != null)
+            return Task.FromException<List<BackupHistoryEntry>>(BackupHistoryThrows);
+
+        var matching = databaseName == null
+            ? BackupHistory
+            : BackupHistory.Where(h => h.DatabaseName == databaseName).ToList();
+
+        // Newest first and capped, as the real one is - so a test can play an instance holding
+        // more history than the caller asked for, which is the case the cap exists for.
+        var newestFirst = matching.OrderByDescending(h => h.StartedAt);
+
+        return Task.FromResult(limit.HasValue
+            ? newestFirst.Take(limit.Value).ToList()
+            : newestFirst.ToList());
+    }
 
     /// <summary>Set to make the target unreachable rather than merely unhelpful.</summary>
     public Exception? ThrowOnCheck { get; set; }

--- a/src/NineLives.Tests/GapCheckButtonComesAliveTests.cs
+++ b/src/NineLives.Tests/GapCheckButtonComesAliveTests.cs
@@ -1,0 +1,109 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// "Check its history" becomes live when a source instance is chosen (#483).
+///
+/// Reported from a real run: the button sat disabled next to a populated dropdown, and the only
+/// way to wake it was to navigate off the Restore screen and back - which rebuilds the visual tree
+/// and re-reads every binding from scratch.
+///
+/// The button binds Command AND IsEnabled, and an explicit IsEnabled wins over the command's own
+/// answer. So the panel's NotifyCanExecuteChanged updated something nothing was looking at, while
+/// CanCheck - what the button actually reads - was never raised anywhere in the file.
+///
+/// This is #130 again, and the same subtlety applies: asking CanCheck in a test always gives the
+/// right answer, because it is computed on the spot. A CONTROL does not ask. It caches what it was
+/// last told and re-reads only when PropertyChanged names the property - so what was broken was
+/// the notification, not the answer, and only a test watching PropertyChanged can see it.
+///
+/// A disabled control is a silent failure: it looks deliberately unavailable, so it reads as "not
+/// allowed yet" rather than "broken", and there is nothing to click to find out otherwise.
+/// </summary>
+public class GapCheckButtonComesAliveTests
+{
+    private static (BackupGapViewModel vm, List<string> told) Watched()
+    {
+        var vm = new BackupGapViewModel(new FakeSqlServerService());
+        vm.Servers.Add(new ServerConnection { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        vm.Servers.Add(new ServerConnection { Id = "s2", Name = "SRV02", ServerName = "SRV02" });
+
+        var told = new List<string>();
+        vm.PropertyChanged += (_, e) => told.Add(e.PropertyName ?? string.Empty);
+        return (vm, told);
+    }
+
+    /// <summary>The reported sequence: pick an instance, watch the button stay dead.</summary>
+    [Fact]
+    public void ChoosingASourceInstanceTellsTheButtonToReadAgain()
+    {
+        var (vm, told) = Watched();
+
+        vm.SourceServer = vm.Servers[0];
+
+        Assert.True(vm.CanCheck);
+
+        // The part that was missing. Without it the button keeps the answer it was given while
+        // the dropdown was still empty, and stays disabled beside a chosen instance.
+        Assert.Contains(nameof(vm.CanCheck), told);
+    }
+
+    /// <summary>
+    /// And when the instance is taken away again, so the button does not stay live against a
+    /// panel that has nothing to ask.
+    /// </summary>
+    [Fact]
+    public void ClearingTheSourceInstanceSaysSoToo()
+    {
+        var (vm, told) = Watched();
+        vm.SourceServer = vm.Servers[0];
+        told.Clear();
+
+        vm.SourceServer = null;
+
+        Assert.False(vm.CanCheck);
+        Assert.Contains(nameof(vm.CanCheck), told);
+    }
+
+    /// <summary>
+    /// The check itself moves the button both ways. It reads the instance's whole backup history,
+    /// which is a round trip somebody can sit through - a button that stays live through it
+    /// invites a second press against a check already running.
+    /// </summary>
+    [Fact]
+    public void RunningTheCheckGreysTheButtonAndBringsItBack()
+    {
+        var (vm, told) = Watched();
+        vm.SourceServer = vm.Servers[0];
+        told.Clear();
+
+        vm.IsChecking = true;
+        Assert.False(vm.CanCheck);
+        Assert.Contains(nameof(vm.CanCheck), told);
+
+        told.Clear();
+        vm.IsChecking = false;
+        Assert.True(vm.CanCheck);
+        Assert.Contains(nameof(vm.CanCheck), told);
+    }
+
+    /// <summary>
+    /// Switching instance keeps saying it, because the answer stays true and a control that was
+    /// told "false" by an earlier state has to hear otherwise.
+    /// </summary>
+    [Fact]
+    public void SwitchingBetweenInstancesKeepsTheButtonLive()
+    {
+        var (vm, told) = Watched();
+        vm.SourceServer = vm.Servers[0];
+        told.Clear();
+
+        vm.SourceServer = vm.Servers[1];
+
+        Assert.True(vm.CanCheck);
+        Assert.Contains(nameof(vm.CanCheck), told);
+    }
+}

--- a/src/NineLives.Tests/GapCheckDoesNotTrustApproximateTimestampsTests.cs
+++ b/src/NineLives.Tests/GapCheckDoesNotTrustApproximateTimestampsTests.cs
@@ -1,0 +1,257 @@
+using Blackcat.NineLives.Models;
+using Blackcat.NineLives.ViewModels;
+using Blackcat.NineLives.Services;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// A backup is not declared present on the strength of a timestamp that was never a backup time
+/// (#487).
+///
+/// The comparison matches by LSN wherever both sides have one, and falls back to type plus
+/// timestamp otherwise - container sets only carry LSNs once they have been audited, so the
+/// fallback is the ordinary path, not the exception. The tolerance is five seconds, on the stated
+/// grounds that "a container set's timestamp is parsed from its file name, which the writer stamps
+/// at the START of the backup; msdb records the start too, so these agree exactly".
+///
+/// That is true only when the timestamp came from the file name. When it could not, the set falls
+/// back to the blob's LastModified, and BackupSet says what that means in its own comment: the
+/// reading is on a DIFFERENT CLOCK from its neighbours and "can sort it hours out of position".
+/// It is also the wrong event - when the upload finished, not when the backup started.
+///
+/// IsHeld never looked at TimestampSource, so it compared that number to msdb's start time as
+/// though the two were the same kind of thing. Two ways that goes wrong, and only one of them is
+/// safe:
+///
+///   No match - the backup is reported missing when it is there. An unnecessary copy.
+///   A match against the WRONG backup - the backup is reported present when it is not.
+///
+/// The second is the one that matters, and at a one-minute log cadence it is not exotic: every
+/// approximate reading lands within five seconds of SOME log's start time roughly one time in six,
+/// and a container holds hundreds of them. The log is then left out of the copy script, the rescan
+/// says everything arrived, and the chain is still broken.
+///
+/// This file's own doctrine already settles it: "Reporting a present backup as missing costs an
+/// unnecessary copy; the reverse would leave somebody restoring to an hour earlier than they could
+/// have, so the bias is deliberate." An approximate timestamp is not evidence of presence.
+/// </summary>
+public class GapCheckDoesNotTrustApproximateTimestampsTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 18, 22, 0, 0);
+
+    private static BackupHistoryEntry Log(DateTime at, decimal? lastLsn = null) => new()
+    {
+        DatabaseName = "MyDb",
+        Type = BackupType.TransactionLog,
+        StartedAt = at,
+        LastLsn = lastLsn,
+        Files = [$@"E:\SQLLogs\MyDb_{at:yyyyMMdd_HHmmss}.trn"],
+        BackupSizeBytes = 10 * 1024 * 1024
+    };
+
+    private static BackupSet Held(
+        DateTime at,
+        BackupTimestampSource source = BackupTimestampSource.FileName,
+        decimal? lastLsn = null) => new()
+    {
+        SetId = at.ToString("yyyyMMdd_HHmmss"),
+        DatabaseName = "MyDb",
+        Type = BackupType.TransactionLog,
+        Timestamp = at,
+        TimestampSource = source,
+        LastLsn = lastLsn,
+        Files = [new BackupFileInfo { BlobName = "x.trn", Type = BackupType.TransactionLog }]
+    };
+
+    private static IReadOnlyList<string> MissingFiles(
+        IReadOnlyList<BackupHistoryEntry> history, IReadOnlyList<BackupSet> held)
+        => BackupGapAnalyser.Compare(history, held, "MyDb")
+            .SelectMany(l => l.Backups)
+            .SelectMany(b => b.Files)
+            .ToList();
+
+    /// <summary>
+    /// The failure, in the shape it actually takes: the container holds ONE log, and the only
+    /// timestamp available for it is when the blob finished uploading - which happens to land
+    /// three seconds after a DIFFERENT log started.
+    ///
+    /// Both logs must still be named. Neither has been shown to be in the container: the one
+    /// that is there cannot be identified, and the one that is not must not inherit its identity.
+    /// </summary>
+    [Fact]
+    public void AnUploadTimeThatLandsNearAnotherBackupDoesNotVouchForIt()
+    {
+        var history = new[] { Log(T0), Log(T0.AddMinutes(1)) };
+        var held = new[] { Held(T0.AddSeconds(3), BackupTimestampSource.BlobLastModified) };
+
+        var missing = MissingFiles(history, held);
+
+        Assert.Contains(missing, f => f.EndsWith("220000.trn", StringComparison.Ordinal));
+        Assert.Contains(missing, f => f.EndsWith("220100.trn", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The same when the clock has been reconciled but the reading is still an upload time. The
+    /// conversion fixes which clock it is on, not which event it describes.
+    /// </summary>
+    [Fact]
+    public void AConvertedUploadTimeIsStillAnUploadTime()
+    {
+        var history = new[] { Log(T0) };
+        var held = new[] { Held(T0.AddSeconds(2), BackupTimestampSource.BlobLastModifiedConverted) };
+
+        Assert.Single(MissingFiles(history, held));
+    }
+
+    // ── what must keep working ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// A filename timestamp is a backup START time, on the backup server's own clock, and matching
+    /// on it is the ordinary path for a container nobody has audited. It has to keep matching, or
+    /// every unaudited container reports its entire contents as missing.
+    /// </summary>
+    [Fact]
+    public void AFilenameTimestampStillMatches()
+    {
+        var history = new[] { Log(T0) };
+        var held = new[] { Held(T0, BackupTimestampSource.FileName) };
+
+        Assert.Empty(MissingFiles(history, held));
+    }
+
+    /// <summary>And still within the tolerance, for a writer that stamps a second late.</summary>
+    [Fact]
+    public void AFilenameTimestampWithinTheToleranceStillMatches()
+    {
+        var history = new[] { Log(T0) };
+        var held = new[] { Held(T0.AddSeconds(2), BackupTimestampSource.FileName) };
+
+        Assert.Empty(MissingFiles(history, held));
+    }
+
+    /// <summary>
+    /// A header timestamp is SQL Server's own account of the backup, on the backup server's clock -
+    /// as good as the filename, and better.
+    /// </summary>
+    [Fact]
+    public void AHeaderTimestampStillMatches()
+    {
+        var history = new[] { Log(T0) };
+        var held = new[] { Held(T0, BackupTimestampSource.BackupHeader) };
+
+        Assert.Empty(MissingFiles(history, held));
+    }
+
+    /// <summary>
+    /// An LSN is the backup itself rather than a description of it, so it settles the question
+    /// whatever the timestamp is doing. An audited set matches on LSN even when its only timestamp
+    /// is an upload time hours out of position.
+    /// </summary>
+    [Fact]
+    public void AMatchingLsnIsBelievedEvenWhenTheTimestampIsApproximate()
+    {
+        var history = new[] { Log(T0, lastLsn: 4200m) };
+        var held = new[]
+        {
+            Held(T0.AddHours(-7), BackupTimestampSource.BlobLastModified, lastLsn: 4200m)
+        };
+
+        Assert.Empty(MissingFiles(history, held));
+    }
+
+    /// <summary>
+    /// And an LSN that does not match is not rescued by a nearby approximate timestamp on some
+    /// other set. This is the two faults compounding: the entry has a definitive identifier, no
+    /// audited set claims it, and an unaudited one vouches for it on a number that is not a
+    /// backup time.
+    /// </summary>
+    [Fact]
+    public void ADefinitiveLsnIsNotOverriddenByAnUnauditedSetsUploadTime()
+    {
+        var history = new[] { Log(T0, lastLsn: 4200m) };
+        var held = new[]
+        {
+            Held(T0.AddMinutes(-1), BackupTimestampSource.FileName, lastLsn: 4100m),
+            Held(T0.AddSeconds(1), BackupTimestampSource.BlobLastModified)
+        };
+
+        Assert.Single(MissingFiles(history, held));
+    }
+}
+
+/// <summary>
+/// The panel says why a container full of unidentifiable sets reports everything as missing
+/// (#487).
+///
+/// The comparison is right to refuse them - an upload time vouches for nothing - but the result
+/// on screen is a container that appears to have lost its entire contents. Without a reason and a
+/// remedy that reads as a catastrophe rather than as a limit on what can be known from a listing.
+/// </summary>
+public class UnidentifiableSetsAreExplainedTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 18, 22, 0, 0);
+
+    private static BackupGapViewModel Panel()
+    {
+        var sql = new FakeSqlServerService
+        {
+            BackupHistory =
+            [
+                new BackupHistoryEntry
+                {
+                    DatabaseName = "MyDb",
+                    Type = BackupType.TransactionLog,
+                    StartedAt = T0,
+                    Files = [@"E:\SQLLogs\MyDb_20260818_220000.trn"]
+                }
+            ]
+        };
+
+        var vm = new BackupGapViewModel(sql);
+        vm.Servers.Add(new ServerConnection { Id = "s1", Name = "SRV01", ServerName = "SRV01" });
+        vm.SourceServer = vm.Servers[0];
+        return vm;
+    }
+
+    private static BlobContainerConfig Container() => new()
+    {
+        Id = "c1",
+        Name = "sqlbackups",
+        ContainerUrl = "https://acct.blob.core.windows.net/sqlbackups"
+    };
+
+    private static BackupSet Set(BackupTimestampSource source) => new()
+    {
+        SetId = "s",
+        DatabaseName = "MyDb",
+        Type = BackupType.TransactionLog,
+        Timestamp = T0,
+        TimestampSource = source,
+        Files = [new BackupFileInfo { BlobName = "x.trn", Type = BackupType.TransactionLog }]
+    };
+
+    [Fact]
+    public async Task ASetThatCannotBeIdentifiedIsCountedAndTheRemedyNamed()
+    {
+        var vm = Panel();
+
+        await vm.CheckCommand.ExecuteAsync(
+            new GapCheckRequest("MyDb", Container(), [Set(BackupTimestampSource.BlobLastModified)]));
+
+        Assert.Contains("1 of those cannot be identified", vm.ComparedWhat);
+        Assert.Contains("Auditing this container", vm.ComparedWhat);
+    }
+
+    /// <summary>Silent when every set carries a real backup time, which is the ordinary case.</summary>
+    [Fact]
+    public async Task NothingIsSaidWhenEverySetCarriesARealBackupTime()
+    {
+        var vm = Panel();
+
+        await vm.CheckCommand.ExecuteAsync(
+            new GapCheckRequest("MyDb", Container(), [Set(BackupTimestampSource.FileName)]));
+
+        Assert.DoesNotContain("cannot be identified", vm.ComparedWhat);
+    }
+}

--- a/src/NineLives/NineLives.csproj
+++ b/src/NineLives/NineLives.csproj
@@ -9,7 +9,7 @@
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <AssemblyName>NineLives</AssemblyName>
     <RootNamespace>Blackcat.NineLives</RootNamespace>
-    <Version>1.7.2</Version>
+    <Version>1.7.3</Version>
     <Product>Nine Lives</Product>
     <Authors>Jake Morgan</Authors>
     <Company>Blackcat Data Solutions Ltd</Company>

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -199,9 +199,23 @@ public partial class BackupGapViewModel : ViewModelBase
             var behind = BackupGapAnalyser.RecoveryTimeNotInContainer(history, held, database);
             BehindBy = behind is { } gap ? Humanise(gap) : string.Empty;
 
+            // Named, because otherwise this reads as a container that has lost everything (#487).
+            // A set whose only timestamp is the blob's upload time cannot confirm any backup, so
+            // every backup it might have accounted for is listed as missing - correctly, but the
+            // reason is invisible and the remedy is not obvious.
+            var unidentifiable = held.Count(h =>
+                string.Equals(h.DatabaseName, database, StringComparison.OrdinalIgnoreCase)
+                && h.IsTimestampApproximate);
+
             ComparedWhat =
                 $"{database} on {server.ServerName}: {history.Count} backup(s) in its history, " +
-                $"{held.Count} set(s) in {container?.Name ?? "this container"}.";
+                $"{held.Count} set(s) in {container?.Name ?? "this container"}." +
+                (unidentifiable > 0
+                    ? $" {unidentifiable} of those cannot be identified: the only time known for " +
+                      "them is when the blob was uploaded, not when the backup was taken, so they " +
+                      "vouch for nothing. Auditing this container reads each backup's own header " +
+                      "and settles it."
+                    : string.Empty);
 
             HasChecked = true;
 

--- a/src/NineLives/ViewModels/BackupGapViewModel.cs
+++ b/src/NineLives/ViewModels/BackupGapViewModel.cs
@@ -53,7 +53,12 @@ public partial class BackupGapViewModel : ViewModelBase
     /// <summary>The servers offered as the source. Filled by the screen that owns this.</summary>
     public ObservableCollection<ServerConnection> Servers { get; } = [];
 
+    /// <summary>
+    /// The instance to ask. Notifies CanCheck, because the button reads that rather than the
+    /// command (#483) - see the property itself.
+    /// </summary>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanCheck))]
     private ServerConnection? _sourceServer;
 
     partial void OnSourceServerChanged(ServerConnection? oldValue, ServerConnection? newValue)
@@ -81,6 +86,7 @@ public partial class BackupGapViewModel : ViewModelBase
     private bool _hasChecked;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanCheck))]
     private bool _isChecking;
 
     /// <summary>How far behind the container is, in words, or empty when it is not behind.</summary>
@@ -110,6 +116,18 @@ public partial class BackupGapViewModel : ViewModelBase
     [ObservableProperty]
     private string _comparedWhat = string.Empty;
 
+    /// <summary>
+    /// Whether the check can run - and a property the BUTTON reads, not just the command (#483).
+    ///
+    /// The button binds IsEnabled to this as well as binding Command, and an explicit IsEnabled
+    /// wins over the command's own answer. So NotifyCanExecuteChanged, which this used to be the
+    /// only subject of, updated something nothing was looking at: choosing a source instance left
+    /// the button dead, and the only way to wake it was to leave the screen and come back, which
+    /// rebuilds the visual tree and re-reads every binding from scratch.
+    ///
+    /// Same lesson as #130. Asking the property in a test always gives the right answer; a control
+    /// caches what it was last told, so only a test watching PropertyChanged can see this.
+    /// </summary>
     public bool CanCheck => SourceServer != null && !IsChecking;
 
     /// <summary>
@@ -164,7 +182,7 @@ public partial class BackupGapViewModel : ViewModelBase
 
         try
         {
-            var history = await _sql.ReadBackupHistoryAsync(server, database, ct);
+            var history = await _sql.ReadBackupHistoryAsync(server, database, ct: ct);
 
             var locations = BackupGapAnalyser.Compare(history, held, database);
             foreach (var location in locations) Locations.Add(new MissingLocationRow(location));
@@ -227,7 +245,7 @@ public partial class BackupGapViewModel : ViewModelBase
 
         try
         {
-            var history = await _sql.ReadBackupHistoryAsync(server, database, ct);
+            var history = await _sql.ReadBackupHistoryAsync(server, database, ct: ct);
             var locations = BackupGapAnalyser.LogsTakenAfter(history, database, after);
 
             foreach (var location in locations) Locations.Add(new MissingLocationRow(location));
@@ -314,10 +332,12 @@ public partial class BackupGapViewModel : ViewModelBase
         RaiseDerived();
     }
 
+
     private void RaiseDerived()
     {
         OnPropertyChanged(nameof(HasGap));
         OnPropertyChanged(nameof(FoundNothingMissing));
+        OnPropertyChanged(nameof(CanCheck));
         CheckCommand.NotifyCanExecuteChanged();
     }
 

--- a/src/NineLives/ViewModels/BackupInventoryViewModel.cs
+++ b/src/NineLives/ViewModels/BackupInventoryViewModel.cs
@@ -819,7 +819,7 @@ public partial class BackupInventoryViewModel : ViewModelBase
     private async Task LoadFromHistoryAsync(BackupLocation location, CancellationToken ct)
     {
         var source = location.SourceServer!;
-        var history = await _sql.ReadBackupHistoryAsync(source, SelectedDatabaseName, ct);
+        var history = await _sql.ReadBackupHistoryAsync(source, SelectedDatabaseName, ct: ct);
 
         // The substitution is applied once, here, so the chain, the file list on screen, the script
         // and the readability check all name the same file. Applying it in some of those places and

--- a/src/NineLives/ViewModels/BlobBrowserViewModel.cs
+++ b/src/NineLives/ViewModels/BlobBrowserViewModel.cs
@@ -365,7 +365,7 @@ public partial class BlobBrowserViewModel : ViewModelBase
     private async Task LoadFromHistoryAsync(CancellationToken ct)
     {
         var source = SourceServer!;
-        var history = await _sqlService.ReadBackupHistoryAsync(source, null, ct);
+        var history = await _sqlService.ReadBackupHistoryAsync(source, null, ct: ct);
         ct.ThrowIfCancellationRequested();
         var sets = BackupHistoryInventory.ToSets(history, BackupPathMapping.None);
 


### PR DESCRIPTION
Promotes `dev` to `main` for the **1.7.3** release.

Six fixes to the missing-backups check. Four of them made it under-report — a backup declared present when it was not, or a container declared current when it was hours behind — which is the direction that reads as an all-clear.

- **#486** the backup history is read whole, with no cap on any path that feeds a restore chain or a missing-backups answer
- **#484** a cap, where a caller asks for one, counts backup sets rather than file rows, and cannot cut a striped set in half
- **#491** the copy script writes into the container's own path layout, so the app can see the files it just copied
- **#487** an approximate timestamp no longer vouches for a backup's presence
- **#489** "this container is N behind" is measured only from real backup times
- **#483** "Check its history" is live as soon as an instance is chosen

`-c Release -warnaserror` clean, 2,291 passed.