### PR TITLE
Make a hung test step name the test (#495)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,13 +97,37 @@ jobs:
           }
           exit 0
 
+      # --blame-hang, because this step hangs intermittently and has done for a while (#495).
+      #
+      # The suite takes about thirteen seconds locally and a minute or two here. When it hangs it
+      # hangs indefinitely, so the job ran to its own 30-minute timeout and was recorded as
+      # cancelled - a red mark on the repo carrying no information about what stopped, and half an
+      # hour gone. The same sha then passes on a re-run, which is what made it easy to shrug at.
+      #
+      # A hung run now aborts at five minutes with a dump naming the test that never returned,
+      # uploaded below. Five is far above any healthy run and far below the job timeout, so this
+      # costs nothing when things are well and produces the one thing thirty minutes of hanging
+      # never did: evidence.
       - name: Run tests
-        run: dotnet test src/NineLives.Tests/NineLives.Tests.csproj -c Release --no-build --verbosity normal
+        run: dotnet test src/NineLives.Tests/NineLives.Tests.csproj -c Release --no-build --verbosity normal --blame-hang --blame-hang-timeout 5m --blame-hang-dump-type mini
 
       # Separate step so a blob-emulator failure is distinguishable at a glance from a logic
       # failure - they have completely different causes and completely different fixes.
       - name: Run integration tests (Azurite)
-        run: dotnet test src/NineLives.IntegrationTests/NineLives.IntegrationTests.csproj -c Release --no-build --verbosity normal
+        run: dotnet test src/NineLives.IntegrationTests/NineLives.IntegrationTests.csproj -c Release --no-build --verbosity normal --blame-hang --blame-hang-timeout 5m --blame-hang-dump-type mini
+
+      # Only when something actually hung or failed - the sequence file names the test that was
+      # running when the clock ran out, which is the whole point of the exercise.
+      - name: Collect hang evidence
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hang-dump-${{ github.run_id }}
+          path: |
+            src/NineLives.Tests/TestResults/**
+            src/NineLives.IntegrationTests/TestResults/**
+          if-no-files-found: ignore
+          retention-days: 7
 
       # The shipping shape is a self-contained single-file exe — prove on every PR that it
       # still publishes, not just that the solution compiles. (~2 min.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ more detail on the user-facing changes; this file is the short history.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The execution console no longer waits for ever on a dispatcher nobody is pumping** (#497). It
+  adopted whichever dispatcher its constructing thread happened to be carrying, and flushes
+  marshal onto that with a blocking call - deliberately, because callers flush in order to read.
+  A thread that has acquired a dispatcher without ever running one is therefore a dead end: the
+  first flush from a different thread, which is every continuation after an await, waited on a
+  queue nothing was draining. It now uses the application's own dispatcher, which by definition
+  has a message loop, and in the app that is the same object it was already getting. This was the
+  cause of the intermittent CI hang (#495).
+
 ## [1.7.3] - 2026-08-18
 
 ### Fixed

--- a/src/NineLives.Tests/ConsoleNeverWaitsOnADeadDispatcherTests.cs
+++ b/src/NineLives.Tests/ConsoleNeverWaitsOnADeadDispatcherTests.cs
@@ -60,7 +60,7 @@ public class ConsoleNeverWaitsOnADeadDispatcherTests
     /// on a queue nothing is draining. Without the fix this never comes back.
     /// </summary>
     [Fact]
-    public void AFlushFromAnotherThreadDoesNotWaitForEver()
+    public async Task AFlushFromAnotherThreadDoesNotWaitForEver()
     {
         ConsoleBuffer? buffer = null;
 
@@ -81,7 +81,11 @@ public class ConsoleNeverWaitsOnADeadDispatcherTests
             return buffer.Text;
         });
 
-        Assert.True(flushed.Wait(TimeSpan.FromSeconds(10)), "Flush never returned");
-        Assert.Contains("something happened", flushed.Result);
+        // Raced against a clock rather than waited on, because a test that BLOCKS on the thing it
+        // is proving does not block would hang exactly as the product did.
+        var finished = await Task.WhenAny(flushed, Task.Delay(TimeSpan.FromSeconds(10)));
+
+        Assert.Same(flushed, finished);
+        Assert.Contains("something happened", await flushed);
     }
 }

--- a/src/NineLives.Tests/ConsoleNeverWaitsOnADeadDispatcherTests.cs
+++ b/src/NineLives.Tests/ConsoleNeverWaitsOnADeadDispatcherTests.cs
@@ -1,0 +1,87 @@
+using Blackcat.NineLives.ViewModels;
+using System.Windows.Threading;
+using Xunit;
+
+namespace Blackcat.NineLives.Tests;
+
+/// <summary>
+/// The console never marshals onto a dispatcher that is not pumping (#497).
+///
+/// Flush and Clear marshal with a BLOCKING Invoke, deliberately: callers flush in order to read,
+/// and an async hop would hand them the text from before the flush. The cost of that choice is
+/// that the dispatcher on the other end has to be one that answers.
+///
+/// It was whichever dispatcher the constructing thread happened to be carrying.
+/// Dispatcher.FromThread does not create one - but a plain thread pool thread acquires a
+/// dispatcher the moment anything constructs a DispatcherObject on it, and pool threads are
+/// reused. So a console built on such a thread captured a dispatcher with no message loop behind
+/// it, and the first Flush running on a DIFFERENT thread - which is every continuation after an
+/// await, there being no synchronization context to return to - blocked for ever.
+///
+/// That is what hung the CI test step (#495). It took a hang dump to find, having been written
+/// off as flaky infrastructure for months: intermittent because it needs both a thread carrying a
+/// stray dispatcher and a continuation landing elsewhere, and invisible on a developer machine
+/// because more cores means less pool-thread reuse.
+/// </summary>
+public class ConsoleNeverWaitsOnADeadDispatcherTests
+{
+    /// <summary>
+    /// The exact shape: a thread that has acquired a dispatcher without ever running one.
+    /// Constructing the buffer there must not adopt it.
+    /// </summary>
+    [Fact]
+    public void AThreadCarryingADispatcherNobodyIsPumpingIsNotAdopted()
+    {
+        ConsoleBuffer? buffer = null;
+        Dispatcher? strayDispatcher = null;
+
+        var worker = new Thread(() =>
+        {
+            // What a DispatcherObject's constructor does to the thread it runs on, and what makes
+            // this reachable from an ordinary pool thread that has run one earlier test.
+            strayDispatcher = Dispatcher.CurrentDispatcher;
+
+            buffer = new ConsoleBuffer();
+        });
+
+        worker.Start();
+        Assert.True(worker.Join(TimeSpan.FromSeconds(10)), "the worker did not finish");
+
+        Assert.NotNull(buffer);
+        Assert.NotNull(strayDispatcher);
+
+        // Whatever it adopted, it is not the one nobody is pumping. With an Application in the
+        // process it takes that instead, which is the point: a dispatcher that answers.
+        Assert.NotSame(strayDispatcher, buffer!.AdoptedDispatcher);
+    }
+
+    /// <summary>
+    /// And the consequence that matters: a flush from another thread returns rather than waiting
+    /// on a queue nothing is draining. Without the fix this never comes back.
+    /// </summary>
+    [Fact]
+    public void AFlushFromAnotherThreadDoesNotWaitForEver()
+    {
+        ConsoleBuffer? buffer = null;
+
+        var builder = new Thread(() =>
+        {
+            _ = Dispatcher.CurrentDispatcher;
+            buffer = new ConsoleBuffer();
+            buffer.Append("something happened");
+        });
+
+        builder.Start();
+        Assert.True(builder.Join(TimeSpan.FromSeconds(10)), "the builder did not finish");
+
+        // A different thread entirely, as an await continuation is.
+        var flushed = Task.Run(() =>
+        {
+            buffer!.Flush();
+            return buffer.Text;
+        });
+
+        Assert.True(flushed.Wait(TimeSpan.FromSeconds(10)), "Flush never returned");
+        Assert.Contains("something happened", flushed.Result);
+    }
+}

--- a/src/NineLives/ViewModels/ConsoleBuffer.cs
+++ b/src/NineLives/ViewModels/ConsoleBuffer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Windows;
 using System.Windows.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Blackcat.NineLives.Models;
@@ -55,9 +56,35 @@ public partial class ConsoleBuffer : ObservableObject
     /// Called with every message as it arrives, so the log file cannot drift from what was shown.
     /// </param>
     public ConsoleBuffer(Action<string>? alsoLog = null)
-        : this(alsoLog, Dispatcher.FromThread(Thread.CurrentThread))
+        : this(alsoLog, PumpingDispatcher())
     {
     }
+
+    /// <summary>
+    /// The dispatcher to marshal onto: the application's, which by definition has a message loop
+    /// running - and NOT merely whichever one the constructing thread happens to be carrying
+    /// (#497).
+    ///
+    /// Flush and Clear marshal with a BLOCKING Invoke, deliberately: callers flush in order to
+    /// read, and an async hop would hand them the text from before the flush. A blocking Invoke
+    /// onto a dispatcher whose thread is not pumping never returns.
+    ///
+    /// Dispatcher.FromThread(Thread.CurrentThread) could hand back exactly that. It does not
+    /// create one, but a plain pool thread acquires a dispatcher the moment anything constructs a
+    /// DispatcherObject on it, and thread pool threads are reused. So a console built on such a
+    /// thread captured a dispatcher with no loop behind it, and the first Flush that ran on a
+    /// DIFFERENT thread - which is every continuation after an await, since there is no
+    /// synchronization context to come back to - blocked for ever.
+    ///
+    /// That is what hung the CI test step for months (#495): intermittent, because it needed both
+    /// a thread carrying a stray dispatcher and a continuation landing elsewhere, and invisible
+    /// locally because more cores means less pool-thread reuse.
+    ///
+    /// In the app this changes nothing: these are built on the UI thread, where the application's
+    /// dispatcher IS the current thread's. It only stops the buffer adopting a dispatcher that
+    /// was never going to answer.
+    /// </summary>
+    private static Dispatcher? PumpingDispatcher() => Application.Current?.Dispatcher;
 
     /// <summary>
     /// Lets a test say outright whether there is a dispatcher, instead of depending on what its
@@ -199,6 +226,12 @@ public partial class ConsoleBuffer : ObservableObject
 
     /// <summary>Whether there is anything to batch on. Only the tests care.</summary>
     internal bool HasDispatcher => _dispatcher != null;
+
+    /// <summary>
+    /// Which dispatcher was adopted, so a test can say it is not the constructing thread's own
+    /// (#497) rather than only that flushing happened to return.
+    /// </summary>
+    internal Dispatcher? AdoptedDispatcher => _dispatcher;
 
     /// <summary>
     /// True while lines are waiting. Only the tests care - it is how "batched, not immediate" is


### PR DESCRIPTION
Closes #495.

Not a failing build — a **hanging** one, which is why it has survived this long.

## What has been happening

`Run tests` hangs indefinitely on roughly every other run. The job reaches its own `timeout-minutes: 30` and is recorded as **cancelled**, showing red beside genuine failures while carrying no information. Five of those today, about two hours of waiting, on a suite that takes thirteen seconds locally.

It has never been diagnosed because thirty minutes of hanging produces nothing to read: the step is killed from outside, so there is no message, no stack, and no clue which test never returned. Cancelling by hand and pushing an empty commit clears it — fixing the symptom and destroying the evidence in one motion. That is what happened every time, including every time today.

## This change

`--blame-hang --blame-hang-timeout 5m --blame-hang-dump-type mini` on both test steps, plus `TestResults` uploaded as an artifact when a step fails.

Five minutes is far above any healthy run (thirteen seconds locally, a minute or two on the runner) and far below the job timeout, so it costs nothing when things are well. When they are not, the run aborts with a **sequence file naming the test that was executing** when the clock ran out.

It does not fix the hang. It produces the one thing thirty minutes of hanging never did.

## Suspicion, deliberately not acted on

The WPF collection is the obvious place — one `Application` per process with thread affinity, a documented deadlock if anything blocks the dispatcher while awaiting off-thread work, and a headless runner is exactly where that behaves differently. But that is a guess, and guessing is how the last several rounds went. The artifact will say.

## Verified

Run locally with the same flags: **2,291 passed** in 14s, unchanged. YAML parses.